### PR TITLE
Ensure case-insensitive contains checks

### DIFF
--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -160,12 +160,12 @@ impl Plugin for ClipboardPlugin {
                 .collect();
         }
 
-        let filter = trimmed[PREFIX.len()..].trim();
+        let filter = trimmed[PREFIX.len()..].trim().to_lowercase();
         let history = self.update_history();
         history
             .iter()
             .enumerate()
-            .filter(|(_, entry)| entry.contains(filter))
+            .filter(|(_, entry)| entry.to_lowercase().contains(&filter))
             .map(|(idx, entry)| Action {
                 label: entry.clone(),
                 desc: "Clipboard".into(),

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -1,6 +1,6 @@
 use crate::actions::Action;
-use crate::plugin::Plugin;
 use crate::history::get_history;
+use crate::plugin::Plugin;
 
 const MAX_HISTORY_RESULTS: usize = 10;
 
@@ -20,11 +20,11 @@ impl Plugin for HistoryPlugin {
                 args: None,
             }];
         }
-        let filter = query[PREFIX.len()..].trim();
+        let filter = query[PREFIX.len()..].trim().to_lowercase();
         get_history()
             .into_iter()
             .enumerate()
-            .filter(|(_, entry)| entry.query.contains(filter))
+            .filter(|(_, entry)| entry.query.to_lowercase().contains(&filter))
             .take(MAX_HISTORY_RESULTS)
             .map(|(idx, entry)| Action {
                 label: entry.query,

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -168,7 +168,7 @@ impl Plugin for TempfilePlugin {
         if trimmed.len() >= RM_PREFIX.len()
             && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
         {
-            let filter = trimmed[RM_PREFIX.len()..].trim();
+            let filter = trimmed[RM_PREFIX.len()..].trim().to_lowercase();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()
@@ -176,7 +176,7 @@ impl Plugin for TempfilePlugin {
                     filter.is_empty()
                         || p.file_name()
                             .and_then(|n| n.to_str())
-                            .map(|n| n.contains(filter))
+                            .map(|n| n.to_lowercase().contains(&filter))
                             .unwrap_or(false)
                 })
                 .map(|p| Action {
@@ -219,7 +219,7 @@ impl Plugin for TempfilePlugin {
         if trimmed.len() >= LIST_PREFIX.len()
             && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
         {
-            let filter = trimmed[LIST_PREFIX.len()..].trim();
+            let filter = trimmed[LIST_PREFIX.len()..].trim().to_lowercase();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()
@@ -227,7 +227,7 @@ impl Plugin for TempfilePlugin {
                     filter.is_empty()
                         || p.file_name()
                             .and_then(|n| n.to_str())
-                            .map(|n| n.contains(filter))
+                            .map(|n| n.to_lowercase().contains(&filter))
                             .unwrap_or(false)
                 })
                 .map(|p| Action {


### PR DESCRIPTION
## Summary
- normalize filter strings to lowercase in clipboard, history and tempfile plugins
- compare candidates in lowercase for case-insensitive matching

## Testing
- `cargo test` *(fails: alsa-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876f31770d08332b5955542e211fc8a