### PR TITLE
Switch calculator plugin to exmex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "exmex"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee7ef9d0ad0bca0963181b4232e4ffce543a0c30fa51ac2ff8a8ece04c3359c"
+dependencies = [
+ "lazy_static",
+ "num",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,12 +1350,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -2210,16 +2216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "meval"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
-dependencies = [
- "fnv",
- "nom",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,11 +2247,11 @@ dependencies = [
  "dirs-next",
  "eframe",
  "egui-toast",
+ "exmex",
  "figlet-rs",
  "fuzzy-matcher",
  "libloading 0.8.8",
  "log",
- "meval",
  "notify",
  "notify-rust",
  "once_cell",
@@ -2359,12 +2355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
-
-[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,10 +2407,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 walkdir = "2.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-meval = "0.2"
+exmex = "0.20"
 libloading = "0.8"
 notify = "6"
 winit = "0.29"

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -1,6 +1,8 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 
+use exmex::eval_str;
+
 pub struct WebSearchPlugin;
 
 impl Plugin for WebSearchPlugin {
@@ -37,7 +39,7 @@ impl Plugin for CalculatorPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         if query.starts_with("=") {
             let expr = &query[1..];
-            match meval::eval_str(expr) {
+            match eval_str::<f64>(expr) {
                 Ok(v) => vec![Action {
                     label: format!("{} = {}", expr, v),
                     desc: "Calculator".into(),

--- a/tests/calculator_plugin.rs
+++ b/tests/calculator_plugin.rs
@@ -1,0 +1,11 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins_builtin::CalculatorPlugin;
+
+#[test]
+fn simple_addition() {
+    let plugin = CalculatorPlugin;
+    let results = plugin.search("=1+2");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "1+2 = 3");
+    assert_eq!(results[0].action, "calc:3");
+}


### PR DESCRIPTION
## Summary
- replace deprecated `meval` with `exmex` expression evaluator
- update calculator plugin accordingly
- add regression test for calculator plugin

## Testing
- `cargo build`
- `cargo test` *(fails: unresolved import `multi_launcher::hotkey::process_test_events`)*

------
https://chatgpt.com/codex/tasks/task_e_687417727cc08332b8e86949634af8e1