### PR TITLE
Remove duplicate Edit Plugins option

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -318,7 +318,7 @@ impl eframe::App for LauncherApp {
                         if ui.button("Edit Commands").clicked() {
                             self.show_editor = !self.show_editor;
                         }
-                        if ui.button("Plugins").clicked() {
+                        if ui.button("Edit Plugins").clicked() {
                             self.show_plugins = !self.show_plugins;
                         }
                     });
@@ -339,9 +339,6 @@ impl eframe::App for LauncherApp {
                 ui.menu_button("Settings", |ui| {
                     if ui.button("Edit Settings").clicked() {
                         self.show_settings = !self.show_settings;
-                    }
-                    if ui.button("Edit Plugins").clicked() {
-                        self.show_plugins = !self.show_plugins;
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- remove "Edit Plugins" from the Settings menu
- rename File→Commands entry from "Plugins" to "Edit Plugins"

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8998a5a48332b67f785a86319599