### PR TITLE
Show plugin commands when search field is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Built-in plugins and their command prefixes are:
    timer completes.
 - Weather lookup (`weather Berlin`)
 
+When the search box is empty the launcher shows these shortcuts along with `app <alias>` entries for saved actions.
+
 On Windows the optional `vol` and `bright` plugins allow changing system volume
 and display brightness. These plugins are stubbed on other platforms and simply
 return no results.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -38,6 +38,10 @@ pub trait Plugin: Send + Sync {
     fn description(&self) -> &str;
     /// Capabilities offered by the plugin
     fn capabilities(&self) -> &[&str];
+    /// Query shortcuts offered by the plugin
+    fn commands(&self) -> Vec<Action> {
+        Vec::new()
+    }
 }
 
 /// A manager that holds plugins
@@ -126,6 +130,15 @@ impl PluginManager {
                 )
             })
             .collect()
+    }
+
+    /// Collect command shortcuts from all plugins.
+    pub fn commands(&self) -> Vec<Action> {
+        let mut out = Vec::new();
+        for p in &self.plugins {
+            out.extend(p.commands());
+        }
+        out
     }
 
     pub fn load_dir(&mut self, path: &str) -> anyhow::Result<()> {

--- a/src/plugins/asciiart.rs
+++ b/src/plugins/asciiart.rs
@@ -52,5 +52,14 @@ impl Plugin for AsciiArtPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "ascii <text>".into(),
+            desc: "AsciiArt".into(),
+            action: "query:ascii ".into(),
+            args: None,
+        }]
+    }
 }
 

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -282,4 +282,33 @@ impl Plugin for BookmarksPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "bm".into(),
+                desc: "Bookmark".into(),
+                action: "query:bm ".into(),
+                args: None,
+            },
+            Action {
+                label: "bm add".into(),
+                desc: "Bookmark".into(),
+                action: "query:bm add ".into(),
+                args: None,
+            },
+            Action {
+                label: "bm rm".into(),
+                desc: "Bookmark".into(),
+                action: "query:bm rm ".into(),
+                args: None,
+            },
+            Action {
+                label: "bm list".into(),
+                desc: "Bookmark".into(),
+                action: "query:bm list".into(),
+                args: None,
+            },
+        ]
+    }
 }

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -45,4 +45,13 @@ impl Plugin for BrightnessPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "bright".into(),
+            desc: "Brightness".into(),
+            action: "query:bright ".into(),
+            args: None,
+        }]
+    }
 }

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -186,4 +186,12 @@ impl Plugin for ClipboardPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "cb".into(), desc: "Clipboard".into(), action: "query:cb".into(), args: None },
+            Action { label: "cb list".into(), desc: "Clipboard".into(), action: "query:cb list".into(), args: None },
+            Action { label: "cb clear".into(), desc: "Clipboard".into(), action: "query:cb clear".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/dropcalc.rs
+++ b/src/plugins/dropcalc.rs
@@ -60,5 +60,14 @@ impl Plugin for DropCalcPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "drop <p> <n>".into(),
+            desc: "DropCalc".into(),
+            action: "query:drop ".into(),
+            args: None,
+        }]
+    }
 }
 

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -252,4 +252,12 @@ impl Plugin for FoldersPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search", "show_full_path"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "f".into(), desc: "Folder".into(), action: "query:f ".into(), args: None },
+            Action { label: "f add".into(), desc: "Folder".into(), action: "query:f add ".into(), args: None },
+            Action { label: "f rm".into(), desc: "Folder".into(), action: "query:f rm ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/help.rs
+++ b/src/plugins/help.rs
@@ -33,5 +33,14 @@ impl Plugin for HelpPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "help".into(),
+            desc: "Help".into(),
+            action: "query:help".into(),
+            args: None,
+        }]
+    }
 }
 

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -46,4 +46,11 @@ impl Plugin for HistoryPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "hi".into(), desc: "History".into(), action: "query:hi".into(), args: None },
+            Action { label: "hi clear".into(), desc: "History".into(), action: "query:hi clear".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -194,4 +194,13 @@ impl Plugin for NotesPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "note".into(), desc: "Note".into(), action: "query:note".into(), args: None },
+            Action { label: "note add".into(), desc: "Note".into(), action: "query:note add ".into(), args: None },
+            Action { label: "note list".into(), desc: "Note".into(), action: "query:note list".into(), args: None },
+            Action { label: "note rm".into(), desc: "Note".into(), action: "query:note rm ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/processes.rs
+++ b/src/plugins/processes.rs
@@ -57,5 +57,9 @@ impl Plugin for ProcessesPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "ps".into(), desc: "Processes".into(), action: "query:ps ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/recycle.rs
+++ b/src/plugins/recycle.rs
@@ -35,5 +35,9 @@ impl Plugin for RecyclePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "rec".into(), desc: "Recycle".into(), action: "query:rec".into(), args: None }]
+    }
 }
 

--- a/src/plugins/reddit.rs
+++ b/src/plugins/reddit.rs
@@ -33,4 +33,8 @@ impl Plugin for RedditPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "red".into(), desc: "Reddit".into(), action: "query:red ".into(), args: None }]
+    }
 }

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -47,5 +47,12 @@ impl Plugin for RunescapeSearchPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "rs".into(), desc: "Runescape".into(), action: "query:rs ".into(), args: None },
+            Action { label: "osrs".into(), desc: "Runescape".into(), action: "query:osrs ".into(), args: None },
+        ]
+    }
 }
 

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -182,4 +182,13 @@ impl Plugin for ShellPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "sh".into(), desc: "Shell".into(), action: "query:sh".into(), args: None },
+            Action { label: "sh add".into(), desc: "Shell".into(), action: "query:sh add ".into(), args: None },
+            Action { label: "sh rm".into(), desc: "Shell".into(), action: "query:sh rm ".into(), args: None },
+            Action { label: "sh list".into(), desc: "Shell".into(), action: "query:sh list".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -222,4 +222,14 @@ impl Plugin for SnippetsPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "cs".into(), desc: "Snippet".into(), action: "query:cs".into(), args: None },
+            Action { label: "cs add".into(), desc: "Snippet".into(), action: "query:cs add ".into(), args: None },
+            Action { label: "cs rm".into(), desc: "Snippet".into(), action: "query:cs rm ".into(), args: None },
+            Action { label: "cs list".into(), desc: "Snippet".into(), action: "query:cs list".into(), args: None },
+            Action { label: "cs edit".into(), desc: "Snippet".into(), action: "query:cs edit".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/sysinfo.rs
+++ b/src/plugins/sysinfo.rs
@@ -105,4 +105,13 @@ impl Plugin for SysInfoPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "info".into(), desc: "SysInfo".into(), action: "query:info".into(), args: None },
+            Action { label: "info cpu".into(), desc: "SysInfo".into(), action: "query:info cpu".into(), args: None },
+            Action { label: "info mem".into(), desc: "SysInfo".into(), action: "query:info mem".into(), args: None },
+            Action { label: "info disk".into(), desc: "SysInfo".into(), action: "query:info disk".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/system.rs
+++ b/src/plugins/system.rs
@@ -34,4 +34,8 @@ impl Plugin for SystemPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "sys".into(), desc: "System".into(), action: "query:sys ".into(), args: None }]
+    }
 }

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -252,4 +252,15 @@ impl Plugin for TempfilePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "tmp".into(), desc: "Tempfile".into(), action: "query:tmp".into(), args: None },
+            Action { label: "tmp new".into(), desc: "Tempfile".into(), action: "query:tmp new ".into(), args: None },
+            Action { label: "tmp open".into(), desc: "Tempfile".into(), action: "query:tmp open".into(), args: None },
+            Action { label: "tmp clear".into(), desc: "Tempfile".into(), action: "query:tmp clear".into(), args: None },
+            Action { label: "tmp list".into(), desc: "Tempfile".into(), action: "query:tmp list".into(), args: None },
+            Action { label: "tmp rm".into(), desc: "Tempfile".into(), action: "query:tmp rm ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -225,4 +225,14 @@ impl Plugin for TodoPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "todo".into(), desc: "Todo".into(), action: "query:todo".into(), args: None },
+            Action { label: "todo add".into(), desc: "Todo".into(), action: "query:todo add ".into(), args: None },
+            Action { label: "todo list".into(), desc: "Todo".into(), action: "query:todo list".into(), args: None },
+            Action { label: "todo rm".into(), desc: "Todo".into(), action: "query:todo rm ".into(), args: None },
+            Action { label: "todo clear".into(), desc: "Todo".into(), action: "query:todo clear".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -118,4 +118,11 @@ impl Plugin for UnitConvertPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "conv".into(), desc: "Unit convert".into(), action: "query:conv ".into(), args: None },
+            Action { label: "convert".into(), desc: "Unit convert".into(), action: "query:convert ".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/volume.rs
+++ b/src/plugins/volume.rs
@@ -55,4 +55,11 @@ impl Plugin for VolumePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "vol".into(), desc: "Volume".into(), action: "query:vol ".into(), args: None },
+            Action { label: "vol ma".into(), desc: "Volume".into(), action: "query:vol ma".into(), args: None },
+        ]
+    }
 }

--- a/src/plugins/weather.rs
+++ b/src/plugins/weather.rs
@@ -35,5 +35,9 @@ impl Plugin for WeatherPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "weather".into(), desc: "Weather".into(), action: "query:weather ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/wikipedia.rs
+++ b/src/plugins/wikipedia.rs
@@ -36,5 +36,9 @@ impl Plugin for WikipediaPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "wiki".into(), desc: "Wikipedia".into(), action: "query:wiki ".into(), args: None }]
+    }
 }
 

--- a/src/plugins/youtube.rs
+++ b/src/plugins/youtube.rs
@@ -36,4 +36,8 @@ impl Plugin for YoutubePlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "yt".into(), desc: "YouTube".into(), action: "query:yt ".into(), args: None }]
+    }
 }

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -29,6 +29,10 @@ impl Plugin for WebSearchPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "g".into(), desc: "Web search".into(), action: "query:g ".into(), args: None }]
+    }
 }
 
 pub struct CalculatorPlugin;
@@ -61,5 +65,9 @@ impl Plugin for CalculatorPlugin {
 
     fn capabilities(&self) -> &[&str] {
         &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "=".into(), desc: "Calculator".into(), action: "query:= ".into(), args: None }]
     }
 }

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -1,0 +1,41 @@
+use eframe::egui;
+use multi_launcher::actions::Action;
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::settings::Settings;
+use std::sync::{Arc, atomic::AtomicBool};
+
+fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    let dirs: Vec<String> = Vec::new();
+    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn empty_query_lists_commands() {
+    let ctx = egui::Context::default();
+    let actions = vec![Action { label: "chrome".into(), desc: "web".into(), action: "chrome".into(), args: None }];
+    let mut app = new_app(&ctx, actions);
+    app.query.clear();
+    app.search();
+    assert!(app.results.iter().any(|a| a.label == "help"));
+    assert!(app.results.iter().any(|a| a.label == "app chrome"));
+}
+


### PR DESCRIPTION
## Summary
- support listing plugin shortcuts through new `commands` method
- collect command info from all built-in plugins
- display these commands plus `app` aliases when query is empty
- allow command suggestions to prefill the query via `query:` prefix
- document default command list behaviour
- test empty query listing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68796200887c83329f4675c25af120e3