### PR TITLE
Fix alarm error handling

### DIFF
--- a/src/timer_dialog.rs
+++ b/src/timer_dialog.rs
@@ -74,6 +74,7 @@ impl TimerDialog {
                                 if let Some((h,m)) = parse_hhmm(&self.time) {
                                     start_alarm_named(h, m, if self.label.is_empty(){None}else{Some(self.label.clone())});
                                     close = true;
+                                } else {
                                     app.error = Some("Invalid time".into());
                                 }
                             }


### PR DESCRIPTION
## Summary
- avoid setting an error when starting a valid alarm

## Testing
- `cargo test` *(fails: set_alias_renames_file etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9b39c5083328df1f9353564a2f3