### PR TITLE
Improve command help window

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,18 @@ running.
 
 Built-in plugins and their command prefixes are:
 
-- Google web search (`g query`)
-- RuneScape Wiki search (`rs query` or `osrs query`)
-- Calculator (`= expression`)
+- Google web search (`g rust`)
+- RuneScape Wiki search (`rs item` or `osrs item`)
+- Calculator (`= 2+2`)
 - Clipboard history (`cb`)
-- Bookmarks (`bm`)
-- Folder shortcuts (`f`)
-- Shell commands (`sh <command>`)
-- System actions (`sys <action>` with `shutdown`, `reboot`, `lock` or `logoff`)
+- Bookmarks (`bm add <url>` or `bm rm <pattern>`)
+- Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
+- Shell commands (`sh echo hi`)
+- System actions (`sys shutdown`)
 - Search history (`hi`)
 - Command overview (`help`)
 
-Selecting a clipboard entry copies it back to the clipboard. Type `help` and press <kbd>Enter</kbd> to open the command list. Additional plugins can be added by building
+Selecting a clipboard entry copies it back to the clipboard. Type `help` and press <kbd>Enter</kbd> to open the command list. The help window groups commands by plugin name and can optionally display example queries. Additional plugins can be added by building
 shared libraries. Each plugin crate should be compiled as a `cdylib` and export
 a `create_plugin` function returning `Box<dyn Plugin>`:
 

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -4,6 +4,7 @@ use eframe::egui;
 #[derive(Default)]
 pub struct HelpWindow {
     pub open: bool,
+    pub show_examples: bool,
 }
 
 impl HelpWindow {
@@ -19,6 +20,8 @@ impl HelpWindow {
             .show(ctx, |ui| {
                 ui.vertical_centered(|ui| ui.heading("Available commands"));
                 ui.separator();
+                ui.checkbox(&mut self.show_examples, "Show examples");
+                ui.separator();
                 let mut infos = app.plugins.plugin_infos();
                 infos.sort_by(|a, b| a.0.cmp(&b.0));
                 let area_height = ui.available_height();
@@ -26,13 +29,35 @@ impl HelpWindow {
                     .max_height(area_height)
                     .show(ui, |ui| {
                         for (name, desc, _) in infos {
-                            ui.horizontal(|ui| {
-                                ui.monospace(format!("{name:>8}"));
-                                ui.label(desc);
-                            });
+                            ui.label(egui::RichText::new(&name).strong());
+                            ui.label(desc);
+                            if self.show_examples {
+                                if let Some(examples) = example_queries(&name) {
+                                    for ex in examples {
+                                        ui.monospace(format!("  {ex}"));
+                                    }
+                                }
+                            }
+                            ui.separator();
                         }
                     });
             });
         self.open = open;
+    }
+}
+
+fn example_queries(name: &str) -> Option<&'static [&'static str]> {
+    match name {
+        "web_search" => Some(&["g rust"]),
+        "runescape_search" => Some(&["rs dragon scimitar", "osrs agility guide"]),
+        "calculator" => Some(&["= 1+2"]),
+        "clipboard" => Some(&["cb"]),
+        "bookmarks" => Some(&["bm add https://example.com"]),
+        "folders" => Some(&["f add C:/path", "f rm docs"]),
+        "shell" => Some(&["sh echo hello"]),
+        "system" => Some(&["sys shutdown"]),
+        "history" => Some(&["hi"]),
+        "help" => Some(&["help"]),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- group help entries by plugin name
- optionally show example queries
- list example queries in README
- mention updated help window functionality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bf3f51ec48332bc555c8156f746a6