### PR TITLE
Add snippets plugin with dialog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod help_window;
 pub mod timer_help_window;
 pub mod timer_dialog;
 pub mod shell_cmd_dialog;
+pub mod snippet_dialog;
 
 pub mod window_manager;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod help_window;
 mod timer_help_window;
 mod timer_dialog;
 mod shell_cmd_dialog;
+mod snippet_dialog;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,6 +16,7 @@ use crate::plugins::wikipedia::WikipediaPlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::timer::TimerPlugin;
 use crate::plugins::notes::NotesPlugin;
+use crate::plugins::snippets::SnippetsPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -65,6 +66,7 @@ impl PluginManager {
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(NotesPlugin::default()));
+        self.register(Box::new(SnippetsPlugin::default()));
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));
         crate::plugins::timer::load_saved_alarms();

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -13,3 +13,4 @@ pub mod processes;
 pub mod weather;
 pub mod notes;
 pub mod timer;
+pub mod snippets;

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -1,0 +1,101 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+
+pub const SNIPPETS_FILE: &str = "snippets.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SnippetEntry {
+    pub alias: String,
+    pub text: String,
+}
+
+pub fn load_snippets(path: &str) -> anyhow::Result<Vec<SnippetEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<SnippetEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_snippets(path: &str, snippets: &[SnippetEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(snippets)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn add_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
+    let mut list = load_snippets(path).unwrap_or_default();
+    list.push(SnippetEntry { alias: alias.to_string(), text: text.to_string() });
+    save_snippets(path, &list)
+}
+
+pub fn set_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
+    let mut list = load_snippets(path).unwrap_or_default();
+    if let Some(entry) = list.iter_mut().find(|e| e.alias == alias) {
+        entry.text = text.to_string();
+    } else {
+        list.push(SnippetEntry { alias: alias.to_string(), text: text.to_string() });
+    }
+    save_snippets(path, &list)
+}
+
+pub struct SnippetsPlugin {
+    matcher: SkimMatcherV2,
+}
+
+impl SnippetsPlugin {
+    pub fn new() -> Self {
+        Self { matcher: SkimMatcherV2::default() }
+    }
+}
+
+impl Default for SnippetsPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for SnippetsPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("cs") {
+            return vec![Action {
+                label: "cs: edit snippets".into(),
+                desc: "Snippet".into(),
+                action: "snippet:dialog".into(),
+                args: None,
+            }];
+        }
+        if !trimmed.starts_with("cs") {
+            return Vec::new();
+        }
+        let filter = trimmed.strip_prefix("cs").unwrap_or("").trim();
+        let list = load_snippets(SNIPPETS_FILE).unwrap_or_default();
+        list.into_iter()
+            .filter(|s| self.matcher.fuzzy_match(&s.alias, filter).is_some() || self.matcher.fuzzy_match(&s.text, filter).is_some())
+            .map(|s| Action {
+                label: s.alias,
+                desc: "Snippet".into(),
+                action: format!("clipboard:{}", s.text),
+                args: None,
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "snippets"
+    }
+
+    fn description(&self) -> &str {
+        "Search saved text snippets (prefix: `cs`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/src/snippet_dialog.rs
+++ b/src/snippet_dialog.rs
@@ -1,0 +1,117 @@
+use crate::gui::LauncherApp;
+use crate::plugins::snippets::{load_snippets, save_snippets, SnippetEntry, SNIPPETS_FILE};
+use eframe::egui;
+
+#[derive(Default)]
+pub struct SnippetDialog {
+    pub open: bool,
+    entries: Vec<SnippetEntry>,
+    edit_idx: Option<usize>,
+    alias: String,
+    text: String,
+}
+
+impl SnippetDialog {
+    pub fn open(&mut self) {
+        self.entries = load_snippets(SNIPPETS_FILE).unwrap_or_default();
+        self.open = true;
+        self.edit_idx = None;
+        self.alias.clear();
+        self.text.clear();
+    }
+
+    pub fn open_edit(&mut self, alias: &str) {
+        self.entries = load_snippets(SNIPPETS_FILE).unwrap_or_default();
+        if let Some(pos) = self.entries.iter().position(|e| e.alias == alias) {
+            self.edit_idx = Some(pos);
+            self.alias = alias.to_string();
+            self.text = self.entries[pos].text.clone();
+        } else {
+            self.edit_idx = Some(self.entries.len());
+            self.alias = alias.to_string();
+            self.text.clear();
+        }
+        self.open = true;
+    }
+
+    fn save(&mut self, app: &mut LauncherApp) {
+        if let Err(e) = save_snippets(SNIPPETS_FILE, &self.entries) {
+            app.error = Some(format!("Failed to save snippets: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        let mut save_now = false;
+        egui::Window::new("Snippets")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                if let Some(idx) = self.edit_idx {
+                    ui.horizontal(|ui| {
+                        ui.label("Alias");
+                        ui.text_edit_singleline(&mut self.alias);
+                    });
+                    ui.label("Text");
+                    ui.text_edit_multiline(&mut self.text);
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            if self.alias.trim().is_empty() || self.text.trim().is_empty() {
+                                app.error = Some("Both fields required".into());
+                            } else {
+                                if idx == self.entries.len() {
+                                    self.entries.push(SnippetEntry { alias: self.alias.clone(), text: self.text.clone() });
+                                } else if let Some(e) = self.entries.get_mut(idx) {
+                                    e.alias = self.alias.clone();
+                                    e.text = self.text.clone();
+                                }
+                                self.edit_idx = None;
+                                self.alias.clear();
+                                self.text.clear();
+                                save_now = true;
+                            }
+                        }
+                        if ui.button("Cancel").clicked() {
+                            self.edit_idx = None;
+                        }
+                    });
+                } else {
+                    let mut remove: Option<usize> = None;
+                    egui::ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
+                        for idx in 0..self.entries.len() {
+                            let entry = self.entries[idx].clone();
+                            let resp = ui.label(format!("{}: {}", entry.alias, entry.text.replace('\n', " ")));
+                            resp.context_menu(|ui| {
+                                if ui.button("Edit").clicked() {
+                                    self.edit_idx = Some(idx);
+                                    self.alias = entry.alias.clone();
+                                    self.text = entry.text.clone();
+                                    ui.close_menu();
+                                }
+                                if ui.button("Remove").clicked() {
+                                    remove = Some(idx);
+                                    ui.close_menu();
+                                }
+                            });
+                        }
+                    });
+                    if let Some(idx) = remove {
+                        self.entries.remove(idx);
+                        save_now = true;
+                    }
+                    if ui.button("Add Snippet").clicked() {
+                        self.edit_idx = Some(self.entries.len());
+                        self.alias.clear();
+                        self.text.clear();
+                    }
+                    if ui.button("Close").clicked() { close = true; }
+                }
+            });
+        if save_now { self.save(app); }
+        if close { self.open = false; }
+    }
+}
+

--- a/tests/snippets_plugin.rs
+++ b/tests/snippets_plugin.rs
@@ -1,0 +1,38 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::snippets::{save_snippets, load_snippets, SnippetEntry, SnippetsPlugin, SNIPPETS_FILE};
+use tempfile::tempdir;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn load_save_roundtrip() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![SnippetEntry { alias: "hw".into(), text: "hello".into() }];
+    save_snippets(SNIPPETS_FILE, &entries).unwrap();
+    let loaded = load_snippets(SNIPPETS_FILE).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].alias, "hw");
+    assert_eq!(loaded[0].text, "hello");
+}
+
+#[test]
+fn search_returns_clipboard_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![SnippetEntry { alias: "hi".into(), text: "hello world".into() }];
+    save_snippets(SNIPPETS_FILE, &entries).unwrap();
+
+    let plugin = SnippetsPlugin::default();
+    let results = plugin.search("cs hi");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "hi");
+    assert_eq!(results[0].action, "clipboard:hello world");
+    assert_eq!(results[0].desc, "Snippet");
+}


### PR DESCRIPTION
## Summary
- implement `SnippetsPlugin` and helper functions
- add snippet editing dialog
- integrate snippets with GUI and plugin manager
- add tests for snippet loading and searching

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ef27cded48332a98ea49ed5b89d81