### PR TITLE
Add context menus for editing/removing notes

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -804,6 +804,36 @@ impl eframe::App for LauncherApp {
                                 ui.close_menu();
                             }
                         });
+                    } else if a.desc == "Note" && (a.action.starts_with("note:copy:") || a.action.starts_with("note:remove:")) {
+                        let idx_str = a.action.rsplit(':').next().unwrap_or("");
+                        if let Ok(note_idx) = idx_str.parse::<usize>() {
+                            let note_label = a.label.clone();
+                            menu_resp.clone().context_menu(|ui| {
+                                if ui.button("Edit Note").clicked() {
+                                    self.notes_dialog.open_edit(note_idx);
+                                    ui.close_menu();
+                                }
+                                if ui.button("Remove Note").clicked() {
+                                    if let Err(e) = crate::plugins::notes::remove_note(
+                                        crate::plugins::notes::QUICK_NOTES_FILE,
+                                        note_idx,
+                                    ) {
+                                        self.error = Some(format!("Failed to remove note: {e}"));
+                                    } else {
+                                        refresh = true;
+                                        set_focus = true;
+                                        if self.enable_toasts {
+                                            self.toasts.add(Toast {
+                                                text: format!("Removed note {}", note_label).into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default().duration_in_seconds(3.0),
+                                            });
+                                        }
+                                    }
+                                    ui.close_menu();
+                                }
+                            });
+                        }
                     }
                     if let Some(idx_act) = custom_idx {
                         menu_resp.clone().context_menu(|ui| {

--- a/src/notes_dialog.rs
+++ b/src/notes_dialog.rs
@@ -76,7 +76,19 @@ impl NotesDialog {
                         for idx in 0..self.entries.len() {
                             let entry = self.entries[idx].clone();
                             ui.horizontal(|ui| {
-                                ui.label(entry.text.replace('\n', " "));
+                                let resp = ui.label(entry.text.replace('\n', " "));
+                                let idx_copy = idx;
+                                resp.clone().context_menu(|ui| {
+                                    if ui.button("Edit Note").clicked() {
+                                        self.edit_idx = Some(idx_copy);
+                                        self.text = entry.text.clone();
+                                        ui.close_menu();
+                                    }
+                                    if ui.button("Remove Note").clicked() {
+                                        remove = Some(idx_copy);
+                                        ui.close_menu();
+                                    }
+                                });
                                 if ui.button("Edit").clicked() {
                                     self.edit_idx = Some(idx);
                                     self.text = entry.text.clone();


### PR DESCRIPTION
## Summary
- add right-click context menu inside the Notes dialog so each entry can be edited or removed
- support editing/removing notes from search results via right-click

## Testing
- `cargo test` *(fails: some crates were downloaded but all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6870430c977883328f9bda996380c617