### PR TITLE
Center window on cursor when toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ off-screen. The default is `[2000, 2000]`.
 The window is restored to this size on the next start. The default is
 `[400, 220]` if the value is missing.
 
-When `follow_mouse` is `true` the window appears at the current cursor
-location whenever it becomes visible. To keep the launcher at a specific
+When `follow_mouse` is `true` the window is centered on the mouse cursor
+whenever it becomes visible. To keep the launcher at a specific
 position instead, set `follow_mouse` to `false` and enable
 `static_location_enabled`. Provide the desired coordinates in `static_pos`
 and optionally a fixed size via `static_size`. The **Settings** window now

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -282,6 +282,7 @@ impl LauncherApp {
             static_enabled,
             static_pos.map(|(x, y)| (x as f32, y as f32)),
             static_size.map(|(w, h)| (w as f32, h as f32)),
+            (win_size.0 as f32, win_size.1 as f32),
         );
 
         #[cfg(target_os = "windows")]
@@ -455,6 +456,7 @@ impl eframe::App for LauncherApp {
                 self.static_location_enabled,
                 self.static_pos.map(|(x, y)| (x as f32, y as f32)),
                 self.static_size.map(|(w, h)| (w as f32, h as f32)),
+                (self.window_size.0 as f32, self.window_size.1 as f32),
             );
             #[cfg(target_os = "windows")]
             if let Some(hwnd) = crate::window_manager::get_hwnd(frame) {
@@ -474,6 +476,7 @@ impl eframe::App for LauncherApp {
                 self.static_location_enabled,
                 self.static_pos.map(|(x, y)| (x as f32, y as f32)),
                 self.static_size.map(|(w, h)| (w as f32, h as f32)),
+                (self.window_size.0 as f32, self.window_size.1 as f32),
             );
             self.last_visible = should_be_visible;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,10 @@ fn main() -> anyhow::Result<()> {
             settings.static_location_enabled,
             settings.static_pos.map(|(x, y)| (x as f32, y as f32)),
             settings.static_size.map(|(w, h)| (w as f32, h as f32)),
+            {
+                let (w, h) = settings.window_size.unwrap_or((400, 220));
+                (w as f32, h as f32)
+            },
         );
 
         std::thread::sleep(std::time::Duration::from_millis(50));

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -33,6 +33,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
     static_enabled: bool,
     static_pos: Option<(f32, f32)>,
     static_size: Option<(f32, f32)>,
+    window_size: (f32, f32),
 ) {
     if trigger.take() {
         let old = visibility.load(Ordering::SeqCst);
@@ -49,6 +50,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
                     static_enabled,
                     static_pos,
                     static_size,
+                    window_size,
                 );
                 if next {
                     restore_flag.store(true, Ordering::SeqCst);
@@ -82,6 +84,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
                     static_enabled,
                     static_pos,
                     static_size,
+                    window_size,
                 );
                 if next {
                     restore_flag.store(true, Ordering::SeqCst);
@@ -102,6 +105,7 @@ pub fn apply_visibility<C: ViewportCtx>(
     static_enabled: bool,
     static_pos: Option<(f32, f32)>,
     static_size: Option<(f32, f32)>,
+    window_size: (f32, f32),
 ) {
     if visible {
         if static_enabled {
@@ -113,7 +117,9 @@ pub fn apply_visibility<C: ViewportCtx>(
             }
         } else if follow_mouse {
             if let Some((x, y)) = crate::window_manager::current_mouse_position() {
-                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(x, y)));
+                let pos_x = x - window_size.0 / 2.0;
+                let pos_y = y - window_size.1 / 2.0;
+                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(egui::pos2(pos_x, pos_y)));
             }
         }
         ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -30,6 +30,7 @@ fn focus_when_becoming_visible() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -28,6 +28,7 @@ fn queued_visibility_applies_when_context_available() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
@@ -51,6 +52,7 @@ fn queued_visibility_applies_when_context_available() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
 
     assert!(queued_visibility.is_none());

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -61,6 +61,7 @@ fn zero_key_events_toggle_visibility() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
@@ -76,6 +77,7 @@ fn zero_key_events_toggle_visibility() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }

--- a/tests/offscreen.rs
+++ b/tests/offscreen.rs
@@ -8,7 +8,7 @@ use mock_ctx::MockCtx;
 #[test]
 fn offscreen_position_when_hidden() {
     let ctx = MockCtx::default();
-    apply_visibility(false, &ctx, (42.0, 84.0), true, false, None, None);
+    apply_visibility(false, &ctx, (42.0, 84.0), true, false, None, None, (400.0, 220.0));
     let cmds = ctx.commands.lock().unwrap();
     assert_eq!(cmds.len(), 1);
     match cmds[0] {

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -30,6 +30,7 @@ fn visibility_toggle_immediate_when_context_present() {
         false,
         None,
         None,
+        (400.0, 220.0),
     );
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);


### PR DESCRIPTION
## Summary
- center the launcher around the mouse cursor on visibility toggle
- document cursor-centering behavior for `follow_mouse`
- adjust tests for new `apply_visibility` signature

## Testing
- `cargo test --quiet`
 