### PR TITLE
Fix compile errors

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -147,7 +147,7 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         if self.close_requested.load(Ordering::SeqCst) {
-            _frame.close();
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,14 +51,6 @@ fn main() -> anyhow::Result<()> {
                 let _ = handle.join();
                 running = None;
             } else {
-                let native_options = eframe::NativeOptions {
-                    viewport: egui::ViewportBuilder::default()
-                        .with_inner_size([400.0, 220.0])
-                        .with_min_inner_size([320.0, 160.0])
-                        .with_always_on_top(),
-                    ..Default::default()
-                };
-
                 let actions_for_window = actions.clone();
                 let mut plugins = PluginManager::new();
                 plugins.register(Box::new(WebSearchPlugin));
@@ -78,6 +70,14 @@ fn main() -> anyhow::Result<()> {
                 let flag_clone = close_flag.clone();
 
                 let handle = thread::spawn(move || {
+                    let native_options = eframe::NativeOptions {
+                        viewport: egui::ViewportBuilder::default()
+                            .with_inner_size([400.0, 220.0])
+                            .with_min_inner_size([320.0, 160.0])
+                            .with_always_on_top(),
+                        ..Default::default()
+                    };
+
                     let _ = eframe::run_native(
                         "Multi_LNCHR",
                         native_options,


### PR DESCRIPTION
## Summary
- request closing the viewport instead of calling removed frame API
- build eframe options inside thread to avoid moving non-Send type

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449310959483328c2fe5f7392d5256