### PR TITLE
Add optional notification feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dirs-next = "2"
 shlex = "1.3"
 sysinfo = "0.35"
 chrono = "0.4"
-notify-rust = "4"
+notify-rust = { version = "4", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = { version = "0.15.3", default-features = false, features = ["common-controls-v6"] }
@@ -49,6 +49,7 @@ rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e301
 
 [features]
 unstable_grab = []
+notify = ["notify-rust"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ cargo build --release --features unstable_grab
 This feature is defined in `Cargo.toml` and enables the underlying `rdev`
 capability used to grab keyboard events.
 
+To show a system notification when a timer or alarm fires, build with the
+`notify` feature. This pulls in the optional `notify-rust` dependency:
+
+```
+cargo build --release --features notify
+```
+
 For debugging, enable **Debug logging** in the settings window. When this
 option is active, you can further adjust the verbosity by setting the
 `RUST_LOG` environment variable before running the program:

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -71,7 +71,8 @@ pub struct LauncherApp {
     pub settings_editor: SettingsEditor,
     pub plugin_editor: PluginEditor,
     pub settings_path: String,
-    #[allow(dead_code)]
+    /// Hold watchers so the `RecommendedWatcher` instances remain active.
+    #[allow(dead_code)] // required to keep watchers alive
     watchers: Vec<RecommendedWatcher>,
     rx: Receiver<WatchEvent>,
     plugin_dirs: Option<Vec<String>>,

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -133,12 +133,16 @@ pub fn cancel_timer(id: u64) {
     }
 }
 
+#[cfg(feature = "notify")]
 fn notify(msg: &str) {
-    #[allow(unused)]
-    {
-        let _ = notify_rust::Notification::new().summary("Multi Launcher").body(msg).show();
-    }
+    let _ = notify_rust::Notification::new()
+        .summary("Multi Launcher")
+        .body(msg)
+        .show();
 }
+
+#[cfg(not(feature = "notify"))]
+fn notify(_msg: &str) {}
 
 fn format_duration(dur: Duration) -> String {
     let secs = dur.as_secs();


### PR DESCRIPTION
## Summary
- hold file watchers alive in the GUI with a comment
- add optional `notify` feature and gate `notify_rust` usage
- document the new feature in the build instructions

## Testing
- `cargo test --quiet` *(fails: create_named_file_rejects_invalid_alias, list_returns_existing_files, search_clear_returns_action, search_new_returns_action, search_open_returns_action, search_tmp_returns_dialog, set_alias_rejects_invalid_alias, set_alias_renames_file)*

------
https://chatgpt.com/codex/tasks/task_e_6873ebdd35cc83329d1615ad331ee889