### PR TITLE
Graceful shutdown for hotkey listeners

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,8 @@ fn main() -> anyhow::Result<()> {
         if let Some(qt) = &quit_trigger {
             if qt.take() {
                 quit_requested = true;
+                qt.stop();
+                trigger.stop();
             }
         }
 


### PR DESCRIPTION
## Summary
- allow signalling hotkey listener threads to stop
- exit listener loop when stop flag is set
- expose `stop()` on `HotkeyTrigger`
- stop listeners when quit hotkey is triggered

## Testing
- `cargo fmt` *(fails: rustfmt component unavailable)*
- `cargo test --quiet` *(fails: x11 library missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845b6ac9388833283f3ff393c014399