### PR TITLE
Add egui toast notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,15 +1014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecolor"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
-dependencies = [
- "emath 0.31.1",
-]
-
-[[package]]
 name = "eframe"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,7 +1022,7 @@ dependencies = [
  "bytemuck",
  "cocoa",
  "document-features",
- "egui 0.27.2",
+ "egui",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
@@ -1064,32 +1055,18 @@ checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
 dependencies = [
  "accesskit",
  "ahash",
- "epaint 0.27.2",
+ "epaint",
  "log",
  "nohash-hasher",
 ]
 
 [[package]]
-name = "egui"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
-dependencies = [
- "ahash",
- "bitflags 2.9.1",
- "emath 0.31.1",
- "epaint 0.31.1",
- "nohash-hasher",
- "profiling",
-]
-
-[[package]]
 name = "egui-toast"
-version = "0.17.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366a31eb8c905835c85a36baff26d7a003a9fd6631a04b1f15f42d9cb20d11ad"
+checksum = "d35b823ed2488732e085cb1abd1144f23f9546e5c89f4492047c123d27a1a826"
 dependencies = [
- "egui 0.31.1",
+ "egui",
 ]
 
 [[package]]
@@ -1100,8 +1077,8 @@ checksum = "469ff65843f88a702b731a1532b7d03b0e8e96d283e70f3a22b0e06c46cb9b37"
 dependencies = [
  "bytemuck",
  "document-features",
- "egui 0.27.2",
- "epaint 0.27.2",
+ "egui",
+ "epaint",
  "log",
  "thiserror",
  "type-map",
@@ -1118,7 +1095,7 @@ checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
 dependencies = [
  "accesskit_winit",
  "arboard",
- "egui 0.27.2",
+ "egui",
  "log",
  "raw-window-handle 0.6.2",
  "smithay-clipboard",
@@ -1134,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
 dependencies = [
  "bytemuck",
- "egui 0.27.2",
+ "egui",
  "glow",
  "log",
  "memoffset 0.9.1",
@@ -1151,12 +1128,6 @@ checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "emath"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 
 [[package]]
 name = "enumflags2"
@@ -1188,26 +1159,11 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor 0.27.2",
- "emath 0.27.2",
+ "ecolor",
+ "emath",
  "log",
  "nohash-hasher",
  "parking_lot",
-]
-
-[[package]]
-name = "epaint"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
-dependencies = [
- "ab_glyph",
- "ahash",
- "ecolor 0.31.1",
- "emath 0.31.1",
- "nohash-hasher",
- "parking_lot",
- "profiling",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecolor"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+dependencies = [
+ "emath 0.31.1",
+]
+
+[[package]]
 name = "eframe"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1031,7 @@ dependencies = [
  "bytemuck",
  "cocoa",
  "document-features",
- "egui",
+ "egui 0.27.2",
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
@@ -1055,9 +1064,32 @@ checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
 dependencies = [
  "accesskit",
  "ahash",
- "epaint",
+ "epaint 0.27.2",
  "log",
  "nohash-hasher",
+]
+
+[[package]]
+name = "egui"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+dependencies = [
+ "ahash",
+ "bitflags 2.9.1",
+ "emath 0.31.1",
+ "epaint 0.31.1",
+ "nohash-hasher",
+ "profiling",
+]
+
+[[package]]
+name = "egui-toast"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366a31eb8c905835c85a36baff26d7a003a9fd6631a04b1f15f42d9cb20d11ad"
+dependencies = [
+ "egui 0.31.1",
 ]
 
 [[package]]
@@ -1068,8 +1100,8 @@ checksum = "469ff65843f88a702b731a1532b7d03b0e8e96d283e70f3a22b0e06c46cb9b37"
 dependencies = [
  "bytemuck",
  "document-features",
- "egui",
- "epaint",
+ "egui 0.27.2",
+ "epaint 0.27.2",
  "log",
  "thiserror",
  "type-map",
@@ -1086,7 +1118,7 @@ checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
 dependencies = [
  "accesskit_winit",
  "arboard",
- "egui",
+ "egui 0.27.2",
  "log",
  "raw-window-handle 0.6.2",
  "smithay-clipboard",
@@ -1102,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
 dependencies = [
  "bytemuck",
- "egui",
+ "egui 0.27.2",
  "glow",
  "log",
  "memoffset 0.9.1",
@@ -1119,6 +1151,12 @@ checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "emath"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 
 [[package]]
 name = "enumflags2"
@@ -1150,11 +1188,26 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor",
- "emath",
+ "ecolor 0.27.2",
+ "emath 0.27.2",
  "log",
  "nohash-hasher",
  "parking_lot",
+]
+
+[[package]]
+name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "ecolor 0.31.1",
+ "emath 0.31.1",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
 ]
 
 [[package]]
@@ -2269,6 +2322,7 @@ dependencies = [
  "arboard",
  "core-graphics",
  "eframe",
+ "egui-toast",
  "fuzzy-matcher",
  "libloading 0.8.8",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Wi
 log = "0.4"
 raw-window-handle = "0.6"
 arboard = "3"
-egui-toast = "0.17"
+egui-toast = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Wi
 log = "0.4"
 raw-window-handle = "0.6"
 arboard = "3"
+egui-toast = "0.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/settings.json
+++ b/settings.json
@@ -3,5 +3,6 @@
     "quit_hotkey": "Shift+Escape",
     "index_paths": null,
     "plugin_dirs": null,
-    "debug_logging": false
+    "debug_logging": false,
+    "enable_toasts": true
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -94,7 +94,7 @@ impl LauncherApp {
     ) -> Self {
         let (tx, rx) = channel();
         let mut watchers = Vec::new();
-        let mut toasts = Toasts::new().anchor(egui::Align2::RIGHT_TOP, [10.0, 10.0]);
+        let toasts = Toasts::new().anchor(egui::Align2::RIGHT_TOP, [10.0, 10.0]);
         let enable_toasts = settings.enable_toasts;
 
         if let Ok(mut watcher) = RecommendedWatcher::new(
@@ -382,17 +382,19 @@ impl eframe::App for LauncherApp {
                     if let Err(e) = launch_action(&a) {
                         self.error = Some(format!("Failed: {e}"));
                         if self.enable_toasts {
-                            self.toasts.add(Toast::new()
-                                .kind(ToastKind::Error)
-                                .text(format!("Failed: {e}"))
-                                .options(ToastOptions::default().duration_in_seconds(3.0)));
+                            self.toasts.add(Toast {
+                                text: format!("Failed: {e}").into(),
+                                kind: ToastKind::Error,
+                                options: ToastOptions::default().duration_in_seconds(3.0),
+                            });
                         }
                     } else {
                         if self.enable_toasts {
-                            self.toasts.add(Toast::new()
-                                .kind(ToastKind::Success)
-                                .text(format!("Launched {}", a.label))
-                                .options(ToastOptions::default().duration_in_seconds(3.0)));
+                            self.toasts.add(Toast {
+                                text: format!("Launched {}", a.label).into(),
+                                kind: ToastKind::Success,
+                                options: ToastOptions::default().duration_in_seconds(3.0),
+                            });
                         }
                         let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
                         let count = self.usage.entry(a.action.clone()).or_insert(0);
@@ -427,17 +429,19 @@ impl eframe::App for LauncherApp {
                         if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             if self.enable_toasts {
-                                self.toasts.add(Toast::new()
-                                    .kind(ToastKind::Error)
-                                    .text(format!("Failed: {e}"))
-                                    .options(ToastOptions::default().duration_in_seconds(3.0)));
+                                self.toasts.add(Toast {
+                                    text: format!("Failed: {e}").into(),
+                                    kind: ToastKind::Error,
+                                    options: ToastOptions::default().duration_in_seconds(3.0),
+                                });
                             }
                         } else {
                             if self.enable_toasts {
-                                self.toasts.add(Toast::new()
-                                    .kind(ToastKind::Success)
-                                    .text(format!("Launched {}", a.label))
-                                    .options(ToastOptions::default().duration_in_seconds(3.0)));
+                                self.toasts.add(Toast {
+                                    text: format!("Launched {}", a.label).into(),
+                                    kind: ToastKind::Success,
+                                    options: ToastOptions::default().duration_in_seconds(3.0),
+                                });
                             }
                             let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
                             let count = self.usage.entry(a.action.clone()).or_insert(0);

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -65,6 +65,7 @@ impl PluginEditor {
                         s.enabled_plugins.clone(),
                         s.enabled_capabilities.clone(),
                         s.offscreen_pos,
+                        Some(s.enable_toasts),
                     );
 
                     app.plugins.reload_from_dirs(&self.plugin_dirs);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -25,7 +25,12 @@ pub struct Settings {
     /// Last known window size. If absent, a default size is used.
     #[serde(default)]
     pub window_size: Option<(i32, i32)>,
+    /// Enable toast notifications in the UI.
+    #[serde(default = "default_toasts")] 
+    pub enable_toasts: bool,
 }
+
+fn default_toasts() -> bool { true }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -39,6 +44,7 @@ impl Default for Settings {
             debug_logging: false,
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),
+            enable_toasts: true,
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -10,6 +10,7 @@ pub struct SettingsEditor {
     index_paths: Vec<String>,
     index_input: String,
     debug_logging: bool,
+    show_toasts: bool,
     offscreen_x: i32,
     offscreen_y: i32,
     window_w: i32,
@@ -24,6 +25,7 @@ impl SettingsEditor {
             index_paths: settings.index_paths.clone().unwrap_or_default(),
             index_input: String::new(),
             debug_logging: settings.debug_logging,
+            show_toasts: settings.enable_toasts,
             offscreen_x: settings.offscreen_pos.unwrap_or((2000, 2000)).0,
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
             window_w: settings.window_size.unwrap_or((400, 220)).0,
@@ -52,6 +54,7 @@ impl SettingsEditor {
             enabled_plugins: current.enabled_plugins.clone(),
             enabled_capabilities: current.enabled_capabilities.clone(),
             debug_logging: self.debug_logging,
+            enable_toasts: self.show_toasts,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
         }
@@ -83,6 +86,8 @@ impl SettingsEditor {
                         ui.selectable_value(&mut self.debug_logging, true, "Enabled");
                     });
             });
+
+            ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
 
             ui.horizontal(|ui| {
                 ui.label("Off-screen X");
@@ -133,6 +138,7 @@ impl SettingsEditor {
                                 new_settings.enabled_plugins.clone(),
                                 new_settings.enabled_capabilities.clone(),
                                 new_settings.offscreen_pos,
+                                Some(new_settings.enable_toasts),
                             );
                             crate::request_hotkey_restart(new_settings);
                         }


### PR DESCRIPTION
## Summary
- add `egui-toast` dependency
- implement toast notifications and option to disable them
- keep selected command visible within results list
- scroll results list using available height

## Testing
- `cargo test` *(fails: glib-2.0 missing)*
 