### PR TITLE
Implement usage persistence

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -23,6 +23,7 @@ use crate::snippet_dialog::SnippetDialog;
 use crate::notes_dialog::NotesDialog;
 use crate::add_bookmark_dialog::AddBookmarkDialog;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
+use crate::usage::{self, USAGE_FILE};
 use std::time::Instant;
 
 fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
@@ -233,7 +234,7 @@ impl LauncherApp {
             error_time: None,
             plugins,
             selected: None,
-            usage: HashMap::new(),
+            usage: usage::load_usage(USAGE_FILE).unwrap_or_default(),
             registered_hotkeys: Mutex::new(HashMap::new()),
             show_editor: false,
             show_settings: false,
@@ -1017,6 +1018,7 @@ impl eframe::App for LauncherApp {
             settings.window_size = Some(self.window_size);
             let _ = settings.save(&self.settings_path);
         }
+        let _ = usage::save_usage(USAGE_FILE, &self.usage);
         #[cfg(not(test))]
         std::process::exit(0);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod indexer;
 pub mod logging;
 pub mod hotkey;
 pub mod history;
+pub mod usage;
 pub mod visibility;
 pub mod help_window;
 pub mod timer_help_window;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod plugin_editor;
 mod gui;
 mod hotkey;
 mod history;
+mod usage;
 mod launcher;
 mod plugin;
 mod plugins_builtin;

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UsageEntry {
+    pub action: String,
+    pub count: u32,
+}
+
+pub const USAGE_FILE: &str = "usage.json";
+
+/// Load usage data from `path`.
+///
+/// Returns a map from action identifier to usage count.
+pub fn load_usage(path: &str) -> anyhow::Result<HashMap<String, u32>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+    let list: Vec<UsageEntry> = serde_json::from_str(&content)?;
+    Ok(list.into_iter().map(|e| (e.action, e.count)).collect())
+}
+
+/// Save usage data in `usage` to `path`.
+pub fn save_usage(path: &str, usage: &HashMap<String, u32>) -> anyhow::Result<()> {
+    let list: Vec<UsageEntry> = usage
+        .iter()
+        .map(|(action, count)| UsageEntry {
+            action: action.clone(),
+            count: *count,
+        })
+        .collect();
+    let json = serde_json::to_string_pretty(&list)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}

--- a/tests/usage.rs
+++ b/tests/usage.rs
@@ -1,0 +1,18 @@
+use multi_launcher::usage::{save_usage, load_usage};
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+#[test]
+fn save_then_load_usage() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("usage.json");
+    let mut usage = HashMap::new();
+    usage.insert("first".to_string(), 3);
+    usage.insert("second".to_string(), 1);
+    save_usage(path.to_str().unwrap(), &usage).unwrap();
+
+    let loaded = load_usage(path.to_str().unwrap()).unwrap();
+    assert_eq!(loaded.get("first"), Some(&3));
+    assert_eq!(loaded.get("second"), Some(&1));
+    assert_eq!(loaded.len(), 2);
+}


### PR DESCRIPTION
## Summary
- track how often actions are executed
- load usage counts on startup and save on exit
- expose `usage` module in the library
- add unit test for usage file

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6871ae9f244c8332ae857b1a22025819