### PR TITLE
Add YouTube search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Built-in plugins and their command prefixes are:
 
 - Google web search (`g rust`)
 - RuneScape Wiki search (`rs item` or `osrs item`)
+- YouTube search (`yt rust`)
 - Calculator (`= 2+2`)
 - Clipboard history (`cb`)
 - Bookmarks (`bm add <url>` or `bm rm <pattern>`)

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -50,6 +50,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
     match name {
         "web_search" => Some(&["g rust"]),
         "runescape_search" => Some(&["rs dragon scimitar", "osrs agility guide"]),
+        "youtube" => Some(&["yt rust"]),
         "calculator" => Some(&["= 1+2"]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,6 +9,7 @@ use crate::plugins::history::HistoryPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::help::HelpPlugin;
+use crate::plugins::youtube::YoutubePlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -47,6 +48,7 @@ impl PluginManager {
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
         self.register(Box::new(RunescapeSearchPlugin));
+        self.register(Box::new(YoutubePlugin));
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(FoldersPlugin::default()));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,3 +6,4 @@ pub mod history;
 pub mod folders;
 pub mod system;
 pub mod help;
+pub mod youtube;

--- a/src/plugins/youtube.rs
+++ b/src/plugins/youtube.rs
@@ -1,0 +1,35 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct YoutubePlugin;
+
+impl Plugin for YoutubePlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(q) = query.strip_prefix("yt ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Search YouTube for {q}"),
+                    desc: "Web search".into(),
+                    action: format!(
+                        "https://www.youtube.com/results?search_query={q}"
+                    ),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "youtube"
+    }
+
+    fn description(&self) -> &str {
+        "Search YouTube (prefix: `yt`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/tests/youtube_plugin.rs
+++ b/tests/youtube_plugin.rs
@@ -1,0 +1,10 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::youtube::YoutubePlugin;
+
+#[test]
+fn search_returns_action() {
+    let plugin = YoutubePlugin;
+    let results = plugin.search("yt rust");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://www.youtube.com/results?search_query=rust");
+}


### PR DESCRIPTION
## Summary
- implement a new YoutubePlugin
- expose the plugin module and register it
- show example query in help window and README
- test the YoutubePlugin

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c037dfb4c8332b5d37019ae0a2d22