### PR TITLE
Improve window controls

### DIFF
--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -25,7 +25,10 @@ impl Default for ActionsEditor {
 
 impl ActionsEditor {
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
-        egui::Window::new("Command Editor").show(ctx, |ui| {
+        let mut open = app.show_editor;
+        egui::Window::new("Command Editor")
+            .open(&mut open)
+            .show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Search");
                 ui.text_edit_singleline(&mut self.search);
@@ -117,5 +120,6 @@ impl ActionsEditor {
                 });
             });
         }
+        app.show_editor = open;
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -190,6 +190,14 @@ impl eframe::App for LauncherApp {
         TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             menu::bar(ui, |ui| {
                 ui.menu_button("File", |ui| {
+                    ui.menu_button("Commands", |ui| {
+                        if ui.button("Edit Commands").clicked() {
+                            self.show_editor = !self.show_editor;
+                        }
+                    });
+                    if ui.button("Force Hide").clicked() {
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+                    }
                     if ui.button("Close Application").clicked() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         self.visible_flag.store(false, Ordering::SeqCst);
@@ -236,12 +244,6 @@ impl eframe::App for LauncherApp {
 
         CentralPanel::default().show(ctx, |ui| {
             ui.heading("🚀 LNCHR");
-            if ui.button("Edit Commands").clicked() {
-                self.show_editor = !self.show_editor;
-            }
-            if ui.button("Force Hide").clicked() {
-                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
-            }
             if let Some(err) = &self.error {
                 ui.colored_label(Color32::RED, err);
             }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -54,7 +54,10 @@ impl SettingsEditor {
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
-        egui::Window::new("Settings").show(ctx, |ui| {
+        let mut open = app.show_settings;
+        egui::Window::new("Settings")
+            .open(&mut open)
+            .show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Launcher hotkey");
                 ui.text_edit_singleline(&mut self.hotkey);
@@ -148,5 +151,6 @@ impl SettingsEditor {
                 }
             }
         });
+        app.show_settings = open;
     }
 }


### PR DESCRIPTION
## Summary
- add closeable command editor window
- add closeable settings dialog
- move "Edit Commands" and "Force Hide" options to the File menu
- add a new `Commands` submenu under File

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca3392908332a2a998e48a90a0cd