### PR TITLE
Fix quit hotkey behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,18 +137,17 @@ fn main() -> anyhow::Result<()> {
             if qt.take() {
                 quit_requested = true;
                 listener.stop();
-            }
-        }
 
-        if quit_requested {
-            if let Ok(guard) = ctx.lock() {
-                if let Some(c) = &*guard {
-                    c.send_viewport_cmd(egui::ViewportCommand::Close);
-                    c.request_repaint();
+                if let Ok(guard) = ctx.lock() {
+                    if let Some(c) = &*guard {
+                        c.send_viewport_cmd(egui::ViewportCommand::Close);
+                        c.request_repaint();
+                    }
                 }
+
+                let _ = handle.join();
+                break Ok(());
             }
-            let _ = handle.join();
-            break Ok(());
         }
 
         handle_visibility_trigger(trigger.as_ref(), &visibility, &ctx, &mut queued_visibility);


### PR DESCRIPTION
## Summary
- exit cleanly when the quit hotkey is triggered

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845df3837e88332b01fc68db49e2059