### PR TITLE
Allow quick notes editor to resize with the window

### DIFF
--- a/src/notes_dialog.rs
+++ b/src/notes_dialog.rs
@@ -47,17 +47,25 @@ impl NotesDialog {
         let mut save_now = false;
         egui::Window::new("Quick Notes")
             .open(&mut self.open)
+            .resizable(true)
             .show(ctx, |ui| {
                 if let Some(idx) = self.edit_idx {
                     ui.label("Text");
-                    ui.text_edit_multiline(&mut self.text);
+                    ui.add(
+                        egui::TextEdit::multiline(&mut self.text)
+                            .desired_width(f32::INFINITY)
+                            .desired_rows(10),
+                    );
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.text.trim().is_empty() {
                                 app.error = Some("Text required".into());
                             } else {
                                 if idx == self.entries.len() {
-                                    self.entries.push(NoteEntry { ts: Local::now().timestamp() as u64, text: self.text.clone() });
+                                    self.entries.push(NoteEntry {
+                                        ts: Local::now().timestamp() as u64,
+                                        text: self.text.clone(),
+                                    });
                                 } else if let Some(e) = self.entries.get_mut(idx) {
                                     e.text = self.text.clone();
                                 }
@@ -120,4 +128,3 @@ impl NotesDialog {
         }
     }
 }
-

--- a/src/notes_dialog.rs
+++ b/src/notes_dialog.rs
@@ -48,6 +48,9 @@ impl NotesDialog {
         egui::Window::new("Quick Notes")
             .open(&mut self.open)
             .resizable(true)
+            .default_size((360.0, 240.0))
+            .min_width(200.0)
+            .min_height(150.0)
             .show(ctx, |ui| {
                 if let Some(idx) = self.edit_idx {
                     ui.label("Text");
@@ -80,7 +83,10 @@ impl NotesDialog {
                     });
                 } else {
                     let mut remove: Option<usize> = None;
-                    egui::ScrollArea::both().max_height(200.0).show(ui, |ui| {
+                    let area_height = ui.available_height();
+                    egui::ScrollArea::both()
+                        .max_height(area_height)
+                        .show(ui, |ui| {
                         for idx in 0..self.entries.len() {
                             let entry = self.entries[idx].clone();
                             ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- make the notes dialog window resizable
- let the multiline text field grow with the window

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68719c5449f8833282ca94582be252a8