### PR TITLE
Warn on invalid hotkey

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,8 +31,14 @@ impl Settings {
 
     pub fn hotkey(&self) -> Hotkey {
         if let Some(hotkey) = &self.hotkey {
-            if let Some(k) = parse_hotkey(hotkey) {
-                return k;
+            match parse_hotkey(hotkey) {
+                Some(k) => return k,
+                None => {
+                    tracing::warn!(
+                        "provided hotkey string '{}' is invalid; using default CapsLock",
+                        hotkey
+                    );
+                }
             }
         }
         Hotkey {


### PR DESCRIPTION
## Summary
- warn when a configured hotkey string can't be parsed and revert to default

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*
- `cargo test` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458aca40648332b6581f63a4e6da13