### PR TITLE
Add plugin descriptions support

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,6 +6,8 @@ pub trait Plugin: Send + Sync {
     fn search(&self, query: &str) -> Vec<Action>;
     /// Name of the plugin
     fn name(&self) -> &str;
+    /// Human readable description of the plugin
+    fn description(&self) -> &str;
     /// Capabilities offered by the plugin
     fn capabilities(&self) -> &[&str];
 }
@@ -41,6 +43,20 @@ impl PluginManager {
             .map(|p| {
                 (
                     p.name().to_string(),
+                    p.capabilities().iter().map(|c| c.to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// Return names, descriptions and capabilities for all plugins.
+    pub fn plugin_infos(&self) -> Vec<(String, String, Vec<String>)> {
+        self.plugins
+            .iter()
+            .map(|p| {
+                (
+                    p.name().to_string(),
+                    p.description().to_string(),
                     p.capabilities().iter().map(|c| c.to_string()).collect(),
                 )
             })

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -77,6 +77,10 @@ impl Plugin for ClipboardPlugin {
         "clipboard"
     }
 
+    fn description(&self) -> &str {
+        "Provides clipboard history search"
+    }
+
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -21,6 +21,10 @@ impl Plugin for WebSearchPlugin {
         "web_search"
     }
 
+    fn description(&self) -> &str {
+        "Perform web searches using Google"
+    }
+
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
@@ -47,6 +51,10 @@ impl Plugin for CalculatorPlugin {
 
     fn name(&self) -> &str {
         "calculator"
+    }
+
+    fn description(&self) -> &str {
+        "Evaluate mathematical expressions"
     }
 
     fn capabilities(&self) -> &[&str] {


### PR DESCRIPTION
## Summary
- extend `Plugin` trait with `description()`
- provide new `plugin_infos()` helper on `PluginManager`
- implement `description()` for built‑in plugins and clipboard plugin

## Testing
- `cargo test --no-run` *(fails: glib-2.0 development headers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869d09f47c88332bec2d08c367f1692