### PR TITLE
Hide launcher window by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ fn spawn_gui(
             viewport: egui::ViewportBuilder::default()
                 .with_inner_size([400.0, 220.0])
                 .with_min_inner_size([320.0, 160.0])
-                .with_always_on_top(),
+                .with_always_on_top()
+                .with_visible(false),
             event_loop_builder: Some(Box::new(|builder| {
                 #[cfg(target_os = "windows")]
                 {


### PR DESCRIPTION
## Summary
- hide the GUI window on startup with `.with_visible(false)`

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

 