### PR TITLE
Update default hotkey documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ capability used to grab keyboard events.
 
 ## Settings
 
-Create a `settings.json` next to the binary to customise the launcher. Example:
+Create a `settings.json` next to the binary to customise the launcher. The
+default hotkey is `F2`. To use a different key, set the `hotkey` value in
+`settings.json` as shown below:
 
 ```json
 {

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-    "hotkey": "CapsLock",
+    "hotkey": "F2",
     "index_paths": null,
     "plugin_dirs": null
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,7 +13,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            hotkey: Some("CapsLock".into()),
+            hotkey: Some("F2".into()),
             index_paths: None,
             plugin_dirs: None,
         }
@@ -35,14 +35,14 @@ impl Settings {
                 Some(k) => return k,
                 None => {
                     tracing::warn!(
-                        "provided hotkey string '{}' is invalid; using default CapsLock",
+                        "provided hotkey string '{}' is invalid; using default F2",
                         hotkey
                     );
                 }
             }
         }
         Hotkey {
-            key: Key::CapsLock,
+            key: Key::F2,
             ctrl: false,
             shift: false,
             alt: false,


### PR DESCRIPTION
## Summary
- default launcher hotkey is now `F2`
- document the default hotkey in README
- update sample settings file

## Testing
- `cargo check` *(fails: system library `xi` missing)*