### PR TITLE
Add UI scale setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ off-screen. The default is `[2000, 2000]`.
 The window is restored to this size on the next start. The default is
 `[400, 220]` if the value is missing.
 
-`ui_scale` controls the overall scaling factor of the graphical interface.
-Values around `1.0` are normal size. Set higher values for bigger text and
-controls. The default is `1.0` when the field is omitted.
+`ui_scale` adjusts the size of the query field and the action list. Values around `1.0` keep the default look. Higher values enlarge those widgets only. The default is `1.0` when the field is omitted.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "debug_logging": false,
   "offscreen_pos": [2000, 2000],
   "window_size": [400, 220],
-  "ui_scale": 1.0
+  "query_scale": 1.0,
+  "list_scale": 1.0
 }
 ```
 
@@ -75,7 +76,7 @@ off-screen. The default is `[2000, 2000]`.
 The window is restored to this size on the next start. The default is
 `[400, 220]` if the value is missing.
 
-`ui_scale` adjusts the size of the query field and the action list. Values around `1.0` keep the default look. Higher values enlarge those widgets only. The default is `1.0` when the field is omitted.
+`query_scale` and `list_scale` control the size of the search field and the results list separately. Values around `1.0` keep the default look while higher numbers enlarge the respective element up to five times.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "enabled_plugins": ["web_search", "calculator", "clipboard", "shell", "runescape_search", "system"],
   "debug_logging": false,
   "offscreen_pos": [2000, 2000],
-  "window_size": [400, 220]
+  "window_size": [400, 220],
+  "ui_scale": 1.0
 }
 ```
 
@@ -73,6 +74,10 @@ off-screen. The default is `[2000, 2000]`.
 `window_size` stores the size of the launcher window when it was last closed.
 The window is restored to this size on the next start. The default is
 `[400, 220]` if the value is missing.
+
+`ui_scale` controls the overall scaling factor of the graphical interface.
+Values around `1.0` are normal size. Set higher values for bigger text and
+controls. The default is `1.0` when the field is omitted.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -17,6 +17,22 @@ use fuzzy_matcher::FuzzyMatcher;
 use crate::visibility::apply_visibility;
 use std::collections::HashMap;
 
+fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
+    ui.scope(|ui| {
+        if (scale - 1.0).abs() > f32::EPSILON {
+            let mut style: egui::Style = (*ui.ctx().style()).clone();
+            style.spacing.item_spacing *= scale;
+            style.spacing.interact_size *= scale;
+            for font in style.text_styles.values_mut() {
+                font.size *= scale;
+            }
+            ui.set_style(style);
+        }
+        add_contents(ui)
+    })
+    .inner
+}
+
 enum WatchEvent {
     Actions,
 }
@@ -55,7 +71,8 @@ pub struct LauncherApp {
     toasts: egui_toast::Toasts,
     enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
-    pub ui_scale: f32,
+    pub query_scale: f32,
+    pub list_scale: f32,
 }
 
 impl LauncherApp {
@@ -130,7 +147,8 @@ impl LauncherApp {
             (x as f32, y as f32)
         };
         let win_size = settings.window_size.unwrap_or((400, 220));
-        let scale = settings.ui_scale.unwrap_or(1.0);
+        let query_scale = settings.query_scale.unwrap_or(1.0).min(5.0);
+        let list_scale = settings.list_scale.unwrap_or(1.0).min(5.0);
 
         let settings_editor = SettingsEditor::new(&settings);
         let plugin_editor = PluginEditor::new(&settings);
@@ -167,7 +185,8 @@ impl LauncherApp {
             toasts,
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
-            ui_scale: scale,
+            query_scale,
+            list_scale,
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);
@@ -318,7 +337,6 @@ impl eframe::App for LauncherApp {
                     });
                     if ui.button("Close Application").clicked() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                        #[cfg(target_os = "windows")]
                         self.unregister_all_hotkeys();
                         self.visible_flag.store(false, Ordering::SeqCst);
                         self.last_visible = false;
@@ -355,17 +373,7 @@ impl eframe::App for LauncherApp {
                 ui.colored_label(Color32::RED, err);
             }
 
-            ui.scope(|ui| {
-                if (self.ui_scale - 1.0).abs() > f32::EPSILON {
-                    let mut style: egui::Style = (*ctx.style()).clone();
-                    style.spacing.item_spacing *= self.ui_scale;
-                    style.spacing.interact_size *= self.ui_scale;
-                    for font in style.text_styles.values_mut() {
-                        font.size *= self.ui_scale;
-                    }
-                    ui.set_style(style);
-                }
-
+            scale_ui(ui, self.query_scale, |ui| {
                 let input = ui.text_edit_singleline(&mut self.query);
                 if just_became_visible || self.focus_query {
                     input.request_focus();
@@ -392,55 +400,57 @@ impl eframe::App for LauncherApp {
                     if let Some(a) = self.results.get(i) {
                         let a = a.clone();
                         let current = self.query.clone();
-                    let mut refresh = false;
-                    let mut set_focus = false;
-                    if let Err(e) = launch_action(&a) {
-                        self.error = Some(format!("Failed: {e}"));
-                        if self.enable_toasts {
-                            self.toasts.add(Toast {
-                                text: format!("Failed: {e}").into(),
-                                kind: ToastKind::Error,
-                                options: ToastOptions::default().duration_in_seconds(3.0),
-                            });
+                        let mut refresh = false;
+                        let mut set_focus = false;
+                        if let Err(e) = launch_action(&a) {
+                            self.error = Some(format!("Failed: {e}"));
+                            if self.enable_toasts {
+                                self.toasts.add(Toast {
+                                    text: format!("Failed: {e}").into(),
+                                    kind: ToastKind::Error,
+                                    options: ToastOptions::default().duration_in_seconds(3.0),
+                                });
+                            }
+                        } else {
+                            if self.enable_toasts {
+                                self.toasts.add(Toast {
+                                    text: format!("Launched {}", a.label).into(),
+                                    kind: ToastKind::Success,
+                                    options: ToastOptions::default().duration_in_seconds(3.0),
+                                });
+                            }
+                            let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
+                            let count = self.usage.entry(a.action.clone()).or_insert(0);
+                            *count += 1;
+                            if a.action.starts_with("bookmark:add:") {
+                                self.query.clear();
+                                refresh = true;
+                                set_focus = true;
+                            } else if a.action.starts_with("bookmark:remove:") {
+                                refresh = true;
+                                set_focus = true;
+                            } else if a.action.starts_with("folder:add:") {
+                                self.query.clear();
+                                refresh = true;
+                                set_focus = true;
+                            } else if a.action.starts_with("folder:remove:") {
+                                refresh = true;
+                                set_focus = true;
+                            }
                         }
-                    } else {
-                        if self.enable_toasts {
-                            self.toasts.add(Toast {
-                                text: format!("Launched {}", a.label).into(),
-                                kind: ToastKind::Success,
-                                options: ToastOptions::default().duration_in_seconds(3.0),
-                            });
+                        if refresh {
+                            self.search();
                         }
-                        let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
-                        let count = self.usage.entry(a.action.clone()).or_insert(0);
-                        *count += 1;
-                        if a.action.starts_with("bookmark:add:") {
-                            self.query.clear();
-                            refresh = true;
-                            set_focus = true;
-                        } else if a.action.starts_with("bookmark:remove:") {
-                            refresh = true;
-                            set_focus = true;
-                        } else if a.action.starts_with("folder:add:") {
-                            self.query.clear();
-                            refresh = true;
-                            set_focus = true;
-                        } else if a.action.starts_with("folder:remove:") {
-                            refresh = true;
-                            set_focus = true;
+                        if set_focus {
+                            self.focus_input();
                         }
-                    }
-                    if refresh {
-                        self.search();
-                    }
-                    if set_focus {
-                        self.focus_input();
                     }
                 }
-                    }
+            });
 
-                let area_height = ui.available_height();
-                ScrollArea::vertical().max_height(area_height).show(ui, |ui| {
+            let area_height = ui.available_height();
+            ScrollArea::vertical().max_height(area_height).show(ui, |ui| {
+                scale_ui(ui, self.list_scale, |ui| {
                     let mut refresh = false;
                     let mut set_focus = false;
                     let alias_list = crate::plugins::folders::load_folders(crate::plugins::folders::FOLDERS_FILE)
@@ -557,7 +567,6 @@ impl eframe::App for LauncherApp {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        #[cfg(target_os = "windows")]
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -129,6 +129,8 @@ impl LauncherApp {
             (x as f32, y as f32)
         };
         let win_size = settings.window_size.unwrap_or((400, 220));
+        let scale = settings.ui_scale.unwrap_or(1.0);
+        ctx.set_pixels_per_point(scale);
 
         let settings_editor = SettingsEditor::new(&settings);
         let plugin_editor = PluginEditor::new(&settings);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,14 +28,17 @@ pub struct Settings {
     /// Enable toast notifications in the UI.
     #[serde(default = "default_toasts")]
     pub enable_toasts: bool,
-    /// Global UI scale factor applied to egui widgets. Defaults to `1.0`.
-    #[serde(default = "default_ui_scale")]
-    pub ui_scale: Option<f32>,
+    /// Scale factor for the search box. Defaults to `1.0`.
+    #[serde(default = "default_scale")]
+    pub query_scale: Option<f32>,
+    /// Scale factor for the action list. Defaults to `1.0`.
+    #[serde(default = "default_scale")]
+    pub list_scale: Option<f32>,
 }
 
 fn default_toasts() -> bool { true }
 
-fn default_ui_scale() -> Option<f32> { Some(1.0) }
+fn default_scale() -> Option<f32> { Some(1.0) }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -50,7 +53,8 @@ impl Default for Settings {
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),
             enable_toasts: true,
-            ui_scale: Some(1.0),
+            query_scale: Some(1.0),
+            list_scale: Some(1.0),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,11 +26,16 @@ pub struct Settings {
     #[serde(default)]
     pub window_size: Option<(i32, i32)>,
     /// Enable toast notifications in the UI.
-    #[serde(default = "default_toasts")] 
+    #[serde(default = "default_toasts")]
     pub enable_toasts: bool,
+    /// Global UI scale factor applied to egui widgets. Defaults to `1.0`.
+    #[serde(default = "default_ui_scale")]
+    pub ui_scale: Option<f32>,
 }
 
 fn default_toasts() -> bool { true }
+
+fn default_ui_scale() -> Option<f32> { Some(1.0) }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -45,6 +50,7 @@ impl Default for Settings {
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),
             enable_toasts: true,
+            ui_scale: Some(1.0),
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -16,7 +16,8 @@ pub struct SettingsEditor {
     offscreen_y: i32,
     window_w: i32,
     window_h: i32,
-    ui_scale: f32,
+    query_scale: f32,
+    list_scale: f32,
 }
 
 impl SettingsEditor {
@@ -32,7 +33,8 @@ impl SettingsEditor {
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
             window_w: settings.window_size.unwrap_or((400, 220)).0,
             window_h: settings.window_size.unwrap_or((400, 220)).1,
-            ui_scale: settings.ui_scale.unwrap_or(1.0),
+            query_scale: settings.query_scale.unwrap_or(1.0),
+            list_scale: settings.list_scale.unwrap_or(1.0),
         }
     }
 
@@ -60,7 +62,8 @@ impl SettingsEditor {
             enable_toasts: self.show_toasts,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
-            ui_scale: Some(self.ui_scale),
+            query_scale: Some(self.query_scale),
+            list_scale: Some(self.list_scale),
         }
     }
 
@@ -94,8 +97,12 @@ impl SettingsEditor {
             ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
 
             ui.horizontal(|ui| {
-                ui.label("UI scale");
-                ui.add(egui::Slider::new(&mut self.ui_scale, 0.5..=2.0).text(""));
+                ui.label("Query scale");
+                ui.add(egui::Slider::new(&mut self.query_scale, 0.5..=5.0).text(""));
+            });
+            ui.horizontal(|ui| {
+                ui.label("List scale");
+                ui.add(egui::Slider::new(&mut self.list_scale, 0.5..=5.0).text(""));
             });
 
             ui.horizontal(|ui| {
@@ -150,7 +157,8 @@ impl SettingsEditor {
                                 new_settings.offscreen_pos,
                                 Some(new_settings.enable_toasts),
                             );
-                            app.ui_scale = new_settings.ui_scale.unwrap_or(1.0);
+                            app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
+                            app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);
                             crate::request_hotkey_restart(new_settings);
                         }
                     }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -16,6 +16,7 @@ pub struct SettingsEditor {
     offscreen_y: i32,
     window_w: i32,
     window_h: i32,
+    ui_scale: f32,
 }
 
 impl SettingsEditor {
@@ -31,6 +32,7 @@ impl SettingsEditor {
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
             window_w: settings.window_size.unwrap_or((400, 220)).0,
             window_h: settings.window_size.unwrap_or((400, 220)).1,
+            ui_scale: settings.ui_scale.unwrap_or(1.0),
         }
     }
 
@@ -58,6 +60,7 @@ impl SettingsEditor {
             enable_toasts: self.show_toasts,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
+            ui_scale: Some(self.ui_scale),
         }
     }
 
@@ -89,6 +92,11 @@ impl SettingsEditor {
             });
 
             ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
+
+            ui.horizontal(|ui| {
+                ui.label("UI scale");
+                ui.add(egui::Slider::new(&mut self.ui_scale, 0.5..=2.0).text(""));
+            });
 
             ui.horizontal(|ui| {
                 ui.label("Off-screen X");
@@ -142,6 +150,7 @@ impl SettingsEditor {
                                 new_settings.offscreen_pos,
                                 Some(new_settings.enable_toasts),
                             );
+                            ctx.set_pixels_per_point(new_settings.ui_scale.unwrap_or(1.0));
                             crate::request_hotkey_restart(new_settings);
                         }
                     }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -150,7 +150,7 @@ impl SettingsEditor {
                                 new_settings.offscreen_pos,
                                 Some(new_settings.enable_toasts),
                             );
-                            ctx.set_pixels_per_point(new_settings.ui_scale.unwrap_or(1.0));
+                            app.ui_scale = new_settings.ui_scale.unwrap_or(1.0);
                             crate::request_hotkey_restart(new_settings);
                         }
                     }


### PR DESCRIPTION
## Summary
- add `ui_scale` to `Settings` with default value
- apply scale when creating `LauncherApp`
- provide slider in settings to edit `ui_scale`
- document the new option in the readme

## Testing
- `cargo test --quiet` *(fails: unresolved import `rdev`)*

------
https://chatgpt.com/codex/tasks/task_e_686bc29fa0148332a1b54a0300928311