### PR TITLE
Add zero-key visibility toggle test

### DIFF
--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -1,6 +1,11 @@
 use multi_launcher::hotkey::{parse_hotkey, HotkeyTrigger, process_test_events};
+use multi_launcher::visibility::handle_visibility_trigger;
 use rdev::{EventType, Key};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
 
 #[test]
 fn launcher_and_quit_hotkeys_toggle_flags() {
@@ -25,4 +30,29 @@ fn launcher_and_quit_hotkeys_toggle_flags() {
 
     assert!(launcher_trigger.take());
     assert!(quit_trigger.take());
+}
+
+#[test]
+fn zero_key_events_toggle_visibility() {
+    let zero_hotkey = parse_hotkey("0").unwrap();
+    let trigger = Arc::new(HotkeyTrigger::new(zero_hotkey));
+
+    let triggers = vec![trigger.clone()];
+    let events = vec![
+        EventType::KeyPress(Key::Num0),
+        EventType::KeyRelease(Key::Num0),
+    ];
+
+    process_test_events(&triggers, &events);
+
+    let visibility = Arc::new(AtomicBool::new(false));
+    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
+    let mut queued_visibility: Option<bool> = None;
+
+    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    assert_eq!(visibility.load(Ordering::SeqCst), true);
+
+    process_test_events(&triggers, &events);
+    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    assert_eq!(visibility.load(Ordering::SeqCst), false);
 }


### PR DESCRIPTION
## Summary
- extend hotkey event tests to include numeric `0` hotkey
- simulate `0` key events and verify visibility toggling

## Testing
- `cargo test -- --nocapture`

 