### PR TITLE
Add todo plugin

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,6 +16,7 @@ use crate::plugins::wikipedia::WikipediaPlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::timer::TimerPlugin;
 use crate::plugins::notes::NotesPlugin;
+use crate::plugins::todo::TodoPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
 use crate::plugins::volume::VolumePlugin;
 use crate::plugins::brightness::BrightnessPlugin;
@@ -68,6 +69,7 @@ impl PluginManager {
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(NotesPlugin::default()));
+        self.register(Box::new(TodoPlugin::default()));
         self.register(Box::new(SnippetsPlugin::default()));
         self.register(Box::new(VolumePlugin));
         self.register(Box::new(BrightnessPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -12,6 +12,7 @@ pub mod wikipedia;
 pub mod processes;
 pub mod weather;
 pub mod notes;
+pub mod todo;
 pub mod timer;
 pub mod snippets;
 pub mod volume;

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -1,0 +1,124 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+
+pub const TODO_FILE: &str = "todo.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TodoEntry {
+    pub text: String,
+}
+
+pub fn load_todos(path: &str) -> anyhow::Result<Vec<TodoEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<TodoEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_todos(path: &str, todos: &[TodoEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(todos)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn append_todo(path: &str, text: &str) -> anyhow::Result<()> {
+    let mut list = load_todos(path).unwrap_or_default();
+    list.push(TodoEntry {
+        text: text.to_string(),
+    });
+    save_todos(path, &list)
+}
+
+pub fn remove_todo(path: &str, index: usize) -> anyhow::Result<()> {
+    let mut list = load_todos(path).unwrap_or_default();
+    if index < list.len() {
+        list.remove(index);
+        save_todos(path, &list)?;
+    }
+    Ok(())
+}
+
+pub struct TodoPlugin {
+    matcher: SkimMatcherV2,
+}
+
+impl TodoPlugin {
+    pub fn new() -> Self {
+        Self {
+            matcher: SkimMatcherV2::default(),
+        }
+    }
+}
+
+impl Default for TodoPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for TodoPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if let Some(text) = query.strip_prefix("todo add ") {
+            let text = text.trim();
+            if !text.is_empty() {
+                return vec![Action {
+                    label: format!("Add todo {text}"),
+                    desc: "Todo".into(),
+                    action: format!("todo:add:{text}"),
+                    args: None,
+                }];
+            }
+        }
+
+        if let Some(pattern) = query.strip_prefix("todo rm ") {
+            let filter = pattern.trim();
+            let todos = load_todos(TODO_FILE).unwrap_or_default();
+            return todos
+                .into_iter()
+                .enumerate()
+                .filter(|(_, t)| self.matcher.fuzzy_match(&t.text, filter).is_some())
+                .map(|(idx, t)| Action {
+                    label: format!("Remove todo {}", t.text),
+                    desc: "Todo".into(),
+                    action: format!("todo:remove:{idx}"),
+                    args: None,
+                })
+                .collect();
+        }
+
+        if let Some(rest) = query.strip_prefix("todo list") {
+            let filter = rest.trim();
+            let todos = load_todos(TODO_FILE).unwrap_or_default();
+            return todos
+                .into_iter()
+                .enumerate()
+                .filter(|(_, t)| self.matcher.fuzzy_match(&t.text, filter).is_some())
+                .map(|(idx, t)| Action {
+                    label: t.text,
+                    desc: "Todo".into(),
+                    action: format!("todo:item:{idx}"),
+                    args: None,
+                })
+                .collect();
+        }
+
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "todo"
+    }
+
+    fn description(&self) -> &str {
+        "Manage todo items (prefix: `todo`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -1,0 +1,57 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::todo::{append_todo, load_todos, remove_todo, TodoPlugin, TODO_FILE};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn search_add_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo add task");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "todo:add:task");
+}
+
+#[test]
+fn list_returns_saved_items() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    append_todo(TODO_FILE, "alpha").unwrap();
+    append_todo(TODO_FILE, "beta").unwrap();
+
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo list");
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|a| a.action.starts_with("todo:item:")));
+}
+
+#[test]
+fn remove_action_deletes_entry() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    append_todo(TODO_FILE, "remove me").unwrap();
+    append_todo(TODO_FILE, "keep").unwrap();
+
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo rm remove");
+    assert_eq!(results.len(), 1);
+    assert!(results[0].action.starts_with("todo:remove:"));
+
+    let idx: usize = results[0]
+        .action
+        .strip_prefix("todo:remove:")
+        .unwrap()
+        .parse()
+        .unwrap();
+    remove_todo(TODO_FILE, idx).unwrap();
+    let todos = load_todos(TODO_FILE).unwrap();
+    assert_eq!(todos.len(), 1);
+    assert_eq!(todos[0].text, "keep");
+}


### PR DESCRIPTION
## Summary
- add a simple todo plugin
- register todo plugin
- test todo operations

## Testing
- `cargo test --test todo_plugin -- --test-threads=1 --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6871b9150fd08332b70d48095e7b75bf