### PR TITLE
Add quick help overlay via F1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
 {
   "hotkey": "F2",
   "quit_hotkey": "Shift+Escape",
+  "help_hotkey": "F1",
   "index_paths": ["C:/ProgramData/Microsoft/Windows/Start Menu/Programs"],
   "plugin_dirs": ["./plugins"],
   "enabled_plugins": [
@@ -83,6 +84,7 @@ keys (`F1`-`F12`) and common keys like `Space`, `Tab`, `Return`, `Escape`,
 `quit_hotkey` can be set to another key combination to close the launcher from
 anywhere. If omitted, the application only quits when the window is closed
 through the GUI.
+`help_hotkey` shows a quick overlay listing commands. Remove it to disable the overlay.
 
 `offscreen_pos` specifies where the window is moved when hiding it. Choose
 coordinates outside the visible monitor area so the window stays accessible but

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
     "hotkey": "F2",
     "quit_hotkey": "Shift+Escape",
+    "help_hotkey": "F1",
     "index_paths": null,
     "plugin_dirs": null,
     "debug_logging": false,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -74,6 +74,10 @@ pub struct LauncherApp {
     pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
     help_window: crate::help_window::HelpWindow,
+    pub help_flag: Arc<AtomicBool>,
+    pub hotkey_str: Option<String>,
+    pub quit_hotkey_str: Option<String>,
+    pub help_hotkey_str: Option<String>,
     pub query_scale: f32,
     pub list_scale: f32,
     /// Number of user defined commands at the start of `actions`.
@@ -150,6 +154,7 @@ impl LauncherApp {
         enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
         visible_flag: Arc<AtomicBool>,
         restore_flag: Arc<AtomicBool>,
+        help_flag: Arc<AtomicBool>,
     ) -> Self {
         let (tx, rx) = channel();
         let mut watchers = Vec::new();
@@ -231,6 +236,10 @@ impl LauncherApp {
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
             help_window: HelpWindow::default(),
+            help_flag: help_flag.clone(),
+            hotkey_str: settings.hotkey.clone(),
+            quit_hotkey_str: settings.quit_hotkey.clone(),
+            help_hotkey_str: settings.help_hotkey.clone(),
             query_scale,
             list_scale,
             custom_len,
@@ -389,6 +398,9 @@ impl eframe::App for LauncherApp {
             self.window_pos = (rect.min.x as i32, rect.min.y as i32);
         }
         let do_restore = self.restore_flag.swap(false, Ordering::SeqCst);
+        if self.help_flag.swap(false, Ordering::SeqCst) {
+            self.help_window.overlay_open = true;
+        }
         if do_restore {
             tracing::debug!("Restoring window on restore_flag");
             apply_visibility(

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -5,10 +5,44 @@ use eframe::egui;
 pub struct HelpWindow {
     pub open: bool,
     pub show_examples: bool,
+    pub overlay_open: bool,
 }
 
 impl HelpWindow {
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if self.overlay_open {
+            let mut open = self.overlay_open;
+            egui::Window::new("Quick Help")
+                .open(&mut open)
+                .resizable(true)
+                .default_size((300.0, 200.0))
+                .collapsible(false)
+                .show(ctx, |ui| {
+                    ui.label(egui::RichText::new("Hotkeys").strong());
+                    if let Some(hk) = &app.hotkey_str {
+                        ui.label(format!("Toggle launcher: {hk}"));
+                    }
+                    if let Some(hk) = &app.quit_hotkey_str {
+                        ui.label(format!("Quit launcher: {hk}"));
+                    }
+                    if let Some(hk) = &app.help_hotkey_str {
+                        ui.label(format!("Help overlay: {hk}"));
+                    }
+                    ui.separator();
+                    ui.label(egui::RichText::new("Commands").strong());
+                    let mut infos = app.plugins.plugin_infos();
+                    infos.sort_by(|a, b| a.0.cmp(&b.0));
+                    let area_height = ui.available_height();
+                    egui::ScrollArea::vertical()
+                        .max_height(area_height)
+                        .show(ui, |ui| {
+                            for (name, desc, _) in &infos {
+                                ui.label(format!("{name}: {desc}"));
+                            }
+                        });
+                });
+            self.overlay_open = open;
+        }
         if !self.open {
             return;
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 pub struct Settings {
     pub hotkey: Option<String>,
     pub quit_hotkey: Option<String>,
+    /// Hotkey to show the quick help overlay. If `None`, the overlay is disabled.
+    pub help_hotkey: Option<String>,
     pub index_paths: Option<Vec<String>>,
     pub plugin_dirs: Option<Vec<String>>,
     /// List of plugin names which should be enabled. If `None`, all loaded
@@ -76,6 +78,7 @@ impl Default for Settings {
         Self {
             hotkey: Some("F2".into()),
             quit_hotkey: None,
+            help_hotkey: Some("F1".into()),
             index_paths: None,
             plugin_dirs: None,
             enabled_plugins: None,
@@ -139,6 +142,22 @@ impl Settings {
                 None => {
                     tracing::warn!(
                         "provided quit_hotkey string '{}' is invalid; ignoring",
+                        hotkey
+                    );
+                }
+            }
+        }
+        None
+    }
+
+    /// Parse the help overlay hotkey if configured.
+    pub fn help_hotkey(&self) -> Option<Hotkey> {
+        if let Some(hotkey) = &self.help_hotkey {
+            match parse_hotkey(hotkey) {
+                Some(k) => return Some(k),
+                None => {
+                    tracing::warn!(
+                        "provided help_hotkey string '{}' is invalid; ignoring",
                         hotkey
                     );
                 }

--- a/tests/ranking.rs
+++ b/tests/ranking.rs
@@ -21,6 +21,7 @@ fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Se
         None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
     )
 }
 

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -21,6 +21,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
     )
 }
 


### PR DESCRIPTION
## Summary
- add a `help_hotkey` setting and show in README
- implement quick overlay window in `help_window.rs`
- trigger overlay via global hotkey managed in `main.rs`
- expose hotkey strings on `LauncherApp` and update when settings save
- update tests for new parameter

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c4b65d8948332acfa74e788cee7b5