### PR TITLE
Add plugin enable list to settings

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -3,7 +3,7 @@ use crate::actions_editor::ActionsEditor;
 use crate::settings_editor::SettingsEditor;
 use crate::settings::Settings;
 use crate::launcher::launch_action;
-use crate::plugin::PluginManager;
+use crate::plugin::{PluginManager, Plugin};
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::indexer;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -42,6 +42,7 @@ pub struct LauncherApp {
     rx: Receiver<WatchEvent>,
     plugin_dirs: Option<Vec<String>>,
     index_paths: Option<Vec<String>>,
+    enabled_plugins: Option<Vec<String>>,
     visible_flag: Arc<AtomicBool>,
     restore_flag: Arc<AtomicBool>,
     last_visible: bool,
@@ -50,9 +51,16 @@ pub struct LauncherApp {
 }
 
 impl LauncherApp {
-    pub fn update_paths(&mut self, plugin_dirs: Option<Vec<String>>, index_paths: Option<Vec<String>>, offscreen_pos: Option<(i32, i32)>) {
+    pub fn update_paths(
+        &mut self,
+        plugin_dirs: Option<Vec<String>>,
+        index_paths: Option<Vec<String>>,
+        enabled_plugins: Option<Vec<String>>,
+        offscreen_pos: Option<(i32, i32)>,
+    ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
+        self.enabled_plugins = enabled_plugins;
         if let Some((x, y)) = offscreen_pos {
             self.offscreen_pos = (x as f32, y as f32);
         }
@@ -67,6 +75,7 @@ impl LauncherApp {
         settings: Settings,
         plugin_dirs: Option<Vec<String>>,
         index_paths: Option<Vec<String>>,
+        enabled_plugins: Option<Vec<String>>,
         visible_flag: Arc<AtomicBool>,
         restore_flag: Arc<AtomicBool>,
     ) -> Self {
@@ -152,6 +161,7 @@ impl LauncherApp {
             rx,
             plugin_dirs,
             index_paths,
+            enabled_plugins,
             visible_flag: visible_flag.clone(),
             restore_flag: restore_flag.clone(),
             last_visible: initial_visible,
@@ -333,12 +343,41 @@ impl eframe::App for LauncherApp {
                 }
                 WatchEvent::Plugins => {
                     let mut plugins = PluginManager::new();
-                    plugins.register(Box::new(WebSearchPlugin));
-                    plugins.register(Box::new(CalculatorPlugin));
-                    plugins.register(Box::new(ClipboardPlugin::default()));
+                    {
+                        let ws = WebSearchPlugin;
+                        if self
+                            .enabled_plugins
+                            .as_ref()
+                            .map_or(true, |l| l.contains(&ws.name().to_string()))
+                        {
+                            plugins.register(Box::new(ws));
+                        }
+                    }
+                    {
+                        let calc = CalculatorPlugin;
+                        if self
+                            .enabled_plugins
+                            .as_ref()
+                            .map_or(true, |l| l.contains(&calc.name().to_string()))
+                        {
+                            plugins.register(Box::new(calc));
+                        }
+                    }
+                    {
+                        let cb = ClipboardPlugin::default();
+                        if self
+                            .enabled_plugins
+                            .as_ref()
+                            .map_or(true, |l| l.contains(&cb.name().to_string()))
+                        {
+                            plugins.register(Box::new(cb));
+                        }
+                    }
                     if let Some(dirs) = &self.plugin_dirs {
                         for dir in dirs {
-                            if let Err(e) = plugins.load_dir(dir) {
+                            if let Err(e) =
+                                plugins.load_dir_filtered(dir, self.enabled_plugins.as_ref())
+                            {
                                 tracing::error!("Failed to load plugins from {}: {}", dir, e);
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;
 use crate::hotkey::HotkeyTrigger;
 use crate::visibility::handle_visibility_trigger;
-use crate::plugin::PluginManager;
+use crate::plugin::{PluginManager, Plugin};
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::settings::Settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,12 +49,39 @@ fn spawn_gui(
 ) {
     let actions_for_window = actions.clone();
     let mut plugins = PluginManager::new();
-    plugins.register(Box::new(WebSearchPlugin));
-    plugins.register(Box::new(CalculatorPlugin));
-    plugins.register(Box::new(ClipboardPlugin::default()));
+    {
+        let ws = WebSearchPlugin;
+        if settings
+            .enabled_plugins
+            .as_ref()
+            .map_or(true, |l| l.contains(&ws.name().to_string()))
+        {
+            plugins.register(Box::new(ws));
+        }
+    }
+    {
+        let calc = CalculatorPlugin;
+        if settings
+            .enabled_plugins
+            .as_ref()
+            .map_or(true, |l| l.contains(&calc.name().to_string()))
+        {
+            plugins.register(Box::new(calc));
+        }
+    }
+    {
+        let cb = ClipboardPlugin::default();
+        if settings
+            .enabled_plugins
+            .as_ref()
+            .map_or(true, |l| l.contains(&cb.name().to_string()))
+        {
+            plugins.register(Box::new(cb));
+        }
+    }
     if let Some(dirs) = &settings.plugin_dirs {
         for dir in dirs {
-            if let Err(e) = plugins.load_dir(dir) {
+            if let Err(e) = plugins.load_dir_filtered(dir, settings.enabled_plugins.as_ref()) {
                 tracing::error!("Failed to load plugins from {}: {}", dir, e);
             }
         }
@@ -64,6 +91,7 @@ fn spawn_gui(
     let settings_path_for_window = settings_path.clone();
     let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
+    let enabled_plugins = settings.enabled_plugins.clone();
     let visible_flag = Arc::new(AtomicBool::new(true));
     let restore_flag = Arc::new(AtomicBool::new(false));
     let flag_clone = visible_flag.clone();
@@ -109,6 +137,7 @@ fn spawn_gui(
                     settings.clone(),
                     plugin_dirs,
                     index_paths,
+                    enabled_plugins,
                     flag_clone,
                     restore_clone,
                 ))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,9 @@ pub struct Settings {
     pub quit_hotkey: Option<String>,
     pub index_paths: Option<Vec<String>>,
     pub plugin_dirs: Option<Vec<String>>,
+    /// List of plugin names which should be enabled. If `None`, all loaded
+    /// plugins are enabled.
+    pub enabled_plugins: Option<Vec<String>>,
     /// When enabled the application initialises the logger at debug level.
     /// Defaults to `false` when the field is missing in the settings file.
     #[serde(default)]
@@ -29,6 +32,7 @@ impl Default for Settings {
             quit_hotkey: None,
             index_paths: None,
             plugin_dirs: None,
+            enabled_plugins: None,
             debug_logging: false,
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -15,6 +15,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         Settings::default(),
         None,
         None,
+        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
     )


### PR DESCRIPTION
## Summary
- allow enabling/disabling plugins through `Settings`
- show plugin list checkboxes in the settings editor UI
- filter loaded plugins based on `enabled_plugins`

## Testing
- `cargo test` *(fails: glib-2.0 pkg-config missing)*
 