### PR TITLE
Fix visibility code and clean warnings

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -157,8 +157,8 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");
-        frame.set_visible(true);
-        ctx.send_viewport_cmd(egui::ViewportCommand::SetTitle("Launcher Visible Debug".into()));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Title("Launcher Visible Debug".into()));
 
         let should_be_visible = self.visible_flag.load(Ordering::SeqCst);
         tracing::debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> anyhow::Result<()> {
 
     let (handle, visibility, ctx) = spawn_gui(actions.clone(), &settings);
     visibility.store(false, Ordering::SeqCst);
-    let mut queued_visibility: Option<bool> = None;
+    let _queued_visibility: Option<bool> = None;
     let mut quit_requested = false;
 
     loop {
@@ -140,7 +140,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         if quit_requested {
-            if let Ok(mut guard) = ctx.lock() {
+            if let Ok(guard) = ctx.lock() {
                 if let Some(c) = &*guard {
                     c.send_viewport_cmd(egui::ViewportCommand::Close);
                     c.request_repaint();
@@ -151,7 +151,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         visibility.store(true, Ordering::SeqCst);
-        if let Ok(mut guard) = ctx.lock() {
+        if let Ok(guard) = ctx.lock() {
             if let Some(c) = &*guard {
                 c.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                 c.request_repaint();

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -33,7 +33,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
         let next = !old;
         tracing::debug!(from=?old, to=?next, "visibility updated");
         visibility.store(next, Ordering::SeqCst);
-        if let Ok(mut guard) = ctx_handle.lock() {
+        if let Ok(guard) = ctx_handle.lock() {
             if let Some(c) = &*guard {
                 c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
                 c.request_repaint();
@@ -47,7 +47,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
         }
     } else if let Some(next) = *queued_visibility {
         tracing::debug!("Processing previously queued visibility: {}", next);
-        if let Ok(mut guard) = ctx_handle.lock() {
+        if let Ok(guard) = ctx_handle.lock() {
             if let Some(c) = &*guard {
                 let old = visibility.load(Ordering::SeqCst);
                 visibility.store(next, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
- replace `frame.set_visible` with viewport commands
- update viewport title command
- remove unnecessary `mut` from guards
- silence unused variable warning

## Testing
- `cargo check` *(fails: system library `xi` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845da55c94c83328a4c1e5dfa40e01c