### PR TITLE
Move hidden window offscreen

### DIFF
--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
 
 use crate::hotkey::HotkeyTrigger;
 
+/// Position used to hide the viewport offscreen when not visible.
+pub const OFFSCREEN_POS: (f32, f32) = (2000.0, 2000.0);
+
 
 /// Trait abstracting over an `egui::Context` for viewport commands.
 pub trait ViewportCtx {
@@ -82,7 +85,8 @@ pub fn apply_visibility<C: ViewportCtx>(visible: bool, ctx: &C) {
         ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
         ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
     } else {
-        ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(OFFSCREEN_POS.0, OFFSCREEN_POS.1)));
+        ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
     }
     ctx.request_repaint();
 }

--- a/tests/visibility_offscreen.rs
+++ b/tests/visibility_offscreen.rs
@@ -1,0 +1,25 @@
+use multi_launcher::visibility::{apply_visibility, OFFSCREEN_POS};
+use eframe::egui;
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
+
+#[test]
+fn hide_moves_window_offscreen() {
+    let ctx = MockCtx::default();
+    apply_visibility(false, &ctx);
+    let cmds = ctx.commands.lock().unwrap();
+    assert_eq!(cmds.len(), 2); // OuterPosition + Visible(true)
+    match cmds[0] {
+        egui::ViewportCommand::OuterPosition(pos) => {
+            assert_eq!(pos.x, OFFSCREEN_POS.0);
+            assert_eq!(pos.y, OFFSCREEN_POS.1);
+        }
+        _ => panic!("unexpected command"),
+    }
+    match cmds[1] {
+        egui::ViewportCommand::Visible(v) => assert!(v),
+        _ => panic!("unexpected command"),
+    }
+}


### PR DESCRIPTION
## Summary
- hide viewport by moving it to `OFFSCREEN_POS` instead of minimizing
- keep the viewport visible when hiding
- test that apply_visibility(false) sends `OuterPosition(OFFSCREEN_POS)` and does not minimize

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68698ad028548332937d3f939f96c812