### PR TITLE
Enforce exclusive CapsLock hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ for these fields.
 If you choose `CapsLock` as the hotkey, the launcher suppresses the normal
 CapsLock toggle **when compiled with the `unstable_grab` feature enabled**.
 Press `Shift`+`CapsLock` to change the keyboard state while the application is
-running.
+running. The launcher only responds when `CapsLock` is pressed on its own; any
+other modifier keys will simply toggle the caps lock state without showing the
+window.
 
 ## Plugins
 

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -355,6 +355,7 @@ impl HotkeyTrigger {
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_clone = stop_flag.clone();
         let vk_keys: Vec<_> = triggers.iter().map(|t| vk_from_key(t.key)).collect();
+        let watch_keys: Vec<Key> = triggers.iter().map(|t| t.key).collect();
         let need_ctrl: Vec<bool> = triggers.iter().map(|t| t.ctrl).collect();
         let need_shift: Vec<bool> = triggers.iter().map(|t| t.shift).collect();
         let need_alt: Vec<bool> = triggers.iter().map(|t| t.alt).collect();
@@ -372,10 +373,18 @@ impl HotkeyTrigger {
                 for i in 0..vk_keys.len() {
                     if let Some(vk) = vk_keys[i] {
                         let key_down = is_down(vk);
-                        let combo = key_down
-                            && (!need_ctrl[i] || ctrl_pressed)
-                            && (!need_shift[i] || shift_pressed)
-                            && (!need_alt[i] || alt_pressed);
+                        let combo = if watch_keys[i] == Key::CapsLock
+                            && !need_ctrl[i]
+                            && !need_shift[i]
+                            && !need_alt[i]
+                        {
+                            key_down && !ctrl_pressed && !shift_pressed && !alt_pressed
+                        } else {
+                            key_down
+                                && (!need_ctrl[i] || ctrl_pressed)
+                                && (!need_shift[i] || shift_pressed)
+                                && (!need_alt[i] || alt_pressed)
+                        };
                         if combo {
                             if !triggered[i] {
                                 triggered[i] = true;
@@ -464,10 +473,18 @@ pub fn process_test_events(triggers: &[Arc<HotkeyTrigger>], events: &[EventType]
         }
 
         for i in 0..watch_keys.len() {
-            let combo = watch_pressed[i]
-                && (!need_ctrl[i] || ctrl_pressed)
-                && (!need_shift[i] || shift_pressed)
-                && (!need_alt[i] || alt_pressed);
+            let combo = if watch_keys[i] == Key::CapsLock
+                && !need_ctrl[i]
+                && !need_shift[i]
+                && !need_alt[i]
+            {
+                watch_pressed[i] && !ctrl_pressed && !shift_pressed && !alt_pressed
+            } else {
+                watch_pressed[i]
+                    && (!need_ctrl[i] || ctrl_pressed)
+                    && (!need_shift[i] || shift_pressed)
+                    && (!need_alt[i] || alt_pressed)
+            };
             if combo {
                 if !triggered[i] {
                     triggered[i] = true;

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -79,3 +79,21 @@ fn zero_key_events_toggle_visibility() {
     );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }
+
+#[test]
+fn shift_capslock_does_not_trigger() {
+    let caps_hotkey = parse_hotkey("CapsLock").unwrap();
+    let trigger = Arc::new(HotkeyTrigger::new(caps_hotkey));
+
+    let triggers = vec![trigger.clone()];
+    let events = vec![
+        EventType::KeyPress(Key::ShiftLeft),
+        EventType::KeyPress(Key::CapsLock),
+        EventType::KeyRelease(Key::CapsLock),
+        EventType::KeyRelease(Key::ShiftLeft),
+    ];
+
+    process_test_events(&triggers, &events);
+
+    assert!(!trigger.take());
+}


### PR DESCRIPTION
## Summary
- ensure CapsLock-only hotkey ignores extra modifiers
- update docs describing CapsLock behaviour
- test CapsLock with Shift does not toggle visibility

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c2c305a5c8332ba1d075ff479c3f9