### PR TITLE
Fix Enter key handling in notes dialog

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -608,6 +608,7 @@ impl eframe::App for LauncherApp {
                 let mut launch_idx: Option<usize> = None;
                 if ctx.input(|i| i.key_pressed(egui::Key::Enter))
                     && !self.bookmark_alias_dialog.open
+                    && !self.notes_dialog.open
                 {
                     launch_idx = self.handle_key(egui::Key::Enter);
                 }

--- a/src/notes_dialog.rs
+++ b/src/notes_dialog.rs
@@ -54,11 +54,15 @@ impl NotesDialog {
             .show(ctx, |ui| {
                 if let Some(idx) = self.edit_idx {
                     ui.label("Text");
-                    ui.add(
+                    let resp = ui.add(
                         egui::TextEdit::multiline(&mut self.text)
                             .desired_width(f32::INFINITY)
                             .desired_rows(10),
                     );
+                    if resp.has_focus() && ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
+                        let modifiers = ctx.input(|i| i.modifiers);
+                        ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+                    }
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.text.trim().is_empty() {


### PR DESCRIPTION
## Summary
- stop Enter from closing the launcher while editing notes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6871a8cb9a988332a7988fe1c04b6428