### PR TITLE
Cleanup unused code and silence warnings

### DIFF
--- a/src/global_hotkey.rs
+++ b/src/global_hotkey.rs
@@ -1,4 +1,6 @@
+#[cfg(target_os = "windows")]
 use crate::workspace::is_valid_key_combo;
+#[cfg(target_os = "windows")]
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -11,6 +13,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Hotkey {
     pub key_sequence: String,
+    #[cfg(target_os = "windows")]
     #[serde(skip)]
     pub id: Option<i32>,
 }
@@ -22,6 +25,7 @@ impl fmt::Display for Hotkey {
 }
 
 impl Hotkey {
+    #[cfg(target_os = "windows")]
     pub fn new(key_sequence: &str) -> Result<Self, String> {
         if is_valid_key_combo(key_sequence) {
             Ok(Self {

--- a/src/global_hotkey.rs
+++ b/src/global_hotkey.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 #[cfg(target_os = "windows")]
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS, MOD_CONTROL, MOD_ALT,
-    MOD_SHIFT, MOD_WIN,
+    RegisterHotKey, HOT_KEY_MODIFIERS, MOD_CONTROL, MOD_ALT, MOD_SHIFT, MOD_WIN,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -72,21 +71,5 @@ impl Hotkey {
     }
 
 
-    #[cfg(target_os = "windows")]
-    pub fn unregister(&self, app: &crate::gui::LauncherApp) -> bool {
-        if let Some(id) = self.id {
-            unsafe {
-                if UnregisterHotKey(None, id).is_ok() {
-                    let mut registered_hotkeys = app.registered_hotkeys.lock().unwrap();
-                    registered_hotkeys.remove(&self.key_sequence);
-                    info!("Unregistered hotkey '{}'.", self.key_sequence);
-                    return true;
-                } else {
-                    warn!("Failed to unregister hotkey '{}'.", self.key_sequence);
-                }
-            }
-        }
-        false
-    }
 
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -528,7 +528,7 @@ impl eframe::App for LauncherApp {
                 (self.window_size.0 as f32, self.window_size.1 as f32),
             );
             #[cfg(target_os = "windows")]
-            if let Some(hwnd) = crate::window_manager::get_hwnd(frame) {
+            if let Some(hwnd) = crate::window_manager::get_hwnd(_frame) {
                 crate::window_manager::force_restore_and_foreground(hwnd);
             }
         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -28,8 +28,10 @@ use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc,
 };
+#[cfg(target_os = "windows")]
+use std::sync::Mutex;
 use std::time::Instant;
 
 fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
@@ -62,6 +64,7 @@ pub struct LauncherApp {
     pub plugins: PluginManager,
     pub selected: Option<usize>,
     pub usage: HashMap<String, u32>,
+    #[cfg(target_os = "windows")]
     pub registered_hotkeys: Mutex<HashMap<String, usize>>,
     pub show_editor: bool,
     pub show_settings: bool,
@@ -250,6 +253,7 @@ impl LauncherApp {
             plugins,
             selected: None,
             usage: usage::load_usage(USAGE_FILE).unwrap_or_default(),
+            #[cfg(target_os = "windows")]
             registered_hotkeys: Mutex::new(HashMap::new()),
             show_editor: false,
             show_settings: false,
@@ -473,7 +477,7 @@ impl LauncherApp {
 }
 
 impl eframe::App for LauncherApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         use egui::*;
 
         tracing::debug!("LauncherApp::update called");

--- a/src/history.rs
+++ b/src/history.rs
@@ -26,14 +26,6 @@ fn load_history_internal() -> anyhow::Result<VecDeque<HistoryEntry>> {
     Ok(list.into())
 }
 
-/// Load history from `history.json` into the global HISTORY list.
-pub fn load_history() -> anyhow::Result<()> {
-    let hist = load_history_internal()?;
-    let mut h = HISTORY.lock().unwrap();
-    *h = hist;
-    Ok(())
-}
-
 /// Save the current HISTORY list to `history.json`.
 pub fn save_history() -> anyhow::Result<()> {
     let h = HISTORY.lock().unwrap();

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "windows")]
-pub use rdev::{EventType, Key};
+pub use rdev::Key;
 
 #[cfg(not(target_os = "windows"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -29,8 +29,6 @@ fn set_system_volume(percent: u32) {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-fn set_system_volume(_percent: u32) {}
 
 #[cfg(target_os = "windows")]
 fn mute_active_window() {
@@ -71,8 +69,6 @@ fn mute_active_window() {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-fn mute_active_window() {}
 
 #[cfg(target_os = "windows")]
 fn set_display_brightness(percent: u32) {
@@ -108,8 +104,6 @@ fn set_display_brightness(percent: u32) {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-fn set_display_brightness(_percent: u32) {}
 
 #[cfg(target_os = "windows")]
 fn clean_recycle_bin() {
@@ -119,8 +113,6 @@ fn clean_recycle_bin() {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-fn clean_recycle_bin() {}
 
 fn system_command(action: &str) -> Option<std::process::Command> {
     #[cfg(target_os = "windows")]
@@ -250,10 +242,10 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         return Ok(());
     }
     if let Some(pid) = action.action.strip_prefix("process:switch:") {
-        if let Ok(pid) = pid.parse::<u32>() {
+        if let Ok(_pid) = pid.parse::<u32>() {
             #[cfg(target_os = "windows")]
             {
-                crate::window_manager::activate_process(pid);
+                crate::window_manager::activate_process(_pid);
             }
         }
         return Ok(());
@@ -330,16 +322,16 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         return Ok(());
     }
     if let Some(val) = action.action.strip_prefix("brightness:set:") {
-        if let Ok(v) = val.parse::<u32>() {
+        if let Ok(_v) = val.parse::<u32>() {
             #[cfg(target_os = "windows")]
-            set_display_brightness(v);
+            set_display_brightness(_v);
         }
         return Ok(());
     }
     if let Some(val) = action.action.strip_prefix("volume:set:") {
-        if let Ok(v) = val.parse::<u32>() {
+        if let Ok(_v) = val.parse::<u32>() {
             #[cfg(target_os = "windows")]
-            set_system_volume(v);
+            set_system_volume(_v);
         }
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,7 @@ mod workspace;
 use crate::actions::{load_actions, Action};
 use crate::gui::LauncherApp;
 use crate::hotkey::HotkeyTrigger;
-use crate::plugin::{Plugin, PluginManager};
-use crate::plugins::clipboard::ClipboardPlugin;
-use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
+use crate::plugin::PluginManager;
 use crate::settings::Settings;
 use crate::visibility::handle_visibility_trigger;
 
@@ -87,7 +85,6 @@ fn spawn_gui(
     let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
     let enabled_plugins = settings.enabled_plugins.clone();
-    let enabled_capabilities = settings.enabled_capabilities.clone();
     let visible_flag = Arc::new(AtomicBool::new(true));
     let restore_flag = Arc::new(AtomicBool::new(false));
     let help_flag = Arc::new(AtomicBool::new(false));
@@ -105,11 +102,11 @@ fn spawn_gui(
                 .with_min_inner_size([320.0, 160.0])
                 .with_always_on_top()
                 .with_visible(true),
-            event_loop_builder: Some(Box::new(|builder| {
+            event_loop_builder: Some(Box::new(|_builder| {
                 #[cfg(target_os = "windows")]
                 {
                     use winit::platform::windows::EventLoopBuilderExtWindows;
-                    builder.with_any_thread(true);
+                    _builder.with_any_thread(true);
                 }
             })),
             ..Default::default()

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -34,15 +34,6 @@ pub fn remove_entry(path: &str, index: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Replace the entry at `index` with `text` in the history file at `path`.
-pub fn set_entry(path: &str, index: usize, text: &str) -> anyhow::Result<()> {
-    let mut history = load_history(path).unwrap_or_default();
-    if index < history.len() {
-        history[index] = text.to_string();
-        save_history(path, &history)?;
-    }
-    Ok(())
-}
 
 /// Clear the clipboard history file at `path`.
 pub fn clear_history_file(path: &str) -> anyhow::Result<()> {

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -29,23 +29,6 @@ pub fn save_snippets(path: &str, snippets: &[SnippetEntry]) -> anyhow::Result<()
     Ok(())
 }
 
-/// Add a new snippet with `alias` and `text`.
-pub fn add_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
-    let mut list = load_snippets(path).unwrap_or_default();
-    list.push(SnippetEntry { alias: alias.to_string(), text: text.to_string() });
-    save_snippets(path, &list)
-}
-
-/// Update an existing snippet or insert a new one.
-pub fn set_snippet(path: &str, alias: &str, text: &str) -> anyhow::Result<()> {
-    let mut list = load_snippets(path).unwrap_or_default();
-    if let Some(entry) = list.iter_mut().find(|e| e.alias == alias) {
-        entry.text = text.to_string();
-    } else {
-        list.push(SnippetEntry { alias: alias.to_string(), text: text.to_string() });
-    }
-    save_snippets(path, &list)
-}
 
 /// Remove the snippet identified by `alias`.
 pub fn remove_snippet(path: &str, alias: &str) -> anyhow::Result<()> {

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -14,7 +14,7 @@ pub fn clear_mock_mouse_position() {
     *MOCK_MOUSE_POSITION.lock().unwrap() = None;
 }
 
-#[cfg(test)]
+#[cfg(any(test, target_os = "windows"))]
 pub fn virtual_key_from_string(key: &str) -> Option<u32> {
     match key.to_uppercase().as_str() {
         "F1" => Some(0x70),

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -4,14 +4,17 @@ use std::sync::Mutex;
 static MOCK_MOUSE_POSITION: Lazy<Mutex<Option<Option<(f32, f32)>>>> =
     Lazy::new(|| Mutex::new(None));
 
+#[cfg(test)]
 pub fn set_mock_mouse_position(pos: Option<(f32, f32)>) {
     *MOCK_MOUSE_POSITION.lock().unwrap() = Some(pos);
 }
 
+#[cfg(test)]
 pub fn clear_mock_mouse_position() {
     *MOCK_MOUSE_POSITION.lock().unwrap() = None;
 }
 
+#[cfg(test)]
 pub fn virtual_key_from_string(key: &str) -> Option<u32> {
     match key.to_uppercase().as_str() {
         "F1" => Some(0x70),

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -217,7 +217,7 @@ pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
         let current_thread = GetCurrentThreadId();
 
         tracing::debug!("Forcing window restore and foreground");
-        ShowWindowAsync(hwnd, SW_RESTORE);
+        let _ = ShowWindowAsync(hwnd, SW_RESTORE);
 
         let _ = AttachThreadInput(fg_thread, current_thread, true);
         let fg_success = SetForegroundWindow(hwnd).as_bool();
@@ -263,6 +263,6 @@ pub fn activate_process(pid: u32) {
     }
 
     unsafe {
-        EnumWindows(Some(enum_cb), LPARAM(pid as isize));
+        let _ = EnumWindows(Some(enum_cb), LPARAM(pid as isize));
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,10 +1,14 @@
+#[cfg(any(test, target_os = "windows"))]
 use once_cell::sync::Lazy;
+#[cfg(any(test, target_os = "windows"))]
 use regex::Regex;
 
+#[cfg(any(test, target_os = "windows"))]
 static HOTKEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:F(?:[1-9]|1[0-2]|1[3-9]|2[0-4])|[A-Z]|[0-9]|NUMPAD[0-9]|NUMPAD(?:MULTIPLY|ADD|SEPARATOR|SUBTRACT|DOT|DIVIDE)|UP|DOWN|LEFT|RIGHT|BACKSPACE|TAB|ENTER|PAUSE|CAPSLOCK|ESCAPE|SPACE|PAGEUP|PAGEDOWN|END|HOME|INSERT|DELETE|OEM_(?:PLUS|COMMA|MINUS|PERIOD|[1-7])|PRINTSCREEN|SCROLLLOCK|NUMLOCK|LEFT(?:SHIFT|CTRL|ALT)|RIGHT(?:SHIFT|CTRL|ALT))$").unwrap()
 });
 
+#[cfg(any(test, target_os = "windows"))]
 pub fn is_valid_key_combo(input: &str) -> bool {
     HOTKEY_REGEX.is_match(input)
 }


### PR DESCRIPTION
## Summary
- strip out unused code and imports across the project
- gate Windows-specific logic with `cfg` attributes
- prefix intentionally unused struct fields with underscores
- trim obsolete helper functions
- update `spawn_gui` closure to avoid unused builder warning

## Testing
- `cargo check`
 