### PR TITLE
Update timer command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Built-in plugins and their command prefixes are:
 - Volume control (`vol 50`) *(Windows only)*
 - Brightness control (`bright 50`) *(Windows only)*
 - Command overview (`help`)
-- Timers and alarms (`timer 5m tea`, `timer 1:30`, `alarm 07:30`). Use `timer list` to view
+- Timers and alarms (`timer add 5m tea`, `timer add 1:30`, `alarm 07:30`). Use `timer list` to view
    remaining time or `timer rm` to remove timers. Pending alarms are saved to `alarms.json` and resume after
    restarting the launcher. A plugin setting controls pop-up dialogs when a
    timer completes.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -831,7 +831,9 @@ impl eframe::App for LauncherApp {
                                 a.label.clone()
                             };
                             let mut resp = ui.selectable_label(self.selected == Some(idx), text);
-                            let tooltip = if a.desc == "Timer" && a.action.starts_with("timer:show:") {
+                            let tooltip = if a.desc == "Timer"
+                                && a.action.starts_with("timer:show:")
+                            {
                                 if let Ok(id) = a.action[11..].parse::<u64>() {
                                     if let Some(ts) = crate::plugins::timer::timer_start_ts(id) {
                                         format!("Started {}", crate::plugins::timer::format_ts(ts))
@@ -917,6 +919,15 @@ impl eframe::App for LauncherApp {
                                             if query.starts_with("timer list") {
                                                 refresh = true;
                                                 set_focus = true;
+                                                if self.enable_toasts {
+                                                    self.toasts.add(Toast {
+                                                        text: format!("Paused timer {}", a.label)
+                                                            .into(),
+                                                        kind: ToastKind::Success,
+                                                        options: ToastOptions::default()
+                                                            .duration_in_seconds(3.0),
+                                                    });
+                                                }
                                             }
                                             ui.close_menu();
                                         }
@@ -925,6 +936,15 @@ impl eframe::App for LauncherApp {
                                             if query.starts_with("timer list") {
                                                 refresh = true;
                                                 set_focus = true;
+                                                if self.enable_toasts {
+                                                    self.toasts.add(Toast {
+                                                        text: format!("Removed timer {}", a.label)
+                                                            .into(),
+                                                        kind: ToastKind::Success,
+                                                        options: ToastOptions::default()
+                                                            .duration_in_seconds(3.0),
+                                                    });
+                                                }
                                             }
                                             ui.close_menu();
                                         }

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -96,7 +96,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "sysinfo" => Some(&["info", "info cpu", "info cpu list 5"]),
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
-        "timer" => Some(&["timer 10s break", "timer list", "alarm 07:30"]),
+        "timer" => Some(&["timer add 10s break", "timer list", "alarm 07:30"]),
         "notes" => Some(&["note", "note add buy milk", "note list", "note rm milk"]),
         "volume" => Some(&["vol 50"]),
         "brightness" => Some(&["bright 50"]),

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -449,7 +449,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if let Some(arg) = trimmed.strip_prefix("timer ") {
+        if let Some(arg) = trimmed.strip_prefix("timer add") {
             let arg = arg.trim();
             let mut parts = arg.splitn(2, ' ');
             let dur_part = parts.next().unwrap_or("");

--- a/src/timer_help_window.rs
+++ b/src/timer_help_window.rs
@@ -18,10 +18,10 @@ impl TimerHelpWindow {
             .show(ctx, |ui| {
                 ui.heading("Timer Plugin Usage");
                 ui.separator();
-                ui.label("Create a timer: use 'timer <duration> [name]'. Examples:");
-                ui.monospace("timer 10s tea");
-                ui.monospace("timer 5m");
-                ui.monospace("timer 1:30");
+                ui.label("Create a timer: use 'timer add <duration> [name]'. Examples:");
+                ui.monospace("timer add 10s tea");
+                ui.monospace("timer add 5m");
+                ui.monospace("timer add 1:30");
                 ui.label(
                     "Supported units are seconds (s), minutes (m) and hours (h). \
 You can also use hh:mm:ss or mm:ss notation.",

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -32,7 +32,7 @@ fn search_alarm_dialog() {
 fn search_timer_returns_start_action() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TimerPlugin;
-    let results = plugin.search("timer 1s");
+    let results = plugin.search("timer add 1s");
     assert_eq!(results.len(), 1);
     assert!(results[0].action.starts_with("timer:start:"));
 }
@@ -41,7 +41,7 @@ fn search_timer_returns_start_action() {
 fn search_named_timer() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TimerPlugin;
-    let results = plugin.search("timer 1s tea");
+    let results = plugin.search("timer add 1s tea");
     assert_eq!(results.len(), 1);
     assert!(results[0].action.starts_with("timer:start:1s|"));
 }
@@ -174,7 +174,7 @@ fn parse_duration_colon_formats() {
 fn search_timer_hms_format() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TimerPlugin;
-    let results = plugin.search("timer 1:30");
+    let results = plugin.search("timer add 1:30");
     assert_eq!(results.len(), 1);
     assert!(results[0].action.starts_with("timer:start:1:30"));
 }


### PR DESCRIPTION
## Summary
- change the timer plugin to use `timer add` for starting timers
- update help examples and readme
- adjust tests for the new command

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68759cbaba3c833293904c073a262323