### PR TITLE
Update visibility handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod workspace;
 pub mod global_hotkey;
 pub mod gui;
 
+pub use visibility::OFFSCREEN_POSITION;
+
 pub fn request_hotkey_restart(_settings: settings::Settings) {
     // no-op stub for library context
 }

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
 
 use crate::hotkey::HotkeyTrigger;
 
+/// When hiding the window, move it far off-screen so that it can't be seen.
+pub const OFFSCREEN_POSITION: (f32, f32) = (2000.0, 2000.0);
+
 
 /// Trait abstracting over an `egui::Context` for viewport commands.
 pub trait ViewportCtx {
@@ -82,7 +85,8 @@ pub fn apply_visibility<C: ViewportCtx>(visible: bool, ctx: &C) {
         ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
         ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
     } else {
-        ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+        let (x, y) = OFFSCREEN_POSITION;
+        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(x, y)));
     }
     ctx.request_repaint();
 }


### PR DESCRIPTION
## Summary
- add a public `OFFSCREEN_POSITION` constant for use when hiding the window
- adjust `apply_visibility` to move the window off-screen instead of minimizing it
- re-export the constant from the crate root

## Testing
- `cargo test` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698af9220883329cb28228d63b51a1