### PR TITLE
Fix initial visibility on startup

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -39,6 +39,7 @@ pub struct LauncherApp {
 
 impl LauncherApp {
     pub fn new(
+        ctx: &egui::Context,
         actions: Vec<Action>,
         plugins: PluginManager,
         actions_path: String,
@@ -100,7 +101,9 @@ impl LauncherApp {
             }
         }
 
-        Self {
+        let initial_visible = visible_flag.load(Ordering::SeqCst);
+
+        let app = Self {
             actions: actions.clone(),
             query: String::new(),
             results: actions,
@@ -116,8 +119,13 @@ impl LauncherApp {
             plugin_dirs,
             index_paths,
             visible_flag: visible_flag.clone(),
-            last_visible: visible_flag.load(Ordering::SeqCst),
-        }
+            last_visible: initial_visible,
+        };
+
+        tracing::debug!("initial viewport visible: {}", initial_visible);
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(initial_visible));
+
+        app
     }
 
     pub fn search(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn spawn_gui(
             Box::new(move |cc| {
                 *ctx_clone.lock().unwrap() = Some(cc.egui_ctx.clone());
                 Box::new(LauncherApp::new(
+                    &cc.egui_ctx,
                     actions_for_window,
                     plugins,
                     actions_path,


### PR DESCRIPTION
## Summary
- ensure the initial window visibility matches the shared flag
- log the initial visibility state

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459178b714833299f5222d4589470e