### PR TITLE
Implement modifier-aware hotkeys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,9 @@ fn main() -> anyhow::Result<()> {
         actions.extend(indexer::index_paths(paths));
     }
 
-    let trigger_key = settings.hotkey_key();
-    tracing::debug!(?trigger_key, "configuring hotkey");
-    let trigger = HotkeyTrigger::new(trigger_key);
+    let hotkey = settings.hotkey();
+    tracing::debug!(?hotkey, "configuring hotkey");
+    let trigger = HotkeyTrigger::new(hotkey);
     trigger.start_listener();
 
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use rdev::Key;
 
-use crate::hotkey::parse_hotkey;
+use crate::hotkey::{parse_hotkey, Hotkey};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -29,12 +29,17 @@ impl Settings {
         Ok(serde_json::from_str(&content)?)
     }
 
-    pub fn hotkey_key(&self) -> Key {
+    pub fn hotkey(&self) -> Hotkey {
         if let Some(hotkey) = &self.hotkey {
             if let Some(k) = parse_hotkey(hotkey) {
                 return k;
             }
         }
-        Key::CapsLock
+        Hotkey {
+            key: Key::CapsLock,
+            ctrl: false,
+            shift: false,
+            alt: false,
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse modifiers from the settings hotkey string
- expose the parsed `Hotkey` via `Settings::hotkey`
- have `HotkeyTrigger` track required modifier state
- create `HotkeyTrigger` using the parsed `Hotkey`

## Testing
- `cargo check` *(fails: could not find system library `xi`)*

 