### PR TITLE
Update visibility handling

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
 use eframe::egui;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use crate::visibility::apply_visibility;
 use std::collections::HashMap;
 
 enum WatchEvent {
@@ -140,7 +141,7 @@ impl LauncherApp {
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);
-        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(initial_visible));
+        apply_visibility(initial_visible, ctx);
 
         #[cfg(target_os = "windows")]
         {
@@ -213,8 +214,7 @@ impl eframe::App for LauncherApp {
         let just_became_visible = !self.last_visible && should_be_visible;
         if self.last_visible != should_be_visible {
             tracing::debug!("gui thread -> visible: {}", should_be_visible);
-            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(should_be_visible));
-            tracing::debug!("ViewportCommand::Visible({}) sent", should_be_visible);
+            apply_visibility(should_be_visible, ctx);
             self.last_visible = should_be_visible;
         }
 
@@ -227,8 +227,7 @@ impl eframe::App for LauncherApp {
                         }
                     });
                     if ui.button("Force Hide").clicked() {
-                        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
-                        ctx.request_repaint();
+                        apply_visibility(false, ctx);
                         self.visible_flag.store(false, Ordering::SeqCst);
                         self.last_visible = false;
                     }

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -1,7 +1,7 @@
 use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
 use multi_launcher::visibility::handle_visibility_trigger;
-use eframe::egui;
 use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+use eframe::egui;
 
 #[path = "mock_ctx.rs"]
 mod mock_ctx;
@@ -24,9 +24,13 @@ fn visibility_toggle_immediate_when_context_present() {
     assert!(queued_visibility.is_none());
 
     let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 1);
+    assert_eq!(cmds.len(), 2);
     match cmds[0] {
         egui::ViewportCommand::Visible(v) => assert!(v),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[1] {
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
         _ => panic!("unexpected command"),
     }
 }


### PR DESCRIPTION
## Summary
- centralize viewport minimize/restore logic in `apply_visibility`
- call the new helper from `LauncherApp` and visibility trigger handler
- update GUI Force Hide logic
- expand tests for new command sequence

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

 