### PR TITLE
Add snapshot button for static location

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ When `follow_mouse` is `true` the window appears at the current cursor
 location whenever it becomes visible. To keep the launcher at a specific
 position instead, set `follow_mouse` to `false` and enable
 `static_location_enabled`. Provide the desired coordinates in `static_pos`
-and optionally a fixed size via `static_size`.
+and optionally a fixed size via `static_size`. The **Settings** window now
+includes a *Snapshot* button to capture the current window position and size
+for these fields.
 
 `query_scale` and `list_scale` control the size of the search field and the results list separately. Values around `1.0` keep the default look while higher numbers enlarge the respective element up to five times.
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -67,7 +67,8 @@ pub struct LauncherApp {
     restore_flag: Arc<AtomicBool>,
     last_visible: bool,
     offscreen_pos: (f32, f32),
-    window_size: (i32, i32),
+    pub window_size: (i32, i32),
+    pub window_pos: (i32, i32),
     focus_query: bool,
     toasts: egui_toast::Toasts,
     enable_toasts: bool,
@@ -221,6 +222,7 @@ impl LauncherApp {
             last_visible: initial_visible,
             offscreen_pos,
             window_size: win_size,
+            window_pos: (0, 0),
             focus_query: false,
             toasts,
             enable_toasts,
@@ -379,6 +381,9 @@ impl eframe::App for LauncherApp {
         }
         if let Some(rect) = ctx.input(|i| i.viewport().inner_rect) {
             self.window_size = (rect.width() as i32, rect.height() as i32);
+        }
+        if let Some(rect) = ctx.input(|i| i.viewport().outer_rect) {
+            self.window_pos = (rect.min.x as i32, rect.min.y as i32);
         }
         let do_restore = self.restore_flag.swap(false, Ordering::SeqCst);
         if do_restore {

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -163,6 +163,12 @@ impl SettingsEditor {
                     ui.add(egui::DragValue::new(&mut self.static_w));
                     ui.label("H");
                     ui.add(egui::DragValue::new(&mut self.static_h));
+                    if ui.button("Snapshot").clicked() {
+                        self.static_x = app.window_pos.0;
+                        self.static_y = app.window_pos.1;
+                        self.static_w = app.window_size.0;
+                        self.static_h = app.window_size.1;
+                    }
                 });
             }
 


### PR DESCRIPTION
## Summary
- expose window position tracking
- add a snapshot button to copy current window position and size when editing static location
- mention the new button in README

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c1c2b9064833285d79995d0e03ba8