### PR TITLE
Add folders plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2298,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "core-graphics",
+ "dirs-next",
  "eframe",
  "egui-toast",
  "fuzzy-matcher",
@@ -2940,6 +2962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4"
 raw-window-handle = "0.6"
 arboard = "3"
 egui-toast = "0.13"
+dirs-next = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.21"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ running.
 ## Plugins
 
 Built-in plugins provide Google web search (`g query`), RuneScape wiki search (`rs query` or `osrs query`), an inline calculator
-(using the `=` prefix), a clipboard history (`cb`) and a shell command runner (`sh <command>`). Selecting a clipboard entry copies it back to the clipboard. Additional plugins can be added by building
+(using the `=` prefix), a clipboard history (`cb`), a folder shortcut list (`f`) and a shell command runner (`sh <command>`). Selecting a clipboard entry copies it back to the clipboard. Additional plugins can be added by building
 shared libraries. Each plugin crate should be compiled as a `cdylib` and export
 a `create_plugin` function returning `Box<dyn Plugin>`:
 
@@ -108,6 +108,8 @@ Example:
   "enabled_plugins": ["web_search", "calculator", "clipboard", "shell", "runescape_search"]
 }
 ```
+The folders plugin recognises the `f` prefix. Use `f add <path>` to add a folder
+shortcut and `f rm <pattern>` to remove one via fuzzy search.
 ### Security Considerations
 The shell plugin runs commands using the system shell without sanitising input. Only enable it if you trust the commands you type. Errors while spawning the process are logged.
 ## Editing Commands

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,5 +1,6 @@
 use crate::actions::Action;
 use crate::plugins::bookmarks::{append_bookmark, remove_bookmark};
+use crate::plugins::folders::{append_folder, remove_folder, FOLDERS_FILE};
 use crate::history;
 use arboard::Clipboard;
 use std::path::Path;
@@ -36,6 +37,14 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     }
     if let Some(url) = action.action.strip_prefix("bookmark:remove:") {
         remove_bookmark("bookmarks.json", url)?;
+        return Ok(());
+    }
+    if let Some(path) = action.action.strip_prefix("folder:add:") {
+        append_folder(FOLDERS_FILE, path)?;
+        return Ok(());
+    }
+    if let Some(path) = action.action.strip_prefix("folder:remove:") {
+        remove_folder(FOLDERS_FILE, path)?;
         return Ok(());
     }
     if let Some(idx) = action.action.strip_prefix("history:") {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,6 +6,7 @@ use crate::plugins::shell::ShellPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
 use crate::plugins::runescape::RunescapeSearchPlugin;
 use crate::plugins::history::HistoryPlugin;
+use crate::plugins::folders::FoldersPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -46,6 +47,7 @@ impl PluginManager {
         self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
+        self.register(Box::new(FoldersPlugin::default()));
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         for dir in dirs {

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -1,0 +1,145 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+
+pub const FOLDERS_FILE: &str = "folders.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FolderEntry {
+    pub label: String,
+    pub path: String,
+}
+
+pub fn default_folders() -> Vec<FolderEntry> {
+    let mut out = Vec::new();
+    if let Some(p) = dirs_next::home_dir() {
+        out.push(FolderEntry { label: "Home".into(), path: p.to_string_lossy().into() });
+    }
+    if let Some(p) = dirs_next::download_dir() {
+        out.push(FolderEntry { label: "Downloads".into(), path: p.to_string_lossy().into() });
+    }
+    if let Some(p) = dirs_next::desktop_dir() {
+        out.push(FolderEntry { label: "Desktop".into(), path: p.to_string_lossy().into() });
+    }
+    if let Some(p) = dirs_next::document_dir() {
+        out.push(FolderEntry { label: "Documents".into(), path: p.to_string_lossy().into() });
+    }
+    out
+}
+
+pub fn load_folders(path: &str) -> anyhow::Result<Vec<FolderEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.is_empty() {
+        return Ok(default_folders());
+    }
+    let list: Vec<FolderEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_folders(path: &str, folders: &[FolderEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(folders)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn append_folder(path: &str, folder: &str) -> anyhow::Result<()> {
+    let mut list = load_folders(path).unwrap_or_else(|_| default_folders());
+    if !list.iter().any(|f| f.path == folder) {
+        let label = std::path::Path::new(folder)
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| folder.to_string());
+        list.push(FolderEntry { label, path: folder.to_string() });
+        save_folders(path, &list)?;
+    }
+    Ok(())
+}
+
+pub fn remove_folder(path: &str, folder: &str) -> anyhow::Result<()> {
+    let mut list = load_folders(path).unwrap_or_else(|_| default_folders());
+    if let Some(pos) = list.iter().position(|f| f.path == folder) {
+        list.remove(pos);
+        save_folders(path, &list)?;
+    }
+    Ok(())
+}
+
+pub struct FoldersPlugin {
+    matcher: SkimMatcherV2,
+}
+
+impl FoldersPlugin {
+    pub fn new() -> Self {
+        Self { matcher: SkimMatcherV2::default() }
+    }
+}
+
+impl Default for FoldersPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for FoldersPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(path) = query.strip_prefix("f add ") {
+            let path = path.trim();
+            if !path.is_empty() {
+                return vec![Action {
+                    label: format!("Add folder {path}"),
+                    desc: "Folder".into(),
+                    action: format!("folder:add:{path}"),
+                }];
+            }
+        }
+
+        if let Some(pattern) = query.strip_prefix("f rm ") {
+            let filter = pattern.trim();
+            let folders = load_folders(FOLDERS_FILE).unwrap_or_else(|_| default_folders());
+            return folders
+                .into_iter()
+                .filter(|f| {
+                    self.matcher.fuzzy_match(&f.label, filter).is_some()
+                        || self.matcher.fuzzy_match(&f.path, filter).is_some()
+                })
+                .map(|f| Action {
+                    label: format!("Remove folder {} ({})", f.label, f.path),
+                    desc: "Folder".into(),
+                    action: format!("folder:remove:{}", f.path),
+                })
+                .collect();
+        }
+
+        if !query.starts_with("f") {
+            return Vec::new();
+        }
+        let filter = query.strip_prefix("f").unwrap_or("").trim();
+        let folders = load_folders(FOLDERS_FILE).unwrap_or_else(|_| default_folders());
+        folders
+            .into_iter()
+            .filter(|f| {
+                self.matcher.fuzzy_match(&f.label, filter).is_some()
+                    || self.matcher.fuzzy_match(&f.path, filter).is_some()
+            })
+            .map(|f| Action {
+                label: f.label.clone(),
+                desc: "Folder".into(),
+                action: f.path,
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "folders"
+    }
+
+    fn description(&self) -> &str {
+        "Search and manage favourite folders"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -3,3 +3,4 @@ pub mod shell;
 pub mod bookmarks;
 pub mod runescape;
 pub mod history;
+pub mod folders;


### PR DESCRIPTION
## Summary
- add `dirs-next` dependency
- implement `FoldersPlugin` for favourite folders and searching with `f` prefix
- register the plugin in the manager and handle add/remove folder actions
- document folder shortcuts in README

## Testing
- `cargo check` *(fails: `glib-sys` missing `glib-2.0`)*

------
https://chatgpt.com/codex/tasks/task_e_686b03ae5a948332b3805acf5c5b4172