### PR TITLE
Handle query prefix on click

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -889,19 +889,23 @@ impl eframe::App for LauncherApp {
                 let input_id = egui::Id::new("query_input");
 
                 if self.move_cursor_end {
-                    let len = self.query.chars().count();
-                    tracing::debug!("moving cursor to end: {len}");
-                    ui.ctx().data_mut(|data| {
-                        let state = data
-                            .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
-                                input_id,
-                            );
-                        state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
-                            egui::text::CCursor::new(len),
-                        )));
-                    });
-                    self.move_cursor_end = false;
-                    tracing::debug!("move_cursor_end cleared after moving");
+                    if ui.ctx().memory(|m| m.has_focus(input_id)) {
+                        let len = self.query.chars().count();
+                        tracing::debug!("moving cursor to end: {len}");
+                        ui.ctx().data_mut(|data| {
+                            let state = data
+                                .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
+                                    input_id,
+                                );
+                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
+                                egui::text::CCursor::new(len),
+                            )));
+                        });
+                        self.move_cursor_end = false;
+                        tracing::debug!("move_cursor_end cleared after moving");
+                    } else {
+                        tracing::debug!("cursor not moved - input not focused");
+                    }
                 }
 
                 let input = ui.add(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -101,6 +101,7 @@ pub struct LauncherApp {
     pub window_size: (i32, i32),
     pub window_pos: (i32, i32),
     focus_query: bool,
+    move_cursor_end: bool,
     toasts: egui_toast::Toasts,
     pub enable_toasts: bool,
     alias_dialog: crate::alias_dialog::AliasDialog,
@@ -377,6 +378,7 @@ impl LauncherApp {
             window_size: win_size,
             window_pos: (0, 0),
             focus_query: false,
+            move_cursor_end: false,
             toasts,
             enable_toasts,
             alias_dialog: crate::alias_dialog::AliasDialog::default(),
@@ -884,11 +886,19 @@ impl eframe::App for LauncherApp {
             }
 
             scale_ui(ui, self.query_scale, |ui| {
-                let input = ui
-                    .add(egui::TextEdit::singleline(&mut self.query).desired_width(f32::INFINITY));
+                let input_id = "query_input";
+                let input = ui.add(
+                    egui::TextEdit::singleline(&mut self.query)
+                        .id_source(input_id)
+                        .cursor_at_end(self.move_cursor_end)
+                        .desired_width(f32::INFINITY),
+                );
                 if just_became_visible || self.focus_query {
                     input.request_focus();
                     self.focus_query = false;
+                }
+                if self.move_cursor_end {
+                    self.move_cursor_end = false;
                 }
                 if input.changed() {
                     self.search();
@@ -922,6 +932,7 @@ impl eframe::App for LauncherApp {
                             self.query = new_q.to_string();
                             self.search();
                             set_focus = true;
+                            self.move_cursor_end = true;
                         } else if a.action == "help:show" {
                             self.help_window.open = true;
                         } else if a.action == "timer:dialog:timer" {
@@ -1436,6 +1447,7 @@ impl eframe::App for LauncherApp {
                                     self.query = new_q.to_string();
                                     refresh = true;
                                     set_focus = true;
+                                    self.move_cursor_end = true;
                                 } else if a.action == "help:show" {
                                     self.help_window.open = true;
                                 } else if a.action == "timer:dialog:timer" {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -901,6 +901,8 @@ impl eframe::App for LauncherApp {
                                 egui::text::CCursor::new(len),
                             )));
                         });
+                        #[cfg(target_os = "windows")]
+                        crate::window_manager::send_end_key();
                         self.move_cursor_end = false;
                         tracing::debug!("move_cursor_end cleared after moving");
                     } else {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1174,6 +1174,7 @@ impl eframe::App for LauncherApp {
                     scale_ui(ui, self.list_scale, |ui| {
                         let mut refresh = false;
                         let mut set_focus = false;
+                        let mut clicked_query: Option<String> = None;
                         let show_full = self
                             .enabled_capabilities
                             .as_ref()
@@ -1464,8 +1465,7 @@ impl eframe::App for LauncherApp {
                                 let current = self.query.clone();
                                 if let Some(new_q) = a.action.strip_prefix("query:") {
                                     tracing::debug!("query action via click: {new_q}");
-                                    self.query = new_q.to_string();
-                                    self.search();
+                                    clicked_query = Some(new_q.to_string());
                                     set_focus = true;
                                     tracing::debug!("move_cursor_end set via mouse click");
                                     self.move_cursor_end = true;
@@ -1657,6 +1657,10 @@ impl eframe::App for LauncherApp {
                                 }
                                 self.selected = Some(idx);
                             }
+                        }
+                        if let Some(new_q) = clicked_query {
+                            self.query = new_q;
+                            self.search();
                         }
                         if refresh {
                             self.search();

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -943,6 +943,7 @@ impl eframe::App for LauncherApp {
                         let mut refresh = false;
                         let mut set_focus = false;
                         if let Some(new_q) = a.action.strip_prefix("query:") {
+                            tracing::debug!("query action via Enter: {new_q}");
                             self.query = new_q.to_string();
                             self.search();
                             set_focus = true;
@@ -1460,6 +1461,7 @@ impl eframe::App for LauncherApp {
                                 let a = a.clone();
                                 let current = self.query.clone();
                                 if let Some(new_q) = a.action.strip_prefix("query:") {
+                                    tracing::debug!("query action via click: {new_q}");
                                     query_update = Some(new_q.to_string());
                                     set_focus = true;
                                     tracing::debug!("move_cursor_end set via mouse click");
@@ -1654,7 +1656,7 @@ impl eframe::App for LauncherApp {
                             }
                         }
                         if let Some(new_q) = query_update {
-                            tracing::debug!("query updated from action click");
+                            tracing::debug!("query updated from action click: {new_q}");
                             self.query = new_q;
                             self.search();
                         }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1174,8 +1174,6 @@ impl eframe::App for LauncherApp {
                     scale_ui(ui, self.list_scale, |ui| {
                         let mut refresh = false;
                         let mut set_focus = false;
-                        let alias_map = &self.folder_aliases;
-                        let bm_map = &self.bookmark_aliases;
                         let show_full = self
                             .enabled_capabilities
                             .as_ref()
@@ -1183,7 +1181,10 @@ impl eframe::App for LauncherApp {
                             .map(|caps| caps.contains(&"show_full_path".to_string()))
                             .unwrap_or(false);
                         for (idx, a) in self.results.iter().enumerate() {
-                            let aliased = alias_map.get(&a.action).and_then(|v| v.as_ref());
+                            let aliased = self
+                                .folder_aliases
+                                .get(&a.action)
+                                .and_then(|v| v.as_ref());
                             let show_path = show_full || aliased.is_none();
                             let text = if show_path {
                                 format!("{} : {}", a.label, a.desc)
@@ -1215,7 +1216,7 @@ impl eframe::App for LauncherApp {
                                 .iter()
                                 .take(self.custom_len)
                                 .position(|act| act.action == a.action && act.label == a.label);
-                            if alias_map.contains_key(&a.action)
+                            if self.folder_aliases.contains_key(&a.action)
                                 && !a.action.starts_with("folder:")
                             {
                                 menu_resp.clone().context_menu(|ui| {
@@ -1246,7 +1247,7 @@ impl eframe::App for LauncherApp {
                                         ui.close_menu();
                                     }
                                 });
-                            } else if bm_map.contains_key(&a.action) {
+                            } else if self.bookmark_aliases.contains_key(&a.action) {
                                 menu_resp.clone().context_menu(|ui| {
                                     if ui.button("Set Alias").clicked() {
                                         self.bookmark_alias_dialog.open(&a.action);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1663,6 +1663,16 @@ impl eframe::App for LauncherApp {
                         if let Some(new_q) = clicked_query {
                             self.query = new_q;
                             self.search();
+                            let input_id = egui::Id::new("query_input");
+                            ui.ctx().memory_mut(|m| m.request_focus(input_id));
+                            let len = self.query.chars().count();
+                            ui.ctx().data_mut(|data| {
+                                let state = data
+                                    .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(input_id);
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
+                                    egui::text::CCursor::new(len),
+                                )));
+                            });
                         }
                         if refresh {
                             self.search();

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -889,21 +889,19 @@ impl eframe::App for LauncherApp {
                 let input_id = egui::Id::new("query_input");
 
                 if self.move_cursor_end {
-                    if ui.ctx().memory(|m| m.has_focus(input_id)) {
-                        let len = self.query.chars().count();
-                        tracing::debug!("moving cursor to end: {len}");
-                        ui.ctx().data_mut(|data| {
-                            let state = data
-                                .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
-                                    input_id,
-                                );
-                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
-                                egui::text::CCursor::new(len),
-                            )));
-                        });
-                        self.move_cursor_end = false;
-                        tracing::debug!("move_cursor_end cleared after moving");
-                    }
+                    let len = self.query.chars().count();
+                    tracing::debug!("moving cursor to end: {len}");
+                    ui.ctx().data_mut(|data| {
+                        let state = data
+                            .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
+                                input_id,
+                            );
+                        state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
+                            egui::text::CCursor::new(len),
+                        )));
+                    });
+                    self.move_cursor_end = false;
+                    tracing::debug!("move_cursor_end cleared after moving");
                 }
 
                 let input = ui.add(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -889,19 +889,21 @@ impl eframe::App for LauncherApp {
                 let input_id = egui::Id::new("query_input");
 
                 if self.move_cursor_end {
-                    let len = self.query.chars().count();
-                    tracing::debug!("moving cursor to end: {len}");
-                    ui.ctx().data_mut(|data| {
-                        let state = data
-                            .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
-                                input_id,
-                            );
-                        state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
-                            egui::text::CCursor::new(len),
-                        )));
-                    });
-                    self.move_cursor_end = false;
-                    tracing::debug!("move_cursor_end cleared after moving");
+                    if ui.ctx().memory(|m| m.has_focus(input_id)) {
+                        let len = self.query.chars().count();
+                        tracing::debug!("moving cursor to end: {len}");
+                        ui.ctx().data_mut(|data| {
+                            let state = data
+                                .get_persisted_mut_or_default::<egui::widgets::text_edit::TextEditState>(
+                                    input_id,
+                                );
+                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(
+                                egui::text::CCursor::new(len),
+                            )));
+                        });
+                        self.move_cursor_end = false;
+                        tracing::debug!("move_cursor_end cleared after moving");
+                    }
                 }
 
                 let input = ui.add(

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -266,3 +266,27 @@ pub fn activate_process(pid: u32) {
         let _ = EnumWindows(Some(enum_cb), LPARAM(pid as isize));
     }
 }
+
+#[cfg(target_os = "windows")]
+pub fn send_end_key() {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_END,
+    };
+    unsafe {
+        let mut input = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VK_END.0 as u16,
+                    wScan: 0,
+                    dwFlags: 0,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let _ = SendInput(&[input], std::mem::size_of::<INPUT>() as i32);
+        input.Anonymous.ki.dwFlags = KEYEVENTF_KEYUP;
+        let _ = SendInput(&[input], std::mem::size_of::<INPUT>() as i32);
+    }
+}

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -270,16 +270,17 @@ pub fn activate_process(pid: u32) {
 #[cfg(target_os = "windows")]
 pub fn send_end_key() {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, VK_END,
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+        KEYBD_EVENT_FLAGS, VIRTUAL_KEY, VK_END,
     };
     unsafe {
         let mut input = INPUT {
             r#type: INPUT_KEYBOARD,
             Anonymous: INPUT_0 {
                 ki: KEYBDINPUT {
-                    wVk: VK_END.0 as u16,
+                    wVk: VIRTUAL_KEY(VK_END.0),
                     wScan: 0,
-                    dwFlags: 0,
+                    dwFlags: KEYBD_EVENT_FLAGS(0),
                     time: 0,
                     dwExtraInfo: 0,
                 },


### PR DESCRIPTION
## Summary
- trigger a query update when clicking plugin commands that start with `query:`
- drop persistent alias map borrows for clickable search results

## Testing
- `cargo test --no-run`
- `cargo test -- --nocapture`

  