### PR TITLE
Add bookmark dialog

### DIFF
--- a/src/add_bookmark_dialog.rs
+++ b/src/add_bookmark_dialog.rs
@@ -1,0 +1,60 @@
+use crate::gui::LauncherApp;
+use crate::plugins::bookmarks::{append_bookmark, set_alias, BOOKMARKS_FILE};
+use eframe::egui;
+
+pub struct AddBookmarkDialog {
+    pub open: bool,
+    url: String,
+    alias: String,
+}
+
+impl Default for AddBookmarkDialog {
+    fn default() -> Self {
+        Self { open: false, url: String::new(), alias: String::new() }
+    }
+}
+
+impl AddBookmarkDialog {
+    pub fn open(&mut self) {
+        self.open = true;
+        self.url.clear();
+        self.alias.clear();
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        egui::Window::new("Add Bookmark")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("URL");
+                    ui.text_edit_singleline(&mut self.url);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Alias");
+                    ui.text_edit_singleline(&mut self.alias);
+                });
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        if self.url.trim().is_empty() {
+                            app.error = Some("URL required".into());
+                        } else {
+                            if let Err(e) = append_bookmark(BOOKMARKS_FILE, &self.url) {
+                                app.error = Some(format!("Failed to save: {e}"));
+                            } else if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {
+                                app.error = Some(format!("Failed to save alias: {e}"));
+                            } else {
+                                close = true;
+                                app.search();
+                                app.focus_input();
+                            }
+                        }
+                    }
+                    if ui.button("Cancel").clicked() { close = true; }
+                });
+            });
+        if close { self.open = false; }
+    }
+}
+

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -21,6 +21,7 @@ use crate::timer_help_window::TimerHelpWindow;
 use crate::timer_dialog::{TimerDialog, TimerCompletionDialog};
 use crate::snippet_dialog::SnippetDialog;
 use crate::notes_dialog::NotesDialog;
+use crate::add_bookmark_dialog::AddBookmarkDialog;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
 use std::time::Instant;
 
@@ -81,6 +82,7 @@ pub struct LauncherApp {
     pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
     bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog,
+    add_bookmark_dialog: crate::add_bookmark_dialog::AddBookmarkDialog,
     help_window: crate::help_window::HelpWindow,
     timer_help: crate::timer_help_window::TimerHelpWindow,
     timer_dialog: crate::timer_dialog::TimerDialog,
@@ -258,6 +260,7 @@ impl LauncherApp {
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
             bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog::default(),
+            add_bookmark_dialog: crate::add_bookmark_dialog::AddBookmarkDialog::default(),
             help_window: HelpWindow::default(),
             timer_help: TimerHelpWindow::default(),
             timer_dialog: TimerDialog::default(),
@@ -623,6 +626,8 @@ impl eframe::App for LauncherApp {
                             self.shell_cmd_dialog.open();
                         } else if a.action == "note:dialog" {
                             self.notes_dialog.open();
+                        } else if a.action == "bookmark:dialog" {
+                            self.add_bookmark_dialog.open();
                         } else if a.action == "snippet:dialog" {
                             self.snippet_dialog.open();
                         } else if a.action == "volume:dialog" {
@@ -869,6 +874,8 @@ impl eframe::App for LauncherApp {
                             self.shell_cmd_dialog.open();
                         } else if a.action == "note:dialog" {
                             self.notes_dialog.open();
+                        } else if a.action == "bookmark:dialog" {
+                            self.add_bookmark_dialog.open();
                         } else if a.action == "snippet:dialog" {
                             self.snippet_dialog.open();
                         } else if a.action == "volume:dialog" {
@@ -967,6 +974,9 @@ impl eframe::App for LauncherApp {
         let mut bm_dlg = std::mem::take(&mut self.bookmark_alias_dialog);
         bm_dlg.ui(ctx, self);
         self.bookmark_alias_dialog = bm_dlg;
+        let mut add_bm_dlg = std::mem::take(&mut self.add_bookmark_dialog);
+        add_bm_dlg.ui(ctx, self);
+        self.add_bookmark_dialog = add_bm_dlg;
         let mut help = std::mem::take(&mut self.help_window);
         help.ui(ctx, self);
         self.help_window = help;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod actions_editor;
 pub mod add_action_dialog;
 pub mod alias_dialog;
 pub mod bookmark_alias_dialog;
+pub mod add_bookmark_dialog;
 pub mod plugin_editor;
 pub mod settings_editor;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod actions_editor;
 mod add_action_dialog;
 mod alias_dialog;
 mod bookmark_alias_dialog;
+mod add_bookmark_dialog;
 mod settings_editor;
 mod plugin_editor;
 mod gui;

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -107,7 +107,17 @@ impl Default for BookmarksPlugin {
 
 impl Plugin for BookmarksPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(url) = query.strip_prefix("bm add ") {
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("bm") || trimmed.eq_ignore_ascii_case("bm add") {
+            return vec![Action {
+                label: "bm: add bookmark".into(),
+                desc: "Bookmark".into(),
+                action: "bookmark:dialog".into(),
+                args: None,
+            }];
+        }
+
+        if let Some(url) = trimmed.strip_prefix("bm add ") {
             let url = url.trim();
             if !url.is_empty() {
                 let norm = normalize_url(url);
@@ -119,8 +129,7 @@ impl Plugin for BookmarksPlugin {
                 }];
             }
         }
-
-        if let Some(pattern) = query.strip_prefix("bm rm ") {
+        if let Some(pattern) = trimmed.strip_prefix("bm rm ") {
             let filter = pattern.trim();
             let bookmarks = load_bookmarks(BOOKMARKS_FILE).unwrap_or_default();
             return bookmarks
@@ -134,11 +143,10 @@ impl Plugin for BookmarksPlugin {
                 })
                 .collect();
         }
-
-        if !query.starts_with("bm") {
+        if !trimmed.starts_with("bm") {
             return Vec::new();
         }
-        let filter = query.strip_prefix("bm").unwrap_or("").trim();
+        let filter = trimmed.strip_prefix("bm").unwrap_or("").trim();
         let bookmarks = load_bookmarks(BOOKMARKS_FILE).unwrap_or_default();
         bookmarks
             .into_iter()

--- a/tests/bookmarks_plugin.rs
+++ b/tests/bookmarks_plugin.rs
@@ -35,3 +35,27 @@ fn search_uses_alias_label() {
     assert_eq!(results[0].action, "https://example.com");
 }
 
+#[test]
+fn plain_bm_shows_dialog_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let plugin = BookmarksPlugin::default();
+    let results = plugin.search("bm");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "bookmark:dialog");
+}
+
+#[test]
+fn bm_add_without_url_shows_dialog() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let plugin = BookmarksPlugin::default();
+    let results = plugin.search("bm add");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "bookmark:dialog");
+}
+


### PR DESCRIPTION
## Summary
- add new `AddBookmarkDialog` to capture url and alias
- show an Add Bookmark action on `bm` or `bm add`
- open the new dialog from GUI and save bookmark+alias on confirm
- test the new query behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6871868c2424833284a0892b64ee7eb6