### PR TITLE
Remember window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "index_paths": ["/usr/share/applications"],
   "plugin_dirs": ["./plugins"],
   "debug_logging": false,
-  "offscreen_pos": [2000, 2000]
+  "offscreen_pos": [2000, 2000],
+  "window_size": [400, 220]
 }
 ```
 
@@ -69,6 +70,8 @@ through the GUI.
 `offscreen_pos` specifies where the window is moved when hiding it. Choose
 coordinates outside the visible monitor area so the window stays accessible but
 off-screen. The default is `[2000, 2000]`.
+`window_size` records the last size of the launcher window. It is updated on
+exit so the next start uses the same dimensions. The default is `[400, 220]`.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -44,6 +44,7 @@ pub struct LauncherApp {
     restore_flag: Arc<AtomicBool>,
     last_visible: bool,
     offscreen_pos: (f32, f32),
+    window_size: (f32, f32),
 }
 
 impl LauncherApp {
@@ -128,6 +129,11 @@ impl LauncherApp {
             (x as f32, y as f32)
         };
 
+        let window_size = {
+            let (w, h) = settings.window_size.unwrap_or((400, 220));
+            (w as f32, h as f32)
+        };
+
         let app = Self {
             actions: actions.clone(),
             query: String::new(),
@@ -151,6 +157,7 @@ impl LauncherApp {
             restore_flag: restore_flag.clone(),
             last_visible: initial_visible,
             offscreen_pos,
+            window_size,
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);
@@ -218,6 +225,9 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");
+        if let Some(rect) = ctx.input(|i| i.viewport().inner_rect) {
+            self.window_size = (rect.width(), rect.height());
+        }
         let do_restore = self.restore_flag.swap(false, Ordering::SeqCst);
         if do_restore {
             tracing::debug!("Restoring window on restore_flag");
@@ -355,6 +365,10 @@ impl eframe::App for LauncherApp {
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
+        if let Ok(mut settings) = crate::settings::Settings::load(&self.settings_path) {
+            settings.window_size = Some((self.window_size.0 as i32, self.window_size.1 as i32));
+            let _ = settings.save(&self.settings_path);
+        }
         #[cfg(not(test))]
         std::process::exit(0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,10 @@ fn spawn_gui(
     let handle = thread::spawn(move || {
         let native_options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
-                .with_inner_size([400.0, 220.0])
+                .with_inner_size([
+                    settings.window_size.unwrap_or((400, 220)).0 as f32,
+                    settings.window_size.unwrap_or((400, 220)).1 as f32,
+                ])
                 .with_min_inner_size([320.0, 160.0])
                 .with_always_on_top()
                 .with_visible(true),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,10 @@ pub struct Settings {
     /// Defaults to `(2000, 2000)` if missing.
     #[serde(default)]
     pub offscreen_pos: Option<(i32, i32)>,
+    /// Last window size in pixels. When present the launcher starts with this
+    /// size instead of the default.
+    #[serde(default)]
+    pub window_size: Option<(i32, i32)>,
 }
 
 impl Default for Settings {
@@ -28,6 +32,7 @@ impl Default for Settings {
             plugin_dirs: None,
             debug_logging: false,
             offscreen_pos: Some((2000, 2000)),
+            window_size: Some((400, 220)),
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -14,6 +14,8 @@ pub struct SettingsEditor {
     debug_logging: bool,
     offscreen_x: i32,
     offscreen_y: i32,
+    window_w: i32,
+    window_h: i32,
 }
 
 impl SettingsEditor {
@@ -28,6 +30,8 @@ impl SettingsEditor {
             debug_logging: settings.debug_logging,
             offscreen_x: settings.offscreen_pos.unwrap_or((2000, 2000)).0,
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
+            window_w: settings.window_size.unwrap_or((400, 220)).0,
+            window_h: settings.window_size.unwrap_or((400, 220)).1,
         }
     }
 
@@ -55,6 +59,7 @@ impl SettingsEditor {
             },
             debug_logging: self.debug_logging,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
+            window_size: Some((self.window_w, self.window_h)),
         }
     }
 


### PR DESCRIPTION
## Summary
- remember last window size in settings
- restore the stored window size on startup
- update user docs

## Testing
- `cargo check` *(fails: glib-sys missing)*

 