### PR TITLE
Remove unreachable match arm

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -487,7 +487,6 @@ pub fn process_test_events(triggers: &[Arc<HotkeyTrigger>], events: &[EventType]
                     }
                 }
             }
-            _ => {}
         }
 
         for i in 0..watch_keys.len() {


### PR DESCRIPTION
## Summary
- clean up unreachable code warning in `process_test_events`

## Testing
- `cargo test --color never`

------
https://chatgpt.com/codex/tasks/task_e_6872fac0785c8332a87bbf6feb7837f5