### PR TITLE
Add shell command management

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -82,6 +82,7 @@ pub struct LauncherApp {
     timer_help: crate::timer_help_window::TimerHelpWindow,
     timer_dialog: crate::timer_dialog::TimerDialog,
     completion_dialog: crate::timer_dialog::TimerCompletionDialog,
+    shell_cmd_dialog: crate::shell_cmd_dialog::ShellCmdDialog,
     pub help_flag: Arc<AtomicBool>,
     pub hotkey_str: Option<String>,
     pub quit_hotkey_str: Option<String>,
@@ -254,6 +255,7 @@ impl LauncherApp {
             timer_help: TimerHelpWindow::default(),
             timer_dialog: TimerDialog::default(),
             completion_dialog: TimerCompletionDialog::default(),
+            shell_cmd_dialog: crate::shell_cmd_dialog::ShellCmdDialog::default(),
             help_flag: help_flag.clone(),
             hotkey_str: settings.hotkey.clone(),
             quit_hotkey_str: settings.quit_hotkey.clone(),
@@ -570,6 +572,8 @@ impl eframe::App for LauncherApp {
                             self.timer_dialog.open_timer();
                         } else if a.action == "timer:dialog:alarm" {
                             self.timer_dialog.open_alarm();
+                        } else if a.action == "shell:dialog" {
+                            self.shell_cmd_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             self.error_time = Some(Instant::now());
@@ -748,6 +752,8 @@ impl eframe::App for LauncherApp {
                             self.timer_dialog.open_timer();
                         } else if a.action == "timer:dialog:alarm" {
                             self.timer_dialog.open_alarm();
+                        } else if a.action == "shell:dialog" {
+                            self.shell_cmd_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             self.error_time = Some(Instant::now());
@@ -847,6 +853,9 @@ impl eframe::App for LauncherApp {
         let mut comp = std::mem::take(&mut self.completion_dialog);
         comp.ui(ctx);
         self.completion_dialog = comp;
+        let mut shell_dlg = std::mem::take(&mut self.shell_cmd_dialog);
+        shell_dlg.ui(ctx, self);
+        self.shell_cmd_dialog = shell_dlg;
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod visibility;
 pub mod help_window;
 pub mod timer_help_window;
 pub mod timer_dialog;
+pub mod shell_cmd_dialog;
 
 pub mod window_manager;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod plugins;
 mod help_window;
 mod timer_help_window;
 mod timer_dialog;
+mod shell_cmd_dialog;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -1,19 +1,76 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+
+pub const SHELL_CMDS_FILE: &str = "shell_cmds.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ShellCmdEntry {
+    pub name: String,
+    pub args: String,
+}
+
+pub fn load_shell_cmds(path: &str) -> anyhow::Result<Vec<ShellCmdEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<ShellCmdEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_shell_cmds(path: &str, cmds: &[ShellCmdEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(cmds)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
 
 pub struct ShellPlugin;
 
 impl Plugin for ShellPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(cmd) = query.strip_prefix("sh ") {
-            if !cmd.trim().is_empty() {
-                return vec![Action {
-                    label: format!("Run `{}`", cmd),
-                    desc: "Shell".into(),
-                    action: format!("shell:{}", cmd),
-                    args: None,
-                }];
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("sh") {
+            return vec![Action {
+                label: "Edit shell commands".into(),
+                desc: "Shell".into(),
+                action: "shell:dialog".into(),
+                args: None,
+            }];
+        }
+
+        if let Some(cmd) = trimmed.strip_prefix("sh ") {
+            let arg = cmd.trim();
+            if arg.is_empty() {
+                return Vec::new();
             }
+            if let Ok(list) = load_shell_cmds(SHELL_CMDS_FILE) {
+                let matcher = SkimMatcherV2::default();
+                let mut best: Option<(ShellCmdEntry, i64)> = None;
+                for entry in list {
+                    if let Some(score) = matcher.fuzzy_match(&entry.name, arg) {
+                        if best.as_ref().map(|(_, s)| score > *s).unwrap_or(true) {
+                            best = Some((entry, score));
+                        }
+                    }
+                }
+                if let Some((entry, _)) = best {
+                    return vec![Action {
+                        label: format!("Run {}", entry.name),
+                        desc: "Shell".into(),
+                        action: format!("shell:{}", entry.args),
+                        args: None,
+                    }];
+                }
+            }
+            return vec![Action {
+                label: format!("Run `{}`", arg),
+                desc: "Shell".into(),
+                action: format!("shell:{}", arg),
+                args: None,
+            }];
         }
         Vec::new()
     }

--- a/src/shell_cmd_dialog.rs
+++ b/src/shell_cmd_dialog.rs
@@ -1,0 +1,106 @@
+use crate::gui::LauncherApp;
+use crate::plugins::shell::{load_shell_cmds, save_shell_cmds, ShellCmdEntry, SHELL_CMDS_FILE};
+use eframe::egui;
+
+#[derive(Default)]
+pub struct ShellCmdDialog {
+    pub open: bool,
+    entries: Vec<ShellCmdEntry>,
+    edit_idx: Option<usize>,
+    name: String,
+    args: String,
+}
+
+impl ShellCmdDialog {
+    pub fn open(&mut self) {
+        self.entries = load_shell_cmds(SHELL_CMDS_FILE).unwrap_or_default();
+        self.open = true;
+        self.edit_idx = None;
+        self.name.clear();
+        self.args.clear();
+    }
+
+    fn save(&mut self, app: &mut LauncherApp) {
+        if let Err(e) = save_shell_cmds(SHELL_CMDS_FILE, &self.entries) {
+            app.error = Some(format!("Failed to save commands: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        let mut save_now = false;
+        egui::Window::new("Shell Commands")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                if let Some(idx) = self.edit_idx {
+                    ui.horizontal(|ui| {
+                        ui.label("Name");
+                        ui.text_edit_singleline(&mut self.name);
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Command");
+                        ui.text_edit_singleline(&mut self.args);
+                    });
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            if self.name.trim().is_empty() || self.args.trim().is_empty() {
+                                app.error = Some("Both fields required".into());
+                            } else {
+                                if idx == self.entries.len() {
+                                    self.entries.push(ShellCmdEntry { name: self.name.clone(), args: self.args.clone() });
+                                } else if let Some(e) = self.entries.get_mut(idx) {
+                                    e.name = self.name.clone();
+                                    e.args = self.args.clone();
+                                }
+                                self.edit_idx = None;
+                                self.name.clear();
+                                self.args.clear();
+                                    save_now = true;
+                            }
+                        }
+                        if ui.button("Cancel").clicked() {
+                            self.edit_idx = None;
+                        }
+                    });
+                } else {
+                    let mut remove: Option<usize> = None;
+                    egui::ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
+                        for idx in 0..self.entries.len() {
+                            let name = self.entries[idx].name.clone();
+                            let args = self.entries[idx].args.clone();
+                            ui.horizontal(|ui| {
+                                ui.label(&name);
+                                ui.label(&args);
+                                if ui.button("Edit").clicked() {
+                                    self.edit_idx = Some(idx);
+                                    self.name = name.clone();
+                                    self.args = args.clone();
+                                }
+                                if ui.button("Remove").clicked() {
+                                    remove = Some(idx);
+                                }
+                            });
+                        }
+                    });
+                    if let Some(idx) = remove {
+                        self.entries.remove(idx);
+                        save_now = true;
+                    }
+                    if ui.button("Add Command").clicked() {
+                        self.edit_idx = Some(self.entries.len());
+                        self.name.clear();
+                        self.args.clear();
+                    }
+                    if ui.button("Close").clicked() { close = true; }
+                }
+            });
+        if save_now {
+            self.save(app);
+        }
+        if close { self.open = false; }
+    }
+}

--- a/tests/shell_plugin.rs
+++ b/tests/shell_plugin.rs
@@ -1,0 +1,36 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::shell::{save_shell_cmds, load_shell_cmds, ShellCmdEntry, ShellPlugin, SHELL_CMDS_FILE};
+use tempfile::tempdir;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn load_shell_cmds_roundtrip() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![ShellCmdEntry { name: "test".into(), args: "echo hi".into() }];
+    save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
+    let loaded = load_shell_cmds(SHELL_CMDS_FILE).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].name, "test");
+    assert_eq!(loaded[0].args, "echo hi");
+}
+
+#[test]
+fn search_named_command_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![ShellCmdEntry { name: "demo".into(), args: "dir".into() }];
+    save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
+
+    let plugin = ShellPlugin;
+    let results = plugin.search("sh demo");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "shell:dir");
+}


### PR DESCRIPTION
## Summary
- introduce `shell_cmd_dialog` for editing saved shell commands
- support loading/saving commands in `ShellPlugin`
- open command editor via `sh` query
- search resolves saved command names
- tests for loading and searching shell commands

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686db41be4648332952bea59f33bc858