### PR TITLE
Add search and new window for command editor

### DIFF
--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -7,6 +7,8 @@ pub struct ActionsEditor {
     label: String,
     desc: String,
     path: String,
+    search: String,
+    show_new: bool,
 }
 
 impl Default for ActionsEditor {
@@ -15,6 +17,8 @@ impl Default for ActionsEditor {
             label: String::new(),
             desc: String::new(),
             path: String::new(),
+            search: String::new(),
+            show_new: false,
         }
     }
 }
@@ -22,15 +26,33 @@ impl Default for ActionsEditor {
 impl ActionsEditor {
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
         egui::Window::new("Command Editor").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Search");
+                ui.text_edit_singleline(&mut self.search);
+            });
+
+            ui.separator();
             let mut remove: Option<usize> = None;
-            for (idx, act) in app.actions.iter().enumerate() {
-                ui.horizontal(|ui| {
-                    ui.label(format!("{} : {} -> {}", act.label, act.desc, act.action));
-                    if ui.button("Remove").clicked() {
-                        remove = Some(idx);
+            egui::ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
+                for (idx, act) in app.actions.iter().enumerate() {
+                    if !self.search.trim().is_empty() {
+                        let q = self.search.to_lowercase();
+                        let label = act.label.to_lowercase();
+                        let desc = act.desc.to_lowercase();
+                        let action = act.action.to_lowercase();
+                        if !label.contains(&q) && !desc.contains(&q) && !action.contains(&q) {
+                            continue;
+                        }
                     }
-                });
-            }
+                    ui.horizontal(|ui| {
+                        ui.label(format!("{} : {} -> {}", act.label, act.desc, act.action));
+                        if ui.button("Remove").clicked() {
+                            remove = Some(idx);
+                        }
+                    });
+                }
+            });
+
             if let Some(i) = remove {
                 app.actions.remove(i);
                 app.search();
@@ -40,44 +62,60 @@ impl ActionsEditor {
             }
 
             ui.separator();
-            ui.label("Add new command:");
-            ui.horizontal(|ui| {
-                ui.label("Label");
-                ui.text_edit_singleline(&mut self.label);
-            });
-            ui.horizontal(|ui| {
-                ui.label("Description");
-                ui.text_edit_singleline(&mut self.desc);
-            });
-            ui.horizontal(|ui| {
-                ui.label("Path");
-                ui.text_edit_singleline(&mut self.path);
-                if ui.button("Browse").clicked() {
-                    if let Some(file) = FileDialog::new().pick_file() {
-                        if let Some(p) = file.to_str() {
-                            self.path = p.to_owned();
-                        } else {
-                            self.path = file.display().to_string();
-                        }
-                    }
-                }
-            });
-            if ui.button("Add").clicked() {
-                if !self.path.is_empty() {
-                    app.actions.push(Action {
-                        label: self.label.clone(),
-                        desc: self.desc.clone(),
-                        action: self.path.clone(),
-                    });
-                    self.label.clear();
-                    self.desc.clear();
-                    self.path.clear();
-                    app.search();
-                    if let Err(e) = save_actions(&app.actions_path, &app.actions) {
-                        app.error = Some(format!("Failed to save: {e}"));
-                    }
-                }
+            if ui.button("New Command").clicked() {
+                self.show_new = true;
             }
         });
+
+        if self.show_new {
+            egui::Window::new("New Command").show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Label");
+                    ui.text_edit_singleline(&mut self.label);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Description");
+                    ui.text_edit_singleline(&mut self.desc);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Path");
+                    ui.text_edit_singleline(&mut self.path);
+                    if ui.button("Browse").clicked() {
+                        if let Some(file) = FileDialog::new().pick_file() {
+                            if let Some(p) = file.to_str() {
+                                self.path = p.to_owned();
+                            } else {
+                                self.path = file.display().to_string();
+                            }
+                        }
+                    }
+                });
+                ui.horizontal(|ui| {
+                    if ui.button("Add").clicked() {
+                        use std::path::Path;
+                        if self.path.is_empty() || !Path::new(&self.path).exists() {
+                            app.error = Some("Path does not exist".into());
+                        } else {
+                            app.actions.push(Action {
+                                label: self.label.clone(),
+                                desc: self.desc.clone(),
+                                action: self.path.clone(),
+                            });
+                            self.label.clear();
+                            self.desc.clear();
+                            self.path.clear();
+                            self.show_new = false;
+                            app.search();
+                            if let Err(e) = save_actions(&app.actions_path, &app.actions) {
+                                app.error = Some(format!("Failed to save: {e}"));
+                            }
+                        }
+                    }
+                    if ui.button("Cancel").clicked() {
+                        self.show_new = false;
+                    }
+                });
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow searching through commands in the command editor
- use a scroll area so large command lists fit
- open a new window to add commands
- validate command path before saving

## Testing
- `cargo check` *(fails: system library `glib-2.0` not found)*

 