### PR TITLE
Handle cursor retrieval failure gracefully

### DIFF
--- a/tests/follow_mouse.rs
+++ b/tests/follow_mouse.rs
@@ -1,0 +1,41 @@
+use eframe::egui;
+use multi_launcher::visibility::apply_visibility;
+use multi_launcher::window_manager::{clear_mock_mouse_position, set_mock_mouse_position};
+
+#[path = "mock_ctx.rs"]
+mod mock_ctx;
+use mock_ctx::MockCtx;
+
+#[test]
+fn cursor_failure_does_not_move_window() {
+    let ctx = MockCtx::default();
+    set_mock_mouse_position(None);
+
+    apply_visibility(
+        true,
+        &ctx,
+        (0.0, 0.0),
+        true,
+        false,
+        None,
+        None,
+        (400.0, 220.0),
+    );
+
+    clear_mock_mouse_position();
+
+    let cmds = ctx.commands.lock().unwrap();
+    assert_eq!(cmds.len(), 3);
+    match cmds[0] {
+        egui::ViewportCommand::Visible(v) => assert!(v),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[1] {
+        egui::ViewportCommand::Minimized(m) => assert!(!m),
+        _ => panic!("unexpected command"),
+    }
+    match cmds[2] {
+        egui::ViewportCommand::Focus => {}
+        _ => panic!("unexpected command"),
+    }
+}


### PR DESCRIPTION
## Summary
- return `None` from `current_mouse_position` when Windows API call fails
- allow tests to override the mouse position for failure simulation
- ensure `apply_visibility` keeps the window still when the cursor can't be read
- add `follow_mouse` unit test

## Testing
- `cargo test --test follow_mouse -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6873f67a045c8332907a30aa9e410597