### PR TITLE
Fix GUI toggle blocking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,8 @@ fn main() -> anyhow::Result<()> {
         }
 
         if trigger.take() {
-            if let Some((handle, flag)) = running.take() {
+            if let Some((_handle, flag)) = &running {
                 flag.store(true, Ordering::SeqCst);
-                let _ = handle.join();
-                running = None;
             } else {
                 let actions_for_window = actions.clone();
                 let mut plugins = PluginManager::new();


### PR DESCRIPTION
## Summary
- fix hotkey toggle logic so closing the GUI doesn't block the main loop

## Testing
- `cargo check` *(fails: libevdev not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7940290833298cb9b007d05c13c