### PR TITLE
Add bookmarks plugin

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -358,41 +358,52 @@ impl eframe::App for LauncherApp {
 
             if let Some(i) = launch_idx {
                 if let Some(a) = self.results.get(i) {
-                    let action_str = a.action.clone();
-                    if let Err(e) = launch_action(a) {
+                    let a = a.clone();
+                    let mut refresh = false;
+                    if let Err(e) = launch_action(&a) {
                         self.error = Some(format!("Failed: {e}"));
                     } else {
-                        let count = self.usage.entry(action_str.clone()).or_insert(0);
+                        let count = self.usage.entry(a.action.clone()).or_insert(0);
                         *count += 1;
-                        if action_str.starts_with("bookmark:add:") {
+                        if a.action.starts_with("bookmark:add:") {
                             self.query.clear();
-                            self.search();
-                        } else if action_str.starts_with("bookmark:remove:") {
-                            self.search();
+                            refresh = true;
+                        } else if a.action.starts_with("bookmark:remove:") {
+                            refresh = true;
                         }
+                    }
+                    if refresh {
+                        self.search();
                     }
                 }
             }
 
             ScrollArea::vertical().max_height(150.0).show(ui, |ui| {
+                let mut refresh = false;
                 for (idx, a) in self.results.iter().enumerate() {
                     let label = format!("{} : {}", a.label, a.desc);
-                    if ui.selectable_label(self.selected == Some(idx), label).clicked() {
-                        let action_str = a.action.clone();
-                        if let Err(e) = launch_action(a) {
+                    if ui
+                        .selectable_label(self.selected == Some(idx), label)
+                        .clicked()
+                    {
+                        let a = a.clone();
+                        if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                         } else {
-                            let count = self.usage.entry(action_str.clone()).or_insert(0);
+                            let count = self.usage.entry(a.action.clone()).or_insert(0);
                             *count += 1;
-                            if action_str.starts_with("bookmark:add:") {
+                            if a.action.starts_with("bookmark:add:") {
                                 self.query.clear();
-                                self.search();
-                            } else if action_str.starts_with("bookmark:remove:") {
-                                self.search();
+                                refresh = true;
+                            } else if a.action.starts_with("bookmark:remove:") {
+                                refresh = true;
                             }
                         }
                         self.selected = Some(idx);
                     }
+                }
+                if refresh {
+                    self.search();
                 }
             });
         });

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -358,11 +358,18 @@ impl eframe::App for LauncherApp {
 
             if let Some(i) = launch_idx {
                 if let Some(a) = self.results.get(i) {
+                    let action_str = a.action.clone();
                     if let Err(e) = launch_action(a) {
                         self.error = Some(format!("Failed: {e}"));
                     } else {
-                        let count = self.usage.entry(a.action.clone()).or_insert(0);
+                        let count = self.usage.entry(action_str.clone()).or_insert(0);
                         *count += 1;
+                        if action_str.starts_with("bookmark:add:") {
+                            self.query.clear();
+                            self.search();
+                        } else if action_str.starts_with("bookmark:remove:") {
+                            self.search();
+                        }
                     }
                 }
             }
@@ -371,11 +378,18 @@ impl eframe::App for LauncherApp {
                 for (idx, a) in self.results.iter().enumerate() {
                     let label = format!("{} : {}", a.label, a.desc);
                     if ui.selectable_label(self.selected == Some(idx), label).clicked() {
+                        let action_str = a.action.clone();
                         if let Err(e) = launch_action(a) {
                             self.error = Some(format!("Failed: {e}"));
                         } else {
-                            let count = self.usage.entry(a.action.clone()).or_insert(0);
+                            let count = self.usage.entry(action_str.clone()).or_insert(0);
                             *count += 1;
+                            if action_str.starts_with("bookmark:add:") {
+                                self.query.clear();
+                                self.search();
+                            } else if action_str.starts_with("bookmark:remove:") {
+                                self.search();
+                            }
                         }
                         self.selected = Some(idx);
                     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,5 +1,5 @@
 use crate::actions::Action;
-use crate::plugins::bookmarks::append_bookmark;
+use crate::plugins::bookmarks::{append_bookmark, remove_bookmark};
 use arboard::Clipboard;
 use std::path::Path;
 
@@ -26,6 +26,10 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     }
     if let Some(url) = action.action.strip_prefix("bookmark:add:") {
         append_bookmark("bookmarks.json", url)?;
+        return Ok(());
+    }
+    if let Some(url) = action.action.strip_prefix("bookmark:remove:") {
+        remove_bookmark("bookmarks.json", url)?;
         return Ok(());
     }
     let path = Path::new(&action.action);

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,4 +1,5 @@
 use crate::actions::Action;
+use crate::plugins::bookmarks::append_bookmark;
 use arboard::Clipboard;
 use std::path::Path;
 
@@ -21,6 +22,10 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     if let Some(text) = action.action.strip_prefix("clipboard:") {
         let mut cb = Clipboard::new()?;
         cb.set_text(text.to_string())?;
+        return Ok(());
+    }
+    if let Some(url) = action.action.strip_prefix("bookmark:add:") {
+        append_bookmark("bookmarks.json", url)?;
         return Ok(());
     }
     let path = Path::new(&action.action);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -42,7 +42,7 @@ impl PluginManager {
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
-        self.register(Box::new(crate::plugins::bookmarks::BookmarksPlugin::default()));
+        self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(ShellPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,6 +3,7 @@ use libloading::Library;
 use crate::plugins_builtin::{WebSearchPlugin, CalculatorPlugin};
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::shell::ShellPlugin;
+use crate::plugins::bookmarks::BookmarksPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -41,6 +42,7 @@ impl PluginManager {
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
+        self.register(Box::new(crate::plugins::bookmarks::BookmarksPlugin::default()));
         self.register(Box::new(ShellPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -15,6 +15,19 @@ impl BookmarksPlugin {
     }
 }
 
+fn normalize_url(url: &str) -> String {
+    let mut out = url.trim().to_string();
+    if out.starts_with("http://") {
+        out = out.replacen("http://", "https://", 1);
+    } else if !out.starts_with("https://") {
+        out = format!("https://{out}");
+    }
+    if !out.contains("://www.") {
+        out = out.replacen("://", "://www.", 1);
+    }
+    out
+}
+
 pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<String>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.is_empty() {
@@ -32,8 +45,9 @@ pub fn save_bookmarks(path: &str, bookmarks: &[String]) -> anyhow::Result<()> {
 
 pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     let mut list = load_bookmarks(path).unwrap_or_default();
-    if !list.contains(&url.to_string()) {
-        list.push(url.to_string());
+    let fixed = normalize_url(url);
+    if !list.contains(&fixed) {
+        list.push(fixed);
         save_bookmarks(path, &list)?;
     }
     Ok(())
@@ -41,7 +55,8 @@ pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
 
 pub fn remove_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     let mut list = load_bookmarks(path).unwrap_or_default();
-    if let Some(pos) = list.iter().position(|u| u == url) {
+    let fixed = normalize_url(url);
+    if let Some(pos) = list.iter().position(|u| u == &fixed) {
         list.remove(pos);
         save_bookmarks(path, &list)?;
     }
@@ -59,10 +74,11 @@ impl Plugin for BookmarksPlugin {
         if let Some(url) = query.strip_prefix("bm add ") {
             let url = url.trim();
             if !url.is_empty() {
+                let norm = normalize_url(url);
                 return vec![Action {
-                    label: format!("Add bookmark {url}"),
+                    label: format!("Add bookmark {norm}"),
                     desc: "Bookmark".into(),
-                    action: format!("bookmark:add:{url}"),
+                    action: format!("bookmark:add:{norm}"),
                 }];
             }
         }

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -1,0 +1,66 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+#[derive(Default)]
+pub struct BookmarksPlugin {
+    bookmarks: Vec<String>,
+}
+
+impl BookmarksPlugin {
+    pub fn new(bookmarks: Vec<String>) -> Self {
+        Self { bookmarks }
+    }
+}
+
+pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<String>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<String> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_bookmarks(path: &str, bookmarks: &[String]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(bookmarks)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+impl Default for BookmarksPlugin {
+    fn default() -> Self {
+        let bookmarks = load_bookmarks("bookmarks.json").unwrap_or_default();
+        Self { bookmarks }
+    }
+}
+
+impl Plugin for BookmarksPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if !query.starts_with("bm") {
+            return Vec::new();
+        }
+        let filter = query.strip_prefix("bm").unwrap_or("").trim();
+        self.bookmarks
+            .iter()
+            .filter(|url| url.contains(filter))
+            .map(|url| Action {
+                label: url.clone(),
+                desc: "Bookmark".into(),
+                action: url.clone(),
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "bookmarks"
+    }
+
+    fn description(&self) -> &str {
+        "Return bookmarked URLs"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,2 +1,3 @@
 pub mod clipboard;
 pub mod shell;
+pub mod bookmarks;


### PR DESCRIPTION
## Summary
- add a new `bookmarks` plugin
- support storing bookmark URLs with load/save helpers
- expose the module and register plugin in `PluginManager`

## Testing
- `cargo test --quiet` *(fails: glib-2.0 missing)*
