### PR TITLE
Add offscreen hide configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "quit_hotkey": "Shift+Escape",
   "index_paths": ["/usr/share/applications"],
   "plugin_dirs": ["./plugins"],
-  "debug_logging": false
+  "debug_logging": false,
+  "offscreen_pos": [2000, 2000]
 }
 ```
 
@@ -64,6 +65,10 @@ keys (`F1`-`F12`) and common keys like `Space`, `Tab`, `Return`, `Escape`,
 `quit_hotkey` can be set to another key combination to close the launcher from
 anywhere. If omitted, the application only quits when the window is closed
 through the GUI.
+
+`offscreen_pos` specifies where the window is moved when hiding it. Choose
+coordinates outside the visible monitor area so the window stays accessible but
+off-screen. The default is `[2000, 2000]`.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,10 @@ fn main() -> anyhow::Result<()> {
             &restore_flag,
             &ctx,
             &mut queued_visibility,
+            {
+                let (x, y) = settings.offscreen_pos.unwrap_or((2000, 2000));
+                (x as f32, y as f32)
+            },
         );
 
         std::thread::sleep(std::time::Duration::from_millis(50));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,10 @@ pub struct Settings {
     /// Defaults to `false` when the field is missing in the settings file.
     #[serde(default)]
     pub debug_logging: bool,
+    /// Position used to hide the window off-screen when not visible.
+    /// Defaults to `(2000, 2000)` if missing.
+    #[serde(default)]
+    pub offscreen_pos: Option<(i32, i32)>,
 }
 
 impl Default for Settings {
@@ -23,6 +27,7 @@ impl Default for Settings {
             index_paths: None,
             plugin_dirs: None,
             debug_logging: false,
+            offscreen_pos: Some((2000, 2000)),
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -12,6 +12,8 @@ pub struct SettingsEditor {
     index_input: String,
     plugin_input: String,
     debug_logging: bool,
+    offscreen_x: i32,
+    offscreen_y: i32,
 }
 
 impl SettingsEditor {
@@ -24,6 +26,8 @@ impl SettingsEditor {
             index_input: String::new(),
             plugin_input: String::new(),
             debug_logging: settings.debug_logging,
+            offscreen_x: settings.offscreen_pos.unwrap_or((2000, 2000)).0,
+            offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
         }
     }
 
@@ -50,6 +54,7 @@ impl SettingsEditor {
                 Some(self.plugin_dirs.clone())
             },
             debug_logging: self.debug_logging,
+            offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
         }
     }
 
@@ -78,6 +83,13 @@ impl SettingsEditor {
                         ui.selectable_value(&mut self.debug_logging, false, "Disabled");
                         ui.selectable_value(&mut self.debug_logging, true, "Enabled");
                     });
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Off-screen X");
+                ui.add(egui::DragValue::new(&mut self.offscreen_x));
+                ui.label("Y");
+                ui.add(egui::DragValue::new(&mut self.offscreen_y));
             });
 
             ui.separator();
@@ -146,6 +158,7 @@ impl SettingsEditor {
                     app.update_paths(
                         new_settings.plugin_dirs.clone(),
                         new_settings.index_paths.clone(),
+                        new_settings.offscreen_pos,
                     );
                     crate::request_hotkey_restart(new_settings);
                 }

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -25,6 +25,7 @@ fn focus_when_becoming_visible() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -23,6 +23,7 @@ fn queued_visibility_applies_when_context_available() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
@@ -41,6 +42,7 @@ fn queued_visibility_applies_when_context_available() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
 
     assert!(queued_visibility.is_none());

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -56,6 +56,7 @@ fn zero_key_events_toggle_visibility() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
@@ -66,6 +67,7 @@ fn zero_key_events_toggle_visibility() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/offscreen.rs
+++ b/tests/offscreen.rs
@@ -1,0 +1,21 @@
+use multi_launcher::visibility::apply_visibility;
+use eframe::egui;
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
+
+#[test]
+fn offscreen_position_when_hidden() {
+    let ctx = MockCtx::default();
+    apply_visibility(false, &ctx, (42.0, 84.0));
+    let cmds = ctx.commands.lock().unwrap();
+    assert_eq!(cmds.len(), 1);
+    match cmds[0] {
+        egui::ViewportCommand::OuterPosition(p) => {
+            assert_eq!(p.x, 42.0);
+            assert_eq!(p.y, 84.0);
+        }
+        _ => panic!("unexpected command"),
+    }
+}

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -25,6 +25,7 @@ fn visibility_toggle_immediate_when_context_present() {
         &restore,
         &ctx_handle,
         &mut queued_visibility,
+        (0.0, 0.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);


### PR DESCRIPTION
## Summary
- expose new `offscreen_pos` setting
- update settings editor with X/Y controls
- store off-screen position in `LauncherApp`
- move windows off-screen instead of minimizing when hiding
- update visibility tests and add a new offscreen test
- document behaviour in README

## Testing
- `cargo test` *(fails: system library `glib-2.0` missing)*

 