### PR TITLE
Add visibility debugging helpers

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -156,10 +156,19 @@ impl eframe::App for LauncherApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         use egui::*;
 
+        tracing::debug!("LauncherApp::update called");
+        frame.set_visible(true);
+        ctx.send_viewport_cmd(egui::ViewportCommand::SetTitle("Launcher Visible Debug".into()));
+
         let should_be_visible = self.visible_flag.load(Ordering::SeqCst);
+        tracing::debug!(
+            should_be_visible=?should_be_visible,
+            last_visible=?self.last_visible
+        );
         if self.last_visible != should_be_visible {
             tracing::debug!("gui thread -> visible: {}", should_be_visible);
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(should_be_visible));
+            tracing::debug!("ViewportCommand::Visible({}) sent", should_be_visible);
             self.last_visible = should_be_visible;
         }
 
@@ -209,6 +218,9 @@ impl eframe::App for LauncherApp {
             ui.heading("🚀 LNCHR");
             if ui.button("Edit Commands").clicked() {
                 self.show_editor = !self.show_editor;
+            }
+            if ui.button("Force Hide").clicked() {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
             }
             if let Some(err) = &self.error {
                 ui.colored_label(Color32::RED, err);

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -251,6 +251,7 @@ impl HotkeyTrigger {
         let mut open = self.open.lock().unwrap();
         if *open {
             *open = false;
+            tracing::debug!("HotkeyTrigger fired!");
             true
         } else {
             false

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -38,6 +38,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
                 c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
                 c.request_repaint();
                 *queued_visibility = None;
+                tracing::debug!("Applied queued visibility: {}", next);
             } else {
                 *queued_visibility = Some(next);
             }
@@ -45,6 +46,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
             *queued_visibility = Some(next);
         }
     } else if let Some(next) = *queued_visibility {
+        tracing::debug!("Processing previously queued visibility: {}", next);
         if let Ok(mut guard) = ctx_handle.lock() {
             if let Some(c) = &*guard {
                 let old = visibility.load(Ordering::SeqCst);
@@ -53,6 +55,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
                 c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
                 c.request_repaint();
                 *queued_visibility = None;
+                tracing::debug!("Applied queued visibility: {}", next);
             }
         }
     }


### PR DESCRIPTION
## Summary
- debug log calls to update() and hotkey trigger events
- add viewport title changes and forced visibility settings in update()
- add manual 'Force Hide' button to GUI
- show/hide queued visibility debug messages
- simplify main loop to always show GUI

## Testing
- `cargo test --quiet` *(fails: system library `xi` not found)*
- `cargo check --quiet` *(fails: system library `xi` not found)*

 