### PR TITLE
Fix hotkey visibility toggle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ fn main() -> anyhow::Result<()> {
             visibility.store(next, Ordering::SeqCst);
             if let Ok(mut guard) = ctx.lock() {
                 if let Some(c) = &*guard {
+                    c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
                     c.request_repaint();
                 }
             }


### PR DESCRIPTION
## Summary
- make the hotkey send the viewport visibility command immediately
- keep repaint request

## Testing
- `cargo build --quiet` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458149f2c883328663c85b4ffa0afe