### PR TITLE
Add brightness control plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,17 @@ notify = "6"
 winit = "0.29"
 once_cell = "1"
 regex = "1"
-windows = { version = "0.58", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_UI_Shell", "Win32_System_Com", "Win32_Media_Audio", "Win32_Media_Audio_Endpoints"] }
+windows = { version = "0.58", features = [
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Threading",
+    "Win32_UI_Shell",
+    "Win32_System_Com",
+    "Win32_Media_Audio",
+    "Win32_Media_Audio_Endpoints",
+    "Win32_Graphics_Gdi",
+    "Win32_Devices_Display"
+] }
 log = "0.4"
 raw-window-handle = "0.6"
 arboard = "3"

--- a/src/brightness_dialog.rs
+++ b/src/brightness_dialog.rs
@@ -67,7 +67,7 @@ fn get_main_display_brightness() -> Option<u8> {
                     let mut min = 0u32;
                     let mut cur = 0u32;
                     let mut max = 0u32;
-                    if GetMonitorBrightness(m.hPhysicalMonitor, &mut min, &mut cur, &mut max).as_bool() {
+                    if GetMonitorBrightness(m.hPhysicalMonitor, &mut min, &mut cur, &mut max) != 0 {
                         if max > min {
                             *percent_ptr = ((cur - min) * 100 / (max - min)) as u32;
                         } else {

--- a/src/brightness_dialog.rs
+++ b/src/brightness_dialog.rs
@@ -1,0 +1,44 @@
+use crate::gui::LauncherApp;
+use crate::launcher::launch_action;
+use crate::actions::Action;
+use eframe::egui;
+
+#[derive(Default)]
+pub struct BrightnessDialog {
+    pub open: bool,
+    value: u8,
+}
+
+impl BrightnessDialog {
+    pub fn open(&mut self) {
+        self.open = true;
+        self.value = 50;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        egui::Window::new("Brightness")
+            .resizable(false)
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                ui.add(egui::Slider::new(&mut self.value, 0..=100).text("Level"));
+                ui.horizontal(|ui| {
+                    if ui.button("Set").clicked() {
+                        let _ = launch_action(&Action {
+                            label: String::new(),
+                            desc: "Brightness".into(),
+                            action: format!("brightness:set:{}", self.value),
+                            args: None,
+                        });
+                        close = true;
+                        app.focus_input();
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if close { self.open = false; }
+    }
+}

--- a/src/brightness_dialog.rs
+++ b/src/brightness_dialog.rs
@@ -12,7 +12,7 @@ pub struct BrightnessDialog {
 impl BrightnessDialog {
     pub fn open(&mut self) {
         self.open = true;
-        self.value = 50;
+        self.value = get_main_display_brightness().unwrap_or(50);
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
@@ -41,4 +41,59 @@ impl BrightnessDialog {
             });
         if close { self.open = false; }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn get_main_display_brightness() -> Option<u8> {
+    use windows::Win32::Foundation::{BOOL, LPARAM, RECT};
+    use windows::Win32::Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR};
+    use windows::Win32::Devices::Display::{
+        DestroyPhysicalMonitors, GetNumberOfPhysicalMonitorsFromHMONITOR,
+        GetPhysicalMonitorsFromHMONITOR, GetMonitorBrightness, PHYSICAL_MONITOR,
+    };
+
+    unsafe extern "system" fn enum_monitors(
+        hmonitor: HMONITOR,
+        _hdc: HDC,
+        _rect: *mut RECT,
+        lparam: LPARAM,
+    ) -> BOOL {
+        let percent_ptr = lparam.0 as *mut u32;
+        let mut count: u32 = 0;
+        if GetNumberOfPhysicalMonitorsFromHMONITOR(hmonitor, &mut count).is_ok() {
+            let mut monitors = vec![PHYSICAL_MONITOR::default(); count as usize];
+            if GetPhysicalMonitorsFromHMONITOR(hmonitor, &mut monitors).is_ok() {
+                if let Some(m) = monitors.first() {
+                    let mut min = 0u32;
+                    let mut cur = 0u32;
+                    let mut max = 0u32;
+                    if GetMonitorBrightness(m.hPhysicalMonitor, &mut min, &mut cur, &mut max).is_ok() {
+                        if max > min {
+                            *percent_ptr = ((cur - min) * 100 / (max - min)) as u32;
+                        } else {
+                            *percent_ptr = 0;
+                        }
+                    }
+                }
+                let _ = DestroyPhysicalMonitors(&monitors);
+            }
+        }
+        false.into()
+    }
+
+    let mut percent: u32 = 50;
+    unsafe {
+        let _ = EnumDisplayMonitors(
+            HDC(std::ptr::null_mut()),
+            None,
+            Some(enum_monitors),
+            LPARAM(&mut percent as *mut u32 as isize),
+        );
+    }
+    Some(percent as u8)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_main_display_brightness() -> Option<u8> {
+    None
 }

--- a/src/brightness_dialog.rs
+++ b/src/brightness_dialog.rs
@@ -67,7 +67,7 @@ fn get_main_display_brightness() -> Option<u8> {
                     let mut min = 0u32;
                     let mut cur = 0u32;
                     let mut max = 0u32;
-                    if GetMonitorBrightness(m.hPhysicalMonitor, &mut min, &mut cur, &mut max).is_ok() {
+                    if GetMonitorBrightness(m.hPhysicalMonitor, &mut min, &mut cur, &mut max).as_bool() {
                         if max > min {
                             *percent_ptr = ((cur - min) * 100 / (max - min)) as u32;
                         } else {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -90,6 +90,7 @@ pub struct LauncherApp {
     snippet_dialog: SnippetDialog,
     notes_dialog: NotesDialog,
     volume_dialog: crate::volume_dialog::VolumeDialog,
+    brightness_dialog: crate::brightness_dialog::BrightnessDialog,
     pub help_flag: Arc<AtomicBool>,
     pub hotkey_str: Option<String>,
     pub quit_hotkey_str: Option<String>,
@@ -266,6 +267,7 @@ impl LauncherApp {
             snippet_dialog: SnippetDialog::default(),
             notes_dialog: NotesDialog::default(),
             volume_dialog: crate::volume_dialog::VolumeDialog::default(),
+            brightness_dialog: crate::brightness_dialog::BrightnessDialog::default(),
             help_flag: help_flag.clone(),
             hotkey_str: settings.hotkey.clone(),
             quit_hotkey_str: settings.quit_hotkey.clone(),
@@ -626,6 +628,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "volume:dialog" {
                             self.volume_dialog.open();
+                        } else if a.action == "brightness:dialog" {
+                            self.brightness_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             self.error_time = Some(Instant::now());
@@ -870,6 +874,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "volume:dialog" {
                             self.volume_dialog.open();
+                        } else if a.action == "brightness:dialog" {
+                            self.brightness_dialog.open();
                         } else if let Err(e) = launch_action(&a) {
                             self.error = Some(format!("Failed: {e}"));
                             self.error_time = Some(Instant::now());
@@ -986,6 +992,9 @@ impl eframe::App for LauncherApp {
         let mut vol_dlg = std::mem::take(&mut self.volume_dialog);
         vol_dlg.ui(ctx, self);
         self.volume_dialog = vol_dlg;
+        let mut bright_dlg = std::mem::take(&mut self.brightness_dialog);
+        bright_dlg.ui(ctx, self);
+        self.brightness_dialog = bright_dlg;
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -21,7 +21,6 @@ use crate::timer_help_window::TimerHelpWindow;
 use crate::timer_dialog::{TimerDialog, TimerCompletionDialog};
 use crate::snippet_dialog::SnippetDialog;
 use crate::notes_dialog::NotesDialog;
-use crate::volume_dialog::VolumeDialog;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
 use std::time::Instant;
 
@@ -732,7 +731,7 @@ impl eframe::App for LauncherApp {
                         a.label.clone()
                     };
                     let mut resp = ui.selectable_label(self.selected == Some(idx), text);
-                    let mut menu_resp = resp.on_hover_text(&a.action);
+                    let menu_resp = resp.on_hover_text(&a.action);
                     let custom_idx = self
                         .actions
                         .iter()

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -97,6 +97,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "timer" => Some(&["timer 10s break", "timer list", "alarm 07:30"]),
         "notes" => Some(&["note", "note add buy milk", "note list", "note rm milk"]),
         "volume" => Some(&["vol 50"]),
+        "brightness" => Some(&["bright 50"]),
         "help" => Some(&["help"]),
         _ => None,
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -77,17 +77,28 @@ fn mute_active_window() {}
 
 #[cfg(target_os = "windows")]
 fn set_display_brightness(percent: u32) {
-    use std::process::Command;
-    let _ = Command::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-Command",
-            &format!(
-                "(Get-WmiObject -Namespace root/WMI -Class WmiMonitorBrightnessMethods).WmiSetBrightness(1,{})",
-                percent
-            ),
-        ])
-        .spawn();
+    use windows::Win32::Foundation::{BOOL, LPARAM, RECT};
+    use windows::Win32::Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR};
+    use windows::Win32::Devices::Display::{DestroyPhysicalMonitors, GetNumberOfPhysicalMonitorsFromHMONITOR, GetPhysicalMonitorsFromHMONITOR, PHYSICAL_MONITOR, SetMonitorBrightness};
+
+    unsafe extern "system" fn enum_monitors(hmonitor: HMONITOR, _hdc: HDC, _rect: *mut RECT, lparam: LPARAM) -> BOOL {
+        let percent = lparam.0 as u32;
+        let mut count: u32 = 0;
+        if GetNumberOfPhysicalMonitorsFromHMONITOR(hmonitor, &mut count).as_bool() {
+            let mut monitors = vec![PHYSICAL_MONITOR::default(); count as usize];
+            if GetPhysicalMonitorsFromHMONITOR(hmonitor, count, monitors.as_mut_ptr()).as_bool() {
+                for m in &monitors {
+                    let _ = SetMonitorBrightness(m.hPhysicalMonitor, percent);
+                }
+                let _ = DestroyPhysicalMonitors(count, monitors.as_ptr());
+            }
+        }
+        true.into()
+    }
+
+    unsafe {
+        let _ = EnumDisplayMonitors(HDC(0), std::ptr::null_mut(), Some(enum_monitors), LPARAM(percent as isize));
+    }
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -12,7 +12,6 @@ use shlex;
 
 #[cfg(target_os = "windows")]
 fn set_system_volume(percent: u32) {
-    use windows::core::Interface;
     use windows::Win32::Media::Audio::{IMMDeviceEnumerator, MMDeviceEnumerator, eRender, eMultimedia};
     use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
     use windows::Win32::System::Com::{CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED};
@@ -36,7 +35,7 @@ fn set_system_volume(_percent: u32) {}
 #[cfg(target_os = "windows")]
 fn mute_active_window() {
     use windows::core::Interface;
-    use windows::Win32::Media::Audio::{IAudioSessionManager2, IAudioSessionEnumerator, IAudioSessionControl2, ISimpleAudioVolume, IMMDeviceEnumerator, MMDeviceEnumerator, eRender, eMultimedia};
+    use windows::Win32::Media::Audio::{IAudioSessionManager2, IAudioSessionControl2, ISimpleAudioVolume, IMMDeviceEnumerator, MMDeviceEnumerator, eRender, eMultimedia};
     use windows::Win32::System::Com::{CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED};
     use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
 
@@ -215,7 +214,7 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     }
     if let Some(pid) = action.action.strip_prefix("process:kill:") {
         if let Ok(pid) = pid.parse::<u32>() {
-            let mut system = System::new_all();
+            let system = System::new_all();
             if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
                 let _ = process.kill();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod shell_cmd_dialog;
 pub mod snippet_dialog;
 pub mod notes_dialog;
 pub mod volume_dialog;
+pub mod brightness_dialog;
 
 pub mod window_manager;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod shell_cmd_dialog;
 mod snippet_dialog;
 mod notes_dialog;
 mod volume_dialog;
+mod brightness_dialog;
 
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -18,6 +18,7 @@ use crate::plugins::timer::TimerPlugin;
 use crate::plugins::notes::NotesPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
 use crate::plugins::volume::VolumePlugin;
+use crate::plugins::brightness::BrightnessPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -69,6 +70,7 @@ impl PluginManager {
         self.register(Box::new(NotesPlugin::default()));
         self.register(Box::new(SnippetsPlugin::default()));
         self.register(Box::new(VolumePlugin));
+        self.register(Box::new(BrightnessPlugin));
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));
         crate::plugins::timer::load_saved_alarms();

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -1,0 +1,42 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct BrightnessPlugin;
+
+impl Plugin for BrightnessPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("bright") {
+            return vec![Action {
+                label: "bright: edit brightness".into(),
+                desc: "Brightness".into(),
+                action: "brightness:dialog".into(),
+                args: None,
+            }];
+        }
+        if let Some(rest) = trimmed.strip_prefix("bright ") {
+            let rest = rest.trim();
+            if let Ok(val) = rest.parse::<u8>() {
+                if val <= 100 {
+                    return vec![Action {
+                        label: format!("Set brightness to {val}%"),
+                        desc: "Brightness".into(),
+                        action: format!("brightness:set:{val}"),
+                        args: None,
+                    }];
+                }
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str { "brightness" }
+
+    fn description(&self) -> &str {
+        "Adjust display brightness (prefix: `bright`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -15,3 +15,4 @@ pub mod notes;
 pub mod timer;
 pub mod snippets;
 pub mod volume;
+pub mod brightness;

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -50,7 +50,7 @@ fn format_ts(ts: u64) -> String {
     Local
         .timestamp_opt(ts as i64, 0)
         .single()
-        .unwrap_or_else(|| Local.timestamp(0, 0))
+        .unwrap_or_else(|| Local.timestamp_opt(0, 0).single().unwrap())
         .format("%Y-%m-%d %H:%M")
         .to_string()
 }

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -200,7 +200,7 @@ pub fn start_timer(duration: Duration) {
 }
 
 pub fn start_alarm_named(hour: u32, minute: u32, name: Option<String>) {
-    use chrono::{Duration as ChronoDuration, Local, Timelike};
+    use chrono::{Duration as ChronoDuration, Local};
     let now = Local::now();
     let mut target = now.date_naive().and_hms_opt(hour, minute, 0).unwrap();
     if target <= now.naive_local() {

--- a/src/timer_dialog.rs
+++ b/src/timer_dialog.rs
@@ -84,7 +84,7 @@ impl TimerDialog {
                     }
                 });
             });
-        if (close) { open_val = false; }
+        if close { open_val = false; }
         self.open = open_val;
     }
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -159,7 +159,6 @@ use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 /// of the foreground window.
 #[cfg(target_os = "windows")]
 pub fn move_to_current_desktop(hwnd: windows::Win32::Foundation::HWND) {
-    use windows::core::GUID;
     use windows::Win32::System::Com::{
         CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
     };

--- a/tests/brightness_plugin.rs
+++ b/tests/brightness_plugin.rs
@@ -1,0 +1,18 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::brightness::BrightnessPlugin;
+
+#[test]
+fn search_set_numeric() {
+    let plugin = BrightnessPlugin;
+    let results = plugin.search("bright 50");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "brightness:set:50");
+}
+
+#[test]
+fn search_plain_bright() {
+    let plugin = BrightnessPlugin;
+    let results = plugin.search("bright");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "brightness:dialog");
+}


### PR DESCRIPTION
## Summary
- add new brightness plugin with dialog for editing brightness
- register the brightness plugin and expose example queries
- handle brightness actions in launcher
- add tests for the plugin

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68715f4789f8833287bcaf37368bbbea