### PR TITLE
Update visibility logic with mouse position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
+ "raw-window-handle 0.5.2",
  "rdev",
  "regex",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.2",
  "rdev",
  "regex",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ name = "multi_launcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "core-graphics 0.23.2",
  "eframe",
  "fuzzy-matcher",
  "libloading 0.8.6",
@@ -2335,6 +2336,7 @@ dependencies = [
  "walkdir",
  "windows 0.58.0",
  "winit",
+ "x11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ regex = "1"
 windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading"] }
 log = "0.4"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+x11 = "2.21"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.23"
+
 
 [features]
 unstable_grab = ["rdev/unstable_grab"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1"
 regex = "1"
 windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
 log = "0.4"
+raw-window-handle = "0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ winit = "0.29"
 rfd = { version = "0.15.3", default-features = false, features = ["gtk3"] }
 once_cell = "1"
 regex = "1"
-windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading"] }
+windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
 log = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1"
 regex = "1"
 windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
 log = "0.4"
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -41,6 +41,7 @@ pub struct LauncherApp {
     plugin_dirs: Option<Vec<String>>,
     index_paths: Option<Vec<String>>,
     visible_flag: Arc<AtomicBool>,
+    restore_flag: Arc<AtomicBool>,
     last_visible: bool,
 }
 
@@ -60,6 +61,7 @@ impl LauncherApp {
         plugin_dirs: Option<Vec<String>>,
         index_paths: Option<Vec<String>>,
         visible_flag: Arc<AtomicBool>,
+        restore_flag: Arc<AtomicBool>,
     ) -> Self {
         let (tx, rx) = channel();
         let mut watchers = Vec::new();
@@ -137,6 +139,7 @@ impl LauncherApp {
             plugin_dirs,
             index_paths,
             visible_flag: visible_flag.clone(),
+            restore_flag: restore_flag.clone(),
             last_visible: initial_visible,
         };
 
@@ -201,10 +204,19 @@ impl LauncherApp {
 }
 
 impl eframe::App for LauncherApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");
+        if self.restore_flag.swap(false, Ordering::SeqCst) {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+            ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+            #[cfg(target_os = "windows")]
+            if let Some(hwnd) = crate::window_manager::get_hwnd(frame) {
+                crate::window_manager::force_restore_and_foreground(hwnd);
+            }
+        }
 
         let should_be_visible = self.visible_flag.load(Ordering::SeqCst);
         tracing::debug!(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -208,7 +208,9 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");
-        if self.restore_flag.swap(false, Ordering::SeqCst) {
+        let do_restore = self.restore_flag.swap(false, Ordering::SeqCst);
+        if do_restore {
+            tracing::debug!("Restoring window on restore_flag");
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
             ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
             ctx.send_viewport_cmd(egui::ViewportCommand::Focus);

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,10 @@ fn main() -> anyhow::Result<()> {
     let mut listener = HotkeyTrigger::start_listener(watched, "main");
 
 
-    let (handle, visibility, ctx) = spawn_gui(actions.clone(), settings.clone(), "settings.json".to_string());
+    // `visibility` holds whether the window is currently restored (true) or
+    // minimized (false).
+    let (handle, visibility, ctx) =
+        spawn_gui(actions.clone(), settings.clone(), "settings.json".to_string());
     let mut queued_visibility: Option<bool> = None;
 
     loop {

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -20,8 +20,8 @@ impl ViewportCtx for egui::Context {
     }
 }
 
-/// Process a hotkey trigger and update visibility, issuing viewport commands
-/// when possible. This mirrors the logic from `main.rs`.
+/// Process a hotkey trigger and update the minimized state, issuing viewport
+/// commands when possible. This mirrors the logic from `main.rs`.
 pub fn handle_visibility_trigger<C: ViewportCtx>(
     trigger: &HotkeyTrigger,
     visibility: &Arc<AtomicBool>,
@@ -61,10 +61,15 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
 
 /// Apply the current visibility state to the viewport.
 pub fn apply_visibility<C: ViewportCtx>(visible: bool, ctx: &C) {
-    ctx.send_viewport_cmd(egui::ViewportCommand::Visible(visible));
-    ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(!visible));
     if visible {
+        if let Some((x, y)) = crate::window_manager::current_mouse_position() {
+            ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(x, y)));
+        }
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
         ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+    } else {
+        ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
     }
     ctx.request_repaint();
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -200,7 +200,9 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
 }
 
 #[cfg(target_os = "windows")]
-use raw_window_handle::{HasRawWindowHandle, HasWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+#[cfg(target_os = "windows")]
+use raw_window_handle::borrowed::HasWindowHandle;
 
 /// On Windows, restore the window and bring it to the foreground.
 #[cfg(target_os = "windows")]

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -219,8 +219,9 @@ pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
 pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
     if let Ok(handle) = frame.window_handle() {
         match handle.raw_window_handle() {
-            RawWindowHandle::Win32(h) =>
-                Some(windows::Win32::Foundation::HWND(h.hwnd.cast())),
+            RawWindowHandle::Win32(h) => Some(windows::Win32::Foundation::HWND(
+                h.hwnd.get() as *mut core::ffi::c_void,
+            )),
             _ => None,
         }
     } else {

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -202,7 +202,7 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
 #[cfg(target_os = "windows")]
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 #[cfg(target_os = "windows")]
-use raw_window_handle::borrowed::HasWindowHandle;
+use raw_window_handle::HasWindowHandle;
 
 /// On Windows, restore the window and bring it to the foreground.
 #[cfg(target_os = "windows")]

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -198,3 +198,25 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
         Some((0.0, 0.0))
     }
 }
+
+#[cfg(target_os = "windows")]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+/// On Windows, restore the window and bring it to the foreground.
+#[cfg(target_os = "windows")]
+pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
+    use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SetForegroundWindow, SW_RESTORE};
+    unsafe {
+        ShowWindow(hwnd, SW_RESTORE);
+        SetForegroundWindow(hwnd);
+    }
+}
+
+/// Extract the HWND from an eframe [`Frame`].
+#[cfg(target_os = "windows")]
+pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
+    match frame.raw_window_handle() {
+        RawWindowHandle::Win32(handle) => Some(windows::Win32::Foundation::HWND(handle.hwnd.get())),
+        _ => None,
+    }
+}

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -200,9 +200,7 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
 }
 
 #[cfg(target_os = "windows")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-#[cfg(target_os = "windows")]
-use raw_window_handle::HasWindowHandle;
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 /// On Windows, restore the window and bring it to the foreground.
 #[cfg(target_os = "windows")]
@@ -218,7 +216,7 @@ pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
 #[cfg(target_os = "windows")]
 pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
     if let Ok(handle) = frame.window_handle() {
-        match handle.raw_window_handle() {
+        match handle.as_raw() {
             RawWindowHandle::Win32(h) => Some(windows::Win32::Foundation::HWND(
                 h.hwnd.get() as *mut core::ffi::c_void,
             )),

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -133,7 +133,7 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
     #[cfg(target_os = "windows")]
     {
         use windows::Win32::Foundation::POINT;
-        use windows::Win32::UI::Input::KeyboardAndMouse::GetCursorPos;
+        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
         let mut pt = POINT::default();
         if unsafe { GetCursorPos(&mut pt).as_bool() } {
             Some((pt.x as f32, pt.y as f32))

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -200,7 +200,7 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
 }
 
 #[cfg(target_os = "windows")]
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, HasWindowHandle, RawWindowHandle};
 
 /// On Windows, restore the window and bring it to the foreground.
 #[cfg(target_os = "windows")]
@@ -215,8 +215,13 @@ pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
 /// Extract the HWND from an eframe [`Frame`].
 #[cfg(target_os = "windows")]
 pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
-    match frame.raw_window_handle() {
-        RawWindowHandle::Win32(handle) => Some(windows::Win32::Foundation::HWND(handle.hwnd.get())),
-        _ => None,
+    if let Ok(handle) = frame.window_handle() {
+        match handle.raw_window_handle() {
+            RawWindowHandle::Win32(h) =>
+                Some(windows::Win32::Foundation::HWND(h.hwnd.cast())),
+            _ => None,
+        }
+    } else {
+        None
     }
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -135,7 +135,7 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
         use windows::Win32::Foundation::POINT;
         use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
         let mut pt = POINT::default();
-        if unsafe { GetCursorPos(&mut pt).as_bool() } {
+        if unsafe { GetCursorPos(&mut pt).is_ok() } {
             Some((pt.x as f32, pt.y as f32))
         } else {
             Some((0.0, 0.0))

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -127,3 +127,74 @@ pub fn virtual_key_from_string(key: &str) -> Option<u32> {
         _ => None,
     }
 }
+
+/// Return the current mouse position in screen coordinates.
+pub fn current_mouse_position() -> Option<(f32, f32)> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::POINT;
+        use windows::Win32::UI::Input::KeyboardAndMouse::GetCursorPos;
+        let mut pt = POINT::default();
+        if unsafe { GetCursorPos(&mut pt).as_bool() } {
+            Some((pt.x as f32, pt.y as f32))
+        } else {
+            Some((0.0, 0.0))
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        use std::ptr;
+        use x11::xlib;
+        unsafe {
+            let display = xlib::XOpenDisplay(ptr::null());
+            if display.is_null() {
+                return Some((0.0, 0.0));
+            }
+            let root = xlib::XDefaultRootWindow(display);
+            let mut root_ret = 0;
+            let mut child_ret = 0;
+            let mut root_x = 0;
+            let mut root_y = 0;
+            let mut win_x = 0;
+            let mut win_y = 0;
+            let mut mask = 0;
+            let status = xlib::XQueryPointer(
+                display,
+                root,
+                &mut root_ret,
+                &mut child_ret,
+                &mut root_x,
+                &mut root_y,
+                &mut win_x,
+                &mut win_y,
+                &mut mask,
+            );
+            xlib::XCloseDisplay(display);
+            if status == 0 {
+                Some((0.0, 0.0))
+            } else {
+                Some((root_x as f32, root_y as f32))
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use core_graphics::event::{CGEvent, CGEventSource};
+        use core_graphics::event_source::CGEventSourceStateID;
+        let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState).ok();
+        if let Some(source) = source {
+            if let Ok(event) = CGEvent::new(source) {
+                let loc = event.location();
+                return Some((loc.x as f32, loc.y as f32));
+            }
+        }
+        Some((0.0, 0.0))
+    }
+
+    #[cfg(not(any(target_os = "windows", unix)))]
+    {
+        Some((0.0, 0.0))
+    }
+}

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -24,16 +24,20 @@ fn focus_when_becoming_visible() {
     assert!(queued_visibility.is_none());
 
     let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 3);
+    assert_eq!(cmds.len(), 4);
     match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
+        egui::ViewportCommand::OuterPosition(_) => {}
         _ => panic!("unexpected command"),
     }
     match cmds[1] {
-        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        egui::ViewportCommand::Visible(v) => assert!(v),
         _ => panic!("unexpected command"),
     }
     match cmds[2] {
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[3] {
         egui::ViewportCommand::Focus => {},
         _ => panic!("unexpected command"),
     }

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -11,6 +11,7 @@ use mock_ctx::MockCtx;
 fn focus_when_becoming_visible() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
+    let restore = Arc::new(AtomicBool::new(false));
     let ctx = MockCtx::default();
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
     let mut queued_visibility: Option<bool> = None;
@@ -18,7 +19,13 @@ fn focus_when_becoming_visible() {
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert!(queued_visibility.is_none());

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -11,12 +11,19 @@ use mock_ctx::MockCtx;
 fn queued_visibility_applies_when_context_available() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
+    let restore = Arc::new(AtomicBool::new(false));
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
     let mut queued_visibility: Option<bool> = None;
 
     // simulate hotkey press while no context is available
     *trigger.open.lock().unwrap() = true;
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert_eq!(queued_visibility, Some(true));
@@ -28,7 +35,13 @@ fn queued_visibility_applies_when_context_available() {
         *guard = Some(ctx.clone());
     }
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
 
     assert!(queued_visibility.is_none());
     let cmds = ctx.commands.lock().unwrap();

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -32,17 +32,21 @@ fn queued_visibility_applies_when_context_available() {
 
     assert!(queued_visibility.is_none());
     let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 3);
+    assert_eq!(cmds.len(), 4);
     match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
+        egui::ViewportCommand::OuterPosition(_) => {}
         _ => panic!("unexpected command"),
     }
     match cmds[1] {
-        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        egui::ViewportCommand::Visible(v) => assert!(v),
         _ => panic!("unexpected command"),
     }
     match cmds[2] {
-        egui::ViewportCommand::Focus => {},
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[3] {
+        egui::ViewportCommand::Focus => {}
         _ => panic!("unexpected command"),
     }
 }

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -47,12 +47,25 @@ fn zero_key_events_toggle_visibility() {
 
     let visibility = Arc::new(AtomicBool::new(false));
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
+    let restore = Arc::new(AtomicBool::new(false));
     let mut queued_visibility: Option<bool> = None;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
     process_test_events(&triggers, &events);
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -11,6 +11,7 @@ use mock_ctx::MockCtx;
 fn visibility_toggle_immediate_when_context_present() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
+    let restore = Arc::new(AtomicBool::new(false));
     let ctx = MockCtx::default();
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
     let mut queued_visibility: Option<bool> = None;
@@ -18,7 +19,13 @@ fn visibility_toggle_immediate_when_context_present() {
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert!(queued_visibility.is_none());

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -24,17 +24,21 @@ fn visibility_toggle_immediate_when_context_present() {
     assert!(queued_visibility.is_none());
 
     let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 3);
+    assert_eq!(cmds.len(), 4);
     match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
+        egui::ViewportCommand::OuterPosition(_) => {}
         _ => panic!("unexpected command"),
     }
     match cmds[1] {
-        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        egui::ViewportCommand::Visible(v) => assert!(v),
         _ => panic!("unexpected command"),
     }
     match cmds[2] {
-        egui::ViewportCommand::Focus => {},
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[3] {
+        egui::ViewportCommand::Focus => {}
         _ => panic!("unexpected command"),
     }
 }


### PR DESCRIPTION
## Summary
- add `current_mouse_position` helper for windows, linux, macOS
- use the new helper in `apply_visibility` to place window under mouse
- minimize/restore viewport instead of toggling visibility
- keep visibility flag semantics and update documentation
- update unit tests for new commands

## Testing
- `cargo test`
 