### PR TITLE
Add labels to hotkey tracing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,11 +103,11 @@ fn main() -> anyhow::Result<()> {
     let hotkey = settings.hotkey();
     tracing::debug!(?hotkey, "configuring hotkey");
     let trigger = HotkeyTrigger::new(hotkey);
-    trigger.start_listener();
+    trigger.start_listener("launch");
 
     let quit_trigger = settings.quit_hotkey().map(|hk| {
         let t = HotkeyTrigger::new(hk);
-        t.start_listener();
+        t.start_listener("quit");
         t
     });
 


### PR DESCRIPTION
## Summary
- allow `HotkeyTrigger::start_listener` to take a label identifying the hotkey
- propagate that label into all tracing messages for clear logging
- supply `"launch"` and `"quit"` labels from `main.rs`

## Testing
- `cargo test --all --quiet` *(fails: required system libraries for `x11` unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6845c63b82d8833284e6ecf45d3caf98