### PR TITLE
Add configurable static window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "window_size": [400, 220],
   "query_scale": 1.0,
   "list_scale": 1.0,
-  "history_limit": 100
+  "history_limit": 100,
+  "follow_mouse": true,
+  "static_location_enabled": false,
+  "static_pos": [0, 0],
+  "static_size": [400, 220]
 }
 ```
 
@@ -87,6 +91,12 @@ off-screen. The default is `[2000, 2000]`.
 `window_size` stores the size of the launcher window when it was last closed.
 The window is restored to this size on the next start. The default is
 `[400, 220]` if the value is missing.
+
+When `follow_mouse` is `true` the window appears at the current cursor
+location whenever it becomes visible. To keep the launcher at a specific
+position instead, set `follow_mouse` to `false` and enable
+`static_location_enabled`. Provide the desired coordinates in `static_pos`
+and optionally a fixed size via `static_size`.
 
 `query_scale` and `list_scale` control the size of the search field and the results list separately. Values around `1.0` keep the default look while higher numbers enlarge the respective element up to five times.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,10 @@ fn main() -> anyhow::Result<()> {
                 let (x, y) = settings.offscreen_pos.unwrap_or((2000, 2000));
                 (x as f32, y as f32)
             },
+            settings.follow_mouse,
+            settings.static_location_enabled,
+            settings.static_pos.map(|(x, y)| (x as f32, y as f32)),
+            settings.static_size.map(|(w, h)| (w as f32, h as f32)),
         );
 
         std::thread::sleep(std::time::Duration::from_millis(50));

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -112,6 +112,10 @@ impl PluginEditor {
                         Some(s.enable_toasts),
                         Some(s.fuzzy_weight),
                         Some(s.usage_weight),
+                        Some(s.follow_mouse),
+                        Some(s.static_location_enabled),
+                        s.static_pos,
+                        s.static_size,
                     );
 
                     app.plugins.reload_from_dirs(&self.plugin_dirs);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,20 @@ pub struct Settings {
     /// Maximum number of entries kept in the history list.
     #[serde(default = "default_history_limit")]
     pub history_limit: usize,
+    /// When true the window spawns at the mouse cursor each time it becomes
+    /// visible.
+    #[serde(default = "default_follow_mouse")]
+    pub follow_mouse: bool,
+    /// Enable positioning and sizing the window at a fixed location rather than
+    /// following the cursor.
+    #[serde(default)]
+    pub static_location_enabled: bool,
+    /// Position of the window when `static_location_enabled` is true.
+    #[serde(default)]
+    pub static_pos: Option<(i32, i32)>,
+    /// Size of the window when `static_location_enabled` is true.
+    #[serde(default)]
+    pub static_size: Option<(i32, i32)>,
 }
 
 fn default_toasts() -> bool { true }
@@ -54,6 +68,8 @@ fn default_history_limit() -> usize { 100 }
 fn default_fuzzy_weight() -> f32 { 1.0 }
 
 fn default_usage_weight() -> f32 { 1.0 }
+
+fn default_follow_mouse() -> bool { true }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -73,6 +89,10 @@ impl Default for Settings {
             fuzzy_weight: default_fuzzy_weight(),
             usage_weight: default_usage_weight(),
             history_limit: default_history_limit(),
+            follow_mouse: true,
+            static_location_enabled: false,
+            static_pos: None,
+            static_size: None,
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -21,6 +21,12 @@ pub struct SettingsEditor {
     history_limit: usize,
     fuzzy_weight: f32,
     usage_weight: f32,
+    follow_mouse: bool,
+    static_enabled: bool,
+    static_x: i32,
+    static_y: i32,
+    static_w: i32,
+    static_h: i32,
 }
 
 impl SettingsEditor {
@@ -41,6 +47,12 @@ impl SettingsEditor {
             history_limit: settings.history_limit,
             fuzzy_weight: settings.fuzzy_weight,
             usage_weight: settings.usage_weight,
+            follow_mouse: settings.follow_mouse,
+            static_enabled: settings.static_location_enabled,
+            static_x: settings.static_pos.unwrap_or((0, 0)).0,
+            static_y: settings.static_pos.unwrap_or((0, 0)).1,
+            static_w: settings.static_size.unwrap_or((400, 220)).0,
+            static_h: settings.static_size.unwrap_or((400, 220)).1,
         }
     }
 
@@ -73,6 +85,10 @@ impl SettingsEditor {
             history_limit: self.history_limit,
             fuzzy_weight: self.fuzzy_weight,
             usage_weight: self.usage_weight,
+            follow_mouse: self.follow_mouse,
+            static_location_enabled: self.static_enabled,
+            static_pos: Some((self.static_x, self.static_y)),
+            static_size: Some((self.static_w, self.static_h)),
         }
     }
 
@@ -133,6 +149,23 @@ impl SettingsEditor {
                 ui.add(egui::DragValue::new(&mut self.offscreen_y));
             });
 
+            ui.checkbox(&mut self.follow_mouse, "Follow mouse");
+            ui.add_enabled_ui(!self.follow_mouse, |ui| {
+                ui.checkbox(&mut self.static_enabled, "Use static position");
+            });
+            if self.static_enabled {
+                ui.horizontal(|ui| {
+                    ui.label("X");
+                    ui.add(egui::DragValue::new(&mut self.static_x));
+                    ui.label("Y");
+                    ui.add(egui::DragValue::new(&mut self.static_y));
+                    ui.label("W");
+                    ui.add(egui::DragValue::new(&mut self.static_w));
+                    ui.label("H");
+                    ui.add(egui::DragValue::new(&mut self.static_h));
+                });
+            }
+
             ui.separator();
             ui.label("Index paths:");
             let mut remove: Option<usize> = None;
@@ -179,6 +212,10 @@ impl SettingsEditor {
                                 Some(new_settings.enable_toasts),
                                 Some(new_settings.fuzzy_weight),
                                 Some(new_settings.usage_weight),
+                                Some(new_settings.follow_mouse),
+                                Some(new_settings.static_location_enabled),
+                                new_settings.static_pos,
+                                new_settings.static_size,
                             );
                             app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
                             app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -26,6 +26,10 @@ fn focus_when_becoming_visible() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -24,6 +24,10 @@ fn queued_visibility_applies_when_context_available() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
@@ -43,6 +47,10 @@ fn queued_visibility_applies_when_context_available() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
 
     assert!(queued_visibility.is_none());

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -57,6 +57,10 @@ fn zero_key_events_toggle_visibility() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
@@ -68,6 +72,10 @@ fn zero_key_events_toggle_visibility() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/offscreen.rs
+++ b/tests/offscreen.rs
@@ -8,7 +8,7 @@ use mock_ctx::MockCtx;
 #[test]
 fn offscreen_position_when_hidden() {
     let ctx = MockCtx::default();
-    apply_visibility(false, &ctx, (42.0, 84.0));
+    apply_visibility(false, &ctx, (42.0, 84.0), true, false, None, None);
     let cmds = ctx.commands.lock().unwrap();
     assert_eq!(cmds.len(), 1);
     match cmds[0] {

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -26,6 +26,10 @@ fn visibility_toggle_immediate_when_context_present() {
         &ctx_handle,
         &mut queued_visibility,
         (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);


### PR DESCRIPTION
## Summary
- add settings for static window position and size
- allow editing static position in Settings editor
- position window using the new fields in `apply_visibility`
- propagate settings through `LauncherApp`
- document how to use the new settings
- update unit tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c150cd5ec8332971d72e5634bb818