### PR TITLE
Support configurable hotkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "anyhow",
  "eframe",
  "fuzzy-matcher",
+ "lazy_static",
  "open",
  "rdev",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ fuzzy-matcher = "0.3"
 rdev = "0.5"                   # Global hotkeys (Windows)
 open = "5.0"                   # Open files/folders/apps cross-platform
 anyhow = "1.0"
+lazy_static = "1.4"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Multi_Launcher
+
+This tool lets you launch predefined actions with a global hotkey.
+
+## Configuration
+
+`settings.json` specifies the hotkey to open the launcher:
+
+```json
+{
+  "hotkey_key": "CapsLock"
+}
+```
+
+`hotkey_key` accepts any key variant defined by the [`rdev`](https://docs.rs/rdev) crate.
+Examples include `F1`, `F12`, `CapsLock`, `KeyA`, `LeftArrow`, etc. The value is case
+insensitive. If an unknown key name is used, the application will return an error
+on startup.
+
+## Running
+
+Provide `actions.json` with your actions and run `cargo run`.

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+  "hotkey_key": "CapsLock"
+}

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -14,12 +14,12 @@ impl HotkeyTrigger {
         }
     }
 
-    pub fn start_listener(&self) {
+    pub fn start_listener(&self, hotkey: Key) {
         let open = self.open.clone();
         thread::spawn(move || {
             listen(move |event| {
                 if let EventType::KeyPress(key) = event.event_type {
-                    if key == Key::CapsLock {
+                    if key == hotkey {
                         if let Ok(mut flag) = open.lock() {
                             *flag = true;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,21 @@
 mod actions;
 mod gui;
 mod hotkey;
+mod settings;
 mod launcher;
 
 use crate::actions::load_actions;
 use crate::gui::LauncherApp;
 use crate::hotkey::HotkeyTrigger;
+use crate::settings::Settings;
 
 use eframe::egui;
 
 fn main() -> anyhow::Result<()> {
     let actions = load_actions("actions.json")?;
+    let settings = Settings::load("settings.json")?;
     let trigger = HotkeyTrigger::new();
-    trigger.start_listener();
+    trigger.start_listener(settings.hotkey_key);
 
     loop {
         if trigger.take() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use rdev::Key;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+
+#[derive(Deserialize)]
+struct RawSettings {
+    hotkey_key: String,
+}
+
+pub struct Settings {
+    pub hotkey_key: Key,
+}
+
+impl Settings {
+    pub fn load(path: &str) -> Result<Self> {
+        let data = fs::read_to_string(path)?;
+        let raw: RawSettings = serde_json::from_str(&data)?;
+        let key = parse_key(&raw.hotkey_key)
+            .ok_or_else(|| anyhow!(format!("Unknown key: {}", raw.hotkey_key)))?;
+        Ok(Self { hotkey_key: key })
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref KEY_MAP: HashMap<String, Key> = {
+        use Key::*;
+        let keys = [
+            Alt, AltGr, Backspace, CapsLock, ControlLeft, ControlRight, Delete,
+            DownArrow, End, Escape, F1, F10, F11, F12, F2, F3, F4, F5, F6,
+            F7, F8, F9, Home, LeftArrow, MetaLeft, MetaRight, PageDown, PageUp,
+            Return, RightArrow, ShiftLeft, ShiftRight, Space, Tab, UpArrow,
+            PrintScreen, ScrollLock, Pause, NumLock, BackQuote, Num1, Num2, Num3,
+            Num4, Num5, Num6, Num7, Num8, Num9, Num0, Minus, Equal, KeyQ, KeyW,
+            KeyE, KeyR, KeyT, KeyY, KeyU, KeyI, KeyO, KeyP, LeftBracket,
+            RightBracket, KeyA, KeyS, KeyD, KeyF, KeyG, KeyH, KeyJ, KeyK, KeyL,
+            SemiColon, Quote, BackSlash, IntlBackslash, KeyZ, KeyX, KeyC, KeyV,
+            KeyB, KeyN, KeyM, Comma, Dot, Slash, Insert, KpReturn, KpMinus,
+            KpPlus, KpMultiply, KpDivide, Kp0, Kp1, Kp2, Kp3, Kp4, Kp5, Kp6,
+            Kp7, Kp8, Kp9, KpDelete, Function
+        ];
+        let mut m = HashMap::new();
+        for k in keys.iter() {
+            m.insert(format!("{:?}", k).to_lowercase(), *k);
+        }
+        m
+    };
+}
+
+pub fn parse_key(name: &str) -> Option<Key> {
+    KEY_MAP.get(&name.to_lowercase()).copied()
+}
+


### PR DESCRIPTION
## Summary
- add new Settings struct that loads a string key name and converts it to `rdev::Key`
- update hotkey listener to accept a `Key`
- read `settings.json` and start listener with the configured key
- document key names in `README`

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684442621c0c8332883725130166f5b2