### PR TITLE
Improve debugging logs

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -188,7 +188,7 @@ impl HotkeyTrigger {
                                 } else if k == watch {
                                     if !shift_pressed && !pressed {
                                         pressed = true;
-                                        tracing::debug!("hotkey triggered");
+                                        tracing::debug!("hotkey match -> open=true");
                                         if let Ok(mut flag) = open.lock() {
                                             *flag = true;
                                         }
@@ -231,7 +231,7 @@ impl HotkeyTrigger {
                                 && (!need_alt || alt_pressed)
                             {
                                 pressed = true;
-                                tracing::debug!("hotkey triggered");
+                                tracing::debug!("hotkey match -> open=true");
                                 if let Ok(mut flag) = open.lock() {
                                     *flag = true;
                                 }
@@ -239,6 +239,7 @@ impl HotkeyTrigger {
                         }
                     }
                     EventType::KeyRelease(k) => {
+                        tracing::debug!("key released: {:?}", k);
                         match k {
                             Key::ControlLeft | Key::ControlRight => ctrl_pressed = false,
                             Key::ShiftLeft | Key::ShiftRight => shift_pressed = false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn main() -> anyhow::Result<()> {
 
         if trigger.take() {
             let next = !visibility.load(Ordering::SeqCst);
+            tracing::debug!("trigger.take -> next visibility: {}", next);
             visibility.store(next, Ordering::SeqCst);
             if let Ok(mut guard) = ctx.lock() {
                 if let Some(c) = &*guard {
@@ -124,7 +125,6 @@ fn main() -> anyhow::Result<()> {
                     c.request_repaint();
                 }
             }
-            tracing::debug!("toggle visible -> {}", next);
         }
 
         std::thread::sleep(std::time::Duration::from_millis(50));


### PR DESCRIPTION
## Summary
- log key release events and open flag changes in `HotkeyTrigger`
- note next visibility state when the hotkey fires

## Testing
- `cargo build --quiet`
- `RUST_LOG=debug cargo run --quiet` *(fails: KeyboardError)*
 