### PR TITLE
Add drop rate calculator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Built-in plugins and their command prefixes are:
 - Weather lookup (`weather Berlin`)
 - Calculator (`= 2+2`)
 - Unit conversions (`conv 10 km to mi`)
+- Drop rate calculator (`drop 1/128 128`)
 - Clipboard history (`cb`) - entries persist in `clipboard_history.json`. Use `cb list` to show all entries or `cb clear` to wipe them. Right-click items to edit or delete.
 - Bookmarks (`bm add <url>`, `bm rm [pattern]` or `bm list`)
 - Folder shortcuts (`f`, `f add <path>`, `f rm <pattern>`)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,6 +2,7 @@ use crate::actions::Action;
 use libloading::Library;
 use crate::plugins_builtin::{WebSearchPlugin, CalculatorPlugin};
 use crate::plugins::unit_convert::UnitConvertPlugin;
+use crate::plugins::dropcalc::DropCalcPlugin;
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
@@ -63,6 +64,7 @@ impl PluginManager {
         self.register(Box::new(WebSearchPlugin));
         self.register(Box::new(CalculatorPlugin));
         self.register(Box::new(UnitConvertPlugin));
+        self.register(Box::new(DropCalcPlugin));
         self.register(Box::new(RunescapeSearchPlugin));
         self.register(Box::new(YoutubePlugin));
         self.register(Box::new(RedditPlugin));

--- a/src/plugins/dropcalc.rs
+++ b/src/plugins/dropcalc.rs
@@ -1,0 +1,61 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+/// Calculate the probability of at least one success after n tries.
+/// Usage: `drop p n` where `p` is a fraction like `1/128` or a decimal
+/// probability and `n` is the number of attempts.
+pub struct DropCalcPlugin;
+
+fn parse_prob(input: &str) -> Option<f64> {
+    if let Some((num, den)) = input.split_once('/') {
+        let num: f64 = num.trim().parse().ok()?;
+        let den: f64 = den.trim().parse().ok()?;
+        if den != 0.0 { Some(num / den) } else { None }
+    } else {
+        input.trim().parse::<f64>().ok()
+    }
+}
+
+impl Plugin for DropCalcPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        let rest = if let Some(r) = trimmed.strip_prefix("drop ") {
+            r.trim()
+        } else {
+            return Vec::new();
+        };
+        let parts: Vec<&str> = rest.split_whitespace().collect();
+        if parts.len() != 2 {
+            return Vec::new();
+        }
+        let p = match parse_prob(parts[0]) {
+            Some(v) => v,
+            None => return Vec::new(),
+        };
+        let n: f64 = match parts[1].parse() {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let chance = 1.0 - (1.0 - p).powf(n);
+        let percent = chance * 100.0;
+        vec![Action {
+            label: format!("{percent:.2}% chance after {n} tries"),
+            desc: "DropCalc".into(),
+            action: format!("calc:{percent:.2}"),
+            args: None,
+        }]
+    }
+
+    fn name(&self) -> &str {
+        "dropcalc"
+    }
+
+    fn description(&self) -> &str {
+        "Calculate drop chance after N tries (prefix: `drop`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -19,4 +19,5 @@ pub mod snippets;
 pub mod volume;
 pub mod brightness;
 pub mod unit_convert;
+pub mod dropcalc;
 pub mod recycle;

--- a/tests/dropcalc_plugin.rs
+++ b/tests/dropcalc_plugin.rs
@@ -1,0 +1,11 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::dropcalc::DropCalcPlugin;
+
+#[test]
+fn half_twice() {
+    let plugin = DropCalcPlugin;
+    let results = plugin.search("drop 1/2 2");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "75.00% chance after 2 tries");
+    assert_eq!(results[0].action, "calc:75.00");
+}


### PR DESCRIPTION
## Summary
- add DropCalcPlugin for computing drop chances
- register DropCalcPlugin
- document the new `drop` command
- test probability calculation

## Testing
- `cargo test --test dropcalc_plugin -- --nocapture`

 