### PR TITLE
Add HistoryPlugin

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -5,6 +5,7 @@ use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
 use crate::plugins::runescape::RunescapeSearchPlugin;
+use crate::plugins::history::HistoryPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -46,6 +47,7 @@ impl PluginManager {
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(ShellPlugin));
+        self.register(Box::new(HistoryPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");
             let _ = self.load_dir(dir);

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -1,0 +1,36 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use crate::history::get_history;
+
+pub struct HistoryPlugin;
+
+impl Plugin for HistoryPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if !query.starts_with("hi") {
+            return Vec::new();
+        }
+        let filter = query.strip_prefix("hi").unwrap_or("").trim();
+        get_history()
+            .into_iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.query.contains(filter))
+            .map(|(idx, entry)| Action {
+                label: entry.query,
+                desc: "History".into(),
+                action: format!("history:{idx}"),
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "history"
+    }
+
+    fn description(&self) -> &str {
+        "Search previously executed queries"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -2,3 +2,4 @@ pub mod clipboard;
 pub mod shell;
 pub mod bookmarks;
 pub mod runescape;
+pub mod history;


### PR DESCRIPTION
## Summary
- implement a new history plugin
- export the plugin from the `plugins` module
- register the history plugin in `PluginManager`

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_686aeef51e788332b7b7f0be9cc281fc