### PR TITLE
Fix hide_after_run for todo done actions

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -746,6 +746,7 @@ impl eframe::App for LauncherApp {
                                 && !a.action.starts_with("folder:add:")
                                 && !a.action.starts_with("folder:remove:")
                                 && !a.action.starts_with("calc:")
+                                && !a.action.starts_with("todo:done:")
                             {
                                 self.visible_flag.store(false, Ordering::SeqCst);
                             }
@@ -1117,6 +1118,7 @@ impl eframe::App for LauncherApp {
                                         && !a.action.starts_with("folder:add:")
                                         && !a.action.starts_with("folder:remove:")
                                         && !a.action.starts_with("calc:")
+                                        && !a.action.starts_with("todo:done:")
                                     {
                                         self.visible_flag.store(false, Ordering::SeqCst);
                                     }

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -1,39 +1,64 @@
+use eframe::egui;
+use multi_launcher::actions::Action;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
-use multi_launcher::actions::Action;
 use multi_launcher::settings::Settings;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-use eframe::egui;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
-fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Settings) -> (LauncherApp, Arc<AtomicBool>) {
+fn new_app_with_settings(
+    ctx: &egui::Context,
+    actions: Vec<Action>,
+    settings: Settings,
+) -> (LauncherApp, Arc<AtomicBool>) {
     let custom_len = actions.len();
     let visible = Arc::new(AtomicBool::new(true));
     (
-    LauncherApp::new(
-        ctx,
-        actions,
-        custom_len,
-        PluginManager::new(),
-        "actions.json".into(),
-        "settings.json".into(),
-        settings,
-        None,
-        None,
-        None,
-        None,
-        visible.clone(),
-        Arc::new(AtomicBool::new(false)),
-        Arc::new(AtomicBool::new(false)),
-    ),
-    visible)
+        LauncherApp::new(
+            ctx,
+            actions,
+            custom_len,
+            PluginManager::new(),
+            "actions.json".into(),
+            "settings.json".into(),
+            settings,
+            None,
+            None,
+            None,
+            None,
+            visible.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        ),
+        visible,
+    )
 }
 
 fn run_action(action: &str) -> bool {
     let ctx = egui::Context::default();
-    let actions = vec![Action { label: "test".into(), desc: "".into(), action: action.into(), args: None }];
+    let actions = vec![Action {
+        label: "test".into(),
+        desc: "".into(),
+        action: action.into(),
+        args: None,
+    }];
     let (mut app, flag) = new_app_with_settings(&ctx, actions, Settings::default());
     app.update_paths(
-        None, None, None, None, None, None, None, None, None, None, None, None, Some(true),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(true),
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();
@@ -44,6 +69,7 @@ fn run_action(action: &str) -> bool {
             && !a.action.starts_with("folder:add:")
             && !a.action.starts_with("folder:remove:")
             && !a.action.starts_with("calc:")
+            && !a.action.starts_with("todo:done:")
         {
             flag.store(false, Ordering::SeqCst);
         }
@@ -79,4 +105,9 @@ fn hide_after_run_not_for_folder_remove() {
 #[test]
 fn hide_after_run_not_for_calc_copy() {
     assert!(!run_action("calc:1+2"));
+}
+
+#[test]
+fn hide_after_run_not_for_todo_done() {
+    assert!(!run_action("todo:done:0"));
 }


### PR DESCRIPTION
## Summary
- adjust GUI hide-after-run checks to ignore `todo:done:` actions
- keep other todo actions unaffected
- test that completed todos do not hide the window

## Testing
- `cargo test --test hide_after_run --quiet`
 