### PR TITLE
Add app prefix for action search

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Built-in plugins and their command prefixes are:
 - Recycle Bin cleanup (`rec`)
 - Temporary files (`tmp`, `tmp new [name]`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)
 - ASCII art (`ascii text`)
+- Saved apps (`app <filter>` or just `app`)
 - Volume control (`vol 50`) *(Windows only)*
 - Brightness control (`bright 50`) *(Windows only)*
 - Command overview (`help`)
@@ -279,6 +280,9 @@ select the file interactively. Existing entries can be edited via the **Edit**
 button or by right clicking an app in the results list and choosing *Edit
 App*. Apps can also be removed from the list. All changes are written to
 `actions.json` immediately.
+
+Type `app <filter>` in the launcher to search these saved entries. Typing `app`
+alone lists all saved apps.
 
 ## Packaging
 

--- a/tests/ranking.rs
+++ b/tests/ranking.rs
@@ -1,4 +1,4 @@
-use multi_launcher::gui::LauncherApp;
+use multi_launcher::gui::{LauncherApp, APP_PREFIX};
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::actions::Action;
 use multi_launcher::settings::Settings;
@@ -35,7 +35,7 @@ fn usage_ranking() {
     let settings = Settings::default();
     let mut app = new_app_with_settings(&ctx, actions, settings);
     app.usage.insert("b".into(), 5);
-    app.query = "foo".into();
+    app.query = format!("{} foo", APP_PREFIX);
     app.search();
     assert_eq!(app.results[0].action, "b");
 }
@@ -52,7 +52,7 @@ fn fuzzy_vs_usage_weight() {
     settings.usage_weight = 1.0;
     let mut app = new_app_with_settings(&ctx, actions, settings);
     app.usage.insert("b".into(), 20);
-    app.query = "abc".into();
+    app.query = format!("{} abc", APP_PREFIX);
     app.search();
     assert_eq!(app.results[0].action, "a");
 }

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -1,4 +1,4 @@
-use multi_launcher::gui::LauncherApp;
+use multi_launcher::gui::{LauncherApp, APP_PREFIX};
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::actions::Action;
 use multi_launcher::settings::Settings;
@@ -33,6 +33,7 @@ fn arrow_keys_update_selection() {
         Action { label: "two".into(), desc: "".into(), action: "two".into(), args: None },
     ];
     let mut app = new_app(&ctx, acts);
+    app.query = APP_PREFIX.into();
     app.search();
     assert_eq!(app.selected, None);
     app.handle_key(egui::Key::ArrowDown);
@@ -51,6 +52,7 @@ fn enter_returns_selected_index() {
         Action { label: "two".into(), desc: "".into(), action: "two".into(), args: None },
     ];
     let mut app = new_app(&ctx, acts);
+    app.query = APP_PREFIX.into();
     app.search();
     app.handle_key(egui::Key::ArrowDown);
     let idx = app.handle_key(egui::Key::Enter);


### PR DESCRIPTION
## Summary
- introduce `APP_PREFIX` constant for user apps
- search actions only when query begins with this prefix
- update tests for the new prefix
- document the prefix in the README

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68795643b2048332b219da4768db512b