### PR TITLE
Add timer and alarm plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "futures-lite 1.13.0",
  "once_cell",
  "serde",
- "zbus",
+ "zbus 3.15.2",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -149,6 +149,12 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -220,6 +226,18 @@ checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
 dependencies = [
  "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -343,6 +361,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+dependencies = [
+ "async-channel",
+ "async-io 2.4.1",
+ "async-lock 3.4.0",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite 2.6.0",
+ "rustix 1.0.7",
+ "tracing",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,9 +451,9 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zbus",
- "zbus_names",
- "zvariant",
+ "zbus 3.15.2",
+ "zbus_names 2.6.1",
+ "zvariant 3.15.2",
 ]
 
 [[package]]
@@ -428,7 +465,7 @@ dependencies = [
  "atspi-common",
  "atspi-proxies",
  "futures-lite 1.13.0",
- "zbus",
+ "zbus 3.15.2",
 ]
 
 [[package]]
@@ -439,7 +476,7 @@ checksum = "6495661273703e7a229356dcbe8c8f38223d697aacfaf0e13590a9ac9977bb52"
 dependencies = [
  "atspi-common",
  "serde",
- "zbus",
+ "zbus 3.15.2",
 ]
 
 [[package]]
@@ -605,7 +642,7 @@ dependencies = [
  "polling 3.8.0",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -619,7 +656,7 @@ dependencies = [
  "polling 3.8.0",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -676,12 +713,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -889,6 +946,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,7 +1093,7 @@ dependencies = [
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1069,7 +1135,7 @@ dependencies = [
  "egui",
  "epaint",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "type-map",
  "web-time",
  "wgpu",
@@ -1117,6 +1183,12 @@ checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enumflags2"
@@ -1462,7 +1534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
 dependencies = [
  "bitflags 2.9.1",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "cgl",
  "core-foundation 0.9.4",
  "dispatch",
@@ -1485,7 +1557,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "glutin",
  "raw-window-handle 0.5.2",
  "winit",
@@ -1547,7 +1619,7 @@ checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows 0.52.0",
 ]
@@ -1598,7 +1670,7 @@ dependencies = [
  "com",
  "libc",
  "libloading 0.8.8",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -1634,6 +1706,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1866,7 +1962,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2030,6 +2126,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1280f4ec61016b4960075c5c090085129647807a77a964bdb352c14903450589"
+dependencies = [
+ "cc",
+ "objc2 0.6.1",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2241,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arboard",
+ "chrono",
  "dirs-next",
  "eframe",
  "egui-toast",
@@ -2141,6 +2250,7 @@ dependencies = [
  "log",
  "meval",
  "notify",
+ "notify-rust",
  "once_cell",
  "open",
  "raw-window-handle 0.6.2",
@@ -2175,7 +2285,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -2192,7 +2302,7 @@ dependencies = [
  "num_enum",
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2220,6 +2330,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2254,6 +2377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
+dependencies = [
+ "futures-lite 2.6.0",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.8.0",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2408,12 @@ dependencies = [
  "overload",
  "winapi",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -2653,6 +2796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,7 +2959,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3101,7 +3250,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3126,7 +3275,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3242,6 +3391,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.12",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,7 +3430,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3277,6 +3447,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3302,6 +3483,25 @@ dependencies = [
  "jpeg-decoder",
  "weezl",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tiny-skia"
@@ -3799,7 +3999,7 @@ checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "js-sys",
  "log",
  "parking_lot",
@@ -3824,7 +4024,7 @@ dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.9.1",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
  "indexmap",
  "log",
@@ -3835,7 +4035,7 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -3851,7 +4051,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bitflags 2.9.1",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
@@ -3875,7 +4075,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -4256,6 +4456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-version"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,7 +4656,7 @@ dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
  "calloop 0.12.4",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
@@ -4620,12 +4829,12 @@ version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
- "async-broadcast",
+ "async-broadcast 0.5.1",
  "async-executor",
  "async-fs",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-process",
+ "async-process 1.8.1",
  "async-recursion",
  "async-task",
  "async-trait",
@@ -4638,7 +4847,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "ordered-stream",
  "rand",
@@ -4650,9 +4859,42 @@ dependencies = [
  "uds_windows",
  "winapi",
  "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 3.15.2",
+ "zbus_names 2.6.1",
+ "zvariant 3.15.2",
+]
+
+[[package]]
+name = "zbus"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
+dependencies = [
+ "async-broadcast 0.7.2",
+ "async-executor",
+ "async-io 2.4.1",
+ "async-lock 3.4.0",
+ "async-process 2.3.1",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-lite 2.6.0",
+ "hex",
+ "nix 0.30.1",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.7.11",
+ "zbus_macros 5.8.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.6.0",
 ]
 
 [[package]]
@@ -4666,7 +4908,22 @@ dependencies = [
  "quote",
  "regex",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.0.1",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "zbus_names 4.2.0",
+ "zvariant 5.6.0",
+ "zvariant_utils 3.2.0",
 ]
 
 [[package]]
@@ -4677,7 +4934,19 @@ checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant",
+ "zvariant 3.15.2",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.11",
+ "zvariant 5.6.0",
 ]
 
 [[package]]
@@ -4765,7 +5034,21 @@ dependencies = [
  "libc",
  "serde",
  "static_assertions",
- "zvariant_derive",
+ "zvariant_derive 3.15.2",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.11",
+ "zvariant_derive 5.6.0",
+ "zvariant_utils 3.2.0",
 ]
 
 [[package]]
@@ -4778,7 +5061,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.0.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "zvariant_utils 3.2.0",
 ]
 
 [[package]]
@@ -4790,4 +5086,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.104",
+ "winnow 0.7.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ egui-toast = "0.13"
 dirs-next = "2"
 shlex = "1.3"
 sysinfo = "0.35"
+chrono = "0.4"
+notify-rust = "4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = { version = "0.15.3", default-features = false, features = ["common-controls-v6"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ quickly open applications or files.
 - Run shell commands without opening a terminal.
 - Perform web searches or look up documentation directly.
 - Jump to frequently used folders with the folders plugin.
-- Set timers or alarms from the launcher.
+- Set timers or alarms from the launcher. Type `timer` or `alarm` and press
+  <kbd>Enter</kbd> to open the creation dialog.
 
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ quickly open applications or files.
 - Run shell commands without opening a terminal.
 - Perform web searches or look up documentation directly.
 - Jump to frequently used folders with the folders plugin.
+- Set timers or alarms from the launcher.
 
 
 ## Building
@@ -70,6 +71,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
     "runescape_search",
     "weather",
     "system",
+    "timer",
     "history",
     "help"
   ],
@@ -149,6 +151,7 @@ Built-in plugins and their command prefixes are:
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
 - Process list (`ps`), providing "Switch to" and "Kill" actions
+- Timers and alarms (`timer 5m tea`, `alarm 07:30`)
 - Search history (`hi`)
 - Command overview (`help`)
 
@@ -186,6 +189,7 @@ Example:
     "system",
     "processes",
     "weather",
+    "timer",
     "history",
     "help"
   ]

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Built-in plugins and their command prefixes are:
 - Process list (`ps`), providing "Switch to" and "Kill" actions
 - Timers and alarms (`timer 5m tea`, `alarm 07:30`). Use `timer list` to view
   remaining time. Pending alarms are saved to `alarms.json` and resume after
-  restarting the launcher.
+  restarting the launcher. A plugin setting controls pop-up dialogs when a
+  timer completes.
 - Search history (`hi`)
 - Command overview (`help`)
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Built-in plugins and their command prefixes are:
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
 - Process list (`ps`), providing "Switch to" and "Kill" actions
-- Timers and alarms (`timer 5m tea`, `alarm 07:30`)
+- Timers and alarms (`timer 5m tea`, `alarm 07:30`). Use `timer list` to view
+  remaining time. Pending alarms are saved to `alarms.json` and resume after
+  restarting the launcher.
 - Search history (`hi`)
 - Command overview (`help`)
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -17,6 +17,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use crate::visibility::apply_visibility;
 use std::collections::HashMap;
 use crate::help_window::HelpWindow;
+use crate::timer_help_window::TimerHelpWindow;
 
 fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
     ui.scope(|ui| {
@@ -74,6 +75,7 @@ pub struct LauncherApp {
     pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
     help_window: crate::help_window::HelpWindow,
+    timer_help: crate::timer_help_window::TimerHelpWindow,
     pub help_flag: Arc<AtomicBool>,
     pub hotkey_str: Option<String>,
     pub quit_hotkey_str: Option<String>,
@@ -236,6 +238,7 @@ impl LauncherApp {
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
             help_window: HelpWindow::default(),
+            timer_help: TimerHelpWindow::default(),
             help_flag: help_flag.clone(),
             hotkey_str: settings.hotkey.clone(),
             quit_hotkey_str: settings.quit_hotkey.clone(),
@@ -465,6 +468,9 @@ impl eframe::App for LauncherApp {
                 ui.menu_button("Help", |ui| {
                     if ui.button("Command List").clicked() {
                         self.help_window.open = true;
+                    }
+                    if ui.button("Timer Plugin Help").clicked() {
+                        self.timer_help.open = true;
                     }
                 });
             });
@@ -714,6 +720,9 @@ impl eframe::App for LauncherApp {
         let mut help = std::mem::take(&mut self.help_window);
         help.ui(ctx, self);
         self.help_window = help;
+        let mut timer_help = std::mem::take(&mut self.timer_help);
+        timer_help.ui(ctx);
+        self.timer_help = timer_help;
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -293,15 +293,7 @@ impl LauncherApp {
         let mut res: Vec<(Action, f32)> = Vec::new();
 
         let trimmed = self.query.trim();
-        if trimmed.eq_ignore_ascii_case("timer") {
-            if !self.timer_dialog.open {
-                self.timer_dialog.open_timer();
-            }
-        } else if trimmed.eq_ignore_ascii_case("alarm") {
-            if !self.timer_dialog.open {
-                self.timer_dialog.open_alarm();
-            }
-        }
+
 
         if self.query.is_empty() {
             res.extend(self.actions.iter().cloned().map(|a| (a, 0.0)));
@@ -557,6 +549,10 @@ impl eframe::App for LauncherApp {
                         let mut set_focus = false;
                         if a.action == "help:show" {
                             self.help_window.open = true;
+                        } else if a.action == "timer:dialog:timer" {
+                            self.timer_dialog.open_timer();
+                        } else if a.action == "timer:dialog:alarm" {
+                            self.timer_dialog.open_alarm();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             if self.enable_toasts {
@@ -670,6 +666,10 @@ impl eframe::App for LauncherApp {
                         let current = self.query.clone();
                         if a.action == "help:show" {
                             self.help_window.open = true;
+                        } else if a.action == "timer:dialog:timer" {
+                            self.timer_dialog.open_timer();
+                        } else if a.action == "timer:dialog:alarm" {
+                            self.timer_dialog.open_alarm();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             if self.enable_toasts {

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -94,6 +94,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "system" => Some(&["sys shutdown"]),
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
+        "timer" => Some(&["timer 10s break", "timer list", "alarm 07:30"]),
         "help" => Some(&["help"]),
         _ => None,
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -134,14 +134,24 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         return Ok(());
     }
     if let Some(arg) = action.action.strip_prefix("timer:start:") {
-        if let Some(dur) = timer::parse_duration(arg) {
-            timer::start_timer(dur);
+        let (dur_str, name) = arg.split_once('|').unwrap_or((arg, ""));
+        if let Some(dur) = timer::parse_duration(dur_str) {
+            if name.is_empty() {
+                timer::start_timer(dur);
+            } else {
+                timer::start_timer_named(dur, Some(name.to_string()));
+            }
         }
         return Ok(());
     }
     if let Some(arg) = action.action.strip_prefix("alarm:set:") {
-        if let Some((h, m)) = timer::parse_hhmm(arg) {
-            timer::start_alarm(h, m);
+        let (time_str, name) = arg.split_once('|').unwrap_or((arg, ""));
+        if let Some((h, m)) = timer::parse_hhmm(time_str) {
+            if name.is_empty() {
+                timer::start_alarm(h, m);
+            } else {
+                timer::start_alarm_named(h, m, Some(name.to_string()));
+            }
         }
         return Ok(());
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,6 +1,7 @@
 use crate::actions::Action;
 use crate::plugins::bookmarks::{append_bookmark, remove_bookmark};
 use crate::plugins::folders::{append_folder, remove_folder, FOLDERS_FILE};
+use crate::plugins::timer;
 use crate::history;
 use sysinfo::System;
 use arboard::Clipboard;
@@ -123,6 +124,24 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
             {
                 crate::window_manager::activate_process(pid);
             }
+        }
+        return Ok(());
+    }
+    if let Some(id) = action.action.strip_prefix("timer:cancel:") {
+        if let Ok(id) = id.parse::<u64>() {
+            timer::cancel_timer(id);
+        }
+        return Ok(());
+    }
+    if let Some(arg) = action.action.strip_prefix("timer:start:") {
+        if let Some(dur) = timer::parse_duration(arg) {
+            timer::start_timer(dur);
+        }
+        return Ok(());
+    }
+    if let Some(arg) = action.action.strip_prefix("alarm:set:") {
+        if let Some((h, m)) = timer::parse_hhmm(arg) {
+            timer::start_alarm(h, m);
         }
         return Ok(());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hotkey;
 pub mod history;
 pub mod visibility;
 pub mod help_window;
+pub mod timer_help_window;
 
 pub mod window_manager;
 pub mod workspace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod history;
 pub mod visibility;
 pub mod help_window;
 pub mod timer_help_window;
+pub mod timer_dialog;
 
 pub mod window_manager;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod workspace;
 mod plugins;
 mod help_window;
 mod timer_help_window;
+mod timer_dialog;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod window_manager;
 mod workspace;
 mod plugins;
 mod help_window;
+mod timer_help_window;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -13,6 +13,7 @@ use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
 use crate::plugins::weather::WeatherPlugin;
+use crate::plugins::timer::TimerPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -61,6 +62,7 @@ impl PluginManager {
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(HelpPlugin));
+        self.register(Box::new(crate::plugins::timer::TimerPlugin));
         self.register(Box::new(WeatherPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -62,7 +62,8 @@ impl PluginManager {
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(HelpPlugin));
-        self.register(Box::new(crate::plugins::timer::TimerPlugin));
+        self.register(Box::new(TimerPlugin));
+        crate::plugins::timer::load_saved_alarms();
         self.register(Box::new(WeatherPlugin));
         for dir in dirs {
             tracing::debug!("loading plugins from {dir}");

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -10,3 +10,4 @@ pub mod youtube;
 pub mod reddit;
 pub mod processes;
 pub mod weather;
+pub mod timer;

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -1,0 +1,162 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use once_cell::sync::Lazy;
+use std::sync::{Mutex, Arc, atomic::{AtomicBool, AtomicU64, Ordering}};
+use std::time::{Duration, Instant};
+use std::thread;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+pub struct TimerEntry {
+    pub id: u64,
+    pub label: String,
+    pub cancel: Arc<AtomicBool>,
+}
+
+pub static ACTIVE_TIMERS: Lazy<Mutex<Vec<TimerEntry>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+pub fn parse_duration(input: &str) -> Option<Duration> {
+    if input.len() < 2 { return None; }
+    let (num_str, unit) = input.split_at(input.len()-1);
+    let value: u64 = num_str.parse().ok()?;
+    match unit {
+        "s" | "S" => Some(Duration::from_secs(value)),
+        "m" | "M" => Some(Duration::from_secs(value * 60)),
+        "h" | "H" => Some(Duration::from_secs(value * 60 * 60)),
+        _ => None,
+    }
+}
+
+pub fn parse_hhmm(input: &str) -> Option<(u32, u32)> {
+    let parts: Vec<&str> = input.split(':').collect();
+    if parts.len() != 2 { return None; }
+    let h: u32 = parts[0].parse().ok()?;
+    let m: u32 = parts[1].parse().ok()?;
+    if h < 24 && m < 60 {
+        Some((h, m))
+    } else {
+        None
+    }
+}
+
+pub fn active_timers() -> Vec<(u64, String)> {
+    ACTIVE_TIMERS.lock().unwrap().iter().map(|t| (t.id, t.label.clone())).collect()
+}
+
+pub fn cancel_timer(id: u64) {
+    let mut timers = ACTIVE_TIMERS.lock().unwrap();
+    if let Some(pos) = timers.iter().position(|t| t.id == id) {
+        let entry = timers.remove(pos);
+        entry.cancel.store(true, Ordering::SeqCst);
+    }
+}
+
+fn notify(msg: &str) {
+    #[allow(unused)]
+    {
+        let _ = notify_rust::Notification::new().summary("Multi Launcher").body(msg).show();
+    }
+}
+
+pub fn start_timer(duration: Duration) {
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let cancel = Arc::new(AtomicBool::new(false));
+    let label = format!("Timer {:?}", duration);
+    {
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        list.push(TimerEntry { id, label: label.clone(), cancel: cancel.clone() });
+    }
+    thread::spawn(move || {
+        let start = Instant::now();
+        loop {
+            let remaining = duration.saturating_sub(start.elapsed());
+            if remaining.is_zero() { break; }
+            if cancel.load(Ordering::SeqCst) { return; }
+            thread::sleep(Duration::from_millis(100));
+        }
+        if !cancel.load(Ordering::SeqCst) {
+            notify(&format!("Timer finished: {}", label));
+        }
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        if let Some(pos) = list.iter().position(|t| t.id == id) { list.remove(pos); }
+    });
+}
+
+pub fn start_alarm(hour: u32, minute: u32) {
+    use chrono::{Timelike, Local, Duration as ChronoDuration};
+    let now = Local::now();
+    let mut target = now.date_naive().and_hms_opt(hour, minute, 0).unwrap();
+    if target <= now.naive_local() {
+        target += ChronoDuration::days(1);
+    }
+    let duration = (target - now.naive_local()).to_std().unwrap_or(Duration::from_secs(0));
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let cancel = Arc::new(AtomicBool::new(false));
+    let label = format!("Alarm {:02}:{:02}", hour, minute);
+    {
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        list.push(TimerEntry { id, label: label.clone(), cancel: cancel.clone() });
+    }
+    thread::spawn(move || {
+        let start = Instant::now();
+        loop {
+            let remaining = duration.saturating_sub(start.elapsed());
+            if remaining.is_zero() { break; }
+            if cancel.load(Ordering::SeqCst) { return; }
+            thread::sleep(Duration::from_millis(100));
+        }
+        if !cancel.load(Ordering::SeqCst) {
+            notify(&format!("Alarm triggered: {}", label));
+        }
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        if let Some(pos) = list.iter().position(|t| t.id == id) { list.remove(pos); }
+    });
+}
+
+pub struct TimerPlugin;
+
+impl Plugin for TimerPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if query.starts_with("timer cancel") {
+            return active_timers()
+                .into_iter()
+                .map(|(id, label)| Action {
+                    label: format!("Cancel {label}"),
+                    desc: "Timer".into(),
+                    action: format!("timer:cancel:{id}"),
+                    args: None,
+                })
+                .collect();
+        }
+        if let Some(arg) = query.strip_prefix("timer ") {
+            let arg = arg.trim();
+            if let Some(_) = parse_duration(arg) {
+                return vec![Action {
+                    label: format!("Start timer {arg}"),
+                    desc: "Timer".into(),
+                    action: format!("timer:start:{arg}"),
+                    args: None,
+                }];
+            }
+        }
+        if let Some(arg) = query.strip_prefix("alarm ") {
+            let arg = arg.trim();
+            if parse_hhmm(arg).is_some() {
+                return vec![Action {
+                    label: format!("Set alarm {arg}"),
+                    desc: "Timer".into(),
+                    action: format!("alarm:set:{arg}"),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str { "timer" }
+
+    fn description(&self) -> &str { "Create timers and alarms (prefix: `timer` / `alarm`)" }
+
+    fn capabilities(&self) -> &[&str] { &["search"] }
+}
+

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -226,7 +226,24 @@ pub struct TimerPlugin;
 
 impl Plugin for TimerPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if query.starts_with("timer list") || query.starts_with("alarm list") {
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("timer") {
+            return vec![Action {
+                label: "Open timer dialog".into(),
+                desc: "Timer".into(),
+                action: "timer:dialog:timer".into(),
+                args: None,
+            }];
+        }
+        if trimmed.eq_ignore_ascii_case("alarm") {
+            return vec![Action {
+                label: "Open alarm dialog".into(),
+                desc: "Timer".into(),
+                action: "timer:dialog:alarm".into(),
+                args: None,
+            }];
+        }
+        if trimmed.starts_with("timer list") || trimmed.starts_with("alarm list") {
             return active_timers()
                 .into_iter()
                 .map(|(id, label, rem)| Action {
@@ -237,7 +254,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if query.starts_with("timer cancel") {
+        if trimmed.starts_with("timer cancel") {
             return active_timers()
                 .into_iter()
                 .map(|(id, label, _)| Action {
@@ -248,7 +265,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if let Some(arg) = query.strip_prefix("timer ") {
+        if let Some(arg) = trimmed.strip_prefix("timer ") {
             let arg = arg.trim();
             let mut parts = arg.splitn(2, ' ');
             let dur_part = parts.next().unwrap_or("");
@@ -267,7 +284,7 @@ impl Plugin for TimerPlugin {
                 return vec![Action { label, desc: "Timer".into(), action, args: None }];
             }
         }
-        if let Some(arg) = query.strip_prefix("alarm ") {
+        if let Some(arg) = trimmed.strip_prefix("alarm ") {
             let arg = arg.trim();
             let mut parts = arg.splitn(2, ' ');
             let time_part = parts.next().unwrap_or("");

--- a/src/timer_dialog.rs
+++ b/src/timer_dialog.rs
@@ -1,0 +1,121 @@
+use crate::gui::LauncherApp;
+use crate::plugins::timer::{parse_duration, parse_hhmm, start_alarm_named, start_timer_named};
+use eframe::egui;
+#[derive(Default)]
+pub struct TimerDialog {
+    pub open: bool,
+    mode: Mode,
+    duration: String,
+    time: String,
+    label: String,
+}
+
+#[derive(Default, Clone, Copy, PartialEq)]
+enum Mode {
+    #[default]
+    Timer,
+    Alarm,
+}
+
+impl TimerDialog {
+    pub fn open_timer(&mut self) {
+        self.mode = Mode::Timer;
+        self.open = true;
+        self.duration.clear();
+        self.label.clear();
+    }
+
+    pub fn open_alarm(&mut self) {
+        self.mode = Mode::Alarm;
+        self.open = true;
+        self.time.clear();
+        self.label.clear();
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut open_val = self.open;
+        let mut close = false;
+        egui::Window::new(match self.mode { Mode::Timer => "Create Timer", Mode::Alarm => "Set Alarm" })
+            .open(&mut open_val)
+            .resizable(false)
+            .show(ctx, |ui| {
+                match self.mode {
+                    Mode::Timer => {
+                        ui.horizontal(|ui| {
+                            ui.label("Duration (Ns/Nm/Nh)");
+                            ui.text_edit_singleline(&mut self.duration);
+                        });
+                    }
+                    Mode::Alarm => {
+                        ui.horizontal(|ui| {
+                            ui.label("Time (HH:MM)");
+                            ui.text_edit_singleline(&mut self.time);
+                        });
+                    }
+                }
+                ui.horizontal(|ui| {
+                    ui.label("Name");
+                    ui.text_edit_singleline(&mut self.label);
+                });
+                ui.horizontal(|ui| {
+                    if ui.button("Start").clicked() {
+                        match self.mode {
+                            Mode::Timer => {
+                                if let Some(d) = parse_duration(&self.duration) {
+                                    start_timer_named(d, if self.label.is_empty() { None } else { Some(self.label.clone()) });
+                                    close = true;
+                                    app.focus_input();
+                                } else {
+                                    app.error = Some("Invalid duration".into());
+                                }
+                            }
+                            Mode::Alarm => {
+                                if let Some((h,m)) = parse_hhmm(&self.time) {
+                                    start_alarm_named(h, m, if self.label.is_empty(){None}else{Some(self.label.clone())});
+                                    close = true;
+                                    app.error = Some("Invalid time".into());
+                                }
+                            }
+                        }
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if (close) { open_val = false; }
+        self.open = open_val;
+    }
+}
+
+#[derive(Default)]
+pub struct TimerCompletionDialog {
+    pub open: bool,
+    msg: String,
+}
+
+impl TimerCompletionDialog {
+    pub fn open_message(&mut self, msg: String) {
+        self.msg = msg;
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context) {
+        if !self.open { return; }
+        let mut open_val = self.open;
+        let mut close = false;
+        egui::Window::new("Timer Finished")
+            .collapsible(false)
+            .resizable(false)
+            .open(&mut open_val)
+            .show(ctx, |ui| {
+                ui.label(&self.msg);
+                if ui.button("OK").clicked() {
+                    close = true;
+                }
+            });
+        if close { open_val = false; }
+        self.open = open_val;
+    }
+}

--- a/src/timer_help_window.rs
+++ b/src/timer_help_window.rs
@@ -1,0 +1,37 @@
+use eframe::egui;
+
+#[derive(Default)]
+pub struct TimerHelpWindow {
+    pub open: bool,
+}
+
+impl TimerHelpWindow {
+    pub fn ui(&mut self, ctx: &egui::Context) {
+        if !self.open {
+            return;
+        }
+        let mut open = self.open;
+        egui::Window::new("Timer Help")
+            .open(&mut open)
+            .resizable(true)
+            .default_size((400.0, 220.0))
+            .show(ctx, |ui| {
+                ui.heading("Timer Plugin Usage");
+                ui.separator();
+                ui.label("Create a timer: use 'timer <duration> [name]'. Examples:");
+                ui.monospace("timer 10s tea");
+                ui.monospace("timer 5m");
+                ui.label("Supported units are seconds (s), minutes (m) and hours (h).");
+                ui.separator();
+                ui.label("Set an alarm: use 'alarm <HH:MM> [name]'. Example:");
+                ui.monospace("alarm 07:30 wake up");
+                ui.separator();
+                ui.label("Manage timers and alarms:");
+                ui.monospace("timer list  # show active timers");
+                ui.monospace("alarm list  # show active alarms");
+                ui.monospace("timer cancel  # cancel timers/alarms");
+            });
+        self.open = open;
+    }
+}
+

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -1,0 +1,26 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::timer::{TimerPlugin, ACTIVE_TIMERS, TimerEntry};
+use std::sync::{Arc, atomic::AtomicBool};
+
+#[test]
+fn search_timer_returns_start_action() {
+    let plugin = TimerPlugin;
+    let results = plugin.search("timer 1s");
+    assert_eq!(results.len(), 1);
+    assert!(results[0].action.starts_with("timer:start:"));
+}
+
+#[test]
+fn search_cancel_lists_timers() {
+    // manually insert an active timer
+    {
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        list.push(TimerEntry { id: 1, label: "test".into(), cancel: Arc::new(AtomicBool::new(false)) });
+    }
+    let plugin = TimerPlugin;
+    let results = plugin.search("timer cancel");
+    assert!(results.iter().any(|a| a.action.starts_with("timer:cancel:")));
+    // clear list
+    ACTIVE_TIMERS.lock().unwrap().clear();
+}
+

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -11,6 +11,14 @@ fn search_timer_returns_start_action() {
 }
 
 #[test]
+fn search_named_timer() {
+    let plugin = TimerPlugin;
+    let results = plugin.search("timer 1s tea");
+    assert_eq!(results.len(), 1);
+    assert!(results[0].action.starts_with("timer:start:1s|"));
+}
+
+#[test]
 fn search_cancel_lists_timers() {
     // manually insert an active timer
     {
@@ -21,6 +29,18 @@ fn search_cancel_lists_timers() {
     let results = plugin.search("timer cancel");
     assert!(results.iter().any(|a| a.action.starts_with("timer:cancel:")));
     // clear list
+    ACTIVE_TIMERS.lock().unwrap().clear();
+}
+
+#[test]
+fn search_list_lists_timers() {
+    {
+        let mut list = ACTIVE_TIMERS.lock().unwrap();
+        list.push(TimerEntry { id: 2, label: "demo".into(), cancel: Arc::new(AtomicBool::new(false)) });
+    }
+    let plugin = TimerPlugin;
+    let results = plugin.search("timer list");
+    assert!(results.iter().any(|a| a.action.starts_with("timer:show:")));
     ACTIVE_TIMERS.lock().unwrap().clear();
 }
 

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -59,3 +59,12 @@ fn search_list_lists_timers() {
     ACTIVE_TIMERS.lock().unwrap().clear();
 }
 
+#[test]
+fn take_finished_returns_messages() {
+    use multi_launcher::plugins::timer::{FINISHED_MESSAGES, take_finished_messages};
+    FINISHED_MESSAGES.lock().unwrap().push("done".to_string());
+    let msgs = take_finished_messages();
+    assert_eq!(msgs, vec!["done".to_string()]);
+    assert!(take_finished_messages().is_empty());
+}
+

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -4,6 +4,22 @@ use std::sync::{Arc, atomic::AtomicBool};
 use std::time::{Duration, Instant, SystemTime};
 
 #[test]
+fn search_timer_dialog() {
+    let plugin = TimerPlugin;
+    let results = plugin.search("timer");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "timer:dialog:timer");
+}
+
+#[test]
+fn search_alarm_dialog() {
+    let plugin = TimerPlugin;
+    let results = plugin.search("alarm");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "timer:dialog:alarm");
+}
+
+#[test]
 fn search_timer_returns_start_action() {
     let plugin = TimerPlugin;
     let results = plugin.search("timer 1s");

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -1,6 +1,7 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::timer::{TimerPlugin, ACTIVE_TIMERS, TimerEntry};
 use std::sync::{Arc, atomic::AtomicBool};
+use std::time::{Duration, Instant, SystemTime};
 
 #[test]
 fn search_timer_returns_start_action() {
@@ -23,7 +24,14 @@ fn search_cancel_lists_timers() {
     // manually insert an active timer
     {
         let mut list = ACTIVE_TIMERS.lock().unwrap();
-        list.push(TimerEntry { id: 1, label: "test".into(), cancel: Arc::new(AtomicBool::new(false)) });
+        list.push(TimerEntry {
+            id: 1,
+            label: "test".into(),
+            deadline: Instant::now() + Duration::from_secs(10),
+            cancel: Arc::new(AtomicBool::new(false)),
+            persist: false,
+            end_ts: 0,
+        });
     }
     let plugin = TimerPlugin;
     let results = plugin.search("timer cancel");
@@ -36,7 +44,14 @@ fn search_cancel_lists_timers() {
 fn search_list_lists_timers() {
     {
         let mut list = ACTIVE_TIMERS.lock().unwrap();
-        list.push(TimerEntry { id: 2, label: "demo".into(), cancel: Arc::new(AtomicBool::new(false)) });
+        list.push(TimerEntry {
+            id: 2,
+            label: "demo".into(),
+            deadline: Instant::now() + Duration::from_secs(20),
+            cancel: Arc::new(AtomicBool::new(false)),
+            persist: false,
+            end_ts: 0,
+        });
     }
     let plugin = TimerPlugin;
     let results = plugin.search("timer list");


### PR DESCRIPTION
## Summary
- implement `TimerPlugin` with timer and alarm commands
- handle timer, cancel and alarm actions in `launch_action`
- register `TimerPlugin`
- add integration tests for the timer plugin

## Testing
- `cargo test --no-run`
- `cargo test --quiet`
 