### PR TITLE
Add pressed state to hotkey listener

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -115,10 +115,12 @@ impl HotkeyTrigger {
         let watch = self.key;
         tracing::debug!("starting hotkey listener for {:?}", watch);
         thread::spawn(move || {
+            let mut pressed = false;
             #[cfg(feature = "unstable_grab")]
             {
                 if watch == Key::CapsLock {
                     let mut shift_pressed = false;
+                    let mut pressed = false;
                     let callback = move |event: Event| -> Option<Event> {
                         tracing::debug!("grabbed event: {:?}", event.event_type);
                         match event.event_type {
@@ -127,7 +129,8 @@ impl HotkeyTrigger {
                                 if k == Key::ShiftLeft || k == Key::ShiftRight {
                                     shift_pressed = true;
                                 } else if k == watch {
-                                    if !shift_pressed {
+                                    if !shift_pressed && !pressed {
+                                        pressed = true;
                                         tracing::debug!("hotkey triggered");
                                         if let Ok(mut flag) = open.lock() {
                                             *flag = true;
@@ -140,6 +143,8 @@ impl HotkeyTrigger {
                                 tracing::debug!("grab key release: {:?}", k);
                                 if k == Key::ShiftLeft || k == Key::ShiftRight {
                                     shift_pressed = false;
+                                } else if k == watch {
+                                    pressed = false;
                                 }
                             }
                             _ => {}
@@ -154,14 +159,23 @@ impl HotkeyTrigger {
             }
 
             listen(move |event| {
-                if let EventType::KeyPress(k) = event.event_type {
-                    tracing::debug!("key pressed: {:?}", k);
-                    if k == watch {
-                        tracing::debug!("hotkey triggered");
-                        if let Ok(mut flag) = open.lock() {
-                            *flag = true;
+                match event.event_type {
+                    EventType::KeyPress(k) => {
+                        tracing::debug!("key pressed: {:?}", k);
+                        if k == watch && !pressed {
+                            pressed = true;
+                            tracing::debug!("hotkey triggered");
+                            if let Ok(mut flag) = open.lock() {
+                                *flag = true;
+                            }
                         }
                     }
+                    EventType::KeyRelease(k) => {
+                        if k == watch {
+                            pressed = false;
+                        }
+                    }
+                    _ => {}
                 }
             })
             .unwrap();


### PR DESCRIPTION
## Summary
- avoid repeated triggers while holding the hotkey
- reset state on key release
- support the same behaviour when using the `unstable_grab` feature

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*
- `rustup component add rustfmt` *(failed to download due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844e2eb27d8833293f91b9d798d0dfa