### PR TITLE
Add clipboard history persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "query_scale": 1.0,
   "list_scale": 1.0,
   "history_limit": 100,
+  "clipboard_limit": 20,
   "follow_mouse": true,
   "static_location_enabled": false,
   "static_pos": [0, 0],
@@ -126,6 +127,7 @@ for these fields.
 `enable_toasts` controls short pop-up notifications when saving settings or commands. Set it to `false` to disable these messages.
 `fuzzy_weight` and `usage_weight` adjust how results are ranked. The fuzzy weight multiplies the match score while the usage weight favours frequently launched actions.
 `history_limit` defines how many entries the history plugin keeps.
+`clipboard_limit` sets how many clipboard entries are persisted for the clipboard plugin.
 `enabled_capabilities` maps plugin names to capability identifiers so features can be toggled individually. The folders plugin, for example, exposes `show_full_path`.
 
 
@@ -146,7 +148,7 @@ Built-in plugins and their command prefixes are:
 - Reddit search (`red cats`)
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
-- Clipboard history (`cb`)
+- Clipboard history (`cb`) - entries persist in `clipboard_history.json`
 - Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Built-in plugins and their command prefixes are:
 - Reddit search (`red cats`)
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
-- Clipboard history (`cb`) - entries persist in `clipboard_history.json`. Use `cb clear` to wipe all entries and right-click items to edit or delete them.
+- Clipboard history (`cb`) - entries persist in `clipboard_history.json`. Use `cb list` to show all entries or `cb clear` to wipe them. Right-click items to edit or delete.
 - Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Built-in plugins and their command prefixes are:
 - Reddit search (`red cats`)
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
-- Clipboard history (`cb`) - entries persist in `clipboard_history.json`
+- Clipboard history (`cb`) - entries persist in `clipboard_history.json`. Use `cb clear` to wipe all entries and right-click items to edit or delete them.
 - Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)
 - Shell commands (`sh echo hi`)

--- a/src/clipboard_dialog.rs
+++ b/src/clipboard_dialog.rs
@@ -1,0 +1,114 @@
+use crate::gui::LauncherApp;
+use crate::plugins::clipboard::{load_history, save_history, CLIPBOARD_FILE};
+use eframe::egui;
+use std::collections::VecDeque;
+
+#[derive(Default)]
+pub struct ClipboardDialog {
+    pub open: bool,
+    entries: Vec<String>,
+    edit_idx: Option<usize>,
+    text: String,
+}
+
+impl ClipboardDialog {
+    pub fn open(&mut self) {
+        self.entries = load_history(CLIPBOARD_FILE).unwrap_or_default().into();
+        self.open = true;
+        self.edit_idx = None;
+        self.text.clear();
+    }
+
+    pub fn open_edit(&mut self, idx: usize) {
+        self.entries = load_history(CLIPBOARD_FILE).unwrap_or_default().into();
+        if idx < self.entries.len() {
+            self.text = self.entries[idx].clone();
+        } else {
+            self.text.clear();
+        }
+        self.edit_idx = Some(idx);
+        self.open = true;
+    }
+
+    fn save(&mut self, app: &mut LauncherApp) {
+        let history: VecDeque<String> = self.entries.clone().into();
+        if let Err(e) = save_history(CLIPBOARD_FILE, &history) {
+            app.error = Some(format!("Failed to save clipboard history: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        let mut save_now = false;
+        egui::Window::new("Clipboard History")
+            .open(&mut self.open)
+            .resizable(true)
+            .default_size((360.0, 240.0))
+            .min_width(200.0)
+            .min_height(150.0)
+            .show(ctx, |ui| {
+                if let Some(idx) = self.edit_idx {
+                    ui.label("Text");
+                    ui.text_edit_multiline(&mut self.text);
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            if self.text.trim().is_empty() {
+                                app.error = Some("Text required".into());
+                            } else {
+                                if idx < self.entries.len() {
+                                    self.entries[idx] = self.text.clone();
+                                }
+                                self.edit_idx = None;
+                                self.text.clear();
+                                save_now = true;
+                            }
+                        }
+                        if ui.button("Cancel").clicked() {
+                            self.edit_idx = None;
+                        }
+                    });
+                } else {
+                    let mut remove: Option<usize> = None;
+                    let area_height = ui.available_height();
+                    egui::ScrollArea::both().max_height(area_height).show(ui, |ui| {
+                        for idx in 0..self.entries.len() {
+                            let entry = self.entries[idx].clone();
+                            ui.horizontal(|ui| {
+                                let resp = ui.label(entry.replace('\n', " "));
+                                let idx_copy = idx;
+                                resp.clone().context_menu(|ui| {
+                                    if ui.button("Edit Entry").clicked() {
+                                        self.edit_idx = Some(idx_copy);
+                                        self.text = self.entries[idx_copy].clone();
+                                        ui.close_menu();
+                                    }
+                                    if ui.button("Remove Entry").clicked() {
+                                        remove = Some(idx_copy);
+                                        ui.close_menu();
+                                    }
+                                });
+                                if ui.button("Edit").clicked() {
+                                    self.edit_idx = Some(idx);
+                                    self.text = entry.clone();
+                                }
+                                if ui.button("Remove").clicked() {
+                                    remove = Some(idx);
+                                }
+                            });
+                        }
+                    });
+                    if let Some(idx) = remove {
+                        self.entries.remove(idx);
+                        save_now = true;
+                    }
+                    if ui.button("Close").clicked() { close = true; }
+                }
+            });
+        if save_now { self.save(app); }
+        if close { self.open = false; }
+    }
+}

--- a/src/clipboard_dialog.rs
+++ b/src/clipboard_dialog.rs
@@ -53,7 +53,11 @@ impl ClipboardDialog {
             .show(ctx, |ui| {
                 if let Some(idx) = self.edit_idx {
                     ui.label("Text");
-                    ui.text_edit_multiline(&mut self.text);
+                    ui.add(
+                        egui::TextEdit::multiline(&mut self.text)
+                            .desired_rows(5)
+                            .desired_width(f32::INFINITY),
+                    );
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.text.trim().is_empty() {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -22,6 +22,7 @@ use crate::timer_dialog::{TimerDialog, TimerCompletionDialog};
 use crate::snippet_dialog::SnippetDialog;
 use crate::notes_dialog::NotesDialog;
 use crate::todo_dialog::TodoDialog;
+use crate::clipboard_dialog::ClipboardDialog;
 use crate::add_bookmark_dialog::AddBookmarkDialog;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
 use crate::usage::{self, USAGE_FILE};
@@ -93,6 +94,7 @@ pub struct LauncherApp {
     snippet_dialog: SnippetDialog,
     notes_dialog: NotesDialog,
     todo_dialog: TodoDialog,
+    clipboard_dialog: ClipboardDialog,
     volume_dialog: crate::volume_dialog::VolumeDialog,
     brightness_dialog: crate::brightness_dialog::BrightnessDialog,
     pub help_flag: Arc<AtomicBool>,
@@ -273,6 +275,7 @@ impl LauncherApp {
             snippet_dialog: SnippetDialog::default(),
             notes_dialog: NotesDialog::default(),
             todo_dialog: TodoDialog::default(),
+            clipboard_dialog: ClipboardDialog::default(),
             volume_dialog: crate::volume_dialog::VolumeDialog::default(),
             brightness_dialog: crate::brightness_dialog::BrightnessDialog::default(),
             help_flag: help_flag.clone(),
@@ -641,6 +644,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
+                        } else if a.action == "clipboard:dialog" {
+                            self.clipboard_dialog.open();
                         } else if a.action == "volume:dialog" {
                             self.volume_dialog.open();
                         } else if a.action == "brightness:dialog" {
@@ -870,6 +875,36 @@ impl eframe::App for LauncherApp {
                                 }
                             });
                         }
+                    } else if a.desc == "Clipboard" && a.action.starts_with("clipboard:copy:") {
+                        let idx_str = a.action.rsplit(':').next().unwrap_or("");
+                        if let Ok(cb_idx) = idx_str.parse::<usize>() {
+                            let cb_label = a.label.clone();
+                            menu_resp.clone().context_menu(|ui| {
+                                if ui.button("Edit Entry").clicked() {
+                                    self.clipboard_dialog.open_edit(cb_idx);
+                                    ui.close_menu();
+                                }
+                                if ui.button("Remove Entry").clicked() {
+                                    if let Err(e) = crate::plugins::clipboard::remove_entry(
+                                        crate::plugins::clipboard::CLIPBOARD_FILE,
+                                        cb_idx,
+                                    ) {
+                                        self.error = Some(format!("Failed to remove entry: {e}"));
+                                    } else {
+                                        refresh = true;
+                                        set_focus = true;
+                                        if self.enable_toasts {
+                                            self.toasts.add(Toast {
+                                                text: format!("Removed entry {}", cb_label).into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default().duration_in_seconds(3.0),
+                                            });
+                                        }
+                                    }
+                                    ui.close_menu();
+                                }
+                            });
+                        }
                     }
                     if let Some(idx_act) = custom_idx {
                         menu_resp.clone().context_menu(|ui| {
@@ -903,6 +938,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
+                        } else if a.action == "clipboard:dialog" {
+                            self.clipboard_dialog.open();
                         } else if a.action == "volume:dialog" {
                             self.volume_dialog.open();
                         } else if a.action == "brightness:dialog" {
@@ -1038,6 +1075,9 @@ impl eframe::App for LauncherApp {
         let mut todo_dlg = std::mem::take(&mut self.todo_dialog);
         todo_dlg.ui(ctx, self);
         self.todo_dialog = todo_dlg;
+        let mut cb_dlg = std::mem::take(&mut self.clipboard_dialog);
+        cb_dlg.ui(ctx, self);
+        self.clipboard_dialog = cb_dlg;
         let mut vol_dlg = std::mem::take(&mut self.volume_dialog);
         vol_dlg.ui(ctx, self);
         self.volume_dialog = vol_dlg;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -104,6 +104,7 @@ pub struct LauncherApp {
     /// Number of user defined commands at the start of `actions`.
     pub custom_len: usize,
     pub history_limit: usize,
+    pub clipboard_limit: usize,
     pub fuzzy_weight: f32,
     pub usage_weight: f32,
     pub follow_mouse: bool,
@@ -282,6 +283,7 @@ impl LauncherApp {
             list_scale,
             custom_len,
             history_limit: settings.history_limit,
+            clipboard_limit: settings.clipboard_limit,
             fuzzy_weight: settings.fuzzy_weight,
             usage_weight: settings.usage_weight,
             follow_mouse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod shell_cmd_dialog;
 pub mod snippet_dialog;
 pub mod notes_dialog;
 pub mod todo_dialog;
+pub mod clipboard_dialog;
 pub mod volume_dialog;
 pub mod brightness_dialog;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod shell_cmd_dialog;
 mod snippet_dialog;
 mod notes_dialog;
 mod todo_dialog;
+mod clipboard_dialog;
 mod volume_dialog;
 mod brightness_dialog;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
-    plugins.reload_from_dirs(dirs, true);
+    plugins.reload_from_dirs(dirs, settings.clipboard_limit, true);
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -53,7 +53,7 @@ impl PluginManager {
     }
 
     /// Rebuild the plugin list, keeping previously loaded libraries alive.
-    pub fn reload_from_dirs(&mut self, dirs: &[String], reset_alarm: bool) {
+    pub fn reload_from_dirs(&mut self, dirs: &[String], clipboard_limit: usize, reset_alarm: bool) {
         self.clear_plugins();
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
@@ -61,7 +61,7 @@ impl PluginManager {
         self.register(Box::new(YoutubePlugin));
         self.register(Box::new(RedditPlugin));
         self.register(Box::new(WikipediaPlugin));
-        self.register(Box::new(ClipboardPlugin::default()));
+        self.register(Box::new(ClipboardPlugin::new(clipboard_limit)));
         self.register(Box::new(BookmarksPlugin::default()));
         self.register(Box::new(FoldersPlugin::default()));
         self.register(Box::new(SystemPlugin));

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -49,7 +49,7 @@ impl PluginEditor {
 
     fn gather_available(plugin_dirs: &[String]) -> Vec<(String, String, Vec<String>)> {
         let mut pm = PluginManager::new();
-        pm.reload_from_dirs(plugin_dirs, false);
+        pm.reload_from_dirs(plugin_dirs, Settings::default().clipboard_limit, false);
         pm.plugin_infos()
     }
 
@@ -119,7 +119,7 @@ impl PluginEditor {
                         Some(s.hide_after_run),
                     );
 
-                    app.plugins.reload_from_dirs(&self.plugin_dirs, false);
+                    app.plugins.reload_from_dirs(&self.plugin_dirs, app.clipboard_limit, false);
                     tracing::debug!(available=?app.plugins.plugin_names(), "plugins reloaded");
                     self.available = Self::gather_available(&self.plugin_dirs);
                     app.search();

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -103,6 +103,20 @@ impl Plugin for ClipboardPlugin {
             }];
         }
 
+        if trimmed == "cb list" {
+            let history = self.update_history();
+            return history
+                .iter()
+                .enumerate()
+                .map(|(idx, entry)| Action {
+                    label: entry.clone(),
+                    desc: "Clipboard".into(),
+                    action: format!("clipboard:copy:{idx}"),
+                    args: None,
+                })
+                .collect();
+        }
+
         let filter = query.strip_prefix("cb").unwrap_or("").trim();
         let history = self.update_history();
         history

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -1,7 +1,6 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
 
 pub const CLIPBOARD_FILE: &str = "clipboard_history.json";
 
@@ -21,45 +20,55 @@ pub fn save_history(path: &str, history: &VecDeque<String>) -> anyhow::Result<()
     Ok(())
 }
 
+pub fn remove_entry(path: &str, index: usize) -> anyhow::Result<()> {
+    let mut history = load_history(path).unwrap_or_default();
+    if index < history.len() {
+        history.remove(index);
+        save_history(path, &history)?;
+    }
+    Ok(())
+}
+
+pub fn set_entry(path: &str, index: usize, text: &str) -> anyhow::Result<()> {
+    let mut history = load_history(path).unwrap_or_default();
+    if index < history.len() {
+        history[index] = text.to_string();
+        save_history(path, &history)?;
+    }
+    Ok(())
+}
+
+pub fn clear_history_file(path: &str) -> anyhow::Result<()> {
+    save_history(path, &VecDeque::new())
+}
+
 pub struct ClipboardPlugin {
-    history: Arc<Mutex<VecDeque<String>>>,
     max_entries: usize,
     path: String,
 }
 
 impl ClipboardPlugin {
     pub fn new(max_entries: usize) -> Self {
-        let hist = load_history(CLIPBOARD_FILE).unwrap_or_default();
-        let history = Arc::new(Mutex::new(hist));
-        Self { history, max_entries, path: CLIPBOARD_FILE.into() }
+        Self { max_entries, path: CLIPBOARD_FILE.into() }
     }
 
-    fn update_history(&self) {
-        let mut clipboard = match arboard::Clipboard::new() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!("failed to init clipboard: {e}");
-                return;
-            }
-        };
-        match clipboard.get_text() {
-            Ok(txt) => {
-                let mut h = self.history.lock().unwrap();
-                if h.front().map(|v| v != &txt).unwrap_or(true) {
-                    if let Some(pos) = h.iter().position(|v| v == &txt) {
-                        h.remove(pos);
+    fn update_history(&self) -> VecDeque<String> {
+        let mut history = load_history(&self.path).unwrap_or_default();
+        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+            if let Ok(txt) = clipboard.get_text() {
+                if history.front().map(|v| v != &txt).unwrap_or(true) {
+                    if let Some(pos) = history.iter().position(|v| v == &txt) {
+                        history.remove(pos);
                     }
-                    h.push_front(txt.clone());
-                    while h.len() > self.max_entries {
-                        h.pop_back();
+                    history.push_front(txt.clone());
+                    while history.len() > self.max_entries {
+                        history.pop_back();
                     }
-                    let _ = save_history(&self.path, &h);
+                    let _ = save_history(&self.path, &history);
                 }
             }
-            Err(e) => {
-                tracing::debug!("clipboard read error: {e}");
-            }
         }
+        history
     }
 }
 
@@ -74,16 +83,36 @@ impl Plugin for ClipboardPlugin {
         if !query.starts_with("cb") {
             return Vec::new();
         }
-        self.update_history();
+
+        let trimmed = query.trim();
+        if trimmed == "cb" {
+            return vec![Action {
+                label: "cb: edit clipboard".into(),
+                desc: "Clipboard".into(),
+                action: "clipboard:dialog".into(),
+                args: None,
+            }];
+        }
+
+        if trimmed == "cb clear" {
+            return vec![Action {
+                label: "Clear clipboard history".into(),
+                desc: "Clipboard".into(),
+                action: "clipboard:clear".into(),
+                args: None,
+            }];
+        }
+
         let filter = query.strip_prefix("cb").unwrap_or("").trim();
-        let history = self.history.lock().unwrap();
+        let history = self.update_history();
         history
             .iter()
-            .filter(|entry| entry.contains(filter))
-            .map(|entry| Action {
+            .enumerate()
+            .filter(|(_, entry)| entry.contains(filter))
+            .map(|(idx, entry)| Action {
                 label: entry.clone(),
                 desc: "Clipboard".into(),
-                action: format!("clipboard:{}", entry),
+                action: format!("clipboard:copy:{idx}"),
                 args: None,
             })
             .collect()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -45,6 +45,8 @@ pub struct Settings {
     /// Maximum number of entries kept in the history list.
     #[serde(default = "default_history_limit")]
     pub history_limit: usize,
+    #[serde(default = "default_clipboard_limit")]
+    pub clipboard_limit: usize,
     /// When true the window spawns at the mouse cursor each time it becomes
     /// visible.
     #[serde(default = "default_follow_mouse")]
@@ -69,6 +71,8 @@ fn default_toasts() -> bool { true }
 fn default_scale() -> Option<f32> { Some(1.0) }
 
 fn default_history_limit() -> usize { 100 }
+
+fn default_clipboard_limit() -> usize { 20 }
 
 fn default_fuzzy_weight() -> f32 { 1.0 }
 
@@ -95,6 +99,7 @@ impl Default for Settings {
             fuzzy_weight: default_fuzzy_weight(),
             usage_weight: default_usage_weight(),
             history_limit: default_history_limit(),
+            clipboard_limit: default_clipboard_limit(),
             follow_mouse: true,
             static_location_enabled: false,
             static_pos: None,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -30,6 +30,7 @@ pub struct SettingsEditor {
     query_scale: f32,
     list_scale: f32,
     history_limit: usize,
+    clipboard_limit: usize,
     fuzzy_weight: f32,
     usage_weight: f32,
     follow_mouse: bool,
@@ -98,6 +99,7 @@ impl SettingsEditor {
             query_scale: settings.query_scale.unwrap_or(1.0),
             list_scale: settings.list_scale.unwrap_or(1.0),
             history_limit: settings.history_limit,
+            clipboard_limit: settings.clipboard_limit,
             fuzzy_weight: settings.fuzzy_weight,
             usage_weight: settings.usage_weight,
             follow_mouse: settings.follow_mouse,
@@ -142,6 +144,7 @@ impl SettingsEditor {
             query_scale: Some(self.query_scale),
             list_scale: Some(self.list_scale),
             history_limit: self.history_limit,
+            clipboard_limit: self.clipboard_limit,
             fuzzy_weight: self.fuzzy_weight,
             usage_weight: self.usage_weight,
             follow_mouse: self.follow_mouse,
@@ -257,6 +260,10 @@ impl SettingsEditor {
             ui.horizontal(|ui| {
                 ui.label("History limit");
                 ui.add(egui::Slider::new(&mut self.history_limit, 10..=500).text(""));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Clipboard limit");
+                ui.add(egui::Slider::new(&mut self.clipboard_limit, 1..=100).text(""));
             });
 
             ui.horizontal(|ui| {
@@ -385,6 +392,7 @@ impl SettingsEditor {
                                 app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
                                 app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);
                                 app.history_limit = new_settings.history_limit;
+                                app.clipboard_limit = new_settings.clipboard_limit;
                                 crate::request_hotkey_restart(new_settings);
                                 if app.enable_toasts {
                                     app.add_toast(Toast {

--- a/tests/clipboard_persistence.rs
+++ b/tests/clipboard_persistence.rs
@@ -1,0 +1,29 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::clipboard::{save_history, ClipboardPlugin, CLIPBOARD_FILE};
+use once_cell::sync::Lazy;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn history_survives_instances() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let mut list = VecDeque::new();
+    list.push_back("first".into());
+    save_history(CLIPBOARD_FILE, &list).unwrap();
+
+    let plugin1 = ClipboardPlugin::new(20);
+    let results1 = plugin1.search("cb");
+    assert_eq!(results1.len(), 1);
+    assert_eq!(results1[0].label, "first");
+
+    let plugin2 = ClipboardPlugin::new(20);
+    let results2 = plugin2.search("cb");
+    assert_eq!(results2.len(), 1);
+    assert_eq!(results2[0].label, "first");
+}

--- a/tests/clipboard_persistence.rs
+++ b/tests/clipboard_persistence.rs
@@ -18,12 +18,12 @@ fn history_survives_instances() {
     save_history(CLIPBOARD_FILE, &list).unwrap();
 
     let plugin1 = ClipboardPlugin::new(20);
-    let results1 = plugin1.search("cb");
+    let results1 = plugin1.search("cb first");
     assert_eq!(results1.len(), 1);
     assert_eq!(results1[0].label, "first");
 
     let plugin2 = ClipboardPlugin::new(20);
-    let results2 = plugin2.search("cb");
+    let results2 = plugin2.search("cb first");
     assert_eq!(results2.len(), 1);
     assert_eq!(results2[0].label, "first");
 }

--- a/tests/clipboard_persistence.rs
+++ b/tests/clipboard_persistence.rs
@@ -27,3 +27,21 @@ fn history_survives_instances() {
     assert_eq!(results2.len(), 1);
     assert_eq!(results2[0].label, "first");
 }
+
+#[test]
+fn cb_list_returns_all_entries() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let mut list = VecDeque::new();
+    list.push_back("alpha".into());
+    list.push_back("beta".into());
+    save_history(CLIPBOARD_FILE, &list).unwrap();
+
+    let plugin = ClipboardPlugin::new(20);
+    let results = plugin.search("cb list");
+    assert_eq!(results.len(), 2);
+    assert!(results[0].action.starts_with("clipboard:copy:"));
+    assert!(results[1].action.starts_with("clipboard:copy:"));
+}

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -9,7 +9,7 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, false);
+    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
     LauncherApp::new(
         ctx,
         actions,


### PR DESCRIPTION
## Summary
- store clipboard history in `clipboard_history.json`
- load/save clipboard history between plugin instances
- control history size via new `clipboard_limit` setting
- pass clipboard limit when loading plugins
- test clipboard persistence
- document clipboard persistence and setting

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68729fcac8548332bbf6f8f1124de532