### PR TITLE
Fix plugin capability selection UI

### DIFF
--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -111,24 +111,27 @@ impl PluginEditor {
                                     }
                                 } else if let Some(pos) = self.enabled_plugins.iter().position(|n| n == name) {
                                     self.enabled_plugins.remove(pos);
+                                    self.enabled_capabilities.remove(name);
                                 }
                             }
                         });
                         ui.indent(name, |ui| {
-                            for cap in caps {
-                                let entry = self.enabled_capabilities.entry(name.clone()).or_default();
-                                let mut cap_enabled = entry.contains(cap);
-                                let label = format!("{}", cap);
-                                if ui.checkbox(&mut cap_enabled, label).changed() {
-                                    if cap_enabled {
-                                        if !entry.contains(cap) {
-                                            entry.push(cap.clone());
+                            ui.add_enabled_ui(enabled, |ui| {
+                                for cap in caps {
+                                    let entry = self.enabled_capabilities.entry(name.clone()).or_default();
+                                    let mut cap_enabled = entry.contains(cap);
+                                    let label = format!("{}", cap);
+                                    if ui.checkbox(&mut cap_enabled, label).changed() {
+                                        if cap_enabled {
+                                            if !entry.contains(cap) {
+                                                entry.push(cap.clone());
+                                            }
+                                        } else if let Some(pos) = entry.iter().position(|c| c == cap) {
+                                            entry.remove(pos);
                                         }
-                                    } else if let Some(pos) = entry.iter().position(|c| c == cap) {
-                                        entry.remove(pos);
                                     }
                                 }
-                            }
+                            });
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- disable capability checkboxes when their plugin is disabled
- remove stale capability selections when plugin is unchecked

## Testing
- `cargo check` *(fails: glib-2.0.pc missing)*
- `cargo test --no-run` *(fails: glib-sys build missing pkg-config)*

------
https://chatgpt.com/codex/tasks/task_e_686a8a9988388332aca0850f4478dace