### PR TITLE
Refactor settings editor

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -148,7 +148,7 @@ impl LauncherApp {
         };
         let win_size = settings.window_size.unwrap_or((400, 220));
 
-        let settings_editor = SettingsEditor::new(&settings, &plugins);
+        let settings_editor = SettingsEditor::new(&settings);
         let plugin_editor = PluginEditor::new(&settings, &plugins);
         let app = Self {
             actions: actions.clone(),

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,56 +1,37 @@
 use crate::settings::Settings;
 use crate::gui::LauncherApp;
-use crate::plugin::PluginManager;
 use eframe::egui;
 use rfd::FileDialog;
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct SettingsEditor {
     hotkey: String,
     quit_hotkey: String,
     index_paths: Vec<String>,
-    plugin_dirs: Vec<String>,
-    enabled_plugins: Vec<String>,
-    enabled_capabilities: HashMap<String, Vec<String>>,
     index_input: String,
-    plugin_input: String,
     debug_logging: bool,
     offscreen_x: i32,
     offscreen_y: i32,
     window_w: i32,
     window_h: i32,
-    available_plugins: Vec<String>,
-    available_capabilities: HashMap<String, Vec<String>>, 
 }
 
 impl SettingsEditor {
-    pub fn new(settings: &Settings, plugins: &PluginManager) -> Self {
-        let available_plugins = plugins.plugin_names();
-        let available_capabilities = plugins
-            .plugin_capabilities()
-            .into_iter()
-            .collect::<HashMap<_, _>>();
+    pub fn new(settings: &Settings) -> Self {
         Self {
             hotkey: settings.hotkey.clone().unwrap_or_default(),
             quit_hotkey: settings.quit_hotkey.clone().unwrap_or_default(),
             index_paths: settings.index_paths.clone().unwrap_or_default(),
-            plugin_dirs: settings.plugin_dirs.clone().unwrap_or_default(),
-            enabled_plugins: settings.enabled_plugins.clone().unwrap_or_default(),
-            enabled_capabilities: settings.enabled_capabilities.clone().unwrap_or_default(),
             index_input: String::new(),
-            plugin_input: String::new(),
             debug_logging: settings.debug_logging,
             offscreen_x: settings.offscreen_pos.unwrap_or((2000, 2000)).0,
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
             window_w: settings.window_size.unwrap_or((400, 220)).0,
             window_h: settings.window_size.unwrap_or((400, 220)).1,
-            available_plugins,
-            available_capabilities,
         }
     }
 
-    fn to_settings(&self) -> Settings {
+    fn to_settings(&self, current: &Settings) -> Settings {
         Settings {
             hotkey: if self.hotkey.trim().is_empty() {
                 None
@@ -67,21 +48,9 @@ impl SettingsEditor {
             } else {
                 Some(self.index_paths.clone())
             },
-            plugin_dirs: if self.plugin_dirs.is_empty() {
-                None
-            } else {
-                Some(self.plugin_dirs.clone())
-            },
-            enabled_plugins: if self.enabled_plugins.is_empty() {
-                None
-            } else {
-                Some(self.enabled_plugins.clone())
-            },
-            enabled_capabilities: if self.enabled_capabilities.is_empty() {
-                None
-            } else {
-                Some(self.enabled_capabilities.clone())
-            },
+            plugin_dirs: current.plugin_dirs.clone(),
+            enabled_plugins: current.enabled_plugins.clone(),
+            enabled_capabilities: current.enabled_capabilities.clone(),
             debug_logging: self.debug_logging,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
@@ -151,82 +120,24 @@ impl SettingsEditor {
                 }
             });
 
-            ui.separator();
-            ui.label("Plugin directories:");
-            let mut remove_p: Option<usize> = None;
-            for (idx, path) in self.plugin_dirs.iter().enumerate() {
-                ui.horizontal(|ui| {
-                    ui.label(path);
-                    if ui.button("Remove").clicked() {
-                        remove_p = Some(idx);
-                    }
-                });
-            }
-            if let Some(i) = remove_p {
-                self.plugin_dirs.remove(i);
-            }
-            ui.horizontal(|ui| {
-                ui.text_edit_singleline(&mut self.plugin_input);
-                if ui.button("Browse").clicked() {
-                    if let Some(dir) = FileDialog::new().pick_folder() {
-                        self.plugin_input = dir.display().to_string();
-                    }
-                }
-                if ui.button("Add").clicked() {
-                    if !self.plugin_input.is_empty() {
-                        self.plugin_dirs.push(self.plugin_input.clone());
-                        self.plugin_input.clear();
-                    }
-                }
-            });
-
-            ui.separator();
-            ui.label("Enabled plugins:");
-            for name in &self.available_plugins {
-                let mut enabled = self.enabled_plugins.contains(name);
-                if ui.checkbox(&mut enabled, name).changed() {
-                    if enabled {
-                        if !self.enabled_plugins.contains(name) {
-                            self.enabled_plugins.push(name.clone());
-                        }
-                    } else if let Some(pos) = self.enabled_plugins.iter().position(|n| n == name) {
-                        self.enabled_plugins.remove(pos);
-                    }
-                }
-            }
-
-            ui.separator();
-            ui.label("Enabled capabilities:");
-            for (pname, caps) in &self.available_capabilities {
-                for cap in caps {
-                    let entry = self.enabled_capabilities.entry(pname.clone()).or_default();
-                    let mut enabled = entry.contains(cap);
-                    let label = format!("{}: {}", pname, cap);
-                    if ui.checkbox(&mut enabled, label).changed() {
-                        if enabled {
-                            if !entry.contains(cap) {
-                                entry.push(cap.clone());
-                            }
-                        } else if let Some(pos) = entry.iter().position(|c| c == cap) {
-                            entry.remove(pos);
-                        }
-                    }
-                }
-            }
-
             if ui.button("Save").clicked() {
-                let new_settings = self.to_settings();
-                if let Err(e) = new_settings.save(&app.settings_path) {
-                    app.error = Some(format!("Failed to save: {e}"));
-                } else {
-                    app.update_paths(
-                        new_settings.plugin_dirs.clone(),
-                        new_settings.index_paths.clone(),
-                        new_settings.enabled_plugins.clone(),
-                        new_settings.enabled_capabilities.clone(),
-                        new_settings.offscreen_pos,
-                    );
-                    crate::request_hotkey_restart(new_settings);
+                match Settings::load(&app.settings_path) {
+                    Ok(current) => {
+                        let new_settings = self.to_settings(&current);
+                        if let Err(e) = new_settings.save(&app.settings_path) {
+                            app.error = Some(format!("Failed to save: {e}"));
+                        } else {
+                            app.update_paths(
+                                new_settings.plugin_dirs.clone(),
+                                new_settings.index_paths.clone(),
+                                new_settings.enabled_plugins.clone(),
+                                new_settings.enabled_capabilities.clone(),
+                                new_settings.offscreen_pos,
+                            );
+                            crate::request_hotkey_restart(new_settings);
+                        }
+                    }
+                    Err(e) => app.error = Some(format!("Failed to read settings: {e}")),
                 }
             }
         });


### PR DESCRIPTION
## Summary
- remove plugin-related fields from `SettingsEditor`
- adjust creation and save logic so plugin settings persist
- update `LauncherApp` to use the new constructor

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

 