### PR TITLE
Allow case-insensitive prefixes

### DIFF
--- a/src/plugins/asciiart.rs
+++ b/src/plugins/asciiart.rs
@@ -21,8 +21,11 @@ impl Default for AsciiArtPlugin {
 
 impl Plugin for AsciiArtPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(text) = query.strip_prefix("ascii ") {
-            let text = text.trim();
+        const PREFIX: &str = "ascii ";
+        if query.len() >= PREFIX.len()
+            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            let text = query[PREFIX.len()..].trim();
             if !text.is_empty() {
                 if let Some(fig) = self.font.convert(text) {
                     let art = fig.to_string();

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -178,8 +178,11 @@ impl Plugin for BookmarksPlugin {
             }];
         }
 
-        if let Some(url) = trimmed.strip_prefix("bm add ") {
-            let url = url.trim();
+        const ADD_PREFIX: &str = "bm add ";
+        if trimmed.len() >= ADD_PREFIX.len()
+            && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
+        {
+            let url = trimmed[ADD_PREFIX.len()..].trim();
             if !url.is_empty() {
                 let norm = normalize_url(url);
                 return vec![Action {
@@ -190,7 +193,11 @@ impl Plugin for BookmarksPlugin {
                 }];
             }
         }
-        if let Some(rest) = trimmed.strip_prefix("bm rm") {
+        const RM_PREFIX: &str = "bm rm";
+        if trimmed.len() >= RM_PREFIX.len()
+            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let rest = &trimmed[RM_PREFIX.len()..];
             let filter = rest.trim();
             let bookmarks = self.data.lock().unwrap().clone();
             return bookmarks
@@ -210,7 +217,11 @@ impl Plugin for BookmarksPlugin {
                 })
                 .collect();
         }
-        if let Some(rest) = trimmed.strip_prefix("bm list") {
+        const LIST_PREFIX: &str = "bm list";
+        if trimmed.len() >= LIST_PREFIX.len()
+            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
+        {
+            let rest = &trimmed[LIST_PREFIX.len()..];
             let filter = rest.trim();
             let bookmarks = self.data.lock().unwrap().clone();
             return bookmarks
@@ -233,10 +244,11 @@ impl Plugin for BookmarksPlugin {
                 })
                 .collect();
         }
-        if !trimmed.starts_with("bm") {
+        const PREFIX: &str = "bm";
+        if trimmed.len() < PREFIX.len() || !trimmed[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
-        let filter = trimmed.strip_prefix("bm").unwrap_or("").trim();
+        let filter = trimmed[PREFIX.len()..].trim();
         let bookmarks = self.data.lock().unwrap().clone();
         bookmarks
             .into_iter()

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -122,12 +122,13 @@ impl Default for ClipboardPlugin {
 
 impl Plugin for ClipboardPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if !query.starts_with("cb") {
+        const PREFIX: &str = "cb";
+        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
 
         let trimmed = query.trim();
-        if trimmed == "cb" {
+        if trimmed.eq_ignore_ascii_case("cb") {
             return vec![Action {
                 label: "cb: edit clipboard".into(),
                 desc: "Clipboard".into(),
@@ -136,7 +137,7 @@ impl Plugin for ClipboardPlugin {
             }];
         }
 
-        if trimmed == "cb clear" {
+        if trimmed.eq_ignore_ascii_case("cb clear") {
             return vec![Action {
                 label: "Clear clipboard history".into(),
                 desc: "Clipboard".into(),
@@ -145,7 +146,7 @@ impl Plugin for ClipboardPlugin {
             }];
         }
 
-        if trimmed == "cb list" {
+        if trimmed.eq_ignore_ascii_case("cb list") {
             let history = self.update_history();
             return history
                 .iter()
@@ -159,7 +160,7 @@ impl Plugin for ClipboardPlugin {
                 .collect();
         }
 
-        let filter = query.strip_prefix("cb").unwrap_or("").trim();
+        let filter = trimmed[PREFIX.len()..].trim();
         let history = self.update_history();
         history
             .iter()

--- a/src/plugins/dropcalc.rs
+++ b/src/plugins/dropcalc.rs
@@ -19,8 +19,11 @@ fn parse_prob(input: &str) -> Option<f64> {
 impl Plugin for DropCalcPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        let rest = if let Some(r) = trimmed.strip_prefix("drop ") {
-            r.trim()
+        const PREFIX: &str = "drop ";
+        let rest = if trimmed.len() >= PREFIX.len()
+            && trimmed[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            trimmed[PREFIX.len()..].trim()
         } else {
             return Vec::new();
         };

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -173,8 +173,11 @@ impl Default for FoldersPlugin {
 
 impl Plugin for FoldersPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(path) = query.strip_prefix("f add ") {
-            let path = path.trim();
+        const ADD_PREFIX: &str = "f add ";
+        if query.len() >= ADD_PREFIX.len()
+            && query[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
+        {
+            let path = query[ADD_PREFIX.len()..].trim();
             if !path.is_empty() {
                 return vec![Action {
                     label: format!("Add folder {path}"),
@@ -185,8 +188,11 @@ impl Plugin for FoldersPlugin {
             }
         }
 
-        if let Some(pattern) = query.strip_prefix("f rm ") {
-            let filter = pattern.trim();
+        const RM_PREFIX: &str = "f rm ";
+        if query.len() >= RM_PREFIX.len()
+            && query[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let filter = query[RM_PREFIX.len()..].trim();
             let folders = self.data.lock().unwrap().clone();
             return folders
                 .into_iter()
@@ -207,10 +213,11 @@ impl Plugin for FoldersPlugin {
                 .collect();
         }
 
-        if !query.starts_with("f") {
+        const PREFIX: &str = "f";
+        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
-        let filter = query.strip_prefix("f").unwrap_or("").trim();
+        let filter = query[PREFIX.len()..].trim();
         let folders = self.data.lock().unwrap().clone();
         folders
             .into_iter()

--- a/src/plugins/help.rs
+++ b/src/plugins/help.rs
@@ -6,7 +6,12 @@ pub struct HelpPlugin;
 impl Plugin for HelpPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let q = query.trim();
-        if q == "help" || q.starts_with("help ") {
+        const PREFIX: &str = "help";
+        const PREFIX_SPACE: &str = "help ";
+        if q.eq_ignore_ascii_case(PREFIX)
+            || (q.len() >= PREFIX_SPACE.len()
+                && q[..PREFIX_SPACE.len()].eq_ignore_ascii_case(PREFIX_SPACE))
+        {
             return vec![Action {
                 label: "Show command list".into(),
                 desc: "Display available command prefixes".into(),

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -8,10 +8,11 @@ pub struct HistoryPlugin;
 
 impl Plugin for HistoryPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if !query.starts_with("hi") {
+        const PREFIX: &str = "hi";
+        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
-        if query.trim() == "hi clear" {
+        if query.trim().eq_ignore_ascii_case("hi clear") {
             return vec![Action {
                 label: "Clear history".into(),
                 desc: "History".into(),
@@ -19,7 +20,7 @@ impl Plugin for HistoryPlugin {
                 args: None,
             }];
         }
-        let filter = query.strip_prefix("hi").unwrap_or("").trim();
+        let filter = query[PREFIX.len()..].trim();
         get_history()
             .into_iter()
             .enumerate()

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -118,8 +118,11 @@ impl Default for NotesPlugin {
 
 impl Plugin for NotesPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(text) = query.strip_prefix("note add ") {
-            let text = text.trim();
+        const ADD_PREFIX: &str = "note add ";
+        if query.len() >= ADD_PREFIX.len()
+            && query[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
+        {
+            let text = query[ADD_PREFIX.len()..].trim();
             if !text.is_empty() {
                 return vec![Action {
                     label: format!("Add note {text}"),
@@ -130,8 +133,11 @@ impl Plugin for NotesPlugin {
             }
         }
 
-        if let Some(pattern) = query.strip_prefix("note rm ") {
-            let filter = pattern.trim();
+        const RM_PREFIX: &str = "note rm ";
+        if query.len() >= RM_PREFIX.len()
+            && query[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let filter = query[RM_PREFIX.len()..].trim();
             let notes = self.data.lock().unwrap().clone();
             return notes
                 .into_iter()
@@ -146,8 +152,11 @@ impl Plugin for NotesPlugin {
                 .collect();
         }
 
-        if let Some(rest) = query.strip_prefix("note list") {
-            let filter = rest.trim();
+        const LIST_PREFIX: &str = "note list";
+        if query.len() >= LIST_PREFIX.len()
+            && query[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
+        {
+            let filter = query[LIST_PREFIX.len()..].trim();
             let notes = self.data.lock().unwrap().clone();
             return notes
                 .into_iter()
@@ -162,7 +171,7 @@ impl Plugin for NotesPlugin {
                 .collect();
         }
 
-        if query.trim() == "note" {
+        if query.trim().eq_ignore_ascii_case("note") {
             return vec![Action {
                 label: "note: edit notes".into(),
                 desc: "Note".into(),

--- a/src/plugins/processes.rs
+++ b/src/plugins/processes.rs
@@ -6,10 +6,11 @@ pub struct ProcessesPlugin;
 
 impl Plugin for ProcessesPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if !query.starts_with("ps") {
+        const PREFIX: &str = "ps";
+        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
-        let filter = query.strip_prefix("ps").unwrap_or("").trim().to_lowercase();
+        let filter = query[PREFIX.len()..].trim().to_lowercase();
         let system = System::new_all();
         system
             .processes()

--- a/src/plugins/recycle.rs
+++ b/src/plugins/recycle.rs
@@ -6,7 +6,9 @@ pub struct RecyclePlugin;
 impl Plugin for RecyclePlugin {
     #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
-        if query.trim_start().starts_with("rec") {
+        const PREFIX: &str = "rec";
+        let trimmed = query.trim_start();
+        if trimmed.len() >= PREFIX.len() && trimmed[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return vec![Action {
                 label: "Clean Recycle Bin".into(),
                 desc: "Recycle Bin".into(),

--- a/src/plugins/reddit.rs
+++ b/src/plugins/reddit.rs
@@ -5,8 +5,11 @@ pub struct RedditPlugin;
 
 impl Plugin for RedditPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(q) = query.strip_prefix("red ") {
-            let q = q.trim();
+        const PREFIX: &str = "red ";
+        if query.len() >= PREFIX.len()
+            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            let q = query[PREFIX.len()..].trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search Reddit for {q}"),

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -5,8 +5,11 @@ pub struct RunescapeSearchPlugin;
 
 impl Plugin for RunescapeSearchPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(q) = query.strip_prefix("rs ") {
-            let q = q.trim();
+        const RS_PREFIX: &str = "rs ";
+        if query.len() >= RS_PREFIX.len()
+            && query[..RS_PREFIX.len()].eq_ignore_ascii_case(RS_PREFIX)
+        {
+            let q = query[RS_PREFIX.len()..].trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search RuneScape Wiki for {q}"),
@@ -16,8 +19,11 @@ impl Plugin for RunescapeSearchPlugin {
                 }];
             }
         }
-        if let Some(q) = query.strip_prefix("osrs ") {
-            let q = q.trim();
+        const OSRS_PREFIX: &str = "osrs ";
+        if query.len() >= OSRS_PREFIX.len()
+            && query[..OSRS_PREFIX.len()].eq_ignore_ascii_case(OSRS_PREFIX)
+        {
+            let q = query[OSRS_PREFIX.len()..].trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search Old School RuneScape Wiki for {q}"),

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -66,7 +66,11 @@ impl Plugin for ShellPlugin {
             }];
         }
 
-        if let Some(rest) = trimmed.strip_prefix("sh add ") {
+        const ADD_PREFIX: &str = "sh add ";
+        if trimmed.len() >= ADD_PREFIX.len()
+            && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
+        {
+            let rest = &trimmed[ADD_PREFIX.len()..];
             let mut parts = rest.trim().splitn(2, ' ');
             let name = parts.next().unwrap_or("").trim();
             let args = parts.next().unwrap_or("").trim();
@@ -80,7 +84,11 @@ impl Plugin for ShellPlugin {
             }
         }
 
-        if let Some(rest) = trimmed.strip_prefix("sh rm") {
+        const RM_PREFIX: &str = "sh rm";
+        if trimmed.len() >= RM_PREFIX.len()
+            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let rest = &trimmed[RM_PREFIX.len()..];
             let filter = rest.trim();
             if let Ok(list) = load_shell_cmds(SHELL_CMDS_FILE) {
                 let matcher = SkimMatcherV2::default();
@@ -101,7 +109,11 @@ impl Plugin for ShellPlugin {
             }
         }
 
-        if let Some(rest) = trimmed.strip_prefix("sh list") {
+        const LIST_PREFIX: &str = "sh list";
+        if trimmed.len() >= LIST_PREFIX.len()
+            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
+        {
+            let rest = &trimmed[LIST_PREFIX.len()..];
             let filter = rest.trim();
             if let Ok(list) = load_shell_cmds(SHELL_CMDS_FILE) {
                 let matcher = SkimMatcherV2::default();
@@ -121,7 +133,11 @@ impl Plugin for ShellPlugin {
             }
         }
 
-        if let Some(cmd) = trimmed.strip_prefix("sh ") {
+        const CMD_PREFIX: &str = "sh ";
+        if trimmed.len() >= CMD_PREFIX.len()
+            && trimmed[..CMD_PREFIX.len()].eq_ignore_ascii_case(CMD_PREFIX)
+        {
+            let cmd = &trimmed[CMD_PREFIX.len()..];
             let arg = cmd.trim();
             if arg.is_empty() {
                 return Vec::new();

--- a/src/plugins/system.rs
+++ b/src/plugins/system.rs
@@ -5,10 +5,11 @@ pub struct SystemPlugin;
 
 impl Plugin for SystemPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if !query.starts_with("sys") {
+        const PREFIX: &str = "sys";
+        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
             return Vec::new();
         }
-        let filter = query.strip_prefix("sys").unwrap_or("").trim();
+        let filter = query[PREFIX.len()..].trim();
         const OPTIONS: [&str; 4] = ["shutdown", "reboot", "lock", "logoff"];
         OPTIONS
             .iter()

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -119,7 +119,7 @@ pub struct TempfilePlugin;
 impl Plugin for TempfilePlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed == "tmp" {
+        if trimmed.eq_ignore_ascii_case("tmp") {
             return vec![Action {
                 label: "tmp: create".into(),
                 desc: "Tempfile".into(),
@@ -127,8 +127,11 @@ impl Plugin for TempfilePlugin {
                 args: None,
             }];
         }
-        if let Some(alias) = trimmed.strip_prefix("tmp new ") {
-            let alias = alias.trim();
+        const NEW_PREFIX: &str = "tmp new ";
+        if trimmed.len() >= NEW_PREFIX.len()
+            && trimmed[..NEW_PREFIX.len()].eq_ignore_ascii_case(NEW_PREFIX)
+        {
+            let alias = trimmed[NEW_PREFIX.len()..].trim();
             if !alias.is_empty() && validate_alias(alias).is_ok() {
                 return vec![Action {
                     label: format!("Create temp file {alias}"),
@@ -137,7 +140,7 @@ impl Plugin for TempfilePlugin {
                     args: None,
                 }];
             }
-        } else if trimmed == "tmp new" {
+        } else if trimmed.eq_ignore_ascii_case("tmp new") {
             return vec![Action {
                 label: "Create temp file".into(),
                 desc: "Tempfile".into(),
@@ -145,7 +148,7 @@ impl Plugin for TempfilePlugin {
                 args: None,
             }];
         }
-        if trimmed == "tmp open" {
+        if trimmed.eq_ignore_ascii_case("tmp open") {
             return vec![Action {
                 label: "Open temp directory".into(),
                 desc: "Tempfile".into(),
@@ -153,7 +156,7 @@ impl Plugin for TempfilePlugin {
                 args: None,
             }];
         }
-        if trimmed == "tmp clear" {
+        if trimmed.eq_ignore_ascii_case("tmp clear") {
             return vec![Action {
                 label: "Clear temp files".into(),
                 desc: "Tempfile".into(),
@@ -161,8 +164,11 @@ impl Plugin for TempfilePlugin {
                 args: None,
             }];
         }
-        if let Some(filter) = trimmed.strip_prefix("tmp rm") {
-            let filter = filter.trim();
+        const RM_PREFIX: &str = "tmp rm";
+        if trimmed.len() >= RM_PREFIX.len()
+            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let filter = trimmed[RM_PREFIX.len()..].trim();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()
@@ -181,7 +187,11 @@ impl Plugin for TempfilePlugin {
                 })
                 .collect();
         }
-        if let Some(rest) = trimmed.strip_prefix("tmp alias") {
+        const ALIAS_PREFIX: &str = "tmp alias";
+        if trimmed.len() >= ALIAS_PREFIX.len()
+            && trimmed[..ALIAS_PREFIX.len()].eq_ignore_ascii_case(ALIAS_PREFIX)
+        {
+            let rest = &trimmed[ALIAS_PREFIX.len()..];
             let mut parts = rest.trim().splitn(2, ' ');
             if let (Some(file), Some(alias)) = (parts.next(), parts.next()) {
                 let file = file.trim();
@@ -205,8 +215,11 @@ impl Plugin for TempfilePlugin {
                 }
             }
         }
-        if let Some(filter) = trimmed.strip_prefix("tmp list") {
-            let filter = filter.trim();
+        const LIST_PREFIX: &str = "tmp list";
+        if trimmed.len() >= LIST_PREFIX.len()
+            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
+        {
+            let filter = trimmed[LIST_PREFIX.len()..].trim();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -131,7 +131,7 @@ impl Plugin for TodoPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
 
-        if trimmed.eq("todo") {
+        if trimmed.eq_ignore_ascii_case("todo") {
             return vec![Action {
                 label: "todo: edit todos".into(),
                 desc: "Todo".into(),
@@ -140,7 +140,7 @@ impl Plugin for TodoPlugin {
             }];
         }
 
-        if trimmed.eq("todo clear") {
+        if trimmed.eq_ignore_ascii_case("todo clear") {
             return vec![Action {
                 label: "Clear completed todos".into(),
                 desc: "Todo".into(),
@@ -149,7 +149,7 @@ impl Plugin for TodoPlugin {
             }];
         }
 
-        if trimmed.eq("todo add") {
+        if trimmed.eq_ignore_ascii_case("todo add") {
             return vec![Action {
                 label: "todo: edit todos".into(),
                 desc: "Todo".into(),
@@ -158,8 +158,11 @@ impl Plugin for TodoPlugin {
             }];
         }
 
-        if let Some(text) = trimmed.strip_prefix("todo add ") {
-            let text = text.trim();
+        const ADD_PREFIX: &str = "todo add ";
+        if trimmed.len() >= ADD_PREFIX.len()
+            && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
+        {
+            let text = trimmed[ADD_PREFIX.len()..].trim();
             if !text.is_empty() {
                 return vec![Action {
                     label: format!("Add todo {text}"),
@@ -170,8 +173,11 @@ impl Plugin for TodoPlugin {
             }
         }
 
-        if let Some(pattern) = trimmed.strip_prefix("todo rm ") {
-            let filter = pattern.trim();
+        const RM_PREFIX: &str = "todo rm ";
+        if trimmed.len() >= RM_PREFIX.len()
+            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
+        {
+            let filter = trimmed[RM_PREFIX.len()..].trim();
             let todos = self.data.lock().unwrap().clone();
             return todos
                 .into_iter()
@@ -186,8 +192,11 @@ impl Plugin for TodoPlugin {
                 .collect();
         }
 
-        if let Some(rest) = trimmed.strip_prefix("todo list") {
-            let filter = rest.trim();
+        const LIST_PREFIX: &str = "todo list";
+        if trimmed.len() >= LIST_PREFIX.len()
+            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
+        {
+            let filter = trimmed[LIST_PREFIX.len()..].trim();
             let todos = self.data.lock().unwrap().clone();
             return todos
                 .into_iter()

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -78,10 +78,16 @@ fn parse_query(query: &str) -> Option<(f64, String, String)> {
 impl Plugin for UnitConvertPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        let rest = if let Some(r) = trimmed.strip_prefix("conv ") {
-            r
-        } else if let Some(r) = trimmed.strip_prefix("convert ") {
-            r
+        const CONV_PREFIX: &str = "conv ";
+        const CONVERT_PREFIX: &str = "convert ";
+        let rest = if trimmed.len() >= CONV_PREFIX.len()
+            && trimmed[..CONV_PREFIX.len()].eq_ignore_ascii_case(CONV_PREFIX)
+        {
+            &trimmed[CONV_PREFIX.len()..]
+        } else if trimmed.len() >= CONVERT_PREFIX.len()
+            && trimmed[..CONVERT_PREFIX.len()].eq_ignore_ascii_case(CONVERT_PREFIX)
+        {
+            &trimmed[CONVERT_PREFIX.len()..]
         } else {
             return Vec::new();
         };

--- a/src/plugins/weather.rs
+++ b/src/plugins/weather.rs
@@ -6,7 +6,11 @@ pub struct WeatherPlugin;
 
 impl Plugin for WeatherPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(q) = query.strip_prefix("weather ") {
+        const PREFIX: &str = "weather ";
+        if query.len() >= PREFIX.len()
+            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            let q = query[PREFIX.len()..].trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {

--- a/src/plugins/wikipedia.rs
+++ b/src/plugins/wikipedia.rs
@@ -5,7 +5,11 @@ pub struct WikipediaPlugin;
 
 impl Plugin for WikipediaPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(q) = query.strip_prefix("wiki ") {
+        const PREFIX: &str = "wiki ";
+        if query.len() >= PREFIX.len()
+            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            let q = query[PREFIX.len()..].trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {

--- a/src/plugins/youtube.rs
+++ b/src/plugins/youtube.rs
@@ -5,7 +5,11 @@ pub struct YoutubePlugin;
 
 impl Plugin for YoutubePlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if let Some(q) = query.strip_prefix("yt ") {
+        const PREFIX: &str = "yt ";
+        if query.len() >= PREFIX.len()
+            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            let q = query[PREFIX.len()..].trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {


### PR DESCRIPTION
## Summary
- update plugin prefix checks to use `eq_ignore_ascii_case`
- install ALSA headers to run tests

## Testing
- `cargo test --workspace --all-features`

------
https://chatgpt.com/codex/tasks/task_e_6876f049c0688332a42eeb938aea45fe