### PR TITLE
Add debug logging setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ cargo build --release --features unstable_grab
 This feature is defined in `Cargo.toml` and enables the underlying `rdev`
 capability used to grab keyboard events.
 
-For debugging, set the `RUST_LOG` environment variable before running the
-program to see informational messages, or enable **Debug logging** in the
-settings window:
+For debugging, enable **Debug logging** in the settings window. When this
+option is active, you can further adjust the verbosity by setting the
+`RUST_LOG` environment variable before running the program:
 
 ```bash
 RUST_LOG=info cargo run --release --features unstable_grab

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This feature is defined in `Cargo.toml` and enables the underlying `rdev`
 capability used to grab keyboard events.
 
 For debugging, set the `RUST_LOG` environment variable before running the
-program to see informational messages:
+program to see informational messages, or enable **Debug logging** in the
+settings window:
 
 ```bash
 RUST_LOG=info cargo run --release --features unstable_grab
@@ -49,7 +50,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "hotkey": "F2",
   "quit_hotkey": "Shift+Escape",
   "index_paths": ["/usr/share/applications"],
-  "plugin_dirs": ["./plugins"]
+  "plugin_dirs": ["./plugins"],
+  "debug_logging": false
 }
 ```
 

--- a/settings.json
+++ b/settings.json
@@ -2,5 +2,6 @@
     "hotkey": "F2",
     "quit_hotkey": "Shift+Escape",
     "index_paths": null,
-    "plugin_dirs": null
+    "plugin_dirs": null,
+    "debug_logging": false
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,10 +5,17 @@ use tracing_subscriber::EnvFilter;
 /// `RUST_LOG` environment variable.
 /// `debug` level can be explicitly enabled via the settings file.
 pub fn init(debug: bool) {
-    // Pick a sensible default but honour any user supplied `RUST_LOG` filter.
-    let default_level = if debug { "debug" } else { "info" };
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(default_level));
+    // When debug logging is disabled we force `info` level regardless of the
+    // `RUST_LOG` environment variable. This prevents accidental verbose output
+    // if the variable happens to be set in the user's environment.
+    let level = if debug { "debug" } else { "info" };
+
+    let filter = if debug {
+        // Allow `RUST_LOG` to override the level when debug logging is enabled.
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level))
+    } else {
+        EnvFilter::new(level)
+    };
 
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,10 +3,10 @@ use tracing_subscriber::EnvFilter;
 /// Initialise logging. In debug builds the default level is `debug` while in
 /// release builds it falls back to `info`. The level can be overridden via the
 /// `RUST_LOG` environment variable.
-pub fn init() {
-    // Pick a sensible default depending on build type but honour any user
-    // supplied `RUST_LOG` filter.
-    let default_level = if cfg!(debug_assertions) { "debug" } else { "info" };
+/// `debug` level can be explicitly enabled via the settings file.
+pub fn init(debug: bool) {
+    // Pick a sensible default but honour any user supplied `RUST_LOG` filter.
+    let default_level = if debug { "debug" } else { "info" };
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(default_level));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,8 @@ fn spawn_gui(
 }
 
 fn main() -> anyhow::Result<()> {
-    logging::init();
     let mut settings = Settings::load("settings.json").unwrap_or_default();
+    logging::init(settings.debug_logging);
     tracing::debug!(?settings, "settings loaded");
     let mut actions = load_actions("actions.json").unwrap_or_default();
     tracing::debug!("{} actions loaded", actions.len());

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,10 @@ pub struct Settings {
     pub quit_hotkey: Option<String>,
     pub index_paths: Option<Vec<String>>,
     pub plugin_dirs: Option<Vec<String>>,
+    /// When enabled the application initialises the logger at debug level.
+    /// Defaults to `false` when the field is missing in the settings file.
+    #[serde(default)]
+    pub debug_logging: bool,
 }
 
 impl Default for Settings {
@@ -18,6 +22,7 @@ impl Default for Settings {
             quit_hotkey: None,
             index_paths: None,
             plugin_dirs: None,
+            debug_logging: false,
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -11,6 +11,7 @@ pub struct SettingsEditor {
     plugin_dirs: Vec<String>,
     index_input: String,
     plugin_input: String,
+    debug_logging: bool,
 }
 
 impl SettingsEditor {
@@ -22,6 +23,7 @@ impl SettingsEditor {
             plugin_dirs: settings.plugin_dirs.clone().unwrap_or_default(),
             index_input: String::new(),
             plugin_input: String::new(),
+            debug_logging: settings.debug_logging,
         }
     }
 
@@ -47,6 +49,7 @@ impl SettingsEditor {
             } else {
                 Some(self.plugin_dirs.clone())
             },
+            debug_logging: self.debug_logging,
         }
     }
 
@@ -59,6 +62,19 @@ impl SettingsEditor {
             ui.horizontal(|ui| {
                 ui.label("Quit hotkey");
                 ui.text_edit_singleline(&mut self.quit_hotkey);
+            });
+
+            ui.horizontal(|ui| {
+                egui::ComboBox::from_label("Debug logging")
+                    .selected_text(if self.debug_logging {
+                        "Enabled"
+                    } else {
+                        "Disabled"
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.debug_logging, false, "Disabled");
+                        ui.selectable_value(&mut self.debug_logging, true, "Enabled");
+                    });
             });
 
             ui.separator();


### PR DESCRIPTION
## Summary
- expose `debug_logging` in `settings.json`
- add `debug_logging` dropdown in Settings window
- plumb debug flag to logging init and default to off
- document debug logging option

## Testing
- `cargo test` *(fails: glib-2.0.pc not found)*

 