### PR TITLE
Add Win hotkey modifier

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -136,6 +136,7 @@ impl Settings {
             ctrl: false,
             shift: false,
             alt: false,
+            win: false,
         }
     }
 

--- a/tests/hotkey.rs
+++ b/tests/hotkey.rs
@@ -5,7 +5,7 @@ use multi_launcher::hotkey::Key;
 fn parse_simple_f_key() {
     let hk = parse_hotkey("F2").expect("should parse F2");
     assert_eq!(hk.key, Key::F2);
-    assert!(!hk.ctrl && !hk.shift && !hk.alt);
+    assert!(!hk.ctrl && !hk.shift && !hk.alt && !hk.win);
 }
 
 #[test]
@@ -20,21 +20,28 @@ fn parse_high_function_keys() {
 fn parse_combo_hotkey() {
     let hk = parse_hotkey("Ctrl+Shift+Space").expect("should parse combination");
     assert_eq!(hk.key, Key::Space);
-    assert!(hk.ctrl && hk.shift && !hk.alt);
+    assert!(hk.ctrl && hk.shift && !hk.alt && !hk.win);
 }
 
 #[test]
 fn parse_shift_escape() {
     let hk = parse_hotkey("Shift+Escape").expect("should parse shift+escape");
     assert_eq!(hk.key, Key::Escape);
-    assert!(!hk.ctrl && hk.shift && !hk.alt);
+    assert!(!hk.ctrl && hk.shift && !hk.alt && !hk.win);
 }
 
 #[test]
 fn parse_zero_hotkey() {
     let hk = parse_hotkey("0").expect("should parse numeric zero");
     assert_eq!(hk.key, Key::Num0);
-    assert!(!hk.ctrl && !hk.shift && !hk.alt);
+    assert!(!hk.ctrl && !hk.shift && !hk.alt && !hk.win);
+}
+
+#[test]
+fn parse_win_modifier() {
+    let hk = parse_hotkey("Win+F3").expect("should parse win modifier");
+    assert_eq!(hk.key, Key::F3);
+    assert!(hk.win && !hk.ctrl && !hk.shift && !hk.alt);
 }
 
 #[test]

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -99,3 +99,21 @@ fn shift_capslock_does_not_trigger() {
 
     assert!(!trigger.take());
 }
+
+#[test]
+fn win_modifier_triggers() {
+    let hotkey = parse_hotkey("Win+F2").unwrap();
+    let trigger = Arc::new(HotkeyTrigger::new(hotkey));
+
+    let triggers = vec![trigger.clone()];
+    let events = vec![
+        EventType::KeyPress(Key::MetaLeft),
+        EventType::KeyPress(Key::F2),
+        EventType::KeyRelease(Key::F2),
+        EventType::KeyRelease(Key::MetaLeft),
+    ];
+
+    process_test_events(&triggers, &events);
+
+    assert!(trigger.take());
+}


### PR DESCRIPTION
## Summary
- extend `Hotkey` with `win` modifier flag
- support `Win` in `parse_hotkey`
- track Win state in Windows listener and test event helper
- return `win` flag from settings
- cover new behaviour with unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687019bbc7108332ba27e2309fc72ada