### PR TITLE
Add visibility toggle helper and integration test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod hotkey;
+pub mod visibility;

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,0 +1,55 @@
+use eframe::egui;
+use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+
+use crate::hotkey::HotkeyTrigger;
+
+
+/// Trait abstracting over an `egui::Context` for viewport commands.
+pub trait ViewportCtx {
+    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand);
+    fn request_repaint(&self);
+}
+
+impl ViewportCtx for egui::Context {
+    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
+        egui::Context::send_viewport_cmd(self, cmd);
+    }
+
+    fn request_repaint(&self) {
+        egui::Context::request_repaint(self);
+    }
+}
+
+/// Process a hotkey trigger and update visibility, issuing viewport commands
+/// when possible. This mirrors the logic from `main.rs`.
+pub fn handle_visibility_trigger<C: ViewportCtx>(
+    trigger: &HotkeyTrigger,
+    visibility: &Arc<AtomicBool>,
+    ctx_handle: &Arc<Mutex<Option<C>>>,
+    queued_visibility: &mut Option<bool>,
+) {
+    if trigger.take() {
+        let next = !visibility.load(Ordering::SeqCst);
+        visibility.store(next, Ordering::SeqCst);
+        if let Ok(mut guard) = ctx_handle.lock() {
+            if let Some(c) = &*guard {
+                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
+                c.request_repaint();
+                *queued_visibility = None;
+            } else {
+                *queued_visibility = Some(next);
+            }
+        } else {
+            *queued_visibility = Some(next);
+        }
+    } else if let Some(next) = *queued_visibility {
+        if let Ok(mut guard) = ctx_handle.lock() {
+            if let Some(c) = &*guard {
+                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
+                c.request_repaint();
+                *queued_visibility = None;
+            }
+        }
+    }
+}
+

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -2,18 +2,9 @@ use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
 use eframe::egui;
 use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
 
-#[derive(Clone, Default)]
-struct MockCtx {
-    commands: Arc<Mutex<Vec<egui::ViewportCommand>>>,
-}
-
-impl MockCtx {
-    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
-        self.commands.lock().unwrap().push(cmd);
-    }
-
-    fn request_repaint(&self) {}
-}
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
 
 #[test]
 fn queued_visibility_applies_when_context_available() {

--- a/tests/mock_ctx.rs
+++ b/tests/mock_ctx.rs
@@ -1,0 +1,26 @@
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub struct MockCtx {
+    pub commands: Arc<Mutex<Vec<egui::ViewportCommand>>>,
+}
+
+impl MockCtx {
+    pub fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
+        self.commands.lock().unwrap().push(cmd);
+    }
+
+    pub fn request_repaint(&self) {}
+}
+
+// Implement the trait from the main crate so tests can reuse visibility logic.
+impl multi_launcher::visibility::ViewportCtx for MockCtx {
+    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
+        self.send_viewport_cmd(cmd);
+    }
+
+    fn request_repaint(&self) {
+        self.request_repaint();
+    }
+}

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -1,0 +1,32 @@
+use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
+use multi_launcher::visibility::handle_visibility_trigger;
+use eframe::egui;
+use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
+
+#[test]
+fn visibility_toggle_immediate_when_context_present() {
+    let trigger = HotkeyTrigger::new(Hotkey::default());
+    let visibility = Arc::new(AtomicBool::new(false));
+    let ctx = MockCtx::default();
+    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
+    let mut queued_visibility: Option<bool> = None;
+
+    // simulate hotkey press
+    *trigger.open.lock().unwrap() = true;
+
+    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+
+    assert_eq!(visibility.load(Ordering::SeqCst), true);
+    assert!(queued_visibility.is_none());
+
+    let cmds = ctx.commands.lock().unwrap();
+    assert_eq!(cmds.len(), 1);
+    match cmds[0] {
+        egui::ViewportCommand::Visible(v) => assert!(v),
+        _ => panic!("unexpected command"),
+    }
+}


### PR DESCRIPTION
## Summary
- share a mock `egui::Context` for tests
- factor out visibility toggle logic into `src/visibility.rs`
- expose the helper via `multi_launcher::visibility`
- reuse mock context in existing `gui_visibility` test
- add new integration test exercising visibility toggle when context is present

## Testing
- `cargo test --quiet` *(fails: The system library `xi` required by crate `x11` was not found)*
 