### PR TITLE
Add history module

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,62 @@
+use crate::actions::Action;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct HistoryEntry {
+    pub query: String,
+    pub action: Action,
+}
+
+const HISTORY_FILE: &str = "history.json";
+
+static HISTORY: Lazy<Mutex<VecDeque<HistoryEntry>>> = Lazy::new(|| {
+    let hist = load_history_internal().unwrap_or_default();
+    Mutex::new(hist)
+});
+
+fn load_history_internal() -> anyhow::Result<VecDeque<HistoryEntry>> {
+    let content = std::fs::read_to_string(HISTORY_FILE).unwrap_or_default();
+    if content.is_empty() {
+        return Ok(VecDeque::new());
+    }
+    let list: Vec<HistoryEntry> = serde_json::from_str(&content)?;
+    Ok(list.into())
+}
+
+/// Load history from `history.json` into the global HISTORY list.
+pub fn load_history() -> anyhow::Result<()> {
+    let hist = load_history_internal()?;
+    let mut h = HISTORY.lock().unwrap();
+    *h = hist;
+    Ok(())
+}
+
+/// Save the current HISTORY list to `history.json`.
+pub fn save_history() -> anyhow::Result<()> {
+    let h = HISTORY.lock().unwrap();
+    let list: Vec<HistoryEntry> = h.iter().cloned().collect();
+    let json = serde_json::to_string_pretty(&list)?;
+    std::fs::write(HISTORY_FILE, json)?;
+    Ok(())
+}
+
+/// Append an entry to the history and persist the list.
+pub fn append_history(entry: HistoryEntry) -> anyhow::Result<()> {
+    {
+        let mut h = HISTORY.lock().unwrap();
+        h.push_front(entry);
+        while h.len() > 100 {
+            h.pop_back();
+        }
+    }
+    save_history()
+}
+
+/// Return a clone of the current history list.
+pub fn get_history() -> VecDeque<HistoryEntry> {
+    HISTORY.lock().unwrap().clone()
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod plugins;
 pub mod indexer;
 pub mod logging;
 pub mod hotkey;
+pub mod history;
 pub mod visibility;
 
 pub mod window_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod settings_editor;
 mod plugin_editor;
 mod gui;
 mod hotkey;
+mod history;
 mod launcher;
 mod plugin;
 mod plugins_builtin;


### PR DESCRIPTION
## Summary
- add a new `history` module with a persistent `HistoryEntry` list
- export the module from `lib.rs` and `main.rs`

## Testing
- `cargo test` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aed8b901c8332b02820bff5531180