### PR TITLE
Add calc prefix to actions

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -24,6 +24,11 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         cb.set_text(text.to_string())?;
         return Ok(());
     }
+    if let Some(value) = action.action.strip_prefix("calc:") {
+        let mut cb = Clipboard::new()?;
+        cb.set_text(value.to_string())?;
+        return Ok(());
+    }
     if let Some(url) = action.action.strip_prefix("bookmark:add:") {
         append_bookmark("bookmarks.json", url)?;
         return Ok(());

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -40,7 +40,7 @@ impl Plugin for CalculatorPlugin {
                 Ok(v) => vec![Action {
                     label: format!("{} = {}", expr, v),
                     desc: "Calculator".into(),
-                    action: format!("{}", v),
+                    action: format!("calc:{}", v),
                 }],
                 Err(_) => Vec::new(),
             }


### PR DESCRIPTION
## Summary
- update calculator plugin to return `calc:` actions
- copy values with the `calc:` prefix to clipboard

## Testing
- `cargo test` *(fails: glib-2.0 required)*

 