### PR TITLE
Handle window close without exit

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -158,7 +158,8 @@ impl eframe::App for LauncherApp {
             menu::bar(ui, |ui| {
                 ui.menu_button("File", |ui| {
                     if ui.button("Close Application").clicked() {
-                        std::process::exit(0);
+                        self.visible_flag.store(false, Ordering::SeqCst);
+                        self.last_visible = false;
                     }
                 });
             });
@@ -227,5 +228,11 @@ impl eframe::App for LauncherApp {
             editor.ui(ctx, self);
             self.editor = editor;
         }
+    }
+
+    fn on_close_event(&mut self) -> bool {
+        self.visible_flag.store(false, Ordering::SeqCst);
+        self.last_visible = false;
+        false
     }
 }


### PR DESCRIPTION
## Summary
- close menu hides the window instead of exiting
- hide the window when the user closes it

## Testing
- `cargo check` *(fails: system libraries not present)*
 