### PR TITLE
Handle Enter key in bookmark alias dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Built-in plugins and their command prefixes are:
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
 - Clipboard history (`cb`)
-- Bookmarks (`bm add <url>` or `bm rm <pattern>`)
+- Bookmarks (`bm add <url>`, `bm rm <pattern>` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
@@ -205,8 +205,9 @@ shortcut and `f rm <pattern>` to remove one via fuzzy search. Custom entries can
 be aliased by right clicking them in the results list. Hovering a folder result
 shows its full path. A plugin setting "show full path always" controls whether
 the full path is displayed next to an alias or only as a tooltip.
-The bookmarks plugin uses the `bm` prefix. Use `bm add <url>` to save a link and
-`bm rm <pattern>` to remove one via fuzzy search.
+The bookmarks plugin uses the `bm` prefix. Use `bm add <url>` to save a link,
+`bm rm <pattern>` to remove one via fuzzy search or `bm list` to show all
+bookmarks. Searching with `bm <term>` matches both URLs and aliases.
 ### Security Considerations
 The shell plugin runs commands using the system shell without sanitising input. Only enable it if you trust the commands you type. Errors while spawning the process are logged.
 Type `sh` in the launcher to open the shell command editor for managing predefined commands.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Built-in plugins and their command prefixes are:
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
 - Clipboard history (`cb`)
-- Bookmarks (`bm add <url>`, `bm rm <pattern>` or `bm list`)
+- Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)
 - System actions (`sys shutdown`)
@@ -206,8 +206,9 @@ be aliased by right clicking them in the results list. Hovering a folder result
 shows its full path. A plugin setting "show full path always" controls whether
 the full path is displayed next to an alias or only as a tooltip.
 The bookmarks plugin uses the `bm` prefix. Use `bm add <url>` to save a link,
-`bm rm <pattern>` to remove one via fuzzy search or `bm list` to show all
-bookmarks. Searching with `bm <term>` matches both URLs and aliases.
+`bm rm` to list and remove bookmarks (optionally filtering with a pattern) or
+`bm list` to show all bookmarks. Searching with `bm <term>` matches both URLs
+and aliases.
 ### Security Considerations
 The shell plugin runs commands using the system shell without sanitising input. Only enable it if you trust the commands you type. Errors while spawning the process are logged.
 Type `sh` in the launcher to open the shell command editor for managing predefined commands.

--- a/src/add_bookmark_dialog.rs
+++ b/src/add_bookmark_dialog.rs
@@ -1,6 +1,7 @@
 use crate::gui::LauncherApp;
 use crate::plugins::bookmarks::{append_bookmark, set_alias, BOOKMARKS_FILE};
 use eframe::egui;
+use egui_toast::{Toast, ToastKind, ToastOptions};
 
 pub struct AddBookmarkDialog {
     pub open: bool,
@@ -46,6 +47,13 @@ impl AddBookmarkDialog {
                                 app.error = Some(format!("Failed to save alias: {e}"));
                             } else {
                                 close = true;
+                                if app.enable_toasts {
+                                    app.add_toast(Toast {
+                                        text: format!("Saved bookmark {}", self.url).into(),
+                                        kind: ToastKind::Success,
+                                        options: ToastOptions::default().duration_in_seconds(3.0),
+                                    });
+                                }
                                 app.search();
                                 app.focus_input();
                             }

--- a/src/bookmark_alias_dialog.rs
+++ b/src/bookmark_alias_dialog.rs
@@ -39,6 +39,19 @@ impl BookmarkAliasDialog {
             .show(ctx, |ui| {
                 ui.label(&self.url);
                 ui.text_edit_singleline(&mut self.alias);
+
+                if ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {
+                        app.error = Some(format!("Failed to save alias: {e}"));
+                    } else {
+                        close = true;
+                        app.search();
+                        app.focus_input();
+                    }
+                    let modifiers = ctx.input(|i| i.modifiers);
+                    ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+                }
+
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -606,7 +606,9 @@ impl eframe::App for LauncherApp {
                 }
 
                 let mut launch_idx: Option<usize> = None;
-                if ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
+                if ctx.input(|i| i.key_pressed(egui::Key::Enter))
+                    && !self.bookmark_alias_dialog.open
+                {
                     launch_idx = self.handle_key(egui::Key::Enter);
                 }
 

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -88,7 +88,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "reddit" => Some(&["red cats"]),
         "calculator" => Some(&["= 1+2"]),
         "clipboard" => Some(&["cb"]),
-        "bookmarks" => Some(&["bm add https://example.com", "bm list"]),
+        "bookmarks" => Some(&["bm add https://example.com", "bm rm", "bm list"]),
         "folders" => Some(&["f add C:/path", "f rm docs"]),
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -88,7 +88,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "reddit" => Some(&["red cats"]),
         "calculator" => Some(&["= 1+2"]),
         "clipboard" => Some(&["cb"]),
-        "bookmarks" => Some(&["bm add https://example.com"]),
+        "bookmarks" => Some(&["bm add https://example.com", "bm list"]),
         "folders" => Some(&["f add C:/path", "f rm docs"]),
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -143,6 +143,30 @@ impl Plugin for BookmarksPlugin {
                 })
                 .collect();
         }
+        if let Some(rest) = trimmed.strip_prefix("bm list") {
+            let filter = rest.trim();
+            let bookmarks = load_bookmarks(BOOKMARKS_FILE).unwrap_or_default();
+            return bookmarks
+                .into_iter()
+                .filter(|b| {
+                    self.matcher.fuzzy_match(&b.url, filter).is_some()
+                        || b
+                            .alias
+                            .as_ref()
+                            .map(|a| self.matcher.fuzzy_match(a, filter).is_some())
+                            .unwrap_or(false)
+                })
+                .map(|b| {
+                    let label = b.alias.clone().unwrap_or_else(|| b.url.clone());
+                    Action {
+                        label,
+                        desc: "Bookmark".into(),
+                        action: b.url,
+                        args: None,
+                    }
+                })
+                .collect();
+        }
         if !trimmed.starts_with("bm") {
             return Vec::new();
         }

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -129,12 +129,19 @@ impl Plugin for BookmarksPlugin {
                 }];
             }
         }
-        if let Some(pattern) = trimmed.strip_prefix("bm rm ") {
-            let filter = pattern.trim();
+        if let Some(rest) = trimmed.strip_prefix("bm rm") {
+            let filter = rest.trim();
             let bookmarks = load_bookmarks(BOOKMARKS_FILE).unwrap_or_default();
             return bookmarks
                 .into_iter()
-                .filter(|b| self.matcher.fuzzy_match(&b.url, filter).is_some())
+                .filter(|b| {
+                    self.matcher.fuzzy_match(&b.url, filter).is_some()
+                        || b
+                            .alias
+                            .as_ref()
+                            .map(|a| self.matcher.fuzzy_match(a, filter).is_some())
+                            .unwrap_or(false)
+                })
                 .map(|b| Action {
                     label: format!("Remove bookmark {}", b.url),
                     desc: "Bookmark".into(),

--- a/tests/bookmarks_plugin.rs
+++ b/tests/bookmarks_plugin.rs
@@ -78,3 +78,26 @@ fn bm_list_returns_bookmarks() {
     assert!(results.iter().any(|a| a.action == "https://rust-lang.org"));
 }
 
+#[test]
+fn bm_rm_lists_bookmarks_without_filter() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![
+        BookmarkEntry { url: "https://example.com".into(), alias: Some("ex".into()) },
+        BookmarkEntry { url: "https://rust-lang.org".into(), alias: None },
+    ];
+    save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
+
+    let plugin = BookmarksPlugin::default();
+    let results = plugin.search("bm rm");
+    assert_eq!(results.len(), 2);
+    assert!(results
+        .iter()
+        .any(|a| a.action == "bookmark:remove:https://example.com"));
+    assert!(results
+        .iter()
+        .any(|a| a.action == "bookmark:remove:https://rust-lang.org"));
+}
+

--- a/tests/bookmarks_plugin.rs
+++ b/tests/bookmarks_plugin.rs
@@ -59,3 +59,22 @@ fn bm_add_without_url_shows_dialog() {
     assert_eq!(results[0].action, "bookmark:dialog");
 }
 
+#[test]
+fn bm_list_returns_bookmarks() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![
+        BookmarkEntry { url: "https://example.com".into(), alias: Some("ex".into()) },
+        BookmarkEntry { url: "https://rust-lang.org".into(), alias: None },
+    ];
+    save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
+
+    let plugin = BookmarksPlugin::default();
+    let results = plugin.search("bm list");
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|a| a.action == "https://example.com"));
+    assert!(results.iter().any(|a| a.action == "https://rust-lang.org"));
+}
+


### PR DESCRIPTION
## Summary
- save bookmark alias when pressing Enter inside alias dialog
- ignore Enter key in command list when alias dialog is open

## Testing
- `cargo check`
- `cargo test`

 