### PR TITLE
Fix event loop panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,20 @@ fn main() -> anyhow::Result<()> {
                             .with_inner_size([400.0, 220.0])
                             .with_min_inner_size([320.0, 160.0])
                             .with_always_on_top(),
+                        event_loop_builder: Some(Box::new(|builder| {
+                            #[cfg(target_os = "windows")]
+                            {
+                                use winit::platform::windows::EventLoopBuilderExtWindows;
+                                builder.with_any_thread(true);
+                            }
+                            #[cfg(target_os = "linux")]
+                            {
+                                use winit::platform::wayland::EventLoopBuilderExtWayland;
+                                use winit::platform::x11::EventLoopBuilderExtX11;
+                                winit::platform::x11::EventLoopBuilderExtX11::with_any_thread(builder, true);
+                                winit::platform::wayland::EventLoopBuilderExtWayland::with_any_thread(builder, true);
+                            }
+                        })),
                         ..Default::default()
                     };
 


### PR DESCRIPTION
## Summary
- configure winit event loop to allow creation on worker thread

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684498f94f888332a7dbd8e88b03eee0