### PR TITLE
Add clipboard history plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,12 +172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f533f8e0af236ffe5eb979b99381df3258853f00ba2e44b6e1955292c75227"
 dependencies = [
  "clipboard-win",
+ "image 0.25.6",
  "log",
  "objc2 0.6.1",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -589,6 +593,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1019,7 +1029,7 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "image",
+ "image 0.24.9",
  "js-sys",
  "log",
  "objc",
@@ -1881,6 +1891,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2020,12 @@ dependencies = [
  "getrandom 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2237,6 +2266,7 @@ name = "multi_launcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "core-graphics",
  "eframe",
  "fuzzy-matcher",
@@ -3399,6 +3429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,6 +3943,12 @@ dependencies = [
  "url",
  "web-sys",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ regex = "1"
 windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
 log = "0.4"
 raw-window-handle = "0.6"
+arboard = "3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ running.
 
 ## Plugins
 
-Built-in plugins provide Google web search (`g query`) and an inline calculator
-(using the `=` prefix). Additional plugins can be added by building separate
+Built-in plugins provide Google web search (`g query`), an inline calculator
+(using the `=` prefix) and a clipboard history (`cb`). Selecting a clipboard entry copies it back to the clipboard. Additional plugins can be added by building separate
 shared libraries. Each plugin crate should be compiled as a `cdylib` and export
 a `create_plugin` function returning `Box<dyn Plugin>`:
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -5,6 +5,7 @@ use crate::settings::Settings;
 use crate::launcher::launch_action;
 use crate::plugin::PluginManager;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
+use crate::plugins::clipboard::ClipboardPlugin;
 use crate::indexer;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config, EventKind};
 use std::sync::mpsc::{channel, Receiver};
@@ -334,6 +335,7 @@ impl eframe::App for LauncherApp {
                     let mut plugins = PluginManager::new();
                     plugins.register(Box::new(WebSearchPlugin));
                     plugins.register(Box::new(CalculatorPlugin));
+                    plugins.register(Box::new(ClipboardPlugin::default()));
                     if let Some(dirs) = &self.plugin_dirs {
                         for dir in dirs {
                             if let Err(e) = plugins.load_dir(dir) {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,7 +1,13 @@
 use crate::actions::Action;
+use arboard::Clipboard;
 use std::path::Path;
 
 pub fn launch_action(action: &Action) -> anyhow::Result<()> {
+    if let Some(text) = action.action.strip_prefix("clipboard:") {
+        let mut cb = Clipboard::new()?;
+        cb.set_text(text.to_string())?;
+        return Ok(());
+    }
     let path = Path::new(&action.action);
 
     // If it's an .exe, launch it directly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod settings;
 pub mod launcher;
 pub mod plugin;
 pub mod plugins_builtin;
+pub mod plugins;
 pub mod indexer;
 pub mod logging;
 pub mod hotkey;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod visibility;
 mod global_hotkey;
 mod window_manager;
 mod workspace;
+mod plugins;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crate::hotkey::HotkeyTrigger;
 use crate::visibility::handle_visibility_trigger;
 use crate::plugin::PluginManager;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
+use crate::plugins::clipboard::ClipboardPlugin;
 use crate::settings::Settings;
 
 use eframe::egui;
@@ -49,6 +50,7 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     plugins.register(Box::new(WebSearchPlugin));
     plugins.register(Box::new(CalculatorPlugin));
+    plugins.register(Box::new(ClipboardPlugin::default()));
     if let Some(dirs) = &settings.plugin_dirs {
         for dir in dirs {
             if let Err(e) = plugins.load_dir(dir) {

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -1,0 +1,79 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+pub struct ClipboardPlugin {
+    history: Arc<Mutex<VecDeque<String>>>,
+    max_entries: usize,
+}
+
+impl ClipboardPlugin {
+    pub fn new(max_entries: usize) -> Self {
+        let history = Arc::new(Mutex::new(VecDeque::new()));
+        let history_clone = history.clone();
+        thread::spawn(move || {
+            let mut clipboard = match arboard::Clipboard::new() {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!("failed to init clipboard: {e}");
+                    return;
+                }
+            };
+            let mut last = String::new();
+            loop {
+                match clipboard.get_text() {
+                    Ok(txt) => {
+                        if txt != last {
+                            let mut h = history_clone.lock().unwrap();
+                            if let Some(pos) = h.iter().position(|v| v == &txt) {
+                                h.remove(pos);
+                            }
+                            h.push_front(txt.clone());
+                            while h.len() > max_entries {
+                                h.pop_back();
+                            }
+                            last = txt;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("clipboard read error: {e}");
+                    }
+                }
+                thread::sleep(Duration::from_millis(500));
+            }
+        });
+        Self { history, max_entries }
+    }
+}
+
+impl Default for ClipboardPlugin {
+    fn default() -> Self {
+        Self::new(20)
+    }
+}
+
+impl Plugin for ClipboardPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if !query.starts_with("cb") {
+            return Vec::new();
+        }
+        let filter = query.strip_prefix("cb").unwrap_or("").trim();
+        let history = self.history.lock().unwrap();
+        history
+            .iter()
+            .filter(|entry| entry.contains(filter))
+            .map(|entry| Action {
+                label: entry.clone(),
+                desc: "Clipboard".into(),
+                action: format!("clipboard:{}", entry),
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "clipboard"
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,1 @@
+pub mod clipboard;


### PR DESCRIPTION
## Summary
- implement clipboard history plugin
- copy entries back to clipboard when launching
- register plugin on startup and reload
- document clipboard plugin usage

## Testing
- `cargo check` *(fails: glib-sys missing)*

 