### PR TITLE
Wait for GUI thread on quit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,8 +144,8 @@ fn main() -> anyhow::Result<()> {
                     c.request_repaint();
                 }
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            continue;
+            let _ = handle.join();
+            break Ok(());
         }
 
         if trigger.take() {

--- a/tests/quit_finished.rs
+++ b/tests/quit_finished.rs
@@ -1,6 +1,9 @@
-use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
 use eframe::egui;
-use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use std::thread;
 use std::time::Duration;
 
@@ -11,7 +14,6 @@ use mock_ctx::MockCtx;
 fn run_quit_loop(
     trigger: &HotkeyTrigger,
     ctx_handle: Arc<Mutex<Option<MockCtx>>>,
-    kill: Arc<AtomicBool>,
     handle: thread::JoinHandle<()>,
 ) {
     let mut quit_requested = false;
@@ -26,7 +28,6 @@ fn run_quit_loop(
                 if let Some(c) = &*guard {
                     c.send_viewport_cmd(egui::ViewportCommand::Close);
                     c.request_repaint();
-                    kill.store(true, Ordering::SeqCst);
                 }
             }
             let _ = handle.join();
@@ -43,30 +44,24 @@ fn run_quit_loop(
 }
 
 #[test]
-fn quit_hotkey_exits_main_loop() {
+fn quit_hotkey_with_finished_thread() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let ctx = MockCtx::default();
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
-    let kill = Arc::new(AtomicBool::new(false));
-    let kill_thread = kill.clone();
 
-    let handle = thread::spawn(move || {
-        while !kill_thread.load(Ordering::SeqCst) {
-            thread::sleep(Duration::from_millis(10));
-        }
-    });
+    let handle = thread::spawn(|| {});
 
-    // simulate pressing the quit hotkey
+    // ensure thread has likely finished
+    thread::sleep(Duration::from_millis(10));
+
     *trigger.open.lock().unwrap() = true;
 
-    run_quit_loop(&trigger, ctx_handle.clone(), kill.clone(), handle);
+    run_quit_loop(&trigger, ctx_handle.clone(), handle);
 
-    assert!(kill.load(Ordering::SeqCst));
     let cmds = ctx.commands.lock().unwrap();
     assert_eq!(cmds.len(), 1);
     match cmds[0] {
-        egui::ViewportCommand::Close => {},
+        egui::ViewportCommand::Close => {}
         _ => panic!("unexpected command"),
     }
 }
-


### PR DESCRIPTION
## Summary
- join the GUI thread when quitting
- ensure quitting handles an already finished GUI thread
- test quit behavior

## Testing
- `cargo test`
 