### PR TITLE
Handle hotkey cleanup on exit

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -167,6 +167,21 @@ impl LauncherApp {
 
         self.results = res;
     }
+
+    #[cfg(target_os = "windows")]
+    pub fn unregister_all_hotkeys(&self) {
+        use windows::Win32::UI::Input::KeyboardAndMouse::UnregisterHotKey;
+        let mut registered_hotkeys = self.registered_hotkeys.lock().unwrap();
+        for id in registered_hotkeys.values() {
+            unsafe {
+                let _ = UnregisterHotKey(None, *id as i32);
+            }
+        }
+        registered_hotkeys.clear();
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn unregister_all_hotkeys(&self) {}
 }
 
 impl eframe::App for LauncherApp {
@@ -298,6 +313,7 @@ impl eframe::App for LauncherApp {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
     }


### PR DESCRIPTION
## Summary
- cleanup global hotkeys for Windows
- call the cleanup on exit

## Testing
- `cargo test --quiet` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68684bb1479483329945bdf839d6337f