### PR TITLE
Refocus query input after commands

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -848,6 +848,8 @@ impl eframe::App for LauncherApp {
                         }
                         if set_focus {
                             self.focus_input();
+                        } else if self.visible_flag.load(Ordering::SeqCst) {
+                            self.focus_input();
                         }
                     }
                 }
@@ -1331,6 +1333,8 @@ impl eframe::App for LauncherApp {
                             self.search();
                         }
                         if set_focus {
+                            self.focus_input();
+                        } else if self.visible_flag.load(Ordering::SeqCst) {
                             self.focus_input();
                         }
                     });


### PR DESCRIPTION
## Summary
- refocus query input on the main GUI after running a command if the window remains visible

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_6876c3d45b888332a6d12873ee81d1bd