### PR TITLE
Improve hotkey error logging

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -255,7 +255,10 @@ impl HotkeyTrigger {
                     _ => {}
                 }
             }) {
-                tracing::error!("hotkey listener failed: {:?}. Hotkeys will no longer work", e);
+                tracing::warn!(
+                    "Hotkey listener failed: {:?}. Hotkeys will not work. Please verify system permissions.",
+                    e
+                );
             }
         });
     }


### PR DESCRIPTION
## Summary
- warn if the hotkey listener fails so users know to check permissions

## Testing
- `cargo check` *(fails: failed to run custom build command for `x11`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a0c9d93883328b00542f32e1c162