### PR TITLE
Fix on_exit method signature

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -230,7 +230,7 @@ impl eframe::App for LauncherApp {
         }
     }
 
-    fn on_exit(&mut self) {
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
     }


### PR DESCRIPTION
## Summary
- update `on_exit` definition to match eframe 0.27 API

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*
 