### PR TITLE
Add weather plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
     "folders",
     "shell",
     "runescape_search",
+    "weather",
     "system",
     "history",
     "help"
@@ -140,6 +141,7 @@ Built-in plugins and their command prefixes are:
 - RuneScape Wiki search (`rs item` or `osrs item`)
 - YouTube search (`yt rust`)
 - Reddit search (`red cats`)
+- Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
 - Clipboard history (`cb`)
 - Bookmarks (`bm add <url>` or `bm rm <pattern>`)
@@ -183,6 +185,7 @@ Example:
     "runescape_search",
     "system",
     "processes",
+    "weather",
     "history",
     "help"
   ]

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -92,6 +92,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "folders" => Some(&["f add C:/path", "f rm docs"]),
         "shell" => Some(&["sh echo hello"]),
         "system" => Some(&["sys shutdown"]),
+        "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
         "help" => Some(&["help"]),
         _ => None,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::plugins::processes::ProcessesPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
+use crate::plugins::weather::WeatherPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -60,6 +61,7 @@ impl PluginManager {
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(HelpPlugin));
+        self.register(Box::new(WeatherPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");
             let _ = self.load_dir(dir);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -9,3 +9,4 @@ pub mod help;
 pub mod youtube;
 pub mod reddit;
 pub mod processes;
+pub mod weather;

--- a/src/plugins/weather.rs
+++ b/src/plugins/weather.rs
@@ -1,0 +1,35 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+/// Simple plugin that opens weather.com for a given location using the `weather` prefix.
+pub struct WeatherPlugin;
+
+impl Plugin for WeatherPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(q) = query.strip_prefix("weather ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Show weather for {q}"),
+                    desc: "Web search".into(),
+                    action: format!("https://www.weather.com/weather/today/l/{q}"),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "weather"
+    }
+
+    fn description(&self) -> &str {
+        "Display the weather for a location using weather.com (prefix: `weather`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/tests/weather_plugin.rs
+++ b/tests/weather_plugin.rs
@@ -1,0 +1,10 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::weather::WeatherPlugin;
+
+#[test]
+fn search_returns_action() {
+    let plugin = WeatherPlugin;
+    let results = plugin.search("weather Berlin");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://www.weather.com/weather/today/l/Berlin");
+}


### PR DESCRIPTION
## Summary
- add new weather plugin
- wire weather plugin into plugin manager
- document weather plugin usage
- show example weather queries in help window
- test the weather plugin

## Testing
- `cargo test --quiet`
 