### PR TITLE
Add command editing via context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ application you can manage this list through **Edit Commands**. Open the
 launcher with the configured hotkey and choose *Edit Commands* from the menu.
 Use the **New Command** button to open the *Add Command* dialog where you enter
 a label, description and the executable path. The **Browse** button lets you
-select the file interactively. Commands can also be removed from the list. All
-changes are written to `actions.json` immediately.
+select the file interactively. Existing entries can be edited via the **Edit**
+button or by right clicking a command in the results list and choosing *Edit
+Command*. Commands can also be removed from the list. All changes are written to
+`actions.json` immediately.
 
 ## Packaging
 

--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -24,6 +24,11 @@ impl Default for ActionsEditor {
 }
 
 impl ActionsEditor {
+    /// Open the dialog for editing an existing command.
+    pub fn open_edit(&mut self, idx: usize, act: &crate::actions::Action) {
+        self.dialog.open_edit(idx, act);
+    }
+
     /// Render the command editor window.
     ///
     /// * `ctx` - Egui context used for drawing the editor UI.
@@ -38,7 +43,7 @@ impl ActionsEditor {
                 ui.label("Search");
                 ui.text_edit_singleline(&mut self.search);
                 if ui.button("New Command").clicked() {
-                    self.dialog.open = true;
+                    self.dialog.open_add();
                 }
             });
 
@@ -59,6 +64,9 @@ impl ActionsEditor {
                     }
                     ui.horizontal(|ui| {
                         ui.label(format!("{} : {} -> {}", act.label, act.desc, act.action));
+                        if ui.button("Edit").clicked() {
+                            self.dialog.open_edit(idx, act);
+                        }
                         if ui.button("Remove").clicked() {
                             remove = Some(idx);
                         }
@@ -68,8 +76,11 @@ impl ActionsEditor {
 
             if let Some(i) = remove {
                 app.actions.remove(i);
+                if i < app.custom_len {
+                    app.custom_len -= 1;
+                }
                 app.search();
-                if let Err(e) = save_actions(&app.actions_path, &app.actions) {
+                if let Err(e) = save_actions(&app.actions_path, &app.actions[..app.custom_len]) {
                     app.error = Some(format!("Failed to save: {e}"));
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ pub fn request_hotkey_restart(settings: Settings) {
 
 fn spawn_gui(
     actions: Vec<Action>,
+    custom_len: usize,
     settings: Settings,
     settings_path: String,
     enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
@@ -55,6 +56,7 @@ fn spawn_gui(
     Arc<Mutex<Option<egui::Context>>>,
 ) {
     let actions_for_window = actions.clone();
+    let custom_len_for_window = custom_len;
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
@@ -100,6 +102,7 @@ fn spawn_gui(
                 Box::new(LauncherApp::new(
                     &cc.egui_ctx,
                     actions_for_window,
+                    custom_len_for_window,
                     plugins,
                     actions_path,
                     settings_path_for_window,
@@ -123,6 +126,7 @@ fn main() -> anyhow::Result<()> {
     logging::init(settings.debug_logging);
     tracing::debug!(?settings, "settings loaded");
     let mut actions = load_actions("actions.json").unwrap_or_default();
+    let custom_len = actions.len();
     tracing::debug!("{} actions loaded", actions.len());
 
     let (restart_tx, restart_rx) = channel::<Settings>();
@@ -150,6 +154,7 @@ fn main() -> anyhow::Result<()> {
     let (handle, visibility, restore_flag, ctx) =
         spawn_gui(
             actions.clone(),
+            custom_len,
             settings.clone(),
             "settings.json".to_string(),
             settings.enabled_capabilities.clone(),

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -6,9 +6,11 @@ use std::sync::{Arc, atomic::AtomicBool};
 use eframe::egui;
 
 fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    let custom_len = actions.len();
     LauncherApp::new(
         ctx,
         actions,
+        custom_len,
         PluginManager::new(),
         "actions.json".into(),
         "settings.json".into(),


### PR DESCRIPTION
## Summary
- allow editing commands
- track custom action count for persistence
- right-click any user-defined command in results to edit it
- document editing workflow in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686be48d19308332b88ea393c45857de