### PR TITLE
Add plugin configuration UI

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -145,6 +145,7 @@ impl LauncherApp {
         };
         let win_size = settings.window_size.unwrap_or((400, 220));
 
+        let settings_editor = SettingsEditor::new(&settings, &plugins);
         let app = Self {
             actions: actions.clone(),
             query: String::new(),
@@ -159,7 +160,7 @@ impl LauncherApp {
             show_settings: false,
             actions_path,
             editor: ActionsEditor::default(),
-            settings_editor: SettingsEditor::new(&settings),
+            settings_editor,
             settings_path,
             watchers,
             rx,

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -16,6 +16,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         None,
         None,
         None,
+        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
     )


### PR DESCRIPTION
## Summary
- gather plugin names and capabilities during `SettingsEditor::new`
- render plugin and capability checkboxes from stored info
- pass `PluginManager` into `SettingsEditor` on app construction
- fix tests for updated `LauncherApp::new` call

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6869c27cf8b88332b78a8114ebd34061