### PR TITLE
Remove debug viewport commands

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -174,8 +174,6 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");
-        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
-        ctx.send_viewport_cmd(egui::ViewportCommand::Title("Launcher Visible Debug".into()));
 
         let should_be_visible = self.visible_flag.load(Ordering::SeqCst);
         tracing::debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn spawn_gui(
     let settings_path_for_window = settings_path.clone();
     let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
-    let visible_flag = Arc::new(AtomicBool::new(false));
+    let visible_flag = Arc::new(AtomicBool::new(true));
     let flag_clone = visible_flag.clone();
     let ctx_handle = Arc::new(Mutex::new(None));
     let ctx_clone = ctx_handle.clone();
@@ -64,7 +64,7 @@ fn spawn_gui(
                 .with_inner_size([400.0, 220.0])
                 .with_min_inner_size([320.0, 160.0])
                 .with_always_on_top()
-                .with_visible(false),
+                .with_visible(true),
             event_loop_builder: Some(Box::new(|builder| {
                 #[cfg(target_os = "windows")]
                 {


### PR DESCRIPTION
## Summary
- clean up GUI update by removing forced viewport visibility and debug title
- rely solely on `visible_flag` for visibility updates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686832f5755c8332877c7701a463d2a5