### PR TITLE
Display plugin commands with empty query

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ RUST_LOG=info cargo run
 ## Tips
 
 - Press the help hotkey (F1 by default) to display a quick list of available commands.
+- Leave the query empty to view plugin shortcut commands.
 - Right click a folder result to set a custom alias for easier access.
 - Use the *Snapshot* button in Settings when adjusting static window placement.
 - Searches are case-insensitive and also match on command aliases.

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -30,14 +30,14 @@ impl HelpWindow {
                     }
                     ui.separator();
                     ui.label(egui::RichText::new("Commands").strong());
-                    let mut infos = app.plugins.plugin_infos();
-                    infos.sort_by(|a, b| a.0.cmp(&b.0));
+                    let mut list = app.command_shortcuts();
+                    list.sort_by(|a, b| a.label.cmp(&b.label));
                     let area_height = ui.available_height();
                     egui::ScrollArea::vertical()
                         .max_height(area_height)
                         .show(ui, |ui| {
-                            for (name, desc, _) in &infos {
-                                ui.label(format!("{name}: {desc}"));
+                            for a in &list {
+                                ui.monospace(&a.label);
                             }
                         });
                 });

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -38,6 +38,10 @@ pub trait Plugin: Send + Sync {
     fn description(&self) -> &str;
     /// Capabilities offered by the plugin
     fn capabilities(&self) -> &[&str];
+    /// Return example query shortcuts provided by the plugin
+    fn commands(&self) -> Vec<Action> {
+        Vec::new()
+    }
 }
 
 /// A manager that holds plugins
@@ -125,6 +129,14 @@ impl PluginManager {
                     p.capabilities().iter().map(|c| c.to_string()).collect(),
                 )
             })
+            .collect()
+    }
+
+    /// Collect command shortcuts from all plugins.
+    pub fn commands(&self) -> Vec<Action> {
+        self.plugins
+            .iter()
+            .flat_map(|p| p.commands())
             .collect()
     }
 

--- a/src/plugins/asciiart.rs
+++ b/src/plugins/asciiart.rs
@@ -52,5 +52,9 @@ impl Plugin for AsciiArtPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "ascii".into(), desc: "asciiart".into(), action: "fill:ascii ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -282,4 +282,13 @@ impl Plugin for BookmarksPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "bm".into(), desc: "bookmarks".into(), action: "fill:bm ".into(), args: None },
+            Action { label: "bm add".into(), desc: "bookmarks".into(), action: "fill:bm add ".into(), args: None },
+            Action { label: "bm rm".into(), desc: "bookmarks".into(), action: "fill:bm rm ".into(), args: None },
+            Action { label: "bm list".into(), desc: "bookmarks".into(), action: "fill:bm list ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -45,4 +45,15 @@ impl Plugin for BrightnessPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        #[cfg(target_os = "windows")]
+        {
+            vec![Action { label: "bright".into(), desc: "brightness".into(), action: "fill:bright ".into(), args: None }]
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Vec::new()
+        }
+    }
 }

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -186,4 +186,12 @@ impl Plugin for ClipboardPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "cb".into(), desc: "clipboard".into(), action: "fill:cb ".into(), args: None },
+            Action { label: "cb clear".into(), desc: "clipboard".into(), action: "fill:cb clear".into(), args: None },
+            Action { label: "cb list".into(), desc: "clipboard".into(), action: "fill:cb list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/dropcalc.rs
+++ b/src/plugins/dropcalc.rs
@@ -60,5 +60,9 @@ impl Plugin for DropCalcPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "drop".into(), desc: "dropcalc".into(), action: "fill:drop ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -252,4 +252,12 @@ impl Plugin for FoldersPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search", "show_full_path"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "f".into(), desc: "folders".into(), action: "fill:f ".into(), args: None },
+            Action { label: "f add".into(), desc: "folders".into(), action: "fill:f add ".into(), args: None },
+            Action { label: "f rm".into(), desc: "folders".into(), action: "fill:f rm ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/help.rs
+++ b/src/plugins/help.rs
@@ -33,5 +33,9 @@ impl Plugin for HelpPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "help".into(), desc: "help".into(), action: "fill:help".into(), args: None }]
+    }
 }
 

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -46,4 +46,11 @@ impl Plugin for HistoryPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "hi".into(), desc: "history".into(), action: "fill:hi ".into(), args: None },
+            Action { label: "hi clear".into(), desc: "history".into(), action: "fill:hi clear".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -194,4 +194,13 @@ impl Plugin for NotesPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "note".into(), desc: "notes".into(), action: "fill:note ".into(), args: None },
+            Action { label: "note add".into(), desc: "notes".into(), action: "fill:note add ".into(), args: None },
+            Action { label: "note rm".into(), desc: "notes".into(), action: "fill:note rm ".into(), args: None },
+            Action { label: "note list".into(), desc: "notes".into(), action: "fill:note list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/processes.rs
+++ b/src/plugins/processes.rs
@@ -57,5 +57,9 @@ impl Plugin for ProcessesPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "ps".into(), desc: "processes".into(), action: "fill:ps ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/recycle.rs
+++ b/src/plugins/recycle.rs
@@ -35,5 +35,16 @@ impl Plugin for RecyclePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        #[cfg(target_os = "windows")]
+        {
+            vec![Action { label: "rec".into(), desc: "recycle".into(), action: "fill:rec".into(), args: None }]
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Vec::new()
+        }
+    }
 }
 

--- a/src/plugins/reddit.rs
+++ b/src/plugins/reddit.rs
@@ -33,4 +33,8 @@ impl Plugin for RedditPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "red".into(), desc: "reddit".into(), action: "fill:red ".into(), args: None }]
+    }
 }

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -47,5 +47,12 @@ impl Plugin for RunescapeSearchPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "rs".into(), desc: "runescape_search".into(), action: "fill:rs ".into(), args: None },
+            Action { label: "osrs".into(), desc: "runescape_search".into(), action: "fill:osrs ".into(), args: None },
+        ]
+    }
 }
 

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -182,4 +182,13 @@ impl Plugin for ShellPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "sh".into(), desc: "shell".into(), action: "fill:sh ".into(), args: None },
+            Action { label: "sh add".into(), desc: "shell".into(), action: "fill:sh add ".into(), args: None },
+            Action { label: "sh rm".into(), desc: "shell".into(), action: "fill:sh rm ".into(), args: None },
+            Action { label: "sh list".into(), desc: "shell".into(), action: "fill:sh list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -222,4 +222,14 @@ impl Plugin for SnippetsPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "cs".into(), desc: "snippets".into(), action: "fill:cs ".into(), args: None },
+            Action { label: "cs add".into(), desc: "snippets".into(), action: "fill:cs add ".into(), args: None },
+            Action { label: "cs rm".into(), desc: "snippets".into(), action: "fill:cs rm ".into(), args: None },
+            Action { label: "cs edit".into(), desc: "snippets".into(), action: "fill:cs edit ".into(), args: None },
+            Action { label: "cs list".into(), desc: "snippets".into(), action: "fill:cs list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/sysinfo.rs
+++ b/src/plugins/sysinfo.rs
@@ -105,4 +105,13 @@ impl Plugin for SysInfoPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "info".into(), desc: "sysinfo".into(), action: "fill:info ".into(), args: None },
+            Action { label: "info cpu".into(), desc: "sysinfo".into(), action: "fill:info cpu".into(), args: None },
+            Action { label: "info mem".into(), desc: "sysinfo".into(), action: "fill:info mem".into(), args: None },
+            Action { label: "info disk".into(), desc: "sysinfo".into(), action: "fill:info disk".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/system.rs
+++ b/src/plugins/system.rs
@@ -34,4 +34,8 @@ impl Plugin for SystemPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "sys".into(), desc: "system".into(), action: "fill:sys ".into(), args: None }]
+    }
 }

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -252,4 +252,16 @@ impl Plugin for TempfilePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "tmp".into(), desc: "tempfile".into(), action: "fill:tmp ".into(), args: None },
+            Action { label: "tmp new".into(), desc: "tempfile".into(), action: "fill:tmp new ".into(), args: None },
+            Action { label: "tmp open".into(), desc: "tempfile".into(), action: "fill:tmp open".into(), args: None },
+            Action { label: "tmp clear".into(), desc: "tempfile".into(), action: "fill:tmp clear".into(), args: None },
+            Action { label: "tmp rm".into(), desc: "tempfile".into(), action: "fill:tmp rm ".into(), args: None },
+            Action { label: "tmp alias".into(), desc: "tempfile".into(), action: "fill:tmp alias ".into(), args: None },
+            Action { label: "tmp list".into(), desc: "tempfile".into(), action: "fill:tmp list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -596,4 +596,16 @@ impl Plugin for TimerPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search", "completion_dialog"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "timer add".into(), desc: "timer".into(), action: "fill:timer add ".into(), args: None },
+            Action { label: "timer list".into(), desc: "timer".into(), action: "fill:timer list".into(), args: None },
+            Action { label: "timer pause".into(), desc: "timer".into(), action: "fill:timer pause ".into(), args: None },
+            Action { label: "timer resume".into(), desc: "timer".into(), action: "fill:timer resume ".into(), args: None },
+            Action { label: "timer rm".into(), desc: "timer".into(), action: "fill:timer rm".into(), args: None },
+            Action { label: "timer cancel".into(), desc: "timer".into(), action: "fill:timer cancel".into(), args: None },
+            Action { label: "alarm".into(), desc: "timer".into(), action: "fill:alarm ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -225,4 +225,14 @@ impl Plugin for TodoPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "todo".into(), desc: "todo".into(), action: "fill:todo ".into(), args: None },
+            Action { label: "todo add".into(), desc: "todo".into(), action: "fill:todo add ".into(), args: None },
+            Action { label: "todo rm".into(), desc: "todo".into(), action: "fill:todo rm ".into(), args: None },
+            Action { label: "todo list".into(), desc: "todo".into(), action: "fill:todo list".into(), args: None },
+            Action { label: "todo clear".into(), desc: "todo".into(), action: "fill:todo clear".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -118,4 +118,11 @@ impl Plugin for UnitConvertPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "conv".into(), desc: "unit_convert".into(), action: "fill:conv ".into(), args: None },
+            Action { label: "convert".into(), desc: "unit_convert".into(), action: "fill:convert ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/volume.rs
+++ b/src/plugins/volume.rs
@@ -55,4 +55,18 @@ impl Plugin for VolumePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        #[cfg(target_os = "windows")]
+        {
+            vec![
+                Action { label: "vol".into(), desc: "volume".into(), action: "fill:vol ".into(), args: None },
+                Action { label: "vol ma".into(), desc: "volume".into(), action: "fill:vol ma".into(), args: None },
+            ]
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Vec::new()
+        }
+    }
 }

--- a/src/plugins/weather.rs
+++ b/src/plugins/weather.rs
@@ -35,5 +35,9 @@ impl Plugin for WeatherPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "weather".into(), desc: "weather".into(), action: "fill:weather ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/wikipedia.rs
+++ b/src/plugins/wikipedia.rs
@@ -36,5 +36,9 @@ impl Plugin for WikipediaPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "wiki".into(), desc: "wikipedia".into(), action: "fill:wiki ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/youtube.rs
+++ b/src/plugins/youtube.rs
@@ -36,4 +36,8 @@ impl Plugin for YoutubePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "yt".into(), desc: "youtube".into(), action: "fill:yt ".into(), args: None }]
+    }
 }

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -29,6 +29,10 @@ impl Plugin for WebSearchPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "g".into(), desc: "web_search".into(), action: "fill:g ".into(), args: None }]
+    }
 }
 
 pub struct CalculatorPlugin;
@@ -61,5 +65,9 @@ impl Plugin for CalculatorPlugin {
 
     fn capabilities(&self) -> &[&str] {
         &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "=".into(), desc: "calculator".into(), action: "fill:=".into(), args: None }]
     }
 }


### PR DESCRIPTION
## Summary
- extend `Plugin` trait with `commands` default method
- implement `commands` for built‑in plugins
- add `PluginManager::commands` helper
- list command shortcuts when the query is empty and via quick help
- update README tips about empty queries

## Testing
- `cargo test --quiet` *(fails: alsa-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_68796200887c83329f4675c25af120e3