### PR TITLE
Improve hotkey debug logging

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -113,18 +113,22 @@ impl HotkeyTrigger {
     pub fn start_listener(&self) {
         let open = self.open.clone();
         let watch = self.key;
+        tracing::debug!("starting hotkey listener for {:?}", watch);
         thread::spawn(move || {
             #[cfg(feature = "unstable_grab")]
             {
                 if watch == Key::CapsLock {
                     let mut shift_pressed = false;
                     let callback = move |event: Event| -> Option<Event> {
+                        tracing::debug!("grabbed event: {:?}", event.event_type);
                         match event.event_type {
                             EventType::KeyPress(k) => {
+                                tracing::debug!("grab key press: {:?}", k);
                                 if k == Key::ShiftLeft || k == Key::ShiftRight {
                                     shift_pressed = true;
                                 } else if k == watch {
                                     if !shift_pressed {
+                                        tracing::debug!("hotkey triggered");
                                         if let Ok(mut flag) = open.lock() {
                                             *flag = true;
                                         }
@@ -133,6 +137,7 @@ impl HotkeyTrigger {
                                 }
                             }
                             EventType::KeyRelease(k) => {
+                                tracing::debug!("grab key release: {:?}", k);
                                 if k == Key::ShiftLeft || k == Key::ShiftRight {
                                     shift_pressed = false;
                                 }
@@ -150,7 +155,9 @@ impl HotkeyTrigger {
 
             listen(move |event| {
                 if let EventType::KeyPress(k) = event.event_type {
+                    tracing::debug!("key pressed: {:?}", k);
                     if k == watch {
+                        tracing::debug!("hotkey triggered");
                         if let Ok(mut flag) = open.lock() {
                             *flag = true;
                         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,16 @@
+use tracing_subscriber::EnvFilter;
+
+/// Initialise logging. In debug builds the default level is `debug` while in
+/// release builds it falls back to `info`. The level can be overridden via the
+/// `RUST_LOG` environment variable.
 pub fn init() {
-    let _ = tracing_subscriber::fmt::try_init();
+    // Pick a sensible default depending on build type but honour any user
+    // supplied `RUST_LOG` filter.
+    let default_level = if cfg!(debug_assertions) { "debug" } else { "info" };
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .try_init();
 }


### PR DESCRIPTION
## Summary
- show more debug information when running in debug mode
- configure tracing subscriber to default to `debug` level in debug builds
- log hotkey events and GUI show/hide lifecycle

## Testing
- `cargo check` *(fails: libevdev missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844de58ab348332877a8d022e25c2de