### PR TITLE
Add processes plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -2150,6 +2150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "sysinfo",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -2250,6 +2251,15 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2418,6 +2428,16 @@ dependencies = [
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3208,6 +3228,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,6 +3962,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,9 +4000,33 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3965,6 +4045,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3994,6 +4085,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,13 +4121,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4108,6 +4244,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ arboard = "3"
 egui-toast = "0.13"
 dirs-next = "2"
 shlex = "1.3"
+sysinfo = "0.35"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = { version = "0.15.3", default-features = false, features = ["common-controls-v6"] }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Built-in plugins and their command prefixes are:
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
+- Process list (`ps`)
 - Search history (`hi`)
 - Command overview (`help`)
 
@@ -181,6 +182,7 @@ Example:
     "shell",
     "runescape_search",
     "system",
+    "processes",
     "history",
     "help"
   ]

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Built-in plugins and their command prefixes are:
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
-- Process list (`ps`)
+- Process list (`ps`), providing "Switch to" and "Kill" actions
 - Search history (`hi`)
 - Command overview (`help`)
 

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -110,7 +110,7 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     }
     if let Some(pid) = action.action.strip_prefix("process:kill:") {
         if let Ok(pid) = pid.parse::<u32>() {
-            let mut system = sysinfo::System::new_all();
+            let mut system = System::new_all();
             if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
                 let _ = process.kill();
             }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,6 +8,7 @@ use crate::plugins::runescape::RunescapeSearchPlugin;
 use crate::plugins::history::HistoryPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::system::SystemPlugin;
+use crate::plugins::processes::ProcessesPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
@@ -55,6 +56,7 @@ impl PluginManager {
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(FoldersPlugin::default()));
         self.register(Box::new(SystemPlugin));
+        self.register(Box::new(ProcessesPlugin));
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(HelpPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -8,3 +8,4 @@ pub mod system;
 pub mod help;
 pub mod youtube;
 pub mod reddit;
+pub mod processes;

--- a/src/plugins/processes.rs
+++ b/src/plugins/processes.rs
@@ -1,0 +1,60 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use sysinfo::System;
+
+pub struct ProcessesPlugin;
+
+impl Plugin for ProcessesPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if !query.starts_with("ps") {
+            return Vec::new();
+        }
+        let filter = query.strip_prefix("ps").unwrap_or("").trim().to_lowercase();
+        let system = System::new_all();
+        system
+            .processes()
+            .values()
+            .filter(|p| {
+                if filter.is_empty() {
+                    true
+                } else {
+                    p.name()
+                        .to_string_lossy()
+                        .to_lowercase()
+                        .contains(&filter)
+                }
+            })
+            .flat_map(|p| {
+                let name = p.name().to_string_lossy().to_string();
+                let pid = p.pid().as_u32();
+                vec![
+                    Action {
+                        label: format!("Switch to {name}"),
+                        desc: format!("PID {pid}"),
+                        action: format!("process:switch:{pid}"),
+                        args: None,
+                    },
+                    Action {
+                        label: format!("Kill {name}"),
+                        desc: format!("PID {pid}"),
+                        action: format!("process:kill:{pid}"),
+                        args: None,
+                    },
+                ]
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "processes"
+    }
+
+    fn description(&self) -> &str {
+        "Enumerate running processes (prefix: `ps`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -222,3 +222,25 @@ pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWN
         None
     }
 }
+
+#[cfg(target_os = "windows")]
+pub fn activate_process(pid: u32) {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindow, GetWindowThreadProcessId, IsWindowVisible, GW_OWNER,
+    };
+    unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let target = lparam.0 as u32;
+        let mut pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        if pid == target && IsWindowVisible(hwnd).as_bool() && GetWindow(hwnd, GW_OWNER).0 == 0 {
+            crate::window_manager::force_restore_and_foreground(hwnd);
+            return BOOL(0);
+        }
+        BOOL(1)
+    }
+
+    unsafe {
+        EnumWindows(Some(enum_cb), LPARAM(pid as isize));
+    }
+}

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -235,7 +235,7 @@ pub fn activate_process(pid: u32) {
         GetWindowThreadProcessId(hwnd, Some(&mut pid));
         if pid == target
             && IsWindowVisible(hwnd).as_bool()
-            && GetWindow(hwnd, GW_OWNER).unwrap_or_default().0 == 0
+            && GetWindow(hwnd, GW_OWNER).unwrap_or_default().0.is_null()
         {
             crate::window_manager::force_restore_and_foreground(hwnd);
             return BOOL(0);

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -233,7 +233,10 @@ pub fn activate_process(pid: u32) {
         let target = lparam.0 as u32;
         let mut pid: u32 = 0;
         GetWindowThreadProcessId(hwnd, Some(&mut pid));
-        if pid == target && IsWindowVisible(hwnd).as_bool() && GetWindow(hwnd, GW_OWNER).0 == 0 {
+        if pid == target
+            && IsWindowVisible(hwnd).as_bool()
+            && GetWindow(hwnd, GW_OWNER).unwrap_or_default().0 == 0
+        {
             crate::window_manager::force_restore_and_foreground(hwnd);
             return BOOL(0);
         }

--- a/tests/processes_plugin.rs
+++ b/tests/processes_plugin.rs
@@ -1,0 +1,9 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::processes::ProcessesPlugin;
+
+#[test]
+fn search_returns_processes() {
+    let plugin = ProcessesPlugin;
+    let results = plugin.search("ps");
+    assert!(!results.is_empty());
+}

--- a/tests/processes_plugin.rs
+++ b/tests/processes_plugin.rs
@@ -2,8 +2,9 @@ use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::processes::ProcessesPlugin;
 
 #[test]
-fn search_returns_processes() {
+fn search_returns_process_actions() {
     let plugin = ProcessesPlugin;
     let results = plugin.search("ps");
-    assert!(!results.is_empty());
+    assert!(results.iter().any(|a| a.action.starts_with("process:switch:")));
+    assert!(results.iter().any(|a| a.action.starts_with("process:kill:")));
 }


### PR DESCRIPTION
## Summary
- add a ProcessesPlugin to list running processes with sysinfo
- register new plugin in the plugin manager
- document `ps` prefix
- include processes plugin in README example
- test that the plugin returns at least one entry

## Testing
- `cargo test`

 