### PR TITLE
Add info-level hotkey logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ bundle` on macOS or `cargo wix` on Windows).
 
 ## Manual Test Plan
 
+For troubleshooting, run the application with `RUST_LOG=info` to enable
+informational logs.
+
 1. Build and run the project with `cargo run`.
 2. **Before** the launcher window appears, press the configured hotkey once.
 3. Observe the log output. There should be a message indicating a visibility

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -230,6 +230,13 @@ impl HotkeyTrigger {
                             );
                             if !triggered {
                                 triggered = true;
+                                tracing::info!(
+                                    "hotkey triggered: key={:?} ctrl={} shift={} alt={}",
+                                    watch,
+                                    need_ctrl,
+                                    need_shift,
+                                    need_alt
+                                );
                                 tracing::debug!("hotkey match -> open=true");
                                 if let Ok(mut flag) = open.lock() {
                                     *flag = true;
@@ -312,6 +319,13 @@ impl HotkeyTrigger {
                     );
                     if !triggered {
                         triggered = true;
+                        tracing::info!(
+                            "hotkey triggered: key={:?} ctrl={} shift={} alt={}",
+                            watch,
+                            need_ctrl,
+                            need_shift,
+                            need_alt
+                        );
                         tracing::debug!("hotkey match -> open=true");
                         if let Ok(mut flag) = open.lock() {
                             *flag = true;


### PR DESCRIPTION
## Summary
- emit `info!` log when a configured hotkey combo is pressed
- document using `RUST_LOG=info` to enable troubleshooting logs

## Testing
- `cargo test` *(fails: `The system library xi required by crate x11 was not found`)*

 