### PR TITLE
Add fuzzy ranking with weights

### DIFF
--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -110,6 +110,8 @@ impl PluginEditor {
                         s.enabled_capabilities.clone(),
                         s.offscreen_pos,
                         Some(s.enable_toasts),
+                        Some(s.fuzzy_weight),
+                        Some(s.usage_weight),
                     );
 
                     app.plugins.reload_from_dirs(&self.plugin_dirs);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -34,6 +34,12 @@ pub struct Settings {
     /// Scale factor for the action list. Defaults to `1.0`.
     #[serde(default = "default_scale")]
     pub list_scale: Option<f32>,
+    /// Weight of the fuzzy match score when ranking results.
+    #[serde(default = "default_fuzzy_weight")]
+    pub fuzzy_weight: f32,
+    /// Weight of the usage count when ranking results.
+    #[serde(default = "default_usage_weight")]
+    pub usage_weight: f32,
     /// Maximum number of entries kept in the history list.
     #[serde(default = "default_history_limit")]
     pub history_limit: usize,
@@ -44,6 +50,10 @@ fn default_toasts() -> bool { true }
 fn default_scale() -> Option<f32> { Some(1.0) }
 
 fn default_history_limit() -> usize { 100 }
+
+fn default_fuzzy_weight() -> f32 { 1.0 }
+
+fn default_usage_weight() -> f32 { 1.0 }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -60,6 +70,8 @@ impl Default for Settings {
             enable_toasts: true,
             query_scale: Some(1.0),
             list_scale: Some(1.0),
+            fuzzy_weight: default_fuzzy_weight(),
+            usage_weight: default_usage_weight(),
             history_limit: default_history_limit(),
         }
     }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -19,6 +19,8 @@ pub struct SettingsEditor {
     query_scale: f32,
     list_scale: f32,
     history_limit: usize,
+    fuzzy_weight: f32,
+    usage_weight: f32,
 }
 
 impl SettingsEditor {
@@ -37,6 +39,8 @@ impl SettingsEditor {
             query_scale: settings.query_scale.unwrap_or(1.0),
             list_scale: settings.list_scale.unwrap_or(1.0),
             history_limit: settings.history_limit,
+            fuzzy_weight: settings.fuzzy_weight,
+            usage_weight: settings.usage_weight,
         }
     }
 
@@ -67,6 +71,8 @@ impl SettingsEditor {
             query_scale: Some(self.query_scale),
             list_scale: Some(self.list_scale),
             history_limit: self.history_limit,
+            fuzzy_weight: self.fuzzy_weight,
+            usage_weight: self.usage_weight,
         }
     }
 
@@ -106,6 +112,14 @@ impl SettingsEditor {
             ui.horizontal(|ui| {
                 ui.label("List scale");
                 ui.add(egui::Slider::new(&mut self.list_scale, 0.5..=5.0).text(""));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Fuzzy weight");
+                ui.add(egui::Slider::new(&mut self.fuzzy_weight, 0.0..=5.0).text(""));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Usage weight");
+                ui.add(egui::Slider::new(&mut self.usage_weight, 0.0..=5.0).text(""));
             });
             ui.horizontal(|ui| {
                 ui.label("History limit");
@@ -163,6 +177,8 @@ impl SettingsEditor {
                                 new_settings.enabled_capabilities.clone(),
                                 new_settings.offscreen_pos,
                                 Some(new_settings.enable_toasts),
+                                Some(new_settings.fuzzy_weight),
+                                Some(new_settings.usage_weight),
                             );
                             app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
                             app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);

--- a/tests/ranking.rs
+++ b/tests/ranking.rs
@@ -1,0 +1,57 @@
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::actions::Action;
+use multi_launcher::settings::Settings;
+use std::sync::{Arc, atomic::AtomicBool};
+use eframe::egui;
+
+fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Settings) -> LauncherApp {
+    let custom_len = actions.len();
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn usage_ranking() {
+    let ctx = egui::Context::default();
+    let actions = vec![
+        Action { label: "foo".into(), desc: "".into(), action: "a".into(), args: None },
+        Action { label: "foo".into(), desc: "".into(), action: "b".into(), args: None },
+    ];
+    let settings = Settings::default();
+    let mut app = new_app_with_settings(&ctx, actions, settings);
+    app.usage.insert("b".into(), 5);
+    app.query = "foo".into();
+    app.search();
+    assert_eq!(app.results[0].action, "b");
+}
+
+#[test]
+fn fuzzy_vs_usage_weight() {
+    let ctx = egui::Context::default();
+    let actions = vec![
+        Action { label: "abc".into(), desc: "".into(), action: "a".into(), args: None },
+        Action { label: "defabc".into(), desc: "".into(), action: "b".into(), args: None },
+    ];
+    let mut settings = Settings::default();
+    settings.fuzzy_weight = 5.0;
+    settings.usage_weight = 1.0;
+    let mut app = new_app_with_settings(&ctx, actions, settings);
+    app.usage.insert("b".into(), 20);
+    app.query = "abc".into();
+    app.search();
+    assert_eq!(app.results[0].action, "a");
+}


### PR DESCRIPTION
## Summary
- integrate fuzzy score ranking in `gui::search`
- make fuzzy and usage weights configurable in `Settings`
- expose new sliders in `SettingsEditor`
- adjust plugin settings to update new values
- test ranking behaviour

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_686bfdfb52988332930ac38038c81522