### PR TITLE
Fix timer alarm reload duplication

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
-    plugins.reload_from_dirs(dirs);
+    plugins.reload_from_dirs(dirs, true);
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -53,7 +53,7 @@ impl PluginManager {
     }
 
     /// Rebuild the plugin list, keeping previously loaded libraries alive.
-    pub fn reload_from_dirs(&mut self, dirs: &[String]) {
+    pub fn reload_from_dirs(&mut self, dirs: &[String], reset_alarm: bool) {
         self.clear_plugins();
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
@@ -75,6 +75,9 @@ impl PluginManager {
         self.register(Box::new(BrightnessPlugin));
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));
+        if reset_alarm {
+            crate::plugins::timer::reset_alarms_loaded();
+        }
         crate::plugins::timer::load_saved_alarms();
         self.register(Box::new(WeatherPlugin));
         for dir in dirs {

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -49,7 +49,7 @@ impl PluginEditor {
 
     fn gather_available(plugin_dirs: &[String]) -> Vec<(String, String, Vec<String>)> {
         let mut pm = PluginManager::new();
-        pm.reload_from_dirs(plugin_dirs);
+        pm.reload_from_dirs(plugin_dirs, false);
         pm.plugin_infos()
     }
 
@@ -119,7 +119,7 @@ impl PluginEditor {
                         Some(s.hide_after_run),
                     );
 
-                    app.plugins.reload_from_dirs(&self.plugin_dirs);
+                    app.plugins.reload_from_dirs(&self.plugin_dirs, false);
                     tracing::debug!(available=?app.plugins.plugin_names(), "plugins reloaded");
                     self.available = Self::gather_available(&self.plugin_dirs);
                     app.search();

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -9,7 +9,7 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs);
+    plugins.reload_from_dirs(&dirs, false);
     LauncherApp::new(
         ctx,
         actions,


### PR DESCRIPTION
## Summary
- prevent repeated `load_saved_alarms` from spawning duplicate timers
- add `reset_alarms_loaded` guard and use in `PluginManager::reload_from_dirs`
- reset guard only on startup
- adjust plugin manager callers
- test that calling `load_saved_alarms` twice only loads alarms once

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68729b9c04ac833281a8f46672f0434e