### PR TITLE
Add RuneScape wiki search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "quit_hotkey": "Shift+Escape",
   "index_paths": ["/usr/share/applications"],
   "plugin_dirs": ["./plugins"],
-  "enabled_plugins": ["web_search", "calculator", "clipboard", "shell"],
+  "enabled_plugins": ["web_search", "calculator", "clipboard", "shell", "runescape_search"],
   "debug_logging": false,
   "offscreen_pos": [2000, 2000],
   "window_size": [400, 220]
@@ -83,7 +83,7 @@ running.
 
 ## Plugins
 
-Built-in plugins provide Google web search (`g query`), an inline calculator
+Built-in plugins provide Google web search (`g query`), RuneScape wiki search (`rs query` or `osrs query`), an inline calculator
 (using the `=` prefix), a clipboard history (`cb`) and a shell command runner (`sh <command>`). Selecting a clipboard entry copies it back to the clipboard. Additional plugins can be added by building
 shared libraries. Each plugin crate should be compiled as a `cdylib` and export
 a `create_plugin` function returning `Box<dyn Plugin>`:
@@ -105,7 +105,7 @@ Example:
 
 ```json
 {
-  "enabled_plugins": ["web_search", "calculator", "clipboard", "shell"]
+  "enabled_plugins": ["web_search", "calculator", "clipboard", "shell", "runescape_search"]
 }
 ```
 ### Security Considerations

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,6 +4,7 @@ use crate::plugins_builtin::{WebSearchPlugin, CalculatorPlugin};
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
+use crate::plugins::runescape::RunescapeSearchPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -41,6 +42,7 @@ impl PluginManager {
         self.clear_plugins();
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
+        self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(ShellPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,3 +1,4 @@
 pub mod clipboard;
 pub mod shell;
 pub mod bookmarks;
+pub mod runescape;

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -1,0 +1,43 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct RunescapeSearchPlugin;
+
+impl Plugin for RunescapeSearchPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(q) = query.strip_prefix("rs ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Search RuneScape Wiki for {q}"),
+                    desc: "Web search".into(),
+                    action: format!("https://runescape.wiki/?search={q}"),
+                }];
+            }
+        }
+        if let Some(q) = query.strip_prefix("osrs ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Search Old School RuneScape Wiki for {q}"),
+                    desc: "Web search".into(),
+                    action: format!("https://oldschool.runescape.wiki/?search={q}"),
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "runescape_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the RuneScape and Old School RuneScape wikis"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `RunescapeSearchPlugin` for quick RuneScape wiki searches
- expose `runescape` module
- register the plugin among built‑ins
- document the plugin and list it in enabled plugins examples

## Testing
- `cargo test` *(fails: could not find system library `glib-2.0`)*
 