### PR TITLE
Add shell command management

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The system information plugin uses the `info` prefix. Type `info` to show CPU,
 memory and disk usage or `info cpu` for a single metric.
 ### Security Considerations
 The shell plugin runs commands using the system shell without sanitising input. Only enable it if you trust the commands you type. Errors while spawning the process are logged.
-Type `sh` in the launcher to open the shell command editor for managing predefined commands.
+Type `sh` in the launcher to open the shell command editor for managing predefined commands. Saved commands can also be added with `sh add <name> <command>`, removed via `sh rm <pattern>` or listed with `sh list`.
 ## Editing Commands
 The launcher stores its custom actions in `actions.json` next to the
 executable. This file is created automatically the first time you save a

--- a/tests/shell_plugin.rs
+++ b/tests/shell_plugin.rs
@@ -1,8 +1,11 @@
 use multi_launcher::plugin::Plugin;
-use multi_launcher::plugins::shell::{save_shell_cmds, load_shell_cmds, ShellCmdEntry, ShellPlugin, SHELL_CMDS_FILE};
-use tempfile::tempdir;
+use multi_launcher::plugins::shell::{
+    load_shell_cmds, save_shell_cmds, ShellCmdEntry, ShellPlugin, SHELL_CMDS_FILE,
+};
+use multi_launcher::{actions::Action, launcher::launch_action};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
+use tempfile::tempdir;
 
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -12,7 +15,10 @@ fn load_shell_cmds_roundtrip() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![ShellCmdEntry { name: "test".into(), args: "echo hi".into() }];
+    let entries = vec![ShellCmdEntry {
+        name: "test".into(),
+        args: "echo hi".into(),
+    }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
     let loaded = load_shell_cmds(SHELL_CMDS_FILE).unwrap();
     assert_eq!(loaded.len(), 1);
@@ -26,7 +32,10 @@ fn search_named_command_returns_action() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![ShellCmdEntry { name: "demo".into(), args: "dir".into() }];
+    let entries = vec![ShellCmdEntry {
+        name: "demo".into(),
+        args: "dir".into(),
+    }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
 
     let plugin = ShellPlugin;
@@ -45,4 +54,85 @@ fn search_plain_sh_opens_dialog() {
     let results = plugin.search("sh");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "shell:dialog");
+}
+
+#[test]
+fn search_add_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = ShellPlugin;
+    let results = plugin.search("sh add greet echo hi");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "shell:add:greet|echo hi");
+}
+
+#[test]
+fn rm_lists_matching_commands() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![
+        ShellCmdEntry {
+            name: "a".into(),
+            args: "cmd_a".into(),
+        },
+        ShellCmdEntry {
+            name: "b".into(),
+            args: "cmd_b".into(),
+        },
+    ];
+    save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
+
+    let plugin = ShellPlugin;
+    let results = plugin.search("sh rm a");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "shell:remove:a");
+}
+
+#[test]
+fn list_returns_saved_commands() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![ShellCmdEntry {
+        name: "x".into(),
+        args: "dir".into(),
+    }];
+    save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
+
+    let plugin = ShellPlugin;
+    let results = plugin.search("sh list");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "x");
+    assert_eq!(results[0].action, "shell:dir");
+}
+
+#[test]
+fn launch_actions_modify_file() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    save_shell_cmds(SHELL_CMDS_FILE, &[]).unwrap();
+    let add = Action {
+        label: String::new(),
+        desc: String::new(),
+        action: "shell:add:test|dir".into(),
+        args: None,
+    };
+    launch_action(&add).unwrap();
+    let list = load_shell_cmds(SHELL_CMDS_FILE).unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].name, "test");
+
+    let rm = Action {
+        label: String::new(),
+        desc: String::new(),
+        action: "shell:remove:test".into(),
+        args: None,
+    };
+    launch_action(&rm).unwrap();
+    let list = load_shell_cmds(SHELL_CMDS_FILE).unwrap();
+    assert!(list.is_empty());
 }


### PR DESCRIPTION
## Summary
- support adding, removing and listing shell commands
- update launcher action handling for new shell commands
- document the commands
- test shell command management

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6875afff69288332bd8a8968023ecefc