### PR TITLE
Handle GUI shutdown when quitting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,14 +119,11 @@ fn main() -> anyhow::Result<()> {
 
     loop {
         if handle.is_finished() {
-            if quit_requested {
-                let _ = handle.join();
-                break Ok(());
-            } else {
+            if !quit_requested {
                 tracing::error!("gui thread terminated unexpectedly");
-                let _ = handle.join();
-                break Ok(());
             }
+            let _ = handle.join();
+            break Ok(());
         }
 
         if let Some(qt) = &quit_trigger {
@@ -142,8 +139,8 @@ fn main() -> anyhow::Result<()> {
                     c.request_repaint();
                 }
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            continue;
+            let _ = handle.join();
+            break Ok(());
         }
 
         if trigger.take() {

--- a/tests/quit_hotkey.rs
+++ b/tests/quit_hotkey.rs
@@ -1,0 +1,52 @@
+use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
+
+#[test]
+fn quit_hotkey_terminates_loop() {
+    let quit_trigger = HotkeyTrigger::new(Hotkey::default());
+    // simulate pressing quit hotkey
+    *quit_trigger.open.lock().unwrap() = true;
+
+    let ctx = MockCtx::default();
+    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx)));
+
+    // dummy gui thread that finishes shortly
+    let handle = thread::spawn(|| {
+        thread::sleep(Duration::from_millis(20));
+    });
+
+    let mut quit_requested = false;
+
+    let result: Result<(), ()> = loop {
+        if handle.is_finished() {
+            handle.join().ok();
+            break Ok(());
+        }
+
+        if quit_trigger.take() {
+            quit_requested = true;
+        }
+
+        if quit_requested {
+            if let Ok(mut guard) = ctx_handle.lock() {
+                if let Some(c) = &*guard {
+                    c.send_viewport_cmd(egui::ViewportCommand::Close);
+                    c.request_repaint();
+                }
+            }
+            handle.join().ok();
+            break Ok(());
+        }
+
+        thread::sleep(Duration::from_millis(5));
+    };
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary
- wait for GUI thread to terminate after sending `ViewportCommand::Close`
- ensure program exits immediately after join
- add integration test for quit hotkey behaviour

## Testing
- `cargo test --no-run`
- `cargo test quit_hotkey -- --nocapture`
 