### PR TITLE
Add test for numeric zero hotkey

### DIFF
--- a/tests/hotkey.rs
+++ b/tests/hotkey.rs
@@ -23,6 +23,13 @@ fn parse_shift_escape() {
 }
 
 #[test]
+fn parse_zero_hotkey() {
+    let hk = parse_hotkey("0").expect("should parse numeric zero");
+    assert_eq!(hk.key, Key::Num0);
+    assert!(!hk.ctrl && !hk.shift && !hk.alt);
+}
+
+#[test]
 fn parse_invalid_hotkey() {
     assert!(parse_hotkey("Ctrl+Foo").is_none());
     assert!(parse_hotkey("Ctrl+Shift").is_none());


### PR DESCRIPTION
## Summary
- verify parsing the digit `0` as a hotkey

## Testing
- `cargo test` *(fails: the x11 crate build requires system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2750da8833296b82446687c955c