### PR TITLE
Add Wikipedia plugin

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::plugins::processes::ProcessesPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
+use crate::plugins::wikipedia::WikipediaPlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::timer::TimerPlugin;
 use crate::plugins::notes::NotesPlugin;
@@ -55,6 +56,7 @@ impl PluginManager {
         self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(YoutubePlugin));
         self.register(Box::new(RedditPlugin));
+        self.register(Box::new(WikipediaPlugin));
         self.register(Box::new(ClipboardPlugin::default()));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(FoldersPlugin::default()));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -8,6 +8,7 @@ pub mod system;
 pub mod help;
 pub mod youtube;
 pub mod reddit;
+pub mod wikipedia;
 pub mod processes;
 pub mod weather;
 pub mod notes;

--- a/src/plugins/wikipedia.rs
+++ b/src/plugins/wikipedia.rs
@@ -1,0 +1,36 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct WikipediaPlugin;
+
+impl Plugin for WikipediaPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(q) = query.strip_prefix("wiki ") {
+            let q = q.trim();
+            if !q.is_empty() {
+                return vec![Action {
+                    label: format!("Search Wikipedia for {q}"),
+                    desc: "Web search".into(),
+                    action: format!(
+                        "https://en.wikipedia.org/wiki/Special:Search?search={q}"
+                    ),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "wikipedia"
+    }
+
+    fn description(&self) -> &str {
+        "Search Wikipedia (prefix: `wiki`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/tests/wikipedia_plugin.rs
+++ b/tests/wikipedia_plugin.rs
@@ -1,0 +1,10 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::wikipedia::WikipediaPlugin;
+
+#[test]
+fn search_returns_action() {
+    let plugin = WikipediaPlugin;
+    let results = plugin.search("wiki space");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://en.wikipedia.org/wiki/Special:Search?search=space");
+}


### PR DESCRIPTION
## Summary
- implement `WikipediaPlugin`
- register new plugin
- expose module in plugin mod
- test opening Wikipedia search URL

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686d94caae40833296d76ec2314ea90d