### PR TITLE
Handle empty todo add and trailing spaces

### DIFF
--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -111,6 +111,15 @@ impl Plugin for TodoPlugin {
             }];
         }
 
+        if trimmed.eq("todo add") {
+            return vec![Action {
+                label: "todo: edit todos".into(),
+                desc: "Todo".into(),
+                action: "todo:dialog".into(),
+                args: None,
+            }];
+        }
+
         if let Some(text) = trimmed.strip_prefix("todo add ") {
             let text = text.trim();
             if !text.is_empty() {

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -10,9 +10,18 @@ static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 fn search_add_returns_action() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TodoPlugin::default();
-    let results = plugin.search("todo add task");
+    let results = plugin.search("todo add task   ");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "todo:add:task");
+}
+
+#[test]
+fn search_add_without_text_opens_dialog() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo add");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "todo:dialog");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- avoid launching an add command for `"todo add"`
- trim trailing spaces when adding todo items
- cover new behaviour in todo plugin tests

## Testing
- `cargo test --quiet` *(fails: unresolved import `multi_launcher::hotkey::process_test_events`)*

 