### PR TITLE
Adjust plugin search filtering when fuzzy disabled

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -36,6 +36,7 @@ use std::time::Instant;
 
 const SUBCOMMANDS: &[&str] = &[
     "add", "rm", "list", "clear", "open", "new", "alias", "set", "pause", "resume", "cancel",
+    "edit", "ma",
 ];
 
 fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -454,9 +454,26 @@ impl LauncherApp {
                 Some(&filter),
                 self.enabled_capabilities.as_ref(),
             );
-            for a in plugin_results {
+            let query_term = trimmed_lc
+                .splitn(2, ' ')
+                .nth(1)
+                .unwrap_or(&trimmed_lc)
+                .to_string();
+            for mut a in plugin_results {
                 if self.fuzzy_weight <= 0.0 {
-                    res.push((a, 0.0));
+                    let alias_match = self
+                        .folder_aliases
+                        .get(&a.action)
+                        .or_else(|| self.bookmark_aliases.get(&a.action))
+                        .and_then(|v| v.as_ref())
+                        .map(|s| s.to_lowercase().contains(&query_term))
+                        .unwrap_or(false);
+                    let label_match = a.label.to_lowercase().contains(&query_term);
+                    let desc_match = a.desc.to_lowercase().contains(&query_term);
+                    if label_match || desc_match || alias_match {
+                        let score = if alias_match { 1.0 } else { 0.0 };
+                        res.push((a, score));
+                    }
                 } else {
                     let score = if self.query.is_empty() {
                         0.0
@@ -504,9 +521,26 @@ impl LauncherApp {
                 self.enabled_plugins.as_ref(),
                 self.enabled_capabilities.as_ref(),
             );
-            for a in plugin_results {
+            let query_term = trimmed_lc
+                .splitn(2, ' ')
+                .nth(1)
+                .unwrap_or(&trimmed_lc)
+                .to_string();
+            for mut a in plugin_results {
                 if self.fuzzy_weight <= 0.0 {
-                    res.push((a, 0.0));
+                    let alias_match = self
+                        .folder_aliases
+                        .get(&a.action)
+                        .or_else(|| self.bookmark_aliases.get(&a.action))
+                        .and_then(|v| v.as_ref())
+                        .map(|s| s.to_lowercase().contains(&query_term))
+                        .unwrap_or(false);
+                    let label_match = a.label.to_lowercase().contains(&query_term);
+                    let desc_match = a.desc.to_lowercase().contains(&query_term);
+                    if label_match || desc_match || alias_match {
+                        let score = if alias_match { 1.0 } else { 0.0 };
+                        res.push((a, score));
+                    }
                 } else {
                     let score = if self.query.is_empty() {
                         0.0

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -454,25 +454,25 @@ impl LauncherApp {
                 Some(&filter),
                 self.enabled_capabilities.as_ref(),
             );
-            let query_term = trimmed_lc
-                .splitn(2, ' ')
-                .nth(1)
-                .unwrap_or(&trimmed_lc)
-                .to_string();
-            for mut a in plugin_results {
+            let query_term = trimmed_lc.splitn(2, ' ').nth(1).unwrap_or("").to_string();
+            for a in plugin_results {
                 if self.fuzzy_weight <= 0.0 {
-                    let alias_match = self
-                        .folder_aliases
-                        .get(&a.action)
-                        .or_else(|| self.bookmark_aliases.get(&a.action))
-                        .and_then(|v| v.as_ref())
-                        .map(|s| s.to_lowercase().contains(&query_term))
-                        .unwrap_or(false);
-                    let label_match = a.label.to_lowercase().contains(&query_term);
-                    let desc_match = a.desc.to_lowercase().contains(&query_term);
-                    if label_match || desc_match || alias_match {
-                        let score = if alias_match { 1.0 } else { 0.0 };
-                        res.push((a, score));
+                    if query_term.is_empty() {
+                        res.push((a, 0.0));
+                    } else {
+                        let alias_match = self
+                            .folder_aliases
+                            .get(&a.action)
+                            .or_else(|| self.bookmark_aliases.get(&a.action))
+                            .and_then(|v| v.as_ref())
+                            .map(|s| s.to_lowercase().contains(&query_term))
+                            .unwrap_or(false);
+                        let label_match = a.label.to_lowercase().contains(&query_term);
+                        let desc_match = a.desc.to_lowercase().contains(&query_term);
+                        if label_match || desc_match || alias_match {
+                            let score = if alias_match { 1.0 } else { 0.0 };
+                            res.push((a, score));
+                        }
                     }
                 } else {
                     let score = if self.query.is_empty() {
@@ -521,25 +521,25 @@ impl LauncherApp {
                 self.enabled_plugins.as_ref(),
                 self.enabled_capabilities.as_ref(),
             );
-            let query_term = trimmed_lc
-                .splitn(2, ' ')
-                .nth(1)
-                .unwrap_or(&trimmed_lc)
-                .to_string();
-            for mut a in plugin_results {
+            let query_term = trimmed_lc.splitn(2, ' ').nth(1).unwrap_or("").to_string();
+            for a in plugin_results {
                 if self.fuzzy_weight <= 0.0 {
-                    let alias_match = self
-                        .folder_aliases
-                        .get(&a.action)
-                        .or_else(|| self.bookmark_aliases.get(&a.action))
-                        .and_then(|v| v.as_ref())
-                        .map(|s| s.to_lowercase().contains(&query_term))
-                        .unwrap_or(false);
-                    let label_match = a.label.to_lowercase().contains(&query_term);
-                    let desc_match = a.desc.to_lowercase().contains(&query_term);
-                    if label_match || desc_match || alias_match {
-                        let score = if alias_match { 1.0 } else { 0.0 };
-                        res.push((a, score));
+                    if query_term.is_empty() {
+                        res.push((a, 0.0));
+                    } else {
+                        let alias_match = self
+                            .folder_aliases
+                            .get(&a.action)
+                            .or_else(|| self.bookmark_aliases.get(&a.action))
+                            .and_then(|v| v.as_ref())
+                            .map(|s| s.to_lowercase().contains(&query_term))
+                            .unwrap_or(false);
+                        let label_match = a.label.to_lowercase().contains(&query_term);
+                        let desc_match = a.desc.to_lowercase().contains(&query_term);
+                        if label_match || desc_match || alias_match {
+                            let score = if alias_match { 1.0 } else { 0.0 };
+                            res.push((a, score));
+                        }
                     }
                 } else {
                     let score = if self.query.is_empty() {
@@ -806,10 +806,8 @@ impl eframe::App for LauncherApp {
             }
 
             scale_ui(ui, self.query_scale, |ui| {
-                let input = ui.add(
-                    egui::TextEdit::singleline(&mut self.query)
-                        .desired_width(f32::INFINITY),
-                );
+                let input = ui
+                    .add(egui::TextEdit::singleline(&mut self.query).desired_width(f32::INFINITY));
                 if just_became_visible || self.focus_query {
                     input.request_focus();
                     self.focus_query = false;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -34,6 +34,10 @@ use std::sync::{
 };
 use std::time::Instant;
 
+const SUBCOMMANDS: &[&str] = &[
+    "add", "rm", "list", "clear", "open", "new", "alias", "set", "pause", "resume", "cancel",
+];
+
 fn scale_ui<R>(ui: &mut egui::Ui, scale: f32, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
     ui.scope(|ui| {
         if (scale - 1.0).abs() > f32::EPSILON {
@@ -521,7 +525,16 @@ impl LauncherApp {
                 self.enabled_plugins.as_ref(),
                 self.enabled_capabilities.as_ref(),
             );
-            let query_term = trimmed_lc.splitn(2, ' ').nth(1).unwrap_or("").to_string();
+            let tail = trimmed_lc.splitn(2, " ").nth(1).unwrap_or("");
+            let mut query_term = tail.splitn(3, " ").nth(1).unwrap_or("").to_string();
+            if query_term.is_empty() {
+                let parts: Vec<&str> = tail.split_whitespace().collect();
+                if parts.len() == 1 && !SUBCOMMANDS.contains(&parts[0]) {
+                    query_term = parts[0].to_string();
+                } else if parts.len() > 1 {
+                    query_term = parts[1..].join(" ");
+                }
+            }
             for a in plugin_results {
                 if self.fuzzy_weight <= 0.0 {
                     if query_term.is_empty() {

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -2,6 +2,7 @@ use eframe::egui;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::plugins::bookmarks::{save_bookmarks, BookmarkEntry, BOOKMARKS_FILE};
+use multi_launcher::plugins::snippets::{save_snippets, SnippetEntry, SNIPPETS_FILE};
 use multi_launcher::settings::Settings;
 use once_cell::sync::Lazy;
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
@@ -73,6 +74,22 @@ fn plugin_command_unfiltered_when_no_query() {
     let ctx = egui::Context::default();
     let mut app = new_app(&ctx, settings);
     app.query = "bm list".into();
+    app.search();
+    assert_eq!(app.results.len(), 1);
+}
+
+#[test]
+fn snippet_edit_command_unfiltered() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let entries = vec![SnippetEntry { alias: "foo".into(), text: "bar".into() }];
+    save_snippets(SNIPPETS_FILE, &entries).unwrap();
+    let mut settings = Settings::default();
+    settings.fuzzy_weight = 0.0;
+    let ctx = egui::Context::default();
+    let mut app = new_app(&ctx, settings);
+    app.query = "cs edit".into();
     app.search();
     assert_eq!(app.results.len(), 1);
 }

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -1,11 +1,11 @@
+use eframe::egui;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
+use multi_launcher::plugins::bookmarks::{save_bookmarks, BookmarkEntry, BOOKMARKS_FILE};
 use multi_launcher::settings::Settings;
-use multi_launcher::plugins::bookmarks::{BookmarkEntry, save_bookmarks, BOOKMARKS_FILE};
-use tempfile::tempdir;
 use once_cell::sync::Lazy;
-use std::sync::{Mutex, Arc, atomic::AtomicBool};
-use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use tempfile::tempdir;
 
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -38,7 +38,10 @@ fn plugin_query_is_exact_when_fuzzy_disabled() {
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
 
-    let entries = vec![BookmarkEntry { url: "https://example.com".into(), alias: Some("foobar".into()) }];
+    let entries = vec![BookmarkEntry {
+        url: "https://example.com".into(),
+        alias: Some("foobar".into()),
+    }];
     save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
 
     let mut settings = Settings::default();
@@ -53,4 +56,23 @@ fn plugin_query_is_exact_when_fuzzy_disabled() {
     app.query = "bm fbr".into();
     app.search();
     assert_eq!(app.results.len(), 0);
+}
+
+#[test]
+fn plugin_command_unfiltered_when_no_query() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let entries = vec![BookmarkEntry {
+        url: "https://example.com".into(),
+        alias: None,
+    }];
+    save_bookmarks(BOOKMARKS_FILE, &entries).unwrap();
+    let mut settings = Settings::default();
+    settings.fuzzy_weight = 0.0;
+    let ctx = egui::Context::default();
+    let mut app = new_app(&ctx, settings);
+    app.query = "bm list".into();
+    app.search();
+    assert_eq!(app.results.len(), 1);
 }


### PR DESCRIPTION
## Summary
- filter plugin actions by alias/label/description when fuzzy search is disabled
- prioritize alias matches in score
- add regression test ensuring plugin search obeys exact-match mode

## Testing
- `cargo test --quiet`

 