### PR TITLE
Add selectable search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,7 @@ dependencies = [
  "serde",
  "serde_json",
  "winapi",
+ "x11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ raw-window-handle = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"
+rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2", features = ["x11"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.23"

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -1,0 +1,53 @@
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::actions::Action;
+use multi_launcher::settings::Settings;
+use std::sync::{Arc, atomic::AtomicBool};
+use eframe::egui;
+
+fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    LauncherApp::new(
+        ctx,
+        actions,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn arrow_keys_update_selection() {
+    let ctx = egui::Context::default();
+    let acts = vec![
+        Action { label: "one".into(), desc: "".into(), action: "one".into() },
+        Action { label: "two".into(), desc: "".into(), action: "two".into() },
+    ];
+    let mut app = new_app(&ctx, acts);
+    app.search();
+    assert_eq!(app.selected, None);
+    app.handle_key(egui::Key::ArrowDown);
+    assert_eq!(app.selected, Some(0));
+    app.handle_key(egui::Key::ArrowDown);
+    assert_eq!(app.selected, Some(1));
+    app.handle_key(egui::Key::ArrowUp);
+    assert_eq!(app.selected, Some(0));
+}
+
+#[test]
+fn enter_returns_selected_index() {
+    let ctx = egui::Context::default();
+    let acts = vec![
+        Action { label: "one".into(), desc: "".into(), action: "one".into() },
+        Action { label: "two".into(), desc: "".into(), action: "two".into() },
+    ];
+    let mut app = new_app(&ctx, acts);
+    app.search();
+    app.handle_key(egui::Key::ArrowDown);
+    let idx = app.handle_key(egui::Key::Enter);
+    assert_eq!(idx, Some(0));
+}


### PR DESCRIPTION
## Summary
- track currently selected search result in `LauncherApp`
- reset selection when searching
- process navigation keys and highlight selected entry
- test selection behaviour

## Testing
- `cargo test`
 