### PR TITLE
Remove unused Force Hide menu item

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -313,11 +313,6 @@ impl eframe::App for LauncherApp {
                             self.show_plugins = !self.show_plugins;
                         }
                     });
-                    if ui.button("Force Hide").clicked() {
-                        apply_visibility(false, ctx, self.offscreen_pos);
-                        self.visible_flag.store(false, Ordering::SeqCst);
-                        self.last_visible = false;
-                    }
                     if ui.button("Close Application").clicked() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         self.unregister_all_hotkeys();


### PR DESCRIPTION
## Summary
- remove the "Force Hide" menu button and its handling logic

## Testing
- `cargo test` *(fails: missing system libraries for the `x11` crate)*

------
https://chatgpt.com/codex/tasks/task_e_686bb89403688332846b8e2ce7bff970