### PR TITLE
Add tempfile plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Built-in plugins and their command prefixes are:
   timer completes.
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
-- Temporary files (`tmp new`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
+- Temporary files (`tmp`, `tmp new`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
 - Recycle Bin cleanup (`rec`)
 - Command overview (`help`)
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Built-in plugins and their command prefixes are:
   timer completes.
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
+- Temporary files (`tmp new`, `tmp open`, `tmp clear`, `tmp list`)
 - Recycle Bin cleanup (`rec`)
 - Command overview (`help`)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Built-in plugins and their command prefixes are:
   timer completes.
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
-- Temporary files (`tmp new`, `tmp open`, `tmp clear`, `tmp list`)
+- Temporary files (`tmp new`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
 - Recycle Bin cleanup (`rec`)
 - Command overview (`help`)
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -13,6 +13,7 @@ use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
 use crate::settings::Settings;
 use crate::settings_editor::SettingsEditor;
 use crate::snippet_dialog::SnippetDialog;
+use crate::tempfile_dialog::TempfileDialog;
 use crate::timer_dialog::{TimerCompletionDialog, TimerDialog};
 use crate::timer_help_window::TimerHelpWindow;
 use crate::todo_dialog::TodoDialog;
@@ -89,6 +90,7 @@ pub struct LauncherApp {
     alias_dialog: crate::alias_dialog::AliasDialog,
     bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog,
     tempfile_alias_dialog: crate::tempfile_alias_dialog::TempfileAliasDialog,
+    tempfile_dialog: TempfileDialog,
     add_bookmark_dialog: crate::add_bookmark_dialog::AddBookmarkDialog,
     help_window: crate::help_window::HelpWindow,
     timer_help: crate::timer_help_window::TimerHelpWindow,
@@ -274,6 +276,7 @@ impl LauncherApp {
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
             bookmark_alias_dialog: crate::bookmark_alias_dialog::BookmarkAliasDialog::default(),
             tempfile_alias_dialog: crate::tempfile_alias_dialog::TempfileAliasDialog::default(),
+            tempfile_dialog: TempfileDialog::default(),
             add_bookmark_dialog: crate::add_bookmark_dialog::AddBookmarkDialog::default(),
             help_window: HelpWindow::default(),
             timer_help: TimerHelpWindow::default(),
@@ -623,6 +626,7 @@ impl eframe::App for LauncherApp {
                 if ctx.input(|i| i.key_pressed(egui::Key::Enter))
                     && !self.bookmark_alias_dialog.open
                     && !self.tempfile_alias_dialog.open
+                    && !self.tempfile_dialog.open
                     && !self.notes_dialog.open
                 {
                     launch_idx = self.handle_key(egui::Key::Enter);
@@ -652,6 +656,8 @@ impl eframe::App for LauncherApp {
                             self.todo_dialog.open();
                         } else if a.action == "clipboard:dialog" {
                             self.clipboard_dialog.open();
+                        } else if a.action == "tempfile:dialog" {
+                            self.tempfile_dialog.open();
                         } else if a.action == "volume:dialog" {
                             self.volume_dialog.open();
                         } else if a.action == "brightness:dialog" {
@@ -1013,6 +1019,8 @@ impl eframe::App for LauncherApp {
                                     self.todo_dialog.open();
                                 } else if a.action == "clipboard:dialog" {
                                     self.clipboard_dialog.open();
+                                } else if a.action == "tempfile:dialog" {
+                                    self.tempfile_dialog.open();
                                 } else if a.action == "volume:dialog" {
                                     self.volume_dialog.open();
                                 } else if a.action == "brightness:dialog" {
@@ -1135,6 +1143,9 @@ impl eframe::App for LauncherApp {
         let mut tf_dlg = std::mem::take(&mut self.tempfile_alias_dialog);
         tf_dlg.ui(ctx, self);
         self.tempfile_alias_dialog = tf_dlg;
+        let mut create_tf = std::mem::take(&mut self.tempfile_dialog);
+        create_tf.ui(ctx, self);
+        self.tempfile_dialog = create_tf;
         let mut add_bm_dlg = std::mem::take(&mut self.add_bookmark_dialog);
         add_bm_dlg.ui(ctx, self);
         self.add_bookmark_dialog = add_bm_dlg;

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -353,6 +353,21 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         clean_recycle_bin();
         return Ok(());
     }
+    if action.action == "tempfile:new" {
+        let path = crate::plugins::tempfile::create_file()?;
+        open::that(&path)?;
+        return Ok(());
+    }
+    if action.action == "tempfile:open" {
+        let dir = crate::plugins::tempfile::storage_dir();
+        std::fs::create_dir_all(&dir)?;
+        open::that(dir)?;
+        return Ok(());
+    }
+    if action.action == "tempfile:clear" {
+        crate::plugins::tempfile::clear_files()?;
+        return Ok(());
+    }
     let path = Path::new(&action.action);
 
     // If it's an .exe or we have additional args, launch it directly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod settings_editor;
 pub mod shell_cmd_dialog;
 pub mod snippet_dialog;
 pub mod tempfile_alias_dialog;
+pub mod tempfile_dialog;
 pub mod timer_dialog;
 pub mod timer_help_window;
 pub mod todo_dialog;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod settings;
 pub mod settings_editor;
 pub mod shell_cmd_dialog;
 pub mod snippet_dialog;
+pub mod tempfile_alias_dialog;
 pub mod timer_dialog;
 pub mod timer_help_window;
 pub mod todo_dialog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod settings;
 mod settings_editor;
 mod shell_cmd_dialog;
 mod snippet_dialog;
+mod tempfile_alias_dialog;
 mod timer_dialog;
 mod timer_help_window;
 mod todo_dialog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod settings_editor;
 mod shell_cmd_dialog;
 mod snippet_dialog;
 mod tempfile_alias_dialog;
+mod tempfile_dialog;
 mod timer_dialog;
 mod timer_help_window;
 mod todo_dialog;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,6 +22,7 @@ use crate::plugins::notes::NotesPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
 use crate::plugins::recycle::RecyclePlugin;
+use crate::plugins::tempfile::TempfilePlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 #[cfg(target_os = "windows")]
@@ -81,6 +82,7 @@ impl PluginManager {
         self.register(Box::new(TodoPlugin::default()));
         self.register(Box::new(SnippetsPlugin::default()));
         self.register(Box::new(RecyclePlugin));
+        self.register(Box::new(TempfilePlugin));
         #[cfg(target_os = "windows")]
         {
             self.register(Box::new(VolumePlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -21,3 +21,4 @@ pub mod brightness;
 pub mod unit_convert;
 pub mod dropcalc;
 pub mod recycle;
+pub mod tempfile;

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -1,0 +1,119 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+/// Return the directory used to store temporary files.
+pub fn storage_dir() -> PathBuf {
+    std::env::temp_dir().join("multi_launcher_tmp")
+}
+
+fn ensure_dir() -> std::io::Result<PathBuf> {
+    let dir = storage_dir();
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Create a new temporary file and return its path.
+pub fn create_file() -> anyhow::Result<PathBuf> {
+    let dir = ensure_dir()?;
+    let mut idx = 0;
+    loop {
+        let path = dir.join(format!("temp_{idx}.txt"));
+        if !path.exists() {
+            File::create(&path)?;
+            return Ok(path);
+        }
+        idx += 1;
+    }
+}
+
+/// Remove all files inside the storage directory.
+pub fn clear_files() -> anyhow::Result<()> {
+    let dir = ensure_dir()?;
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+    Ok(())
+}
+
+/// Return all files in the storage directory.
+pub fn list_files() -> anyhow::Result<Vec<PathBuf>> {
+    let dir = ensure_dir()?;
+    let mut list = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            list.push(entry.path());
+        }
+    }
+    Ok(list)
+}
+
+pub struct TempfilePlugin;
+
+impl Plugin for TempfilePlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if trimmed == "tmp new" {
+            return vec![Action {
+                label: "Create temp file".into(),
+                desc: "Tempfile".into(),
+                action: "tempfile:new".into(),
+                args: None,
+            }];
+        }
+        if trimmed == "tmp open" {
+            return vec![Action {
+                label: "Open temp directory".into(),
+                desc: "Tempfile".into(),
+                action: "tempfile:open".into(),
+                args: None,
+            }];
+        }
+        if trimmed == "tmp clear" {
+            return vec![Action {
+                label: "Clear temp files".into(),
+                desc: "Tempfile".into(),
+                action: "tempfile:clear".into(),
+                args: None,
+            }];
+        }
+        if let Some(filter) = trimmed.strip_prefix("tmp list") {
+            let filter = filter.trim();
+            let files = list_files().unwrap_or_default();
+            return files
+                .into_iter()
+                .filter(|p| {
+                    filter.is_empty()
+                        || p.file_name()
+                            .and_then(|n| n.to_str())
+                            .map(|n| n.contains(filter))
+                            .unwrap_or(false)
+                })
+                .map(|p| Action {
+                    label: p.file_name().unwrap().to_string_lossy().into(),
+                    desc: "Tempfile".into(),
+                    action: p.to_string_lossy().into(),
+                    args: None,
+                })
+                .collect();
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "tempfile"
+    }
+
+    fn description(&self) -> &str {
+        "Manage temporary files (prefix: `tmp`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+}

--- a/src/tempfile_alias_dialog.rs
+++ b/src/tempfile_alias_dialog.rs
@@ -1,0 +1,62 @@
+use crate::gui::LauncherApp;
+use crate::plugins::tempfile::set_alias;
+use eframe::egui;
+use std::path::Path;
+
+pub struct TempfileAliasDialog {
+    pub open: bool,
+    path: String,
+    alias: String,
+}
+
+impl Default for TempfileAliasDialog {
+    fn default() -> Self {
+        Self {
+            open: false,
+            path: String::new(),
+            alias: String::new(),
+        }
+    }
+}
+
+impl TempfileAliasDialog {
+    pub fn open(&mut self, path: &str) {
+        self.path = path.to_string();
+        let name = Path::new(path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        self.alias = name.trim_start_matches("temp_").to_string();
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut close = false;
+        egui::Window::new("Set Tempfile Alias")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                ui.label(&self.path);
+                ui.text_edit_singleline(&mut self.alias);
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        if let Err(e) = set_alias(Path::new(&self.path), &self.alias) {
+                            app.error = Some(format!("Failed to rename: {e}"));
+                        } else {
+                            close = true;
+                            app.search();
+                            app.focus_input();
+                        }
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if close {
+            self.open = false;
+        }
+    }
+}

--- a/src/tempfile_dialog.rs
+++ b/src/tempfile_dialog.rs
@@ -1,0 +1,87 @@
+use crate::gui::LauncherApp;
+use crate::plugins::tempfile::create_named_file;
+use eframe::egui;
+use egui_toast::{Toast, ToastKind, ToastOptions};
+
+pub struct TempfileDialog {
+    pub open: bool,
+    alias: String,
+    text: String,
+}
+
+impl Default for TempfileDialog {
+    fn default() -> Self {
+        Self {
+            open: false,
+            alias: String::new(),
+            text: String::new(),
+        }
+    }
+}
+
+impl TempfileDialog {
+    pub fn open(&mut self) {
+        self.open = true;
+        self.alias.clear();
+        self.text.clear();
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut close = false;
+        egui::Window::new("Create Temp File")
+            .open(&mut self.open)
+            .resizable(true)
+            .default_size((360.0, 240.0))
+            .min_width(200.0)
+            .min_height(150.0)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Alias");
+                    ui.text_edit_singleline(&mut self.alias);
+                });
+                ui.label("Text");
+                ui.text_edit_multiline(&mut self.text);
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        if self.alias.trim().is_empty() {
+                            app.error = Some("Alias required".into());
+                        } else {
+                            match create_named_file(&self.alias, &self.text) {
+                                Ok(path) => {
+                                    if let Err(e) = open::that(&path) {
+                                        app.error = Some(format!("Failed to open: {e}"));
+                                    } else {
+                                        if app.enable_toasts {
+                                            app.add_toast(Toast {
+                                                text: format!(
+                                                    "Created {}",
+                                                    path.file_name().unwrap().to_string_lossy()
+                                                )
+                                                .into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default()
+                                                    .duration_in_seconds(3.0),
+                                            });
+                                        }
+                                        close = true;
+                                        app.search();
+                                        app.focus_input();
+                                    }
+                                }
+                                Err(e) => app.error = Some(format!("Failed to save: {e}")),
+                            }
+                        }
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if close {
+            self.open = false;
+        }
+    }
+}

--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -1,0 +1,55 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::tempfile::{clear_files, create_file, list_files, TempfilePlugin};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn search_new_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp new");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:new");
+}
+
+#[test]
+fn search_open_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp open");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:open");
+}
+
+#[test]
+fn search_clear_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp clear");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:clear");
+}
+
+#[test]
+fn list_returns_existing_files() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    // override temp dir for this test
+    std::env::set_var("TMPDIR", dir.path());
+    #[cfg(windows)]
+    std::env::set_var("TEMP", dir.path());
+
+    let _ = create_file();
+    let _ = create_file();
+
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp list");
+    let files = list_files().unwrap();
+    assert_eq!(results.len(), files.len());
+    assert!(results.iter().all(|a| a.args.is_none()));
+
+    clear_files().unwrap();
+}

--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -9,6 +9,15 @@ use tempfile::tempdir;
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 #[test]
+fn search_tmp_returns_dialog() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:dialog");
+}
+
+#[test]
 fn search_new_returns_action() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TempfilePlugin;


### PR DESCRIPTION
## Summary
- implement tempfile plugin with `tmp` commands
- register new plugin
- handle tempfile actions in launcher
- document usage in README
- test plugin search paths

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6873970e6ef483328c05afc0e886d29f