### PR TITLE
Fix join handle borrow error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,9 @@ fn main() -> anyhow::Result<()> {
     loop {
         if let Some((handle, flag)) = &running {
             if handle.is_finished() {
-                let _ = handle.join();
-                running = None;
+                if let Some((handle, _)) = running.take() {
+                    let _ = handle.join();
+                }
             } else if flag.load(Ordering::SeqCst) {
                 // waiting for close
             }


### PR DESCRIPTION
## Summary
- handle JoinHandle in owned manner before joining

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684496b8f68c8332bef4718880347503