### PR TITLE
Wrap settings UI in scroll area

### DIFF
--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -111,6 +111,9 @@ impl SettingsEditor {
         egui::Window::new("Settings")
             .open(&mut open)
             .show(ctx, |ui| {
+                egui::ScrollArea::vertical()
+                    .max_height(300.0)
+                    .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Launcher hotkey");
                 let resp = ui.text_edit_singleline(&mut self.hotkey);
@@ -280,6 +283,7 @@ impl SettingsEditor {
                     }
                 }
             }
+            });
         });
         app.show_settings = open;
     }


### PR DESCRIPTION
## Summary
- add a vertical scroll area to the settings editor so it doesn't enlarge the window

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c3d9e07848332bba644e8cc7cfd00