### PR TITLE
Update build docs about CapsLock handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Requirements:
 cargo build --release
 ```
 
-To build with support for suppressing the `CapsLock` toggle, enable the optional
-`unstable_grab` feature:
+To capture `CapsLock` reliably and suppress its normal toggle, build with the
+optional `unstable_grab` feature. Without this feature some systems may ignore
+the `CapsLock` hotkey:
 
 ```
 cargo build --release --features unstable_grab


### PR DESCRIPTION
## Summary
- clarify in the **Building** section that capturing `CapsLock` hotkey requires `--features unstable_grab`
- mention potential `CapsLock` hotkey issues when the feature is disabled

## Testing
- `cargo test` *(fails: system library `xi` for crate `x11` missing)*

 