### PR TITLE
Update visibility logic with mouse position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ name = "multi_launcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "core-graphics 0.23.2",
  "eframe",
  "fuzzy-matcher",
  "libloading 0.8.6",
@@ -2325,6 +2326,7 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
+ "raw-window-handle 0.6.2",
  "rdev",
  "regex",
  "rfd",
@@ -2335,6 +2337,7 @@ dependencies = [
  "walkdir",
  "windows 0.58.0",
  "winit",
+ "x11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,15 @@ winit = "0.29"
 rfd = { version = "0.15.3", default-features = false, features = ["gtk3"] }
 once_cell = "1"
 regex = "1"
-windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading"] }
+windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
 log = "0.4"
+raw-window-handle = "0.6"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+x11 = "2.21"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.23"
 
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,12 @@ fn spawn_gui(
     actions: Vec<Action>,
     settings: Settings,
     settings_path: String,
-) -> (thread::JoinHandle<()>, Arc<AtomicBool>, Arc<Mutex<Option<egui::Context>>>) {
+) -> (
+    thread::JoinHandle<()>,
+    Arc<AtomicBool>,
+    Arc<AtomicBool>,
+    Arc<Mutex<Option<egui::Context>>>,
+) {
     let actions_for_window = actions.clone();
     let mut plugins = PluginManager::new();
     plugins.register(Box::new(WebSearchPlugin));
@@ -57,7 +62,9 @@ fn spawn_gui(
     let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
     let visible_flag = Arc::new(AtomicBool::new(true));
+    let restore_flag = Arc::new(AtomicBool::new(false));
     let flag_clone = visible_flag.clone();
+    let restore_clone = restore_flag.clone();
     let ctx_handle = Arc::new(Mutex::new(None));
     let ctx_clone = ctx_handle.clone();
 
@@ -99,12 +106,13 @@ fn spawn_gui(
                     plugin_dirs,
                     index_paths,
                     flag_clone,
+                    restore_clone,
                 ))
             }),
         );
     });
 
-    (handle, visible_flag, ctx_handle)
+    (handle, visible_flag, restore_flag, ctx_handle)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -134,7 +142,10 @@ fn main() -> anyhow::Result<()> {
     let mut listener = HotkeyTrigger::start_listener(watched, "main");
 
 
-    let (handle, visibility, ctx) = spawn_gui(actions.clone(), settings.clone(), "settings.json".to_string());
+    // `visibility` holds whether the window is currently restored (true) or
+    // minimized (false).
+    let (handle, visibility, restore_flag, ctx) =
+        spawn_gui(actions.clone(), settings.clone(), "settings.json".to_string());
     let mut queued_visibility: Option<bool> = None;
 
     loop {
@@ -173,7 +184,13 @@ fn main() -> anyhow::Result<()> {
             listener = HotkeyTrigger::start_listener(watched, "main");
         }
 
-        handle_visibility_trigger(trigger.as_ref(), &visibility, &ctx, &mut queued_visibility);
+        handle_visibility_trigger(
+            trigger.as_ref(),
+            &visibility,
+            &restore_flag,
+            &ctx,
+            &mut queued_visibility,
+        );
 
         std::thread::sleep(std::time::Duration::from_millis(50));
     }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -127,3 +127,116 @@ pub fn virtual_key_from_string(key: &str) -> Option<u32> {
         _ => None,
     }
 }
+
+/// Return the current mouse position in screen coordinates.
+pub fn current_mouse_position() -> Option<(f32, f32)> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::POINT;
+        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
+        let mut pt = POINT::default();
+        if unsafe { GetCursorPos(&mut pt).is_ok() } {
+            Some((pt.x as f32, pt.y as f32))
+        } else {
+            Some((0.0, 0.0))
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        use std::ptr;
+        use x11::xlib;
+        unsafe {
+            let display = xlib::XOpenDisplay(ptr::null());
+            if display.is_null() {
+                return Some((0.0, 0.0));
+            }
+            let root = xlib::XDefaultRootWindow(display);
+            let mut root_ret = 0;
+            let mut child_ret = 0;
+            let mut root_x = 0;
+            let mut root_y = 0;
+            let mut win_x = 0;
+            let mut win_y = 0;
+            let mut mask = 0;
+            let status = xlib::XQueryPointer(
+                display,
+                root,
+                &mut root_ret,
+                &mut child_ret,
+                &mut root_x,
+                &mut root_y,
+                &mut win_x,
+                &mut win_y,
+                &mut mask,
+            );
+            xlib::XCloseDisplay(display);
+            if status == 0 {
+                Some((0.0, 0.0))
+            } else {
+                Some((root_x as f32, root_y as f32))
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use core_graphics::event::{CGEvent, CGEventSource};
+        use core_graphics::event_source::CGEventSourceStateID;
+        let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState).ok();
+        if let Some(source) = source {
+            if let Ok(event) = CGEvent::new(source) {
+                let loc = event.location();
+                return Some((loc.x as f32, loc.y as f32));
+            }
+        }
+        Some((0.0, 0.0))
+    }
+
+    #[cfg(not(any(target_os = "windows", unix)))]
+    {
+        Some((0.0, 0.0))
+    }
+}
+
+#[cfg(target_os = "windows")]
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+/// On Windows, restore the window and bring it to the foreground.
+#[cfg(target_os = "windows")]
+pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
+    use windows::Win32::UI::WindowsAndMessaging::{
+        ShowWindowAsync, SetForegroundWindow, SW_RESTORE, GetForegroundWindow,
+        GetWindowThreadProcessId,
+    };
+    use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
+    unsafe {
+        let fg_hwnd = GetForegroundWindow();
+        let fg_thread = GetWindowThreadProcessId(fg_hwnd, None);
+        let current_thread = GetCurrentThreadId();
+
+        tracing::debug!("Forcing window restore and foreground");
+        ShowWindowAsync(hwnd, SW_RESTORE);
+
+        let _ = AttachThreadInput(fg_thread, current_thread, true);
+        let fg_success = SetForegroundWindow(hwnd).as_bool();
+        let _ = AttachThreadInput(fg_thread, current_thread, false);
+
+        tracing::debug!("SetForegroundWindow success: {fg_success}");
+    }
+}
+
+/// Extract the HWND from an eframe [`Frame`].
+#[cfg(target_os = "windows")]
+pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
+    if let Ok(handle) = frame.window_handle() {
+        match handle.as_raw() {
+            RawWindowHandle::Win32(h) => Some(windows::Win32::Foundation::HWND(
+                h.hwnd.get() as *mut core::ffi::c_void,
+            )),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -47,12 +47,25 @@ fn zero_key_events_toggle_visibility() {
 
     let visibility = Arc::new(AtomicBool::new(false));
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(None));
+    let restore = Arc::new(AtomicBool::new(false));
     let mut queued_visibility: Option<bool> = None;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
     process_test_events(&triggers, &events);
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -11,6 +11,7 @@ use mock_ctx::MockCtx;
 fn visibility_toggle_immediate_when_context_present() {
     let trigger = HotkeyTrigger::new(Hotkey::default());
     let visibility = Arc::new(AtomicBool::new(false));
+    let restore = Arc::new(AtomicBool::new(false));
     let ctx = MockCtx::default();
     let ctx_handle: Arc<Mutex<Option<MockCtx>>> = Arc::new(Mutex::new(Some(ctx.clone())));
     let mut queued_visibility: Option<bool> = None;
@@ -18,23 +19,33 @@ fn visibility_toggle_immediate_when_context_present() {
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(&trigger, &visibility, &ctx_handle, &mut queued_visibility);
+    handle_visibility_trigger(
+        &trigger,
+        &visibility,
+        &restore,
+        &ctx_handle,
+        &mut queued_visibility,
+    );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert!(queued_visibility.is_none());
 
     let cmds = ctx.commands.lock().unwrap();
-    assert_eq!(cmds.len(), 3);
+    assert_eq!(cmds.len(), 4);
     match cmds[0] {
-        egui::ViewportCommand::Visible(v) => assert!(v),
+        egui::ViewportCommand::OuterPosition(_) => {}
         _ => panic!("unexpected command"),
     }
     match cmds[1] {
-        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        egui::ViewportCommand::Visible(v) => assert!(v),
         _ => panic!("unexpected command"),
     }
     match cmds[2] {
-        egui::ViewportCommand::Focus => {},
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[3] {
+        egui::ViewportCommand::Focus => {}
         _ => panic!("unexpected command"),
     }
 }


### PR DESCRIPTION
## Summary
- add `current_mouse_position` helper for windows, linux, macOS
- use the new helper in `apply_visibility` to place window under mouse
- minimize/restore viewport instead of toggling visibility
- keep visibility flag semantics and update documentation
- update unit tests for new commands
- fix GetCursorPos import and cargo features
- fix GetCursorPos call
- add window restore utilities and pending restore logic
- fix HWND extraction for latest eframe
- fix WindowHandle trait import for Windows builds
- fix restore logic
- use AttachThreadInput when forcing the window to foreground
- fix Windows restore helper imports
- fix restore logic to call `apply_visibility` when `restore_flag` is set

## Testing
- `cargo check` *(failed to build `glib-sys` due to missing system library)*
- `cargo test --locked --color never` *(failed to build `glib-sys` due to missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_68693422ddcc83328a19bd592992e44c