### PR TITLE
Add unit conversion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ default hotkey is `F2`. To use a different key, set the `hotkey` value in
   "enabled_plugins": [
     "web_search",
     "calculator",
+    "unit_convert",
     "clipboard",
     "bookmarks",
     "folders",
@@ -148,6 +149,7 @@ Built-in plugins and their command prefixes are:
 - Reddit search (`red cats`)
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
+- Unit conversions (`conv 10 km to mi`)
 - Clipboard history (`cb`) - entries persist in `clipboard_history.json`. Use `cb list` to show all entries or `cb clear` to wipe them. Right-click items to edit or delete.
 - Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -87,6 +87,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "youtube" => Some(&["yt rust"]),
         "reddit" => Some(&["red cats"]),
         "calculator" => Some(&["= 1+2"]),
+        "unit_convert" => Some(&["conv 10 km to mi"]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com", "bm rm", "bm list"]),
         "folders" => Some(&["f add C:/path", "f rm docs"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,7 @@
 use crate::actions::Action;
 use libloading::Library;
 use crate::plugins_builtin::{WebSearchPlugin, CalculatorPlugin};
+use crate::plugins::unit_convert::UnitConvertPlugin;
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
@@ -57,6 +58,7 @@ impl PluginManager {
         self.clear_plugins();
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
+        self.register(Box::new(UnitConvertPlugin));
         self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(YoutubePlugin));
         self.register(Box::new(RedditPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -17,3 +17,4 @@ pub mod timer;
 pub mod snippets;
 pub mod volume;
 pub mod brightness;
+pub mod unit_convert;

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -5,18 +5,59 @@ pub struct UnitConvertPlugin;
 
 fn convert(value: f64, from: &str, to: &str) -> Option<f64> {
     match (from, to) {
+        // Length
         ("km", "mi") => Some(value * 0.621_371),
         ("mi", "km") => Some(value / 0.621_371),
         ("m", "ft") => Some(value * 3.280_84),
         ("ft", "m") => Some(value / 3.280_84),
-        ("kg", "lb") => Some(value * 2.204_62),
-        ("lb", "kg") => Some(value / 2.204_62),
-        ("c", "f") => Some(value * 9.0 / 5.0 + 32.0),
-        ("f", "c") => Some((value - 32.0) * 5.0 / 9.0),
+        ("cm", "in") => Some(value / 2.54),
+        ("in", "cm") => Some(value * 2.54),
+        ("mm", "in") => Some(value / 25.4),
+        ("in", "mm") => Some(value * 25.4),
         ("nm", "ft") => Some(value * 6076.12),
         ("ft", "nm") => Some(value / 6076.12),
         ("nm", "mi") => Some(value * 1.150_78),
         ("mi", "nm") => Some(value / 1.150_78),
+
+        // Weight / Mass
+        ("kg", "lb") => Some(value * 2.204_62),
+        ("lb", "kg") => Some(value / 2.204_62),
+        ("g", "oz") => Some(value / 28.3495),
+        ("oz", "g") => Some(value * 28.3495),
+        ("g", "kg") => Some(value / 1000.0),
+        ("kg", "g") => Some(value * 1000.0),
+
+        // Temperature
+        ("c", "f") => Some(value * 9.0 / 5.0 + 32.0),
+        ("f", "c") => Some((value - 32.0) * 5.0 / 9.0),
+        ("c", "k") => Some(value + 273.15),
+        ("k", "c") => Some(value - 273.15),
+        ("f", "k") => Some((value - 32.0) * 5.0 / 9.0 + 273.15),
+        ("k", "f") => Some((value - 273.15) * 9.0 / 5.0 + 32.0),
+
+        // Volume
+        ("l", "gal") => Some(value / 3.785_41),
+        ("gal", "l") => Some(value * 3.785_41),
+        ("ml", "oz") => Some(value / 29.5735),
+        ("oz", "ml") => Some(value * 29.5735),
+
+        // Area
+        ("sq_m", "sq_ft") => Some(value * 10.7639),
+        ("sq_ft", "sq_m") => Some(value / 10.7639),
+        ("ha", "ac") => Some(value * 2.47105),
+        ("ac", "ha") => Some(value / 2.47105),
+
+        // Speed
+        ("kph", "mph") => Some(value * 0.621_371),
+        ("mph", "kph") => Some(value / 0.621_371),
+        ("mps", "fps") => Some(value * 3.280_84),
+        ("fps", "mps") => Some(value / 3.280_84),
+
+        // Pressure
+        ("atm", "pa") => Some(value * 101_325.0),
+        ("pa", "atm") => Some(value / 101_325.0),
+        ("bar", "psi") => Some(value * 14.5038),
+        ("psi", "bar") => Some(value / 14.5038),
         _ => None,
     }
 }

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -1,0 +1,74 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct UnitConvertPlugin;
+
+fn convert(value: f64, from: &str, to: &str) -> Option<f64> {
+    match (from, to) {
+        ("km", "mi") => Some(value * 0.621_371),
+        ("mi", "km") => Some(value / 0.621_371),
+        ("m", "ft") => Some(value * 3.280_84),
+        ("ft", "m") => Some(value / 3.280_84),
+        ("kg", "lb") => Some(value * 2.204_62),
+        ("lb", "kg") => Some(value / 2.204_62),
+        ("c", "f") => Some(value * 9.0 / 5.0 + 32.0),
+        ("f", "c") => Some((value - 32.0) * 5.0 / 9.0),
+        ("nm", "ft") => Some(value * 6076.12),
+        ("ft", "nm") => Some(value / 6076.12),
+        ("nm", "mi") => Some(value * 1.150_78),
+        ("mi", "nm") => Some(value / 1.150_78),
+        _ => None,
+    }
+}
+
+fn parse_query(query: &str) -> Option<(f64, String, String)> {
+    let rest = query.trim();
+    let parts: Vec<&str> = rest.split_whitespace().collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    if !parts[2].eq_ignore_ascii_case("to") {
+        return None;
+    }
+    let val: f64 = parts[0].parse().ok()?;
+    Some((val, parts[1].to_lowercase(), parts[3].to_lowercase()))
+}
+
+impl Plugin for UnitConvertPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        let rest = if let Some(r) = trimmed.strip_prefix("conv ") {
+            r
+        } else if let Some(r) = trimmed.strip_prefix("convert ") {
+            r
+        } else {
+            return Vec::new();
+        };
+
+        if let Some((value, from, to)) = parse_query(rest) {
+            if let Some(result) = convert(value, &from, &to) {
+                let label = format!("{} {} = {:.4} {}", value, from, result, to);
+                let action = format!("clipboard:{:.4}", result);
+                return vec![Action {
+                    label,
+                    desc: "Unit convert".into(),
+                    action,
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "unit_convert"
+    }
+
+    fn description(&self) -> &str {
+        "Convert between units (prefix: `conv` or `convert`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/tests/unit_convert_plugin.rs
+++ b/tests/unit_convert_plugin.rs
@@ -1,0 +1,20 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::unit_convert::UnitConvertPlugin;
+
+#[test]
+fn km_to_mi() {
+    let plugin = UnitConvertPlugin;
+    let results = plugin.search("conv 1 km to mi");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "1 km = 0.6214 mi");
+    assert_eq!(results[0].action, "clipboard:0.6214");
+}
+
+#[test]
+fn f_to_c() {
+    let plugin = UnitConvertPlugin;
+    let results = plugin.search("conv 32 f to c");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "32 f = 0.0000 c");
+    assert_eq!(results[0].action, "clipboard:0.0000");
+}

--- a/tests/unit_convert_plugin.rs
+++ b/tests/unit_convert_plugin.rs
@@ -18,3 +18,21 @@ fn f_to_c() {
     assert_eq!(results[0].label, "32 f = 0.0000 c");
     assert_eq!(results[0].action, "clipboard:0.0000");
 }
+
+#[test]
+fn cm_to_in() {
+    let plugin = UnitConvertPlugin;
+    let results = plugin.search("conv 100 cm to in");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "100 cm = 39.3701 in");
+    assert_eq!(results[0].action, "clipboard:39.3701");
+}
+
+#[test]
+fn l_to_gal() {
+    let plugin = UnitConvertPlugin;
+    let results = plugin.search("conv 1 l to gal");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "1 l = 0.2642 gal");
+    assert_eq!(results[0].action, "clipboard:0.2642");
+}


### PR DESCRIPTION
## Summary
- add `UnitConvertPlugin` for quick unit conversions via `conv`/`convert` prefix
- wire the plugin into the default plugin manager
- expose an example conversion query in the help window
- document the plugin and update settings example
- test unit conversion results

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872c0f8b9688332bffd371a08980f7a