### PR TITLE
Handle note dialog search

### DIFF
--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -119,6 +119,15 @@ impl Plugin for NotesPlugin {
                 .collect();
         }
 
+        if query.trim() == "note" {
+            return vec![Action {
+                label: "note: edit notes".into(),
+                desc: "Note".into(),
+                action: "note:dialog".into(),
+                args: None,
+            }];
+        }
+
         Vec::new()
     }
 

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -53,3 +53,16 @@ fn remove_action_returns_indices() {
     assert_eq!(notes.len(), 1);
     assert_eq!(notes[0].text, "second");
 }
+
+#[test]
+fn search_plain_note_opens_dialog() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let plugin = NotesPlugin::default();
+    let results = plugin.search("note");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "note:dialog");
+    assert_eq!(results[0].label, "note: edit notes");
+}


### PR DESCRIPTION
## Summary
- show new action when query is `note`
- test that the search triggers the dialog

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6870359ef1dc8332aabb2602459a97ea