### PR TITLE
Add hide_after_run option

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -611,7 +611,13 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                                 set_focus = true;
                             }
-                            if self.hide_after_run {
+                            if self.hide_after_run
+                                && !a.action.starts_with("bookmark:add:")
+                                && !a.action.starts_with("bookmark:remove:")
+                                && !a.action.starts_with("folder:add:")
+                                && !a.action.starts_with("folder:remove:")
+                                && !a.action.starts_with("calc:")
+                            {
                                 self.visible_flag.store(false, Ordering::SeqCst);
                             }
                         }
@@ -783,7 +789,13 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                                 set_focus = true;
                             }
-                            if self.hide_after_run {
+                            if self.hide_after_run
+                                && !a.action.starts_with("bookmark:add:")
+                                && !a.action.starts_with("bookmark:remove:")
+                                && !a.action.starts_with("folder:add:")
+                                && !a.action.starts_with("folder:remove:")
+                                && !a.action.starts_with("calc:")
+                            {
                                 self.visible_flag.store(false, Ordering::SeqCst);
                             }
                         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -97,6 +97,7 @@ pub struct LauncherApp {
     pub static_location_enabled: bool,
     pub static_pos: Option<(i32, i32)>,
     pub static_size: Option<(i32, i32)>,
+    pub hide_after_run: bool,
 }
 
 impl LauncherApp {
@@ -117,6 +118,7 @@ impl LauncherApp {
         static_enabled: Option<bool>,
         static_pos: Option<(i32, i32)>,
         static_size: Option<(i32, i32)>,
+        hide_after_run: Option<bool>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -145,6 +147,9 @@ impl LauncherApp {
         }
         if static_size.is_some() {
             self.static_size = static_size;
+        }
+        if let Some(v) = hide_after_run {
+            self.hide_after_run = v;
         }
     }
 
@@ -263,6 +268,7 @@ impl LauncherApp {
             static_location_enabled: static_enabled,
             static_pos,
             static_size,
+            hide_after_run: settings.hide_after_run,
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);
@@ -605,6 +611,9 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                                 set_focus = true;
                             }
+                            if self.hide_after_run {
+                                self.visible_flag.store(false, Ordering::SeqCst);
+                            }
                         }
                         if refresh {
                             self.search();
@@ -773,6 +782,9 @@ impl eframe::App for LauncherApp {
                             } else if a.action.starts_with("folder:remove:") {
                                 refresh = true;
                                 set_focus = true;
+                            }
+                            if self.hide_after_run {
+                                self.visible_flag.store(false, Ordering::SeqCst);
                             }
                         }
                         self.selected = Some(idx);

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -116,6 +116,7 @@ impl PluginEditor {
                         Some(s.static_location_enabled),
                         s.static_pos,
                         s.static_size,
+                        Some(s.hide_after_run),
                     );
 
                     app.plugins.reload_from_dirs(&self.plugin_dirs);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -59,6 +59,9 @@ pub struct Settings {
     /// Size of the window when `static_location_enabled` is true.
     #[serde(default)]
     pub static_size: Option<(i32, i32)>,
+    /// Hide the main window automatically after successfully launching an action.
+    #[serde(default)]
+    pub hide_after_run: bool,
 }
 
 fn default_toasts() -> bool { true }
@@ -96,6 +99,7 @@ impl Default for Settings {
             static_location_enabled: false,
             static_pos: None,
             static_size: None,
+            hide_after_run: false,
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -38,6 +38,7 @@ pub struct SettingsEditor {
     static_y: i32,
     static_w: i32,
     static_h: i32,
+    hide_after_run: bool,
 }
 
 impl SettingsEditor {
@@ -105,6 +106,7 @@ impl SettingsEditor {
             static_y: settings.static_pos.unwrap_or((0, 0)).1,
             static_w: settings.static_size.unwrap_or((400, 220)).0,
             static_h: settings.static_size.unwrap_or((400, 220)).1,
+            hide_after_run: settings.hide_after_run,
         }
     }
 
@@ -146,6 +148,7 @@ impl SettingsEditor {
             static_location_enabled: self.static_enabled,
             static_pos: Some((self.static_x, self.static_y)),
             static_size: Some((self.static_w, self.static_h)),
+            hide_after_run: self.hide_after_run,
         }
     }
 
@@ -233,6 +236,7 @@ impl SettingsEditor {
             });
 
             ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
+            ui.checkbox(&mut self.hide_after_run, "Hide window after running action");
 
             ui.horizontal(|ui| {
                 ui.label("Query scale");
@@ -373,6 +377,7 @@ impl SettingsEditor {
                                     Some(new_settings.static_location_enabled),
                                     new_settings.static_pos,
                                     new_settings.static_size,
+                                    Some(new_settings.hide_after_run),
                                 );
                                 app.hotkey_str = new_settings.hotkey.clone();
                                 app.quit_hotkey_str = new_settings.quit_hotkey.clone();

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -1,0 +1,60 @@
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::actions::Action;
+use multi_launcher::settings::Settings;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use eframe::egui;
+
+fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Settings) -> (LauncherApp, Arc<AtomicBool>) {
+    let custom_len = actions.len();
+    let visible = Arc::new(AtomicBool::new(true));
+    (
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        None,
+        None,
+        visible.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    ),
+    visible)
+}
+
+#[test]
+fn hide_after_run_updates_visibility() {
+    let ctx = egui::Context::default();
+    let actions = vec![Action { label: "clear".into(), desc: "".into(), action: "history:clear".into(), args: None }];
+    let (mut app, flag) = new_app_with_settings(&ctx, actions, Settings::default());
+    app.update_paths(
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(true),
+    );
+    assert!(app.hide_after_run);
+    assert!(flag.load(Ordering::SeqCst));
+    let a = app.results[0].clone();
+    if multi_launcher::launcher::launch_action(&a).is_ok() {
+        if app.hide_after_run {
+            flag.store(false, Ordering::SeqCst);
+        }
+    }
+    assert!(!flag.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
## Summary
- allow hiding the launcher window after running a command
- surface `hide_after_run` in settings editing UI
- track the flag in `LauncherApp` and respect it after launching
- update settings saving logic
- test visibility behaviour

## Testing
- `cargo test --quiet`
 