### PR TITLE
Bookmark focus fix

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -335,7 +335,7 @@ impl eframe::App for LauncherApp {
                 ui.colored_label(Color32::RED, err);
             }
 
-            let input = ui.text_edit_singleline(&mut self.query);
+            let input = ui.add(egui::TextEdit::singleline(&mut self.query).id_source("search_input"));
             if just_became_visible {
                 input.request_focus();
             }
@@ -371,6 +371,13 @@ impl eframe::App for LauncherApp {
                         } else if a.action.starts_with("bookmark:remove:") {
                             refresh = true;
                         }
+                        if a.action.starts_with("bookmark:add:")
+                            || a.action.starts_with("bookmark:remove:")
+                        {
+                            ui.ctx().memory_mut(|m| {
+                                m.request_focus(egui::Id::new("search_input"))
+                            });
+                        }
                     }
                     if refresh {
                         self.search();
@@ -397,6 +404,13 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                             } else if a.action.starts_with("bookmark:remove:") {
                                 refresh = true;
+                            }
+                            if a.action.starts_with("bookmark:add:")
+                                || a.action.starts_with("bookmark:remove:")
+                            {
+                                ui.ctx().memory_mut(|m| {
+                                    m.request_focus(egui::Id::new("search_input"))
+                                });
                             }
                         }
                         self.selected = Some(idx);


### PR DESCRIPTION
## Summary
- focus the search input field after adding or removing a bookmark
- assign a stable widget id to the search box so focus can be restored

## Testing
- `cargo test` *(fails: glib-sys build command failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ad9a1b4948332803117f2f4ed61ce