### PR TITLE
Add hotkey info log

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ The project can be compiled for Windows, macOS and Linux using `cargo build
 --release`. Afterwards bundle the binary for distribution (e.g. using `cargo
 bundle` on macOS or `cargo wix` on Windows).
 
+## Troubleshooting
+
+When diagnosing hotkey issues it can be helpful to enable info level logging:
+
+```bash
+RUST_LOG=info cargo run
+```
+
 ## Manual Test Plan
 
 1. Build and run the project with `cargo run`.

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -228,6 +228,10 @@ impl HotkeyTrigger {
                             );
                             if !triggered {
                                 triggered = true;
+                                tracing::info!(
+                                    "hotkey triggered: key={:?} ctrl={} shift={} alt={}",
+                                    watch, need_ctrl, need_shift, need_alt
+                                );
                                 tracing::debug!("hotkey match -> open=true");
                                 if let Ok(mut flag) = open.lock() {
                                     *flag = true;
@@ -318,6 +322,10 @@ impl HotkeyTrigger {
                         );
                         if !triggered {
                             triggered = true;
+                            tracing::info!(
+                                "hotkey triggered: key={:?} ctrl={} shift={} alt={}",
+                                watch, need_ctrl, need_shift, need_alt
+                            );
                             tracing::debug!("hotkey match -> open=true");
                             if let Ok(mut flag) = open_listener.lock() {
                                 *flag = true;


### PR DESCRIPTION
## Summary
- log an info message when the hotkey combo activates
- document using `RUST_LOG=info` for troubleshooting

## Testing
- `cargo test` *(fails: x11 library not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b330e83083329cd98c91e39527ad