### PR TITLE
Add timer sound selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +508,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bindgen"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +788,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -897,6 +957,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1047,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "deranged"
@@ -1174,6 +1283,12 @@ dependencies = [
  "web-sys",
  "winit",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -1542,6 +1657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1854,12 @@ checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "iana-time-zone"
@@ -1972,6 +2099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2426,7 @@ dependencies = [
  "rdev",
  "regex",
  "rfd",
+ "rodio",
  "serde",
  "serde_json",
  "shlex",
@@ -2370,6 +2522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2621,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "num-integer"
@@ -2687,6 +2860,29 @@ name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
 dependencies = [
  "cc",
 ]
@@ -3107,6 +3303,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rodio"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
+dependencies = [
+ "cpal",
+ "hound",
 ]
 
 [[package]]
@@ -4297,6 +4503,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -4333,6 +4549,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -4453,6 +4679,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ dirs-next = "2"
 shlex = "1.3"
 sysinfo = "0.35"
 chrono = "0.4"
+rodio = { version = "0.17", default-features = false, features = ["wav"] }
 notify-rust = { version = "4", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -301,9 +301,9 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         let (dur_str, name) = arg.split_once('|').unwrap_or((arg, ""));
         if let Some(dur) = timer::parse_duration(dur_str) {
             if name.is_empty() {
-                timer::start_timer(dur);
+                timer::start_timer(dur, "None".to_string());
             } else {
-                timer::start_timer_named(dur, Some(name.to_string()));
+                timer::start_timer_named(dur, Some(name.to_string()), "None".to_string());
             }
         }
         return Ok(());
@@ -312,9 +312,9 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         let (time_str, name) = arg.split_once('|').unwrap_or((arg, ""));
         if let Some((h, m)) = timer::parse_hhmm(time_str) {
             if name.is_empty() {
-                timer::start_alarm(h, m);
+                timer::start_alarm(h, m, "None".to_string());
             } else {
-                timer::start_alarm_named(h, m, Some(name.to_string()));
+                timer::start_alarm_named(h, m, Some(name.to_string()), "None".to_string());
             }
         }
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod plugin;
 pub mod plugin_editor;
 pub mod plugins;
 pub mod plugins_builtin;
+pub mod sound;
 pub mod settings;
 pub mod settings_editor;
 pub mod shell_cmd_dialog;

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,0 +1,67 @@
+use once_cell::sync::Lazy;
+use std::io::Cursor;
+
+pub static SOUND_NAMES: &[&str] = &[
+    "None",
+    "Alarm.wav",
+    "Alarm02.wav",
+    "Alarm03.wav",
+    "Alarm04.wav",
+    "Alarm05.wav",
+    "Alarm06.wav",
+    "Alarm07.wav",
+    "Alarm08.wav",
+    "Alarm09.wav",
+    "AlarmNag.wav",
+    "ReminderDelete.wav",
+    "ReminderHold.wav",
+    "ReminderStart.wav",
+    "StartUp.wav",
+];
+
+static SOUNDS: Lazy<Vec<(&'static str, &'static [u8])>> = Lazy::new(|| {
+    vec![
+        ("Alarm.wav", include_bytes!("../Resources/sounds/Alarm.wav")),
+        ("Alarm02.wav", include_bytes!("../Resources/sounds/Alarm02.wav")),
+        ("Alarm03.wav", include_bytes!("../Resources/sounds/Alarm03.wav")),
+        ("Alarm04.wav", include_bytes!("../Resources/sounds/Alarm04.wav")),
+        ("Alarm05.wav", include_bytes!("../Resources/sounds/Alarm05.wav")),
+        ("Alarm06.wav", include_bytes!("../Resources/sounds/Alarm06.wav")),
+        ("Alarm07.wav", include_bytes!("../Resources/sounds/Alarm07.wav")),
+        ("Alarm08.wav", include_bytes!("../Resources/sounds/Alarm08.wav")),
+        ("Alarm09.wav", include_bytes!("../Resources/sounds/Alarm09.wav")),
+        ("AlarmNag.wav", include_bytes!("../Resources/sounds/AlarmNag.wav")),
+        (
+            "ReminderDelete.wav",
+            include_bytes!("../Resources/sounds/ReminderDelete.wav"),
+        ),
+        (
+            "ReminderHold.wav",
+            include_bytes!("../Resources/sounds/ReminderHold.wav"),
+        ),
+        (
+            "ReminderStart.wav",
+            include_bytes!("../Resources/sounds/ReminderStart.wav"),
+        ),
+        ("StartUp.wav", include_bytes!("../Resources/sounds/StartUp.wav")),
+    ]
+});
+
+pub fn play_sound(name: &str) {
+    if name == "None" {
+        return;
+    }
+    let data = SOUNDS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, d)| *d);
+    let Some(bytes) = data else { return; };
+    if let Ok((_stream, handle)) = rodio::OutputStream::try_default() {
+        if let Ok(source) = rodio::Decoder::new(Cursor::new(bytes)) {
+            if let Ok(sink) = rodio::Sink::try_new(&handle) {
+                sink.append(source);
+                sink.detach();
+            }
+        }
+    }
+}

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -62,6 +62,7 @@ fn search_cancel_lists_timers() {
             paused: false,
             remaining: Duration::from_secs(10),
             generation: 0,
+            sound: "None".into(),
         });
     }
     let plugin = TimerPlugin;
@@ -88,6 +89,7 @@ fn search_list_lists_timers() {
             paused: false,
             remaining: Duration::from_secs(20),
             generation: 0,
+            sound: "None".into(),
         });
     }
     let plugin = TimerPlugin;
@@ -111,6 +113,7 @@ fn search_rm_lists_timers() {
             paused: false,
             remaining: Duration::from_secs(30),
             generation: 0,
+            sound: "None".into(),
         });
     }
     let plugin = TimerPlugin;
@@ -145,6 +148,7 @@ fn search_pause_lists_running_timers() {
             paused: false,
             remaining: Duration::from_secs(5),
             generation: 0,
+            sound: "None".into(),
         });
     }
     let plugin = TimerPlugin;
@@ -177,6 +181,7 @@ fn search_resume_lists_paused_timers() {
             paused: true,
             remaining: Duration::from_secs(5),
             generation: 0,
+            sound: "None".into(),
         });
     }
     let plugin = TimerPlugin;


### PR DESCRIPTION
## Summary
- add `rodio` dependency
- include wav files from `Resources/sounds`
- allow choosing a sound in the timer dialog
- store the selected sound with timers and play it when finished
- default timer actions trigger with `None` sound

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6876daa1d41c8332bf2e9325e6a87e5f