### PR TITLE
Add plugin function documentation

### DIFF
--- a/src/plugins/asciiart.rs
+++ b/src/plugins/asciiart.rs
@@ -7,6 +7,7 @@ pub struct AsciiArtPlugin {
 }
 
 impl AsciiArtPlugin {
+    /// Create a new plugin instance with the bundled standard font.
     pub fn new() -> Self {
         Self { font: FIGfont::standard().unwrap() }
     }

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -18,6 +18,7 @@ pub struct BookmarksPlugin {
 }
 
 impl BookmarksPlugin {
+    /// Construct a new `BookmarksPlugin` with a fuzzy matcher.
     pub fn new() -> Self {
         Self { matcher: SkimMatcherV2::default() }
     }
@@ -44,6 +45,9 @@ fn normalize_url(url: &str) -> String {
     out
 }
 
+/// Load bookmarks from `path`.
+///
+/// Returns an empty list if the file does not exist or is empty.
 pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<BookmarkEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -63,12 +67,16 @@ pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<BookmarkEntry>> {
     }
 }
 
+/// Save the provided `bookmarks` to `path` in JSON format.
 pub fn save_bookmarks(path: &str, bookmarks: &[BookmarkEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(bookmarks)?;
     std::fs::write(path, json)?;
     Ok(())
 }
 
+/// Append a new bookmark `url` to the file at `path`.
+///
+/// The URL is normalized and duplicates are ignored.
 pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     let mut list = load_bookmarks(path).unwrap_or_default();
     let fixed = normalize_url(url);
@@ -79,6 +87,7 @@ pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Remove the bookmark matching `url` from the file at `path`.
 pub fn remove_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     let mut list = load_bookmarks(path).unwrap_or_default();
     let fixed = normalize_url(url);
@@ -89,6 +98,9 @@ pub fn remove_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Set or clear the alias of a bookmark.
+///
+/// Passing an empty `alias` removes the existing alias.
 pub fn set_alias(path: &str, url: &str, alias: &str) -> anyhow::Result<()> {
     let mut list = load_bookmarks(path).unwrap_or_default();
     let fixed = normalize_url(url);

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -4,6 +4,9 @@ use std::collections::VecDeque;
 
 pub const CLIPBOARD_FILE: &str = "clipboard_history.json";
 
+/// Load clipboard history from `path`.
+///
+/// Returns an empty queue when the file is missing or empty.
 pub fn load_history(path: &str) -> anyhow::Result<VecDeque<String>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -13,6 +16,7 @@ pub fn load_history(path: &str) -> anyhow::Result<VecDeque<String>> {
     Ok(list.into())
 }
 
+/// Save the clipboard `history` to `path`.
 pub fn save_history(path: &str, history: &VecDeque<String>) -> anyhow::Result<()> {
     let list: Vec<String> = history.iter().cloned().collect();
     let json = serde_json::to_string_pretty(&list)?;
@@ -20,6 +24,7 @@ pub fn save_history(path: &str, history: &VecDeque<String>) -> anyhow::Result<()
     Ok(())
 }
 
+/// Remove the history entry at `index` from the file at `path`.
 pub fn remove_entry(path: &str, index: usize) -> anyhow::Result<()> {
     let mut history = load_history(path).unwrap_or_default();
     if index < history.len() {
@@ -29,6 +34,7 @@ pub fn remove_entry(path: &str, index: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Replace the entry at `index` with `text` in the history file at `path`.
 pub fn set_entry(path: &str, index: usize, text: &str) -> anyhow::Result<()> {
     let mut history = load_history(path).unwrap_or_default();
     if index < history.len() {
@@ -38,6 +44,7 @@ pub fn set_entry(path: &str, index: usize, text: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Clear the clipboard history file at `path`.
 pub fn clear_history_file(path: &str) -> anyhow::Result<()> {
     save_history(path, &VecDeque::new())
 }
@@ -48,6 +55,7 @@ pub struct ClipboardPlugin {
 }
 
 impl ClipboardPlugin {
+    /// Create a new plugin keeping up to `max_entries` in history.
     pub fn new(max_entries: usize) -> Self {
         Self { max_entries, path: CLIPBOARD_FILE.into() }
     }

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -14,6 +14,7 @@ pub struct FolderEntry {
     pub alias: Option<String>,
 }
 
+/// Return a set of default commonly used folders.
 pub fn default_folders() -> Vec<FolderEntry> {
     let mut out = Vec::new();
     if let Some(p) = dirs_next::home_dir() {
@@ -31,6 +32,7 @@ pub fn default_folders() -> Vec<FolderEntry> {
     out
 }
 
+/// Load folder entries from `path` or return the defaults if the file is empty.
 pub fn load_folders(path: &str) -> anyhow::Result<Vec<FolderEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.is_empty() {
@@ -40,12 +42,16 @@ pub fn load_folders(path: &str) -> anyhow::Result<Vec<FolderEntry>> {
     Ok(list)
 }
 
+/// Save `folders` to `path` in JSON format.
 pub fn save_folders(path: &str, folders: &[FolderEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(folders)?;
     std::fs::write(path, json)?;
     Ok(())
 }
 
+/// Append a folder path to the list stored at `path`.
+///
+/// Returns an error if the folder does not exist.
 pub fn append_folder(path: &str, folder: &str) -> anyhow::Result<()> {
     if !std::path::Path::new(folder).exists() {
         anyhow::bail!("folder does not exist: {folder}");
@@ -63,6 +69,7 @@ pub fn append_folder(path: &str, folder: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Remove a folder entry matching `folder` from the file at `path`.
 pub fn remove_folder(path: &str, folder: &str) -> anyhow::Result<()> {
     let mut list = load_folders(path).unwrap_or_else(|_| default_folders());
     if let Some(pos) = list.iter().position(|f| f.path == folder) {
@@ -72,6 +79,7 @@ pub fn remove_folder(path: &str, folder: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Set or clear the alias for a folder entry.
 pub fn set_alias(path: &str, folder: &str, alias: &str) -> anyhow::Result<()> {
     let mut list = load_folders(path).unwrap_or_else(|_| default_folders());
     if let Some(item) = list.iter_mut().find(|f| f.path == folder) {
@@ -86,6 +94,7 @@ pub struct FoldersPlugin {
 }
 
 impl FoldersPlugin {
+    /// Create a new folders plugin.
     pub fn new() -> Self {
         Self { matcher: SkimMatcherV2::default() }
     }

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -13,6 +13,7 @@ pub struct NoteEntry {
     pub text: String,
 }
 
+/// Load notes from `path`.
 pub fn load_notes(path: &str) -> anyhow::Result<Vec<NoteEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -22,12 +23,14 @@ pub fn load_notes(path: &str) -> anyhow::Result<Vec<NoteEntry>> {
     Ok(list)
 }
 
+/// Save `notes` to `path` in JSON format.
 pub fn save_notes(path: &str, notes: &[NoteEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(notes)?;
     std::fs::write(path, json)?;
     Ok(())
 }
 
+/// Append a note with the provided `text` and current timestamp.
 pub fn append_note(path: &str, text: &str) -> anyhow::Result<()> {
     let mut list = load_notes(path).unwrap_or_default();
     list.push(NoteEntry {
@@ -37,6 +40,7 @@ pub fn append_note(path: &str, text: &str) -> anyhow::Result<()> {
     save_notes(path, &list)
 }
 
+/// Remove the note at `index` from `path`.
 pub fn remove_note(path: &str, index: usize) -> anyhow::Result<()> {
     let mut list = load_notes(path).unwrap_or_default();
     if index < list.len() {
@@ -60,6 +64,7 @@ pub struct NotesPlugin {
 }
 
 impl NotesPlugin {
+    /// Create a new notes plugin with a fuzzy matcher.
     pub fn new() -> Self {
         Self {
             matcher: SkimMatcherV2::default(),

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -12,6 +12,7 @@ pub struct ShellCmdEntry {
     pub args: String,
 }
 
+/// Load saved shell commands from `path`.
 pub fn load_shell_cmds(path: &str) -> anyhow::Result<Vec<ShellCmdEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -21,6 +22,7 @@ pub fn load_shell_cmds(path: &str) -> anyhow::Result<Vec<ShellCmdEntry>> {
     Ok(list)
 }
 
+/// Save the list of shell command entries to `path`.
 pub fn save_shell_cmds(path: &str, cmds: &[ShellCmdEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(cmds)?;
     std::fs::write(path, json)?;

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -12,6 +12,7 @@ pub struct SnippetEntry {
     pub text: String,
 }
 
+/// Load all snippets from the JSON file at `path`.
 pub fn load_snippets(path: &str) -> anyhow::Result<Vec<SnippetEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -21,18 +22,21 @@ pub fn load_snippets(path: &str) -> anyhow::Result<Vec<SnippetEntry>> {
     Ok(list)
 }
 
+/// Persist `snippets` to `path`.
 pub fn save_snippets(path: &str, snippets: &[SnippetEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(snippets)?;
     std::fs::write(path, json)?;
     Ok(())
 }
 
+/// Add a new snippet with `alias` and `text`.
 pub fn add_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
     let mut list = load_snippets(path).unwrap_or_default();
     list.push(SnippetEntry { alias: alias.to_string(), text: text.to_string() });
     save_snippets(path, &list)
 }
 
+/// Update an existing snippet or insert a new one.
 pub fn set_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
     let mut list = load_snippets(path).unwrap_or_default();
     if let Some(entry) = list.iter_mut().find(|e| e.alias == alias) {
@@ -43,6 +47,7 @@ pub fn set_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
     save_snippets(path, &list)
 }
 
+/// Remove the snippet identified by `alias`.
 pub fn remove_snippet(path: &str, alias: &str) -> anyhow::Result<()> {
     let mut list = load_snippets(path).unwrap_or_default();
     if let Some(pos) = list.iter().position(|e| e.alias == alias) {
@@ -57,6 +62,7 @@ pub struct SnippetsPlugin {
 }
 
 impl SnippetsPlugin {
+    /// Create a new snippets plugin instance.
     pub fn new() -> Self {
         Self { matcher: SkimMatcherV2::default() }
     }

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -28,7 +28,7 @@ fn ensure_dir() -> std::io::Result<PathBuf> {
     Ok(dir)
 }
 
-/// Create a new temporary file and return its path.
+/// Create a new unnamed temporary file and return its path.
 pub fn create_file() -> anyhow::Result<PathBuf> {
     let dir = ensure_dir()?;
     let mut idx = 0;
@@ -42,8 +42,8 @@ pub fn create_file() -> anyhow::Result<PathBuf> {
     }
 }
 
-/// Create a new temp file with a specific alias and contents. The filename is
-/// prefixed with `temp_` and suffixed with a number if needed.
+/// Create a new temp file with a specific `alias` and initial `contents`.
+/// The filename is prefixed with `temp_` and suffixed with a number if needed.
 pub fn create_named_file(alias: &str, contents: &str) -> anyhow::Result<PathBuf> {
     validate_alias(alias)?;
     let dir = ensure_dir()?;
@@ -64,6 +64,8 @@ pub fn create_named_file(alias: &str, contents: &str) -> anyhow::Result<PathBuf>
 }
 
 /// Remove a specific file inside the storage directory.
+///
+/// Does nothing if the file does not exist.
 pub fn remove_file(path: &Path) -> anyhow::Result<()> {
     if path.exists() && path.is_file() {
         fs::remove_file(path)?;
@@ -71,7 +73,7 @@ pub fn remove_file(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Rename a temp file to use the provided alias.
+/// Rename a temp file to use the provided `alias`.
 /// The resulting file name will always start with `temp_`.
 pub fn set_alias(path: &Path, alias: &str) -> anyhow::Result<PathBuf> {
     validate_alias(alias)?;

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -12,6 +12,7 @@ pub struct TodoEntry {
     pub done: bool,
 }
 
+/// Load todo entries from `path`.
 pub fn load_todos(path: &str) -> anyhow::Result<Vec<TodoEntry>> {
     let content = std::fs::read_to_string(path).unwrap_or_default();
     if content.trim().is_empty() {
@@ -21,12 +22,14 @@ pub fn load_todos(path: &str) -> anyhow::Result<Vec<TodoEntry>> {
     Ok(list)
 }
 
+/// Save `todos` to `path` as JSON.
 pub fn save_todos(path: &str, todos: &[TodoEntry]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(todos)?;
     std::fs::write(path, json)?;
     Ok(())
 }
 
+/// Append a new todo entry with `text`.
 pub fn append_todo(path: &str, text: &str) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     list.push(TodoEntry {
@@ -36,6 +39,7 @@ pub fn append_todo(path: &str, text: &str) -> anyhow::Result<()> {
     save_todos(path, &list)
 }
 
+/// Remove the todo at `index` from the list stored at `path`.
 pub fn remove_todo(path: &str, index: usize) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     if index < list.len() {
@@ -45,7 +49,7 @@ pub fn remove_todo(path: &str, index: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Toggle completion status of the todo at the given index.
+/// Toggle completion status of the todo at `index` in `path`.
 pub fn mark_done(path: &str, index: usize) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     if let Some(entry) = list.get_mut(index) {
@@ -55,6 +59,7 @@ pub fn mark_done(path: &str, index: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Remove all completed todos from `path`.
 pub fn clear_done(path: &str) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     let orig_len = list.len();
@@ -70,6 +75,7 @@ pub struct TodoPlugin {
 }
 
 impl TodoPlugin {
+    /// Create a new todo plugin with a fuzzy matcher.
     pub fn new() -> Self {
         Self {
             matcher: SkimMatcherV2::default(),


### PR DESCRIPTION
## Summary
- document constructors and helpers in `asciiart` and `shell`
- document bookmark, clipboard, snippet, todo, note, timer and tempfile helpers
- document folder management utilities

## Testing
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_6873e31160fc8332b3ad06969b3fd02a