### PR TITLE
Ensure search runs during initialization

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -342,7 +342,7 @@ impl LauncherApp {
 
         let settings_editor = SettingsEditor::new(&settings);
         let plugin_editor = PluginEditor::new(&settings);
-        let app = Self {
+        let mut app = Self {
             actions: actions.clone(),
             query: String::new(),
             results: actions,
@@ -445,6 +445,7 @@ impl LauncherApp {
             }
         }
 
+        app.search();
         app
     }
 


### PR DESCRIPTION
## Summary
- populate `LauncherApp` search results at startup
- initialize mutable app and run the search

## Testing
- `cargo test --quiet`

 