### PR TITLE
Update visibility logic

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -192,7 +192,10 @@ impl eframe::App for LauncherApp {
 
         let should_be_visible = self.visible_flag.load(Ordering::SeqCst);
         let just_became_visible = !self.show_window && should_be_visible;
-        self.show_window = should_be_visible;
+        if self.show_window != should_be_visible {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(should_be_visible));
+            self.show_window = should_be_visible;
+        }
 
         TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             menu::bar(ui, |ui| {
@@ -204,6 +207,7 @@ impl eframe::App for LauncherApp {
                     });
                     if ui.button("Toggle Window").clicked() {
                         self.show_window = !self.show_window;
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(self.show_window));
                         self.visible_flag.store(self.show_window, Ordering::SeqCst);
                     }
                     if ui.button("Close Application").clicked() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,6 @@ fn main() -> anyhow::Result<()> {
 
 
     let (handle, visibility, ctx) = spawn_gui(actions.clone(), settings.clone(), "settings.json".to_string());
-    let mut queued_visibility: Option<bool> = None;
 
     loop {
         if handle.is_finished() {
@@ -170,7 +169,7 @@ fn main() -> anyhow::Result<()> {
             listener = HotkeyTrigger::start_listener(watched, "main");
         }
 
-        handle_visibility_trigger(trigger.as_ref(), &visibility, &ctx, &mut queued_visibility);
+        handle_visibility_trigger(trigger.as_ref(), &visibility);
 
         std::thread::sleep(std::time::Duration::from_millis(50));
     }

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -2,11 +2,13 @@ use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 use crate::hotkey::HotkeyTrigger;
 
-/// Hide the launcher window when the given hotkey trigger fires.
+/// Toggle the launcher window when the given hotkey trigger fires.
 pub fn handle_visibility_trigger(trigger: &HotkeyTrigger, visibility: &Arc<AtomicBool>) {
     if trigger.take() {
-        tracing::debug!("launcher hotkey pressed; hiding window");
-        visibility.store(false, Ordering::SeqCst);
+        let current = visibility.load(Ordering::SeqCst);
+        let next = !current;
+        tracing::debug!(from=?current, to=?next, "launcher hotkey toggled visibility");
+        visibility.store(next, Ordering::SeqCst);
     }
 }
 

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -2,13 +2,11 @@ use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 use crate::hotkey::HotkeyTrigger;
 
-/// Toggle the visibility flag when the given hotkey trigger fires.
+/// Hide the launcher window when the given hotkey trigger fires.
 pub fn handle_visibility_trigger(trigger: &HotkeyTrigger, visibility: &Arc<AtomicBool>) {
     if trigger.take() {
-        let old = visibility.load(Ordering::SeqCst);
-        let next = !old;
-        tracing::debug!(from=?old, to=?next, "visibility updated");
-        visibility.store(next, Ordering::SeqCst);
+        tracing::debug!("launcher hotkey pressed; hiding window");
+        visibility.store(false, Ordering::SeqCst);
     }
 }
 

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,63 +1,14 @@
-use eframe::egui;
-use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 use crate::hotkey::HotkeyTrigger;
 
-
-/// Trait abstracting over an `egui::Context` for viewport commands.
-pub trait ViewportCtx {
-    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand);
-    fn request_repaint(&self);
-}
-
-impl ViewportCtx for egui::Context {
-    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
-        egui::Context::send_viewport_cmd(self, cmd);
-    }
-
-    fn request_repaint(&self) {
-        egui::Context::request_repaint(self);
-    }
-}
-
-/// Process a hotkey trigger and update visibility, issuing viewport commands
-/// when possible. This mirrors the logic from `main.rs`.
-pub fn handle_visibility_trigger<C: ViewportCtx>(
-    trigger: &HotkeyTrigger,
-    visibility: &Arc<AtomicBool>,
-    ctx_handle: &Arc<Mutex<Option<C>>>,
-    queued_visibility: &mut Option<bool>,
-) {
+/// Toggle the visibility flag when the given hotkey trigger fires.
+pub fn handle_visibility_trigger(trigger: &HotkeyTrigger, visibility: &Arc<AtomicBool>) {
     if trigger.take() {
         let old = visibility.load(Ordering::SeqCst);
         let next = !old;
         tracing::debug!(from=?old, to=?next, "visibility updated");
         visibility.store(next, Ordering::SeqCst);
-        if let Ok(guard) = ctx_handle.lock() {
-            if let Some(c) = &*guard {
-                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
-                c.request_repaint();
-                *queued_visibility = None;
-                tracing::debug!("Applied queued visibility: {}", next);
-            } else {
-                *queued_visibility = Some(next);
-            }
-        } else {
-            *queued_visibility = Some(next);
-        }
-    } else if let Some(next) = *queued_visibility {
-        tracing::debug!("Processing previously queued visibility: {}", next);
-        if let Ok(guard) = ctx_handle.lock() {
-            if let Some(c) = &*guard {
-                let old = visibility.load(Ordering::SeqCst);
-                visibility.store(next, Ordering::SeqCst);
-                tracing::debug!(from=?old, to=?next, "visibility updated");
-                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
-                c.request_repaint();
-                *queued_visibility = None;
-                tracing::debug!("Applied queued visibility: {}", next);
-            }
-        }
     }
 }
 

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -1,16 +1,17 @@
 use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
+use multi_launcher::visibility::handle_visibility_trigger;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
-fn queued_visibility_applies_when_context_available() {
+fn trigger_hides_ui() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
-    let visibility = Arc::new(AtomicBool::new(false));
+    let visibility = Arc::new(AtomicBool::new(true));
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
     handle_visibility_trigger(&trigger, &visibility);
 
-    assert_eq!(visibility.load(Ordering::SeqCst), true);
+    assert_eq!(visibility.load(Ordering::SeqCst), false);
 }
 

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -1,63 +1,16 @@
 use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
-use eframe::egui;
-use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
-
-#[path = "mock_ctx.rs"]
-mod mock_ctx;
-use mock_ctx::MockCtx;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
 fn queued_visibility_applies_when_context_available() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
-    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
-    let mut queued_visibility: Option<bool> = None;
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    if trigger.take() {
-        let next = !visibility.load(Ordering::SeqCst);
-        visibility.store(next, Ordering::SeqCst);
-        if let Ok(mut guard) = ctx_handle.lock() {
-            if let Some(c) = &*guard {
-                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
-                c.request_repaint();
-                queued_visibility = None;
-            } else {
-                queued_visibility = Some(next);
-            }
-        } else {
-            queued_visibility = Some(next);
-        }
-    }
+    handle_visibility_trigger(&trigger, &visibility);
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
-    assert_eq!(queued_visibility, Some(true));
-
-    // now context becomes available
-    let ctx = MockCtx::default();
-    {
-        let mut guard = ctx_handle.lock().unwrap();
-        *guard = Some(ctx.clone());
-    }
-
-    if let Some(next) = queued_visibility {
-        if let Ok(mut guard) = ctx_handle.lock() {
-            if let Some(c) = &*guard {
-                c.send_viewport_cmd(egui::ViewportCommand::Visible(next));
-                c.request_repaint();
-                queued_visibility = None;
-            }
-        }
-    }
-
-    assert!(queued_visibility.is_none());
-    let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 1);
-    match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
-        _ => panic!("unexpected command"),
-    }
 }
 

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -3,15 +3,15 @@ use multi_launcher::visibility::handle_visibility_trigger;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
-fn trigger_hides_ui() {
+fn trigger_toggles_ui() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
-    let visibility = Arc::new(AtomicBool::new(true));
+    let visibility = Arc::new(AtomicBool::new(false));
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
     handle_visibility_trigger(&trigger, &visibility);
 
-    assert_eq!(visibility.load(Ordering::SeqCst), false);
+    assert_eq!(visibility.load(Ordering::SeqCst), true);
 }
 

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -29,7 +29,7 @@ fn launcher_and_quit_hotkeys_toggle_flags() {
 }
 
 #[test]
-fn zero_key_events_toggle_visibility() {
+fn zero_key_events_hide_visibility() {
     let zero_hotkey = parse_hotkey("0").unwrap();
     let trigger = Arc::new(HotkeyTrigger::new(zero_hotkey));
 
@@ -41,12 +41,8 @@ fn zero_key_events_toggle_visibility() {
 
     process_test_events(&triggers, &events);
 
-    let visibility = Arc::new(AtomicBool::new(false));
+    let visibility = Arc::new(AtomicBool::new(true));
 
-    handle_visibility_trigger(&trigger, &visibility);
-    assert_eq!(visibility.load(Ordering::SeqCst), true);
-
-    process_test_events(&triggers, &events);
     handle_visibility_trigger(&trigger, &visibility);
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -29,7 +29,7 @@ fn launcher_and_quit_hotkeys_toggle_flags() {
 }
 
 #[test]
-fn zero_key_events_hide_visibility() {
+fn zero_key_events_toggle_visibility() {
     let zero_hotkey = parse_hotkey("0").unwrap();
     let trigger = Arc::new(HotkeyTrigger::new(zero_hotkey));
 
@@ -41,8 +41,8 @@ fn zero_key_events_hide_visibility() {
 
     process_test_events(&triggers, &events);
 
-    let visibility = Arc::new(AtomicBool::new(true));
+    let visibility = Arc::new(AtomicBool::new(false));
 
     handle_visibility_trigger(&trigger, &visibility);
-    assert_eq!(visibility.load(Ordering::SeqCst), false);
+    assert_eq!(visibility.load(Ordering::SeqCst), true);
 }

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -1,11 +1,7 @@
 use multi_launcher::hotkey::{parse_hotkey, HotkeyTrigger, process_test_events};
 use multi_launcher::visibility::handle_visibility_trigger;
 use rdev::{EventType, Key};
-use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
-
-#[path = "mock_ctx.rs"]
-mod mock_ctx;
-use mock_ctx::MockCtx;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
 fn launcher_and_quit_hotkeys_toggle_flags() {
@@ -46,13 +42,11 @@ fn zero_key_events_toggle_visibility() {
     process_test_events(&triggers, &events);
 
     let visibility = Arc::new(AtomicBool::new(false));
-    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
-    let mut queued_visibility: Option<bool> = None;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(&trigger, &visibility);
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
     process_test_events(&triggers, &events);
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(&trigger, &visibility);
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/mock_ctx.rs
+++ b/tests/mock_ctx.rs
@@ -14,13 +14,3 @@ impl MockCtx {
     pub fn request_repaint(&self) {}
 }
 
-// Implement the trait from the main crate so tests can reuse visibility logic.
-impl multi_launcher::visibility::ViewportCtx for MockCtx {
-    fn send_viewport_cmd(&self, cmd: egui::ViewportCommand) {
-        self.send_viewport_cmd(cmd);
-    }
-
-    fn request_repaint(&self) {
-        self.request_repaint();
-    }
-}

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -3,14 +3,14 @@ use multi_launcher::visibility::handle_visibility_trigger;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
-fn visibility_toggle_immediate_when_context_present() {
+fn visibility_flag_set_to_false_on_trigger() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
-    let visibility = Arc::new(AtomicBool::new(false));
+    let visibility = Arc::new(AtomicBool::new(true));
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
     handle_visibility_trigger(&trigger, &visibility);
 
-    assert_eq!(visibility.load(Ordering::SeqCst), true);
+    assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -1,32 +1,16 @@
 use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
 use multi_launcher::visibility::handle_visibility_trigger;
-use eframe::egui;
-use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
-
-#[path = "mock_ctx.rs"]
-mod mock_ctx;
-use mock_ctx::MockCtx;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
 fn visibility_toggle_immediate_when_context_present() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
-    let ctx = MockCtx::default();
-    let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
-    let mut queued_visibility: Option<bool> = None;
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(&trigger, &visibility);
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
-    assert!(queued_visibility.is_none());
-
-    let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 1);
-    match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
-        _ => panic!("unexpected command"),
-    }
 }

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -3,14 +3,14 @@ use multi_launcher::visibility::handle_visibility_trigger;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 #[test]
-fn visibility_flag_set_to_false_on_trigger() {
+fn visibility_flag_toggles_on_trigger() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
-    let visibility = Arc::new(AtomicBool::new(true));
+    let visibility = Arc::new(AtomicBool::new(false));
 
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
     handle_visibility_trigger(&trigger, &visibility);
 
-    assert_eq!(visibility.load(Ordering::SeqCst), false);
+    assert_eq!(visibility.load(Ordering::SeqCst), true);
 }


### PR DESCRIPTION
## Summary
- control launcher visibility with a new `show_window` field
- simplify `handle_visibility_trigger` and visibility management
- update menu toggle and tests for the new boolean approach

## Testing
- `cargo test --quiet` *(fails: glib-2.0.pc not found)*

 