### PR TITLE
Add snippet add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ quickly open applications or files.
 - Set timers or alarms from the launcher. Type `timer` or `alarm` and press
   <kbd>Enter</kbd> to open the creation dialog.
 - Keep track of quick todo items or notes.
-- Insert saved text snippets and add new ones with `cs add <alias> <text>`.
+- Insert saved text snippets, add new ones with `cs add <alias> <text>` or edit them with `cs edit`.
 
 
 ## Building
@@ -190,7 +190,7 @@ Built-in plugins and their command prefixes are:
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
 - Todo items (`todo add <task>`, `todo list`, `todo rm <pattern>`, `todo clear`)
-- Text snippets (`cs`, `cs list`, `cs rm`, `cs add <alias> <text>`)
+- Text snippets (`cs`, `cs list`, `cs rm`, `cs add <alias> <text>`, `cs edit`)
 - Recycle Bin cleanup (`rec`)
 - Temporary files (`tmp`, `tmp new [name]`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
 - ASCII art (`ascii text`)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Built-in plugins and their command prefixes are:
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
 - Todo items (`todo add <task>`, `todo list`, `todo rm <pattern>`, `todo clear`)
-- Text snippets (`cs`, `cs list`, `cs rm`)
+- Text snippets (`cs`, `cs list`, `cs rm`, `cs add <alias> <text>`)
 - Recycle Bin cleanup (`rec`)
 - Temporary files (`tmp`, `tmp new [name]`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
 - ASCII art (`ascii text`)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ quickly open applications or files.
 - Set timers or alarms from the launcher. Type `timer` or `alarm` and press
   <kbd>Enter</kbd> to open the creation dialog.
 - Keep track of quick todo items or notes.
-- Insert saved text snippets without opening a file.
+- Insert saved text snippets and add new ones with `cs add <alias> <text>`.
 
 
 ## Building

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -680,6 +680,8 @@ impl eframe::App for LauncherApp {
                             self.add_bookmark_dialog.open();
                         } else if a.action == "snippet:dialog" {
                             self.snippet_dialog.open();
+                        } else if let Some(alias) = a.action.strip_prefix("snippet:edit:") {
+                            self.snippet_dialog.open_edit(alias);
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
                         } else if a.action == "clipboard:dialog" {
@@ -754,6 +756,9 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                                 set_focus = true;
                             } else if a.action == "todo:clear" {
+                                refresh = true;
+                                set_focus = true;
+                            } else if a.action.starts_with("snippet:remove:") {
                                 refresh = true;
                                 set_focus = true;
                             } else if a.action.starts_with("tempfile:remove:") {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -3,7 +3,7 @@ use crate::history;
 use crate::plugins::bookmarks::{append_bookmark, remove_bookmark};
 use crate::plugins::folders::{append_folder, remove_folder, FOLDERS_FILE};
 use crate::plugins::notes::{append_note, load_notes, remove_note, QUICK_NOTES_FILE};
-use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
+use crate::plugins::snippets::{append_snippet, remove_snippet, SNIPPETS_FILE};
 use crate::plugins::timer;
 use arboard::Clipboard;
 use shlex;
@@ -344,6 +344,12 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
     }
     if let Some(alias) = action.action.strip_prefix("snippet:remove:") {
         remove_snippet(SNIPPETS_FILE, alias)?;
+        return Ok(());
+    }
+    if let Some(rest) = action.action.strip_prefix("snippet:add:") {
+        if let Some((alias, text)) = rest.split_once('|') {
+            append_snippet(SNIPPETS_FILE, alias, text)?;
+        }
         return Ok(());
     }
     if let Some(val) = action.action.strip_prefix("brightness:set:") {

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -82,13 +82,14 @@ impl Plugin for SnippetsPlugin {
                 args: None,
             }];
         }
-        if let Some(pattern) = trimmed.strip_prefix("cs rm ") {
-            let filter = pattern.trim();
+        if let Some(rest) = trimmed.strip_prefix("cs rm") {
+            let filter = rest.trim();
             let list = load_snippets(SNIPPETS_FILE).unwrap_or_default();
             return list
                 .into_iter()
                 .filter(|s| {
-                    self.matcher.fuzzy_match(&s.alias, filter).is_some()
+                    filter.is_empty()
+                        || self.matcher.fuzzy_match(&s.alias, filter).is_some()
                         || self.matcher.fuzzy_match(&s.text, filter).is_some()
                 })
                 .map(|s| Action {

--- a/tests/snippets_plugin.rs
+++ b/tests/snippets_plugin.rs
@@ -1,9 +1,11 @@
 use multi_launcher::plugin::Plugin;
-use multi_launcher::plugins::snippets::{save_snippets, load_snippets, SnippetEntry, SnippetsPlugin, SNIPPETS_FILE};
+use multi_launcher::plugins::snippets::{
+    load_snippets, save_snippets, SnippetEntry, SnippetsPlugin, SNIPPETS_FILE,
+};
 use multi_launcher::{actions::Action, launcher::launch_action};
-use tempfile::tempdir;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
+use tempfile::tempdir;
 
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -13,7 +15,10 @@ fn load_save_roundtrip() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![SnippetEntry { alias: "hw".into(), text: "hello".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "hw".into(),
+        text: "hello".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
     let loaded = load_snippets(SNIPPETS_FILE).unwrap();
     assert_eq!(loaded.len(), 1);
@@ -27,7 +32,10 @@ fn search_returns_clipboard_action() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![SnippetEntry { alias: "hi".into(), text: "hello world".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "hi".into(),
+        text: "hello world".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
 
     let plugin = SnippetsPlugin::default();
@@ -45,8 +53,14 @@ fn list_command_returns_entries() {
     std::env::set_current_dir(dir.path()).unwrap();
 
     let entries = vec![
-        SnippetEntry { alias: "a".into(), text: "alpha".into() },
-        SnippetEntry { alias: "b".into(), text: "beta".into() },
+        SnippetEntry {
+            alias: "a".into(),
+            text: "alpha".into(),
+        },
+        SnippetEntry {
+            alias: "b".into(),
+            text: "beta".into(),
+        },
     ];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
 
@@ -61,7 +75,10 @@ fn rm_command_returns_remove_actions() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![SnippetEntry { alias: "todelete".into(), text: "bye".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "todelete".into(),
+        text: "bye".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
 
     let plugin = SnippetsPlugin::default();
@@ -76,7 +93,10 @@ fn search_preserves_newlines() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![SnippetEntry { alias: "multi".into(), text: "a\nb".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "multi".into(),
+        text: "a\nb".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
 
     let plugin = SnippetsPlugin::default();
@@ -112,4 +132,22 @@ fn launch_action_add_saves_snippet() {
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].alias, "alias");
     assert_eq!(list[0].text, "text");
+}
+
+#[test]
+fn search_edit_returns_actions() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![SnippetEntry {
+        alias: "greet".into(),
+        text: "hello".into(),
+    }];
+    save_snippets(SNIPPETS_FILE, &entries).unwrap();
+
+    let plugin = SnippetsPlugin::default();
+    let results = plugin.search("cs edit");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "snippet:edit:greet");
 }


### PR DESCRIPTION
## Summary
- parse `cs add <alias> <text>` in snippets plugin
- handle `snippet:add` actions in launcher to save snippets
- document add command in README
- test new snippet command behavior

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6875a71ea8fc8332be730b1522b1b9c6