### PR TITLE
Add actions editor GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ pub extern "C" fn create_plugin() -> Box<dyn Plugin> {
 Place the resulting library file in one of the directories listed under
 `plugin_dirs` in `settings.json`.
 
+## Editing Commands
+
+The launcher stores its custom actions in `actions.json`. While running the
+application you can manage this list using the **Edit Commands** dialog. Open
+the launcher with the configured hotkey and press the *Edit Commands* button to
+add or remove entries. Changes are saved back to `actions.json` immediately.
+
 ## Packaging
 
 The project can be compiled for Windows, macOS and Linux using `cargo build

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -12,3 +12,9 @@ pub fn load_actions(path: &str) -> anyhow::Result<Vec<Action>> {
     let actions: Vec<Action> = serde_json::from_str(&content)?;
     Ok(actions)
 }
+
+pub fn save_actions(path: &str, actions: &[Action]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(actions)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}

--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -1,0 +1,73 @@
+use crate::actions::{Action, save_actions};
+use crate::gui::LauncherApp;
+use eframe::egui;
+
+pub struct ActionsEditor {
+    label: String,
+    desc: String,
+    path: String,
+}
+
+impl Default for ActionsEditor {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            desc: String::new(),
+            path: String::new(),
+        }
+    }
+}
+
+impl ActionsEditor {
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        egui::Window::new("Command Editor").show(ctx, |ui| {
+            let mut remove: Option<usize> = None;
+            for (idx, act) in app.actions.iter().enumerate() {
+                ui.horizontal(|ui| {
+                    ui.label(format!("{} : {} -> {}", act.label, act.desc, act.action));
+                    if ui.button("Remove").clicked() {
+                        remove = Some(idx);
+                    }
+                });
+            }
+            if let Some(i) = remove {
+                app.actions.remove(i);
+                app.search();
+                if let Err(e) = save_actions(&app.actions_path, &app.actions) {
+                    app.error = Some(format!("Failed to save: {e}"));
+                }
+            }
+
+            ui.separator();
+            ui.label("Add new command:");
+            ui.horizontal(|ui| {
+                ui.label("Label");
+                ui.text_edit_singleline(&mut self.label);
+            });
+            ui.horizontal(|ui| {
+                ui.label("Description");
+                ui.text_edit_singleline(&mut self.desc);
+            });
+            ui.horizontal(|ui| {
+                ui.label("Path");
+                ui.text_edit_singleline(&mut self.path);
+            });
+            if ui.button("Add").clicked() {
+                if !self.path.is_empty() {
+                    app.actions.push(Action {
+                        label: self.label.clone(),
+                        desc: self.desc.clone(),
+                        action: self.path.clone(),
+                    });
+                    self.label.clear();
+                    self.desc.clear();
+                    self.path.clear();
+                    app.search();
+                    if let Err(e) = save_actions(&app.actions_path, &app.actions) {
+                        app.error = Some(format!("Failed to save: {e}"));
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,5 @@
 use crate::actions::Action;
+use crate::actions_editor::ActionsEditor;
 use crate::launcher::launch_action;
 use crate::plugin::PluginManager;
 use eframe::egui;
@@ -14,10 +15,13 @@ pub struct LauncherApp {
     pub error: Option<String>,
     pub plugins: PluginManager,
     pub usage: HashMap<String, u32>,
+    pub show_editor: bool,
+    pub actions_path: String,
+    pub editor: ActionsEditor,
 }
 
 impl LauncherApp {
-    pub fn new(actions: Vec<Action>, plugins: PluginManager) -> Self {
+    pub fn new(actions: Vec<Action>, plugins: PluginManager, actions_path: String) -> Self {
         Self {
             actions: actions.clone(),
             query: String::new(),
@@ -26,10 +30,13 @@ impl LauncherApp {
             error: None,
             plugins,
             usage: HashMap::new(),
+            show_editor: false,
+            actions_path,
+            editor: ActionsEditor::default(),
         }
     }
 
-    fn search(&mut self) {
+    pub fn search(&mut self) {
         let mut res: Vec<Action> = if self.query.is_empty() {
             self.actions.clone()
         } else {
@@ -59,6 +66,9 @@ impl eframe::App for LauncherApp {
 
         CentralPanel::default().show(ctx, |ui| {
             ui.heading("🚀 LNCHR");
+            if ui.button("Edit Commands").clicked() {
+                self.show_editor = !self.show_editor;
+            }
             if let Some(err) = &self.error {
                 ui.colored_label(Color32::RED, err);
             }
@@ -80,6 +90,9 @@ impl eframe::App for LauncherApp {
                     }
                 }
             });
+            if self.show_editor {
+                self.editor.ui(ctx, self);
+            }
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod actions_editor;
 mod gui;
 mod hotkey;
 mod launcher;
@@ -52,10 +53,11 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
+            let actions_path = "actions.json".to_string();
             let _ = eframe::run_native(
                 "Multi_LNCHR",
                 native_options,
-                Box::new(move |_cc| Box::new(LauncherApp::new(actions_for_window, plugins))),
+                Box::new(move |_cc| Box::new(LauncherApp::new(actions_for_window, plugins, actions_path))),
             );
         }
         std::thread::sleep(std::time::Duration::from_millis(50));


### PR DESCRIPTION
## Summary
- add `save_actions` to persist command list
- create `ActionsEditor` to manage commands via egui
- extend `LauncherApp` with fields for editing
- hook editor into the GUI and toggle with "Edit Commands"
- document command editing in README

## Testing
 