### PR TITLE
Update plugin descriptions

### DIFF
--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -126,7 +126,7 @@ impl Plugin for BookmarksPlugin {
     }
 
     fn description(&self) -> &str {
-        "Return bookmarked URLs"
+        "Return bookmarked URLs (prefix: `bm`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -72,7 +72,7 @@ impl Plugin for ClipboardPlugin {
     }
 
     fn description(&self) -> &str {
-        "Provides clipboard history search"
+        "Provides clipboard history search (prefix: `cb`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -160,7 +160,7 @@ impl Plugin for FoldersPlugin {
     }
 
     fn description(&self) -> &str {
-        "Search and manage favourite folders"
+        "Search and manage favourite folders (prefix: `f`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -30,7 +30,7 @@ impl Plugin for HistoryPlugin {
     }
 
     fn description(&self) -> &str {
-        "Search previously executed queries"
+        "Search previously executed queries (prefix: `hi`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -33,7 +33,7 @@ impl Plugin for RunescapeSearchPlugin {
     }
 
     fn description(&self) -> &str {
-        "Search the RuneScape and Old School RuneScape wikis"
+        "Search the RuneScape and Old School RuneScape wikis (prefix: `rs`/`osrs`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -22,7 +22,7 @@ impl Plugin for ShellPlugin {
     }
 
     fn description(&self) -> &str {
-        "Run arbitrary shell commands"
+        "Run arbitrary shell commands (prefix: `sh`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins/system.rs
+++ b/src/plugins/system.rs
@@ -26,7 +26,7 @@ impl Plugin for SystemPlugin {
     }
 
     fn description(&self) -> &str {
-        "Execute system actions like shutdown or reboot"
+        "Execute system actions like shutdown or reboot (prefix: `sys`)"
     }
 
     fn capabilities(&self) -> &[&str] {

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -22,7 +22,7 @@ impl Plugin for WebSearchPlugin {
     }
 
     fn description(&self) -> &str {
-        "Perform web searches using Google"
+        "Perform web searches using Google (prefix: `g`)"
     }
 
     fn capabilities(&self) -> &[&str] {
@@ -54,7 +54,7 @@ impl Plugin for CalculatorPlugin {
     }
 
     fn description(&self) -> &str {
-        "Evaluate mathematical expressions"
+        "Evaluate mathematical expressions (prefix: `=`)"
     }
 
     fn capabilities(&self) -> &[&str] {


### PR DESCRIPTION
## Summary
- clarify web search and calculator plugin descriptions
- describe prefixes for built-in plugins

## Testing
- `cargo test` *(fails: could not compile due to missing `rdev` crate)*
 