### PR TITLE
Fix Timer plugin command registration

### DIFF
--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -598,4 +598,17 @@ impl Plugin for TimerPlugin {
     fn capabilities(&self) -> &[&str] {
         &["search", "completion_dialog"]
     }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "timer".into(), desc: "Timer".into(), action: "query:timer".into(), args: None },
+            Action { label: "timer add".into(), desc: "Timer".into(), action: "query:timer add ".into(), args: None },
+            Action { label: "timer list".into(), desc: "Timer".into(), action: "query:timer list".into(), args: None },
+            Action { label: "timer pause".into(), desc: "Timer".into(), action: "query:timer pause".into(), args: None },
+            Action { label: "timer resume".into(), desc: "Timer".into(), action: "query:timer resume".into(), args: None },
+            Action { label: "timer cancel".into(), desc: "Timer".into(), action: "query:timer cancel".into(), args: None },
+            Action { label: "timer rm".into(), desc: "Timer".into(), action: "query:timer rm".into(), args: None },
+            Action { label: "alarm".into(), desc: "Timer".into(), action: "query:alarm".into(), args: None },
+        ]
+    }
 }


### PR DESCRIPTION
## Summary
- add a `commands` implementation to Timer plugin so its prefixes
  show up when there is no query entered

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ba7dd10b48332b18b55688808e33c