### PR TITLE
Add tempfile remove support

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -390,6 +390,16 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         crate::plugins::tempfile::clear_files()?;
         return Ok(());
     }
+    if let Some(path) = action.action.strip_prefix("tempfile:remove:") {
+        crate::plugins::tempfile::remove_file(Path::new(path))?;
+        return Ok(());
+    }
+    if let Some(rest) = action.action.strip_prefix("tempfile:alias:") {
+        if let Some((path, alias)) = rest.split_once('|') {
+            crate::plugins::tempfile::set_alias(Path::new(path), alias)?;
+        }
+        return Ok(());
+    }
     let path = Path::new(&action.action);
 
     // If it's an .exe or we have additional args, launch it directly

--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -2,6 +2,7 @@ use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::tempfile::{
     clear_files, create_file, create_named_file, list_files, remove_file, set_alias, TempfilePlugin,
 };
+use multi_launcher::{actions::Action, launcher::launch_action};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 use tempfile::tempdir;
@@ -83,6 +84,23 @@ fn rm_lists_files_for_deletion() {
     assert_eq!(results.len(), 1);
     assert!(results[0].action.starts_with("tempfile:remove:"));
     remove_file(&file).unwrap();
+}
+
+#[test]
+fn launch_action_remove_deletes_file() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let file = create_file().unwrap();
+    let action = Action {
+        label: "".into(),
+        desc: "".into(),
+        action: format!("tempfile:remove:{}", file.to_string_lossy()),
+        args: None,
+    };
+    launch_action(&action).unwrap();
+    assert!(!file.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- support removing and aliasing tempfile actions in `launch_action`
- add test verifying file deletion via `launch_action`

## Testing
- `cargo test --features unstable_grab` *(fails: unresolved imports in follow_mouse.rs)*

------
https://chatgpt.com/codex/tasks/task_e_6875742ce8908332b1d62c8ea303c786