### PR TITLE
Add notes plugin with clipboard actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Built-in plugins and their command prefixes are:
   restarting the launcher. A plugin setting controls pop-up dialogs when a
   timer completes.
 - Search history (`hi`)
+- Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
 - Command overview (`help`)
 
 Selecting a clipboard entry copies it back to the clipboard. Type `help` and press <kbd>Enter</kbd> to open the command list. The help window groups commands by plugin name and can optionally display example queries. Additional plugins can be added by building

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -95,6 +95,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
         "timer" => Some(&["timer 10s break", "timer list", "alarm 07:30"]),
+        "notes" => Some(&["note add buy milk", "note list", "note rm milk"]),
         "help" => Some(&["help"]),
         _ => None,
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,6 +1,7 @@
 use crate::actions::Action;
 use crate::plugins::bookmarks::{append_bookmark, remove_bookmark};
 use crate::plugins::folders::{append_folder, remove_folder, FOLDERS_FILE};
+use crate::plugins::notes::{append_note, remove_note, load_notes, QUICK_NOTES_FILE};
 use crate::plugins::timer;
 use crate::history;
 use sysinfo::System;
@@ -151,6 +152,25 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
                 timer::start_alarm(h, m);
             } else {
                 timer::start_alarm_named(h, m, Some(name.to_string()));
+            }
+        }
+        return Ok(());
+    }
+    if let Some(text) = action.action.strip_prefix("note:add:") {
+        append_note(QUICK_NOTES_FILE, text)?;
+        return Ok(());
+    }
+    if let Some(idx) = action.action.strip_prefix("note:remove:") {
+        if let Ok(i) = idx.parse::<usize>() {
+            remove_note(QUICK_NOTES_FILE, i)?;
+        }
+        return Ok(());
+    }
+    if let Some(idx) = action.action.strip_prefix("note:copy:") {
+        if let Ok(i) = idx.parse::<usize>() {
+            if let Some(entry) = load_notes(QUICK_NOTES_FILE)?.get(i).cloned() {
+                let mut cb = Clipboard::new()?;
+                cb.set_text(entry.text)?;
             }
         }
         return Ok(());

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,6 +14,7 @@ use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::timer::TimerPlugin;
+use crate::plugins::notes::NotesPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -61,6 +62,7 @@ impl PluginManager {
         self.register(Box::new(ProcessesPlugin));
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
+        self.register(Box::new(NotesPlugin::default()));
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));
         crate::plugins::timer::load_saved_alarms();

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -10,4 +10,5 @@ pub mod youtube;
 pub mod reddit;
 pub mod processes;
 pub mod weather;
+pub mod notes;
 pub mod timer;

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -1,0 +1,135 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+use chrono::{Local, TimeZone};
+
+pub const QUICK_NOTES_FILE: &str = "quick_notes.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct NoteEntry {
+    pub ts: u64,
+    pub text: String,
+}
+
+pub fn load_notes(path: &str) -> anyhow::Result<Vec<NoteEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<NoteEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_notes(path: &str, notes: &[NoteEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(notes)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn append_note(path: &str, text: &str) -> anyhow::Result<()> {
+    let mut list = load_notes(path).unwrap_or_default();
+    list.push(NoteEntry { ts: Local::now().timestamp() as u64, text: text.to_string() });
+    save_notes(path, &list)
+}
+
+pub fn remove_note(path: &str, index: usize) -> anyhow::Result<()> {
+    let mut list = load_notes(path).unwrap_or_default();
+    if index < list.len() {
+        list.remove(index);
+        save_notes(path, &list)?;
+    }
+    Ok(())
+}
+
+fn format_ts(ts: u64) -> String {
+    Local.timestamp_opt(ts as i64, 0)
+        .single()
+        .unwrap_or_else(|| Local.timestamp(0, 0))
+        .format("%Y-%m-%d %H:%M")
+        .to_string()
+}
+
+pub struct NotesPlugin {
+    matcher: SkimMatcherV2,
+}
+
+impl NotesPlugin {
+    pub fn new() -> Self {
+        Self { matcher: SkimMatcherV2::default() }
+    }
+}
+
+impl Default for NotesPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for NotesPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(text) = query.strip_prefix("note add ") {
+            let text = text.trim();
+            if !text.is_empty() {
+                return vec![Action {
+                    label: format!("Add note {text}"),
+                    desc: "Note".into(),
+                    action: format!("note:add:{text}"),
+                    args: None,
+                }];
+            }
+        }
+
+        if let Some(pattern) = query.strip_prefix("note rm ") {
+            let filter = pattern.trim();
+            let notes = load_notes(QUICK_NOTES_FILE).unwrap_or_default();
+            return notes
+                .into_iter()
+                .enumerate()
+                .filter(|(_, n)| self.matcher.fuzzy_match(&n.text, filter).is_some())
+                .map(|(idx, n)| Action {
+                    label: format!("Remove note {} - {}", format_ts(n.ts), n.text),
+                    desc: "Note".into(),
+                    action: format!("note:remove:{idx}"),
+                    args: None,
+                })
+                .collect();
+        }
+
+        if query.starts_with("note list") || query.starts_with("note search") {
+            let filter = if let Some(rest) = query.strip_prefix("note list") {
+                rest.trim()
+            } else {
+                query.strip_prefix("note search").unwrap_or("").trim()
+            };
+            let notes = load_notes(QUICK_NOTES_FILE).unwrap_or_default();
+            return notes
+                .into_iter()
+                .enumerate()
+                .filter(|(_, n)| self.matcher.fuzzy_match(&n.text, filter).is_some())
+                .map(|(idx, n)| Action {
+                    label: format!("{} - {}", format_ts(n.ts), n.text),
+                    desc: "Note".into(),
+                    action: format!("note:copy:{idx}"),
+                    args: None,
+                })
+                .collect();
+        }
+
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "notes"
+    }
+
+    fn description(&self) -> &str {
+        "Quick notes (prefix: `note`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -1,9 +1,9 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use chrono::{Local, TimeZone};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use serde::{Deserialize, Serialize};
-use chrono::{Local, TimeZone};
 
 pub const QUICK_NOTES_FILE: &str = "quick_notes.json";
 
@@ -30,7 +30,10 @@ pub fn save_notes(path: &str, notes: &[NoteEntry]) -> anyhow::Result<()> {
 
 pub fn append_note(path: &str, text: &str) -> anyhow::Result<()> {
     let mut list = load_notes(path).unwrap_or_default();
-    list.push(NoteEntry { ts: Local::now().timestamp() as u64, text: text.to_string() });
+    list.push(NoteEntry {
+        ts: Local::now().timestamp() as u64,
+        text: text.to_string(),
+    });
     save_notes(path, &list)
 }
 
@@ -44,7 +47,8 @@ pub fn remove_note(path: &str, index: usize) -> anyhow::Result<()> {
 }
 
 fn format_ts(ts: u64) -> String {
-    Local.timestamp_opt(ts as i64, 0)
+    Local
+        .timestamp_opt(ts as i64, 0)
         .single()
         .unwrap_or_else(|| Local.timestamp(0, 0))
         .format("%Y-%m-%d %H:%M")
@@ -57,7 +61,9 @@ pub struct NotesPlugin {
 
 impl NotesPlugin {
     pub fn new() -> Self {
-        Self { matcher: SkimMatcherV2::default() }
+        Self {
+            matcher: SkimMatcherV2::default(),
+        }
     }
 }
 
@@ -97,12 +103,8 @@ impl Plugin for NotesPlugin {
                 .collect();
         }
 
-        if query.starts_with("note list") || query.starts_with("note search") {
-            let filter = if let Some(rest) = query.strip_prefix("note list") {
-                rest.trim()
-            } else {
-                query.strip_prefix("note search").unwrap_or("").trim()
-            };
+        if let Some(rest) = query.strip_prefix("note list") {
+            let filter = rest.trim();
             let notes = load_notes(QUICK_NOTES_FILE).unwrap_or_default();
             return notes
                 .into_iter()
@@ -132,4 +134,3 @@ impl Plugin for NotesPlugin {
         &["search"]
     }
 }
-

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -1,0 +1,55 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::notes::{append_note, remove_note, load_notes, NotesPlugin, QUICK_NOTES_FILE};
+use tempfile::tempdir;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn search_add_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = NotesPlugin::default();
+    let results = plugin.search("note add demo");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "note:add:demo");
+}
+
+#[test]
+fn list_returns_saved_notes() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    append_note(QUICK_NOTES_FILE, "alpha").unwrap();
+    append_note(QUICK_NOTES_FILE, "beta").unwrap();
+
+    let plugin = NotesPlugin::default();
+    let results = plugin.search("note list");
+    println!("results: {:?}", results.iter().map(|r| &r.action).collect::<Vec<_>>());
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|a| a.action.starts_with("note:copy:")));
+}
+
+#[test]
+fn remove_action_returns_indices() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    append_note(QUICK_NOTES_FILE, "first").unwrap();
+    append_note(QUICK_NOTES_FILE, "second").unwrap();
+
+    let plugin = NotesPlugin::default();
+    let results = plugin.search("note rm first");
+    println!("rm results: {:?}", results.iter().map(|r| &r.action).collect::<Vec<_>>());
+    assert_eq!(results.len(), 1);
+    assert!(results[0].action.starts_with("note:remove:"));
+
+    let idx: usize = results[0].action.strip_prefix("note:remove:").unwrap().parse().unwrap();
+    remove_note(QUICK_NOTES_FILE, idx).unwrap();
+    let notes = load_notes(QUICK_NOTES_FILE).unwrap();
+    println!("remaining notes: {}", notes.len());
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].text, "second");
+}


### PR DESCRIPTION
## Summary
- add notes plugin for quick note management
- support note actions in `launch_action`
- register notes plugin in plugin manager
- export notes module
- test adding, listing and removing notes

## Testing
- `cargo test --quiet`

 