### PR TITLE
Rename command editor to app editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,18 +266,18 @@ memory and disk usage or `info cpu` for a single metric.
 ### Security Considerations
 The shell plugin runs commands using the system shell without sanitising input. Only enable it if you trust the commands you type. Errors while spawning the process are logged.
 Type `sh` in the launcher to open the shell command editor for managing predefined commands. Saved commands can also be added with `sh add <name> <command>`, removed via `sh rm <pattern>` or listed with `sh list`.
-## Editing Commands
+## Editing Apps
 The launcher stores its custom actions in `actions.json` next to the
-executable. This file is created automatically the first time you save a
-command. While running the application you can manage this list through
-**Edit Commands**. Open the launcher with the configured hotkey and choose
-*Edit Commands* from the menu.
-Use the **New Command** button to open the *Add Command* dialog where you enter
+executable. This file is created automatically the first time you save an
+app. While running the application you can manage this list through
+**Edit Apps**. Open the launcher with the configured hotkey and choose
+*Edit Apps* from the menu.
+Use the **New App** button to open the *Add App* dialog where you enter
 a label, description and the executable path. Enable **Add arguments** to supply
 extra command line parameters. The **Browse** button lets you
 select the file interactively. Existing entries can be edited via the **Edit**
-button or by right clicking a command in the results list and choosing *Edit
-Command*. Commands can also be removed from the list. All changes are written to
+button or by right clicking an app in the results list and choosing *Edit
+App*. Apps can also be removed from the list. All changes are written to
 `actions.json` immediately.
 
 ## Packaging

--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -3,10 +3,10 @@ use crate::add_action_dialog::AddActionDialog;
 use crate::gui::LauncherApp;
 use eframe::egui;
 
-/// State container for the command editor window.
+/// State container for the app editor window.
 ///
 /// It tracks the current search filter and manages the nested
-/// [`AddActionDialog`] used when creating new commands.
+/// [`AddActionDialog`] used when creating new apps.
 pub struct ActionsEditor {
     /// Search text used to filter the displayed actions.
     search: String,
@@ -24,25 +24,25 @@ impl Default for ActionsEditor {
 }
 
 impl ActionsEditor {
-    /// Open the dialog for editing an existing command.
+    /// Open the dialog for editing an existing app.
     pub fn open_edit(&mut self, idx: usize, act: &crate::actions::Action) {
         self.dialog.open_edit(idx, act);
     }
 
-    /// Render the command editor window.
+    /// Render the app editor window.
     ///
     /// * `ctx` - Egui context used for drawing the editor UI.
     /// * `app` - Mutable reference to the application state. Actions can be
     ///   added or removed and will be persisted when modified.
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
         let mut open = app.show_editor;
-        egui::Window::new("Command Editor")
+        egui::Window::new("App Editor")
             .open(&mut open)
             .show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Search");
                 ui.text_edit_singleline(&mut self.search);
-                if ui.button("New Command").clicked() {
+                if ui.button("New App").clicked() {
                     self.dialog.open_add();
                 }
             });

--- a/src/add_action_dialog.rs
+++ b/src/add_action_dialog.rs
@@ -74,7 +74,7 @@ impl AddActionDialog {
         self.mode = DialogMode::Edit(idx);
     }
 
-    /// Draw the "Add Command" dialog and update `app` with any new action.
+    /// Draw the "Add App" dialog and update `app` with any new action.
     ///
     /// * `ctx` - Egui context used to render the window.
     /// * `app` - Application state that will receive the new action if the
@@ -85,8 +85,8 @@ impl AddActionDialog {
         }
         let mut should_close = false;
         let title = match self.mode {
-            DialogMode::Add => "Add Command",
-            DialogMode::Edit(_) => "Edit Command",
+            DialogMode::Add => "Add App",
+            DialogMode::Edit(_) => "Edit App",
         };
         egui::Window::new(title)
             .open(&mut self.open)

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -736,8 +736,8 @@ impl eframe::App for LauncherApp {
         TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             menu::bar(ui, |ui| {
                 ui.menu_button("File", |ui| {
-                    ui.menu_button("Commands", |ui| {
-                        if ui.button("Edit Commands").clicked() {
+                    ui.menu_button("Apps", |ui| {
+                        if ui.button("Edit Apps").clicked() {
                             self.show_editor = !self.show_editor;
                         }
                         if ui.button("Edit Plugins").clicked() {
@@ -1350,7 +1350,7 @@ impl eframe::App for LauncherApp {
                             }
                             if let Some(idx_act) = custom_idx {
                                 menu_resp.clone().context_menu(|ui| {
-                                    if ui.button("Edit Command").clicked() {
+                                    if ui.button("Edit App").clicked() {
                                         self.editor.open_edit(idx_act, &self.actions[idx_act]);
                                         self.show_editor = true;
                                         ui.close_menu();


### PR DESCRIPTION
## Summary
- rename menu label to `Apps` and button to `Edit Apps`
- update context menu to say `Edit App`
- rename `Command Editor` window to `App Editor`
- rename `New Command` button to `New App`
- update add action dialog titles to `Add App` / `Edit App`
- update docs to use `App Editor` wording

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_687953f63fd4833290c4ad70b13a6a45