### PR TITLE
Fix notes dialog scrolling

### DIFF
--- a/src/notes_dialog.rs
+++ b/src/notes_dialog.rs
@@ -72,7 +72,7 @@ impl NotesDialog {
                     });
                 } else {
                     let mut remove: Option<usize> = None;
-                    egui::ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
+                    egui::ScrollArea::both().max_height(200.0).show(ui, |ui| {
                         for idx in 0..self.entries.len() {
                             let entry = self.entries[idx].clone();
                             ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in `NotesDialog`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68719aa767908332b702a57c9393653a