### PR TITLE
Add notes dialog support

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -20,6 +20,7 @@ use crate::help_window::HelpWindow;
 use crate::timer_help_window::TimerHelpWindow;
 use crate::timer_dialog::{TimerDialog, TimerCompletionDialog};
 use crate::snippet_dialog::SnippetDialog;
+use crate::notes_dialog::NotesDialog;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
 use std::time::Instant;
 
@@ -86,6 +87,7 @@ pub struct LauncherApp {
     completion_dialog: crate::timer_dialog::TimerCompletionDialog,
     shell_cmd_dialog: crate::shell_cmd_dialog::ShellCmdDialog,
     snippet_dialog: SnippetDialog,
+    notes_dialog: NotesDialog,
     pub help_flag: Arc<AtomicBool>,
     pub hotkey_str: Option<String>,
     pub quit_hotkey_str: Option<String>,
@@ -260,6 +262,7 @@ impl LauncherApp {
             completion_dialog: TimerCompletionDialog::default(),
             shell_cmd_dialog: crate::shell_cmd_dialog::ShellCmdDialog::default(),
             snippet_dialog: SnippetDialog::default(),
+            notes_dialog: NotesDialog::default(),
             help_flag: help_flag.clone(),
             hotkey_str: settings.hotkey.clone(),
             quit_hotkey_str: settings.quit_hotkey.clone(),
@@ -614,6 +617,8 @@ impl eframe::App for LauncherApp {
                             self.timer_dialog.open_alarm();
                         } else if a.action == "shell:dialog" {
                             self.shell_cmd_dialog.open();
+                        } else if a.action == "note:dialog" {
+                            self.notes_dialog.open();
                         } else if a.action == "snippet:dialog" {
                             self.snippet_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
@@ -824,6 +829,8 @@ impl eframe::App for LauncherApp {
                             self.timer_dialog.open_alarm();
                         } else if a.action == "shell:dialog" {
                             self.shell_cmd_dialog.open();
+                        } else if a.action == "note:dialog" {
+                            self.notes_dialog.open();
                         } else if a.action == "snippet:dialog" {
                             self.snippet_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
@@ -936,6 +943,9 @@ impl eframe::App for LauncherApp {
         let mut snip_dlg = std::mem::take(&mut self.snippet_dialog);
         snip_dlg.ui(ctx, self);
         self.snippet_dialog = snip_dlg;
+        let mut notes_dlg = std::mem::take(&mut self.notes_dialog);
+        notes_dlg.ui(ctx, self);
+        self.notes_dialog = notes_dlg;
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {


### PR DESCRIPTION
## Summary
- expose `NotesDialog` in `LauncherApp`
- instantiate and render quick notes dialog
- handle `note:dialog` actions

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68703283faa48332a1fa61fd4990be38