### PR TITLE
Add Reddit search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Built-in plugins and their command prefixes are:
 - Google web search (`g rust`)
 - RuneScape Wiki search (`rs item` or `osrs item`)
 - YouTube search (`yt rust`)
+- Reddit search (`red cats`)
 - Calculator (`= 2+2`)
 - Clipboard history (`cb`)
 - Bookmarks (`bm add <url>` or `bm rm <pattern>`)

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -51,6 +51,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "web_search" => Some(&["g rust"]),
         "runescape_search" => Some(&["rs dragon scimitar", "osrs agility guide"]),
         "youtube" => Some(&["yt rust"]),
+        "reddit" => Some(&["red cats"]),
         "calculator" => Some(&["= 1+2"]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -10,6 +10,7 @@ use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
+use crate::plugins::reddit::RedditPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -49,6 +50,7 @@ impl PluginManager {
         self.register(Box::new(CalculatorPlugin));
         self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(YoutubePlugin));
+        self.register(Box::new(RedditPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(FoldersPlugin::default()));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -7,3 +7,4 @@ pub mod folders;
 pub mod system;
 pub mod help;
 pub mod youtube;
+pub mod reddit;

--- a/src/plugins/reddit.rs
+++ b/src/plugins/reddit.rs
@@ -1,0 +1,33 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct RedditPlugin;
+
+impl Plugin for RedditPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(q) = query.strip_prefix("red ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Search Reddit for {q}"),
+                    desc: "Web search".into(),
+                    action: format!("https://www.reddit.com/search/?q={q}"),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "reddit"
+    }
+
+    fn description(&self) -> &str {
+        "Search Reddit (prefix: `red`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/tests/reddit_plugin.rs
+++ b/tests/reddit_plugin.rs
@@ -1,0 +1,10 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::reddit::RedditPlugin;
+
+#[test]
+fn search_returns_action() {
+    let plugin = RedditPlugin;
+    let results = plugin.search("red cats");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://www.reddit.com/search/?q=cats");
+}


### PR DESCRIPTION
## Summary
- support `red` prefix to search Reddit
- document new plugin
- show example query in help window
- test the new plugin

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c065e842c8332b98fa9a9a7cafe96