### PR TITLE
Fix compile error with eframe 0.27

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -230,9 +230,8 @@ impl eframe::App for LauncherApp {
         }
     }
 
-    fn on_close_event(&mut self) -> bool {
+    fn on_exit(&mut self) {
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
-        false
     }
 }


### PR DESCRIPTION
## Summary
- update `LauncherApp`'s `App` implementation for eframe 0.27
- replace the removed `on_close_event` with `on_exit`

## Testing
- `cargo check --no-default-features` *(fails: failed to run custom build command for `x11`)*
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

 