### PR TITLE
Cache lowercase strings for actions

### DIFF
--- a/src/add_action_dialog.rs
+++ b/src/add_action_dialog.rs
@@ -143,6 +143,7 @@ impl AddActionDialog {
                                             },
                                         });
                                         app.custom_len += 1;
+                                        app.update_action_cache();
                                     }
                                     DialogMode::Edit(idx) => {
                                         if let Some(act) = app.actions.get_mut(idx) {
@@ -154,6 +155,7 @@ impl AddActionDialog {
                                             } else {
                                                 None
                                             };
+                                            app.update_action_cache();
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary
- store lowercased action labels/descs in `LauncherApp`
- refresh cached values whenever actions change
- use cached values during search to avoid repeated allocations

## Testing
- `cargo test --no-run`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9d4fcfb08332867af30a02ca3f8f