### PR TITLE
Add toast helper and success feedback

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -71,7 +71,7 @@ pub struct LauncherApp {
     pub window_pos: (i32, i32),
     focus_query: bool,
     toasts: egui_toast::Toasts,
-    enable_toasts: bool,
+    pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
     help_window: crate::help_window::HelpWindow,
     pub query_scale: f32,
@@ -88,6 +88,9 @@ pub struct LauncherApp {
 }
 
 impl LauncherApp {
+    pub fn add_toast(&mut self, toast: Toast) {
+        self.toasts.add(toast);
+    }
     pub fn update_paths(
         &mut self,
         plugin_dirs: Option<Vec<String>>,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,6 +1,7 @@
 use crate::settings::Settings;
 use crate::gui::LauncherApp;
 use eframe::egui;
+use egui_toast::{Toast, ToastKind, ToastOptions};
 #[cfg(target_os = "windows")]
 use rfd::FileDialog;
 
@@ -227,6 +228,13 @@ impl SettingsEditor {
                             app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);
                             app.history_limit = new_settings.history_limit;
                             crate::request_hotkey_restart(new_settings);
+                            if app.enable_toasts {
+                                app.add_toast(Toast {
+                                    text: "Settings saved".into(),
+                                    kind: ToastKind::Success,
+                                    options: ToastOptions::default().duration_in_seconds(3.0),
+                                });
+                            }
                         }
                     }
                     Err(e) => app.error = Some(format!("Failed to read settings: {e}")),


### PR DESCRIPTION
## Summary
- expose `enable_toasts` and add `LauncherApp::add_toast`
- emit a toast on successful settings save
- import toast types for settings editor

## Testing
- `cargo test --workspace --lib --tests`

 