### PR TITLE
Add windows subsystem attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ changes are written to `actions.json` immediately.
 The project can be compiled for Windows using `cargo build --release`.
 Afterwards bundle the binary for distribution using a Windows packaging tool
 such as `cargo wix`.
+When compiled this way the executable is built with `windows_subsystem = "windows"`, which prevents an extra console window from appearing.
 
 ## Troubleshooting
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 mod actions;
 mod actions_editor;
 mod add_action_dialog;


### PR DESCRIPTION
## Summary
- ensure no console window on Windows
- document the behaviour in README

## Testing
- `cargo build --target x86_64-pc-windows-gnu` *(fails: target not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bb38c0dbc833294802a6986402f42