### PR TITLE
Limit volume and brightness plugins to Windows

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -19,7 +19,9 @@ use crate::plugins::timer::TimerPlugin;
 use crate::plugins::notes::NotesPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
+#[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
+#[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
 
 pub trait Plugin: Send + Sync {
@@ -73,8 +75,11 @@ impl PluginManager {
         self.register(Box::new(NotesPlugin::default()));
         self.register(Box::new(TodoPlugin::default()));
         self.register(Box::new(SnippetsPlugin::default()));
-        self.register(Box::new(VolumePlugin));
-        self.register(Box::new(BrightnessPlugin));
+        #[cfg(target_os = "windows")]
+        {
+            self.register(Box::new(VolumePlugin));
+            self.register(Box::new(BrightnessPlugin));
+        }
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));
         if reset_alarm {

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -4,6 +4,7 @@ use crate::plugin::Plugin;
 pub struct BrightnessPlugin;
 
 impl Plugin for BrightnessPlugin {
+    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
         if trimmed.eq_ignore_ascii_case("bright") {
@@ -27,6 +28,11 @@ impl Plugin for BrightnessPlugin {
                 }
             }
         }
+        Vec::new()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/src/plugins/volume.rs
+++ b/src/plugins/volume.rs
@@ -4,6 +4,7 @@ use crate::plugin::Plugin;
 pub struct VolumePlugin;
 
 impl Plugin for VolumePlugin {
+    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
         if trimmed.eq_ignore_ascii_case("vol") {
@@ -35,6 +36,11 @@ impl Plugin for VolumePlugin {
                 }
             }
         }
+        Vec::new()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/tests/brightness_plugin.rs
+++ b/tests/brightness_plugin.rs
@@ -5,14 +5,22 @@ use multi_launcher::plugins::brightness::BrightnessPlugin;
 fn search_set_numeric() {
     let plugin = BrightnessPlugin;
     let results = plugin.search("bright 50");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "brightness:set:50");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "brightness:set:50");
+    } else {
+        assert!(results.is_empty());
+    }
 }
 
 #[test]
 fn search_plain_bright() {
     let plugin = BrightnessPlugin;
     let results = plugin.search("bright");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "brightness:dialog");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "brightness:dialog");
+    } else {
+        assert!(results.is_empty());
+    }
 }

--- a/tests/volume_plugin.rs
+++ b/tests/volume_plugin.rs
@@ -5,30 +5,46 @@ use multi_launcher::plugins::volume::VolumePlugin;
 fn search_set_zero() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol 0");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "volume:set:0");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "volume:set:0");
+    } else {
+        assert!(results.is_empty());
+    }
 }
 
 #[test]
 fn search_set_fifty() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol 50");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "volume:set:50");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "volume:set:50");
+    } else {
+        assert!(results.is_empty());
+    }
 }
 
 #[test]
 fn search_mute_active() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol ma");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "volume:mute_active");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "volume:mute_active");
+    } else {
+        assert!(results.is_empty());
+    }
 }
 
 #[test]
 fn search_plain_vol() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol");
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "volume:dialog");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "volume:dialog");
+    } else {
+        assert!(results.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `VolumePlugin` and `BrightnessPlugin` only produce results on Windows
- register these plugins only on Windows
- update plugin tests to expect no results on other OSes

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6872fd9e7a848332bc948e3c3f71b769