### PR TITLE
Add virtual desktop awareness on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,13 @@ notify = "6"
 winit = "0.29"
 once_cell = "1"
 regex = "1"
-windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading"] }
+windows = { version = "0.58", features = [
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
+    "Win32_System_Com",
+    "Win32_System_Threading"
+] }
 log = "0.4"
 raw-window-handle = "0.6"
 arboard = "3"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ and optionally a fixed size via `static_size`. The **Settings** window now
 includes a *Snapshot* button to capture the current window position and size
 for these fields.
 
+On Windows the window will also move from other virtual desktops to the
+current one whenever it becomes visible.
+
 `query_scale` and `list_scale` control the size of the search field and the results list separately. Values around `1.0` keep the default look while higher numbers enlarge the respective element up to five times.
 
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal


### PR DESCRIPTION
## Summary
- move windows to the active desktop when restoring
- only compile this logic on Windows
- document the behaviour

## Testing
- `cargo test --no-run`
- `cargo test` *(fails: `rustfmt` not installed due to network restrictions)*
 