### PR TITLE
Ensure hotkeys cleanup on close

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -219,8 +219,11 @@ impl eframe::App for LauncherApp {
                     }
                     if ui.button("Close Application").clicked() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        self.unregister_all_hotkeys();
                         self.visible_flag.store(false, Ordering::SeqCst);
                         self.last_visible = false;
+                        #[cfg(not(test))]
+                        std::process::exit(0);
                     }
                 });
                 ui.menu_button("Settings", |ui| {
@@ -316,5 +319,7 @@ impl eframe::App for LauncherApp {
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
+        #[cfg(not(test))]
+        std::process::exit(0);
     }
 }


### PR DESCRIPTION
## Summary
- call `unregister_all_hotkeys` when closing via menu
- exit the process after closing the application

## Testing
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_e_686865dd692c8332abd16e2ac6b5a8ec