### PR TITLE
Add bookmark aliases support

### DIFF
--- a/src/bookmark_alias_dialog.rs
+++ b/src/bookmark_alias_dialog.rs
@@ -1,0 +1,61 @@
+use crate::gui::LauncherApp;
+use crate::plugins::bookmarks::{set_alias, BOOKMARKS_FILE, load_bookmarks};
+use eframe::egui;
+
+pub struct BookmarkAliasDialog {
+    pub open: bool,
+    url: String,
+    alias: String,
+}
+
+impl Default for BookmarkAliasDialog {
+    fn default() -> Self {
+        Self { open: false, url: String::new(), alias: String::new() }
+    }
+}
+
+impl BookmarkAliasDialog {
+    pub fn open(&mut self, url: &str) {
+        self.url = url.to_string();
+        if let Ok(list) = load_bookmarks(BOOKMARKS_FILE) {
+            if let Some(entry) = list.into_iter().find(|b| b.url == self.url) {
+                if let Some(a) = entry.alias {
+                    self.alias = a;
+                } else {
+                    self.alias.clear();
+                }
+            }
+        }
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut close = false;
+        egui::Window::new("Set Bookmark Alias")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                ui.label(&self.url);
+                ui.text_edit_singleline(&mut self.alias);
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {
+                            app.error = Some(format!("Failed to save alias: {e}"));
+                        } else {
+                            close = true;
+                            app.search();
+                            app.focus_input();
+                        }
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if close {
+            self.open = false;
+        }
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -77,6 +77,7 @@ pub struct LauncherApp {
     toasts: egui_toast::Toasts,
     pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
+    bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog,
     help_window: crate::help_window::HelpWindow,
     timer_help: crate::timer_help_window::TimerHelpWindow,
     timer_dialog: crate::timer_dialog::TimerDialog,
@@ -243,6 +244,7 @@ impl LauncherApp {
             toasts,
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
+            bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog::default(),
             help_window: HelpWindow::default(),
             timer_help: TimerHelpWindow::default(),
             timer_dialog: TimerDialog::default(),
@@ -629,6 +631,12 @@ impl eframe::App for LauncherApp {
                     .into_iter()
                     .map(|f| (f.path, f.alias))
                     .collect::<std::collections::HashMap<_, _>>();
+                let bm_list = crate::plugins::bookmarks::load_bookmarks(crate::plugins::bookmarks::BOOKMARKS_FILE)
+                    .unwrap_or_default();
+                let bm_custom = bm_list
+                    .iter()
+                    .map(|b| b.url.clone())
+                    .collect::<std::collections::HashSet<_>>();
                 let show_full = self
                     .enabled_capabilities
                     .as_ref()
@@ -654,6 +662,13 @@ impl eframe::App for LauncherApp {
                         menu_resp.clone().context_menu(|ui| {
                             if ui.button("Set Alias").clicked() {
                                 self.alias_dialog.open(&a.action);
+                                ui.close_menu();
+                            }
+                        });
+                    } else if bm_custom.contains(&a.action) {
+                        menu_resp.clone().context_menu(|ui| {
+                            if ui.button("Set Alias").clicked() {
+                                self.bookmark_alias_dialog.open(&a.action);
                                 ui.close_menu();
                             }
                         });
@@ -755,6 +770,9 @@ impl eframe::App for LauncherApp {
         let mut dlg = std::mem::take(&mut self.alias_dialog);
         dlg.ui(ctx, self);
         self.alias_dialog = dlg;
+        let mut bm_dlg = std::mem::take(&mut self.bookmark_alias_dialog);
+        bm_dlg.ui(ctx, self);
+        self.bookmark_alias_dialog = bm_dlg;
         let mut help = std::mem::take(&mut self.help_window);
         help.ui(ctx, self);
         self.help_window = help;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod actions_editor;
 pub mod add_action_dialog;
 pub mod alias_dialog;
+pub mod bookmark_alias_dialog;
 pub mod plugin_editor;
 pub mod settings_editor;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod actions;
 mod actions_editor;
 mod add_action_dialog;
 mod alias_dialog;
+mod bookmark_alias_dialog;
 mod settings_editor;
 mod plugin_editor;
 mod gui;

--- a/tests/bookmarks_plugin.rs
+++ b/tests/bookmarks_plugin.rs
@@ -1,0 +1,37 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::bookmarks::{save_bookmarks, load_bookmarks, BookmarkEntry, BookmarksPlugin, BOOKMARKS_FILE};
+use tempfile::tempdir;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn alias_roundtrip() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![BookmarkEntry { url: "https://example.com".into(), alias: Some("ex".into()) }];
+    save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
+    let loaded = load_bookmarks(BOOKMARKS_FILE).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].alias.as_deref(), Some("ex"));
+}
+
+#[test]
+fn search_uses_alias_label() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![BookmarkEntry { url: "https://example.com".into(), alias: Some("ex".into()) }];
+    save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
+
+    let plugin = BookmarksPlugin::default();
+    let results = plugin.search("bm ex");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "ex");
+    assert_eq!(results[0].action, "https://example.com");
+}
+


### PR DESCRIPTION
## Summary
- add BookmarkEntry with optional alias field
- update bookmark load/save/append/remove for BookmarkEntry
- allow setting bookmark aliases via dialog and context menu
- show bookmark aliases in search results
- add tests for bookmark alias save/load and search

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686d9f5330708332b38fab8981a72a4d