### PR TITLE
Add configurable history limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "offscreen_pos": [2000, 2000],
   "window_size": [400, 220],
   "query_scale": 1.0,
-  "list_scale": 1.0
+  "list_scale": 1.0,
+  "history_limit": 100
 }
 ```
 

--- a/settings.json
+++ b/settings.json
@@ -4,5 +4,6 @@
     "index_paths": null,
     "plugin_dirs": null,
     "debug_logging": false,
-    "enable_toasts": true
+    "enable_toasts": true,
+    "history_limit": 100
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -77,6 +77,7 @@ pub struct LauncherApp {
     pub list_scale: f32,
     /// Number of user defined commands at the start of `actions`.
     pub custom_len: usize,
+    pub history_limit: usize,
 }
 
 impl LauncherApp {
@@ -194,6 +195,7 @@ impl LauncherApp {
             query_scale,
             list_scale,
             custom_len,
+            history_limit: settings.history_limit,
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);
@@ -439,7 +441,10 @@ impl eframe::App for LauncherApp {
                                 });
                             }
                             if a.action != "help:show" {
-                                let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
+                                let _ = history::append_history(
+                                    HistoryEntry { query: current, action: a.clone() },
+                                    self.history_limit,
+                                );
                                 let count = self.usage.entry(a.action.clone()).or_insert(0);
                                 *count += 1;
                             }
@@ -549,7 +554,10 @@ impl eframe::App for LauncherApp {
                                 });
                             }
                             if a.action != "help:show" {
-                                let _ = history::append_history(HistoryEntry { query: current, action: a.clone() });
+                                let _ = history::append_history(
+                                    HistoryEntry { query: current, action: a.clone() },
+                                    self.history_limit,
+                                );
                                 let count = self.usage.entry(a.action.clone()).or_insert(0);
                                 *count += 1;
                             }

--- a/src/history.rs
+++ b/src/history.rs
@@ -43,12 +43,13 @@ pub fn save_history() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Append an entry to the history and persist the list.
-pub fn append_history(entry: HistoryEntry) -> anyhow::Result<()> {
+/// Append an entry to the history and persist the list. The `limit` parameter
+/// specifies the maximum number of entries kept.
+pub fn append_history(entry: HistoryEntry, limit: usize) -> anyhow::Result<()> {
     {
         let mut h = HISTORY.lock().unwrap();
         h.push_front(entry);
-        while h.len() > 100 {
+        while h.len() > limit {
             h.pop_back();
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,11 +34,16 @@ pub struct Settings {
     /// Scale factor for the action list. Defaults to `1.0`.
     #[serde(default = "default_scale")]
     pub list_scale: Option<f32>,
+    /// Maximum number of entries kept in the history list.
+    #[serde(default = "default_history_limit")]
+    pub history_limit: usize,
 }
 
 fn default_toasts() -> bool { true }
 
 fn default_scale() -> Option<f32> { Some(1.0) }
+
+fn default_history_limit() -> usize { 100 }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -55,6 +60,7 @@ impl Default for Settings {
             enable_toasts: true,
             query_scale: Some(1.0),
             list_scale: Some(1.0),
+            history_limit: default_history_limit(),
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -18,6 +18,7 @@ pub struct SettingsEditor {
     window_h: i32,
     query_scale: f32,
     list_scale: f32,
+    history_limit: usize,
 }
 
 impl SettingsEditor {
@@ -35,6 +36,7 @@ impl SettingsEditor {
             window_h: settings.window_size.unwrap_or((400, 220)).1,
             query_scale: settings.query_scale.unwrap_or(1.0),
             list_scale: settings.list_scale.unwrap_or(1.0),
+            history_limit: settings.history_limit,
         }
     }
 
@@ -64,6 +66,7 @@ impl SettingsEditor {
             window_size: Some((self.window_w, self.window_h)),
             query_scale: Some(self.query_scale),
             list_scale: Some(self.list_scale),
+            history_limit: self.history_limit,
         }
     }
 
@@ -103,6 +106,10 @@ impl SettingsEditor {
             ui.horizontal(|ui| {
                 ui.label("List scale");
                 ui.add(egui::Slider::new(&mut self.list_scale, 0.5..=5.0).text(""));
+            });
+            ui.horizontal(|ui| {
+                ui.label("History limit");
+                ui.add(egui::Slider::new(&mut self.history_limit, 10..=500).text(""));
             });
 
             ui.horizontal(|ui| {
@@ -159,6 +166,7 @@ impl SettingsEditor {
                             );
                             app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
                             app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);
+                            app.history_limit = new_settings.history_limit;
                             crate::request_hotkey_restart(new_settings);
                         }
                     }


### PR DESCRIPTION
## Summary
- add `history_limit` to `Settings`
- enforce this limit when appending history
- expose setting in `SettingsEditor`
- document the new setting in README and sample settings file

## Testing
- `cargo test --quiet`
 