### PR TITLE
Fix bookmarks normalization

### DIFF
--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -22,8 +22,16 @@ fn normalize_url(url: &str) -> String {
     } else if !out.starts_with("https://") {
         out = format!("https://{out}");
     }
-    if !out.contains("://www.") {
-        out = out.replacen("://", "://www.", 1);
+    if let Some(rest) = out.strip_prefix("https://") {
+        let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+        if !host.starts_with("www.") && !host.contains('.') {
+            let host = format!("www.{host}");
+            out = if path.is_empty() {
+                format!("https://{host}")
+            } else {
+                format!("https://{host}/{path}")
+            };
+        }
     }
     out
 }


### PR DESCRIPTION
## Summary
- fix bookmark url normalization to only add `www.` when the host has no dots

## Testing
- `cargo test` *(fails: glib library missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b1007e69c833295dc077db41f2971