### PR TITLE
Add settings editor with hotkey restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "futures-lite 1.13.0",
  "once_cell",
  "serde",
- "zbus 3.15.2",
+ "zbus",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -208,25 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
-dependencies = [
- "async-fs 2.1.2",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.1",
- "raw-window-handle 0.6.2",
- "serde",
- "serde_repr",
- "url",
- "zbus 5.7.1",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,18 +215,6 @@ checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
 dependencies = [
  "event-listener 2.5.3",
  "futures-core",
-]
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener 5.4.0",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -283,17 +252,6 @@ dependencies = [
  "autocfg",
  "blocking",
  "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock 3.4.0",
- "blocking",
- "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -356,17 +314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io 2.4.0",
- "blocking",
- "futures-lite 2.6.0",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,25 +334,6 @@ dependencies = [
  "futures-lite 1.13.0",
  "rustix 0.38.43",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
-dependencies = [
- "async-channel",
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.0",
- "futures-lite 2.6.0",
- "rustix 1.0.7",
- "tracing",
 ]
 
 [[package]]
@@ -455,6 +383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,9 +420,9 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zbus 3.15.2",
- "zbus_names 2.6.1",
- "zvariant 3.15.2",
+ "zbus",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -494,7 +434,7 @@ dependencies = [
  "atspi-common",
  "atspi-proxies",
  "futures-lite 1.13.0",
- "zbus 3.15.2",
+ "zbus",
 ]
 
 [[package]]
@@ -505,7 +445,7 @@ checksum = "6495661273703e7a229356dcbe8c8f38223d697aacfaf0e13590a9ac9977bb52"
 dependencies = [
  "atspi-common",
  "serde",
- "zbus 3.15.2",
+ "zbus",
 ]
 
 [[package]]
@@ -664,6 +604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +683,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,12 +703,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgl"
@@ -1209,12 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
-
-[[package]]
 name = "enumflags2"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,15 +1405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,17 +1445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,7 +1464,6 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1552,6 +1479,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
@@ -1582,19 +1539,20 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
+name = "gio-sys"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "cfg-if",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "system-deps",
+ "winapi",
 ]
 
 [[package]]
@@ -1606,6 +1564,16 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1627,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
 dependencies = [
  "bitflags 2.7.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "cgl",
  "core-foundation 0.9.4",
  "dispatch",
@@ -1650,7 +1618,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
 dependencies = [
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle 0.5.2",
  "winit",
@@ -1683,6 +1651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
 dependencies = [
  "gl_generator",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1738,6 +1717,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1764,12 @@ dependencies = [
  "widestring",
  "winapi",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2184,12 +2187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,7 +2308,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2398,19 +2395,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.7.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2739,6 +2723,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,12 +2855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,30 +2922,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2965,17 +2939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2984,16 +2948,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -3101,18 +3056,18 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d"
 dependencies = [
- "ashpd",
  "block2 0.6.1",
  "dispatch2 0.2.0",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
  "js-sys",
  "log",
  "objc2 0.6.1",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
- "pollster",
  "raw-window-handle 0.6.2",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3149,19 +3104,6 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags 2.7.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3252,6 +3194,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3460,6 +3411,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3437,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "rustix 0.38.43",
  "windows-sys 0.59.0",
@@ -3548,10 +3518,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.22",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3571,6 +3556,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.6.24",
 ]
@@ -3701,14 +3688,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"
@@ -3727,6 +3707,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -3755,15 +3741,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4015,7 +3992,7 @@ checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "js-sys",
  "log",
  "parking_lot",
@@ -4040,7 +4017,7 @@ dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.7.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "codespan-reporting",
  "indexmap",
  "log",
@@ -4067,7 +4044,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bitflags 2.7.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
@@ -4415,7 +4392,7 @@ dependencies = [
  "bitflags 2.7.0",
  "bytemuck",
  "calloop 0.12.4",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
  "cursor-icon",
@@ -4468,24 +4445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.7.0",
 ]
 
 [[package]]
@@ -4613,12 +4572,12 @@ version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
- "async-broadcast 0.5.1",
+ "async-broadcast",
  "async-executor",
- "async-fs 1.6.0",
+ "async-fs",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-process 1.8.1",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
@@ -4631,10 +4590,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.26.4",
+ "nix",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "sha1",
@@ -4643,42 +4602,9 @@ dependencies = [
  "uds_windows",
  "winapi",
  "xdg-home",
- "zbus_macros 3.15.2",
- "zbus_names 2.6.1",
- "zvariant 3.15.2",
-]
-
-[[package]]
-name = "zbus"
-version = "5.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
-dependencies = [
- "async-broadcast 0.7.2",
- "async-executor",
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "async-process 2.3.1",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener 5.4.0",
- "futures-core",
- "futures-lite 2.6.0",
- "hex",
- "nix 0.30.1",
- "ordered-stream",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "windows-sys 0.59.0",
- "winnow 0.7.11",
- "zbus_macros 5.7.1",
- "zbus_names 4.2.0",
- "zvariant 5.5.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -4692,22 +4618,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 1.0.109",
- "zvariant_utils 1.0.1",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
- "zbus_names 4.2.0",
- "zvariant 5.5.3",
- "zvariant_utils 3.2.0",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4718,19 +4629,7 @@ checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant 3.15.2",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
-dependencies = [
- "serde",
- "static_assertions",
- "winnow 0.7.11",
- "zvariant 5.5.3",
+ "zvariant",
 ]
 
 [[package]]
@@ -4808,22 +4707,7 @@ dependencies = [
  "libc",
  "serde",
  "static_assertions",
- "zvariant_derive 3.15.2",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "url",
- "winnow 0.7.11",
- "zvariant_derive 5.5.3",
- "zvariant_utils 3.2.0",
+ "zvariant_derive",
 ]
 
 [[package]]
@@ -4836,20 +4720,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "zvariant_utils 1.0.1",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
- "zvariant_utils 3.2.0",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4861,18 +4732,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "static_assertions",
- "syn 2.0.96",
- "winnow 0.7.11",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,7 @@ dependencies = [
  "libloading 0.8.6",
  "meval",
  "notify",
+ "once_cell",
  "open",
  "rdev",
  "rfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ meval = "0.2"
 libloading = "0.8"
 notify = "6"
 winit = "0.29"
-rfd = "0.15.3"
+rfd = { version = "0.15.3", default-features = false, features = ["gtk3"] }
 once_cell = "1"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ libloading = "0.8"
 notify = "6"
 winit = "0.29"
 rfd = "0.15.3"
+once_cell = "1"
 
 
 [features]

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -43,6 +43,11 @@ pub struct LauncherApp {
 }
 
 impl LauncherApp {
+    pub fn update_paths(&mut self, plugin_dirs: Option<Vec<String>>, index_paths: Option<Vec<String>>) {
+        self.plugin_dirs = plugin_dirs;
+        self.index_paths = index_paths;
+    }
+
     pub fn new(
         ctx: &egui::Context,
         actions: Vec<Action>,
@@ -163,7 +168,7 @@ impl LauncherApp {
 }
 
 impl eframe::App for LauncherApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,5 +1,7 @@
 use crate::actions::{load_actions, Action};
 use crate::actions_editor::ActionsEditor;
+use crate::settings_editor::SettingsEditor;
+use crate::settings::Settings;
 use crate::launcher::launch_action;
 use crate::plugin::PluginManager;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
@@ -26,8 +28,11 @@ pub struct LauncherApp {
     pub plugins: PluginManager,
     pub usage: HashMap<String, u32>,
     pub show_editor: bool,
+    pub show_settings: bool,
     pub actions_path: String,
     pub editor: ActionsEditor,
+    pub settings_editor: SettingsEditor,
+    pub settings_path: String,
     #[allow(dead_code)]
     watchers: Vec<RecommendedWatcher>,
     rx: Receiver<WatchEvent>,
@@ -43,6 +48,8 @@ impl LauncherApp {
         actions: Vec<Action>,
         plugins: PluginManager,
         actions_path: String,
+        settings_path: String,
+        settings: Settings,
         plugin_dirs: Option<Vec<String>>,
         index_paths: Option<Vec<String>>,
         visible_flag: Arc<AtomicBool>,
@@ -112,8 +119,11 @@ impl LauncherApp {
             plugins,
             usage: HashMap::new(),
             show_editor: false,
+            show_settings: false,
             actions_path,
             editor: ActionsEditor::default(),
+            settings_editor: SettingsEditor::new(&settings),
+            settings_path,
             watchers,
             rx,
             plugin_dirs,
@@ -179,6 +189,11 @@ impl eframe::App for LauncherApp {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         self.visible_flag.store(false, Ordering::SeqCst);
                         self.last_visible = false;
+                    }
+                });
+                ui.menu_button("Settings", |ui| {
+                    if ui.button("Edit Settings").clicked() {
+                        self.show_settings = !self.show_settings;
                     }
                 });
             });
@@ -249,6 +264,12 @@ impl eframe::App for LauncherApp {
             let mut editor = std::mem::take(&mut self.editor);
             editor.ui(ctx, self);
             self.editor = editor;
+        }
+        let show_settings = self.show_settings;
+        if show_settings {
+            let mut ed = std::mem::take(&mut self.settings_editor);
+            ed.ui(ctx, self);
+            self.settings_editor = ed;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod actions;
 mod actions_editor;
+mod settings_editor;
 mod gui;
 mod hotkey;
 mod launcher;
@@ -19,12 +20,22 @@ use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::Settings;
 
 use eframe::egui;
-use std::sync::{Arc, atomic::AtomicBool, Mutex};
+use std::sync::{Arc, atomic::AtomicBool, Mutex, mpsc::{Sender, Receiver, channel}};
 use std::thread;
+use once_cell::sync::Lazy;
+
+static RESTART_TX: Lazy<Mutex<Option<Sender<Settings>>>> = Lazy::new(|| Mutex::new(None));
+
+pub fn request_hotkey_restart(settings: Settings) {
+    if let Some(tx) = RESTART_TX.lock().unwrap().as_ref() {
+        let _ = tx.send(settings);
+    }
+}
 
 fn spawn_gui(
     actions: Vec<Action>,
     settings: &Settings,
+    settings_path: String,
 ) -> (thread::JoinHandle<()>, Arc<AtomicBool>, Arc<Mutex<Option<egui::Context>>>) {
     let actions_for_window = actions.clone();
     let mut plugins = PluginManager::new();
@@ -39,6 +50,7 @@ fn spawn_gui(
     }
 
     let actions_path = "actions.json".to_string();
+    let settings_path_for_window = settings_path.clone();
     let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
     let visible_flag = Arc::new(AtomicBool::new(false));
@@ -81,6 +93,8 @@ fn spawn_gui(
                     actions_for_window,
                     plugins,
                     actions_path,
+                    settings_path_for_window,
+                    settings.clone(),
                     plugin_dirs,
                     index_paths,
                     flag_clone,
@@ -94,10 +108,13 @@ fn spawn_gui(
 
 fn main() -> anyhow::Result<()> {
     logging::init();
-    let settings = Settings::load("settings.json").unwrap_or_default();
+    let mut settings = Settings::load("settings.json").unwrap_or_default();
     tracing::debug!(?settings, "settings loaded");
     let mut actions = load_actions("actions.json").unwrap_or_default();
     tracing::debug!("{} actions loaded", actions.len());
+
+    let (restart_tx, restart_rx) = channel::<Settings>();
+    *RESTART_TX.lock().unwrap() = Some(restart_tx);
 
     if let Some(paths) = &settings.index_paths {
         actions.extend(indexer::index_paths(paths));
@@ -105,18 +122,18 @@ fn main() -> anyhow::Result<()> {
 
     let hotkey = settings.hotkey();
     tracing::debug!(?hotkey, "configuring hotkeys");
-    let trigger = Arc::new(HotkeyTrigger::new(hotkey));
-    let quit_trigger = settings.quit_hotkey().map(|hk| Arc::new(HotkeyTrigger::new(hk)));
+    let mut trigger = Arc::new(HotkeyTrigger::new(hotkey));
+    let mut quit_trigger = settings.quit_hotkey().map(|hk| Arc::new(HotkeyTrigger::new(hk)));
 
     let mut watched = vec![trigger.clone()];
     if let Some(qt) = &quit_trigger {
         watched.push(qt.clone());
     }
 
-    let listener = HotkeyTrigger::start_listener(watched, "main");
+    let mut listener = HotkeyTrigger::start_listener(watched, "main");
 
 
-    let (handle, visibility, ctx) = spawn_gui(actions.clone(), &settings);
+    let (handle, visibility, ctx) = spawn_gui(actions.clone(), &settings, "settings.json".to_string());
     let mut queued_visibility: Option<bool> = None;
     let mut quit_requested = false;
 
@@ -148,6 +165,19 @@ fn main() -> anyhow::Result<()> {
                 let _ = handle.join();
                 break Ok(());
             }
+        }
+
+
+        if let Ok(new_settings) = restart_rx.try_recv() {
+            listener.stop();
+            settings = new_settings.clone();
+            trigger = Arc::new(HotkeyTrigger::new(settings.hotkey()));
+            quit_trigger = settings.quit_hotkey().map(|hk| Arc::new(HotkeyTrigger::new(hk)));
+            let mut watched = vec![trigger.clone()];
+            if let Some(qt) = &quit_trigger {
+                watched.push(qt.clone());
+            }
+            listener = HotkeyTrigger::start_listener(watched, "main");
         }
 
         handle_visibility_trigger(trigger.as_ref(), &visibility, &ctx, &mut queued_visibility);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,6 +31,12 @@ impl Settings {
         Ok(serde_json::from_str(&content)?)
     }
 
+    pub fn save(&self, path: &str) -> anyhow::Result<()> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
     pub fn hotkey(&self) -> Hotkey {
         if let Some(hotkey) = &self.hotkey {
             match parse_hotkey(hotkey) {

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -3,6 +3,7 @@ use crate::gui::LauncherApp;
 use eframe::egui;
 use rfd::FileDialog;
 
+#[derive(Default)]
 pub struct SettingsEditor {
     hotkey: String,
     quit_hotkey: String,
@@ -123,8 +124,10 @@ impl SettingsEditor {
                 if let Err(e) = new_settings.save(&app.settings_path) {
                     app.error = Some(format!("Failed to save: {e}"));
                 } else {
-                    app.plugin_dirs = new_settings.plugin_dirs.clone();
-                    app.index_paths = new_settings.index_paths.clone();
+                    app.update_paths(
+                        new_settings.plugin_dirs.clone(),
+                        new_settings.index_paths.clone(),
+                    );
                     crate::request_hotkey_restart(new_settings);
                 }
             }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,0 +1,133 @@
+use crate::settings::Settings;
+use crate::gui::LauncherApp;
+use eframe::egui;
+use rfd::FileDialog;
+
+pub struct SettingsEditor {
+    hotkey: String,
+    quit_hotkey: String,
+    index_paths: Vec<String>,
+    plugin_dirs: Vec<String>,
+    index_input: String,
+    plugin_input: String,
+}
+
+impl SettingsEditor {
+    pub fn new(settings: &Settings) -> Self {
+        Self {
+            hotkey: settings.hotkey.clone().unwrap_or_default(),
+            quit_hotkey: settings.quit_hotkey.clone().unwrap_or_default(),
+            index_paths: settings.index_paths.clone().unwrap_or_default(),
+            plugin_dirs: settings.plugin_dirs.clone().unwrap_or_default(),
+            index_input: String::new(),
+            plugin_input: String::new(),
+        }
+    }
+
+    fn to_settings(&self) -> Settings {
+        Settings {
+            hotkey: if self.hotkey.trim().is_empty() {
+                None
+            } else {
+                Some(self.hotkey.clone())
+            },
+            quit_hotkey: if self.quit_hotkey.trim().is_empty() {
+                None
+            } else {
+                Some(self.quit_hotkey.clone())
+            },
+            index_paths: if self.index_paths.is_empty() {
+                None
+            } else {
+                Some(self.index_paths.clone())
+            },
+            plugin_dirs: if self.plugin_dirs.is_empty() {
+                None
+            } else {
+                Some(self.plugin_dirs.clone())
+            },
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        egui::Window::new("Settings").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Launcher hotkey");
+                ui.text_edit_singleline(&mut self.hotkey);
+            });
+            ui.horizontal(|ui| {
+                ui.label("Quit hotkey");
+                ui.text_edit_singleline(&mut self.quit_hotkey);
+            });
+
+            ui.separator();
+            ui.label("Index paths:");
+            let mut remove: Option<usize> = None;
+            for (idx, path) in self.index_paths.iter().enumerate() {
+                ui.horizontal(|ui| {
+                    ui.label(path);
+                    if ui.button("Remove").clicked() {
+                        remove = Some(idx);
+                    }
+                });
+            }
+            if let Some(i) = remove {
+                self.index_paths.remove(i);
+            }
+            ui.horizontal(|ui| {
+                ui.text_edit_singleline(&mut self.index_input);
+                if ui.button("Browse").clicked() {
+                    if let Some(dir) = FileDialog::new().pick_folder() {
+                        self.index_input = dir.display().to_string();
+                    }
+                }
+                if ui.button("Add").clicked() {
+                    if !self.index_input.is_empty() {
+                        self.index_paths.push(self.index_input.clone());
+                        self.index_input.clear();
+                    }
+                }
+            });
+
+            ui.separator();
+            ui.label("Plugin directories:");
+            let mut remove_p: Option<usize> = None;
+            for (idx, path) in self.plugin_dirs.iter().enumerate() {
+                ui.horizontal(|ui| {
+                    ui.label(path);
+                    if ui.button("Remove").clicked() {
+                        remove_p = Some(idx);
+                    }
+                });
+            }
+            if let Some(i) = remove_p {
+                self.plugin_dirs.remove(i);
+            }
+            ui.horizontal(|ui| {
+                ui.text_edit_singleline(&mut self.plugin_input);
+                if ui.button("Browse").clicked() {
+                    if let Some(dir) = FileDialog::new().pick_folder() {
+                        self.plugin_input = dir.display().to_string();
+                    }
+                }
+                if ui.button("Add").clicked() {
+                    if !self.plugin_input.is_empty() {
+                        self.plugin_dirs.push(self.plugin_input.clone());
+                        self.plugin_input.clear();
+                    }
+                }
+            });
+
+            if ui.button("Save").clicked() {
+                let new_settings = self.to_settings();
+                if let Err(e) = new_settings.save(&app.settings_path) {
+                    app.error = Some(format!("Failed to save: {e}"));
+                } else {
+                    app.plugin_dirs = new_settings.plugin_dirs.clone();
+                    app.index_paths = new_settings.index_paths.clone();
+                    crate::request_hotkey_restart(new_settings);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- create `SettingsEditor` for editing hotkey and paths
- expose `request_hotkey_restart` in main and restart listener when called
- integrate settings editor UI into menu bar
- persist settings through `Settings::save`
- depend on `once_cell`

## Testing
- `cargo check` *(fails: could not compile `async-process`)*

 