### PR TITLE
Add priority and tags to todo entries

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -339,7 +339,12 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         return Ok(());
     }
     if let Some(text) = action.action.strip_prefix("todo:add:") {
-        crate::plugins::todo::append_todo(crate::plugins::todo::TODO_FILE, text)?;
+        crate::plugins::todo::append_todo(
+            crate::plugins::todo::TODO_FILE,
+            text,
+            0,
+            &[],
+        )?;
         return Ok(());
     }
     if let Some(idx) = action.action.strip_prefix("todo:remove:") {

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -12,6 +12,10 @@ pub const TODO_FILE: &str = "todo.json";
 pub struct TodoEntry {
     pub text: String,
     pub done: bool,
+    #[serde(default)]
+    pub priority: u8,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Load todo entries from `path`.
@@ -31,12 +35,14 @@ pub fn save_todos(path: &str, todos: &[TodoEntry]) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Append a new todo entry with `text`.
-pub fn append_todo(path: &str, text: &str) -> anyhow::Result<()> {
+/// Append a new todo entry with `text`, `priority` and `tags`.
+pub fn append_todo(path: &str, text: &str, priority: u8, tags: &[String]) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     list.push(TodoEntry {
         text: text.to_string(),
         done: false,
+        priority,
+        tags: tags.to_vec(),
     });
     save_todos(path, &list)
 }
@@ -56,6 +62,26 @@ pub fn mark_done(path: &str, index: usize) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
     if let Some(entry) = list.get_mut(index) {
         entry.done = !entry.done;
+        save_todos(path, &list)?;
+    }
+    Ok(())
+}
+
+/// Set the priority of the todo at `index` in `path`.
+pub fn set_priority(path: &str, index: usize, priority: u8) -> anyhow::Result<()> {
+    let mut list = load_todos(path).unwrap_or_default();
+    if let Some(entry) = list.get_mut(index) {
+        entry.priority = priority;
+        save_todos(path, &list)?;
+    }
+    Ok(())
+}
+
+/// Replace the tags of the todo at `index` in `path`.
+pub fn set_tags(path: &str, index: usize, tags: &[String]) -> anyhow::Result<()> {
+    let mut list = load_todos(path).unwrap_or_default();
+    if let Some(entry) = list.get_mut(index) {
+        entry.tags = tags.to_vec();
         save_todos(path, &list)?;
     }
     Ok(())

--- a/src/todo_dialog.rs
+++ b/src/todo_dialog.rs
@@ -7,6 +7,8 @@ pub struct TodoDialog {
     pub open: bool,
     entries: Vec<TodoEntry>,
     text: String,
+    priority: u8,
+    tags: String,
 }
 
 impl TodoDialog {
@@ -14,6 +16,8 @@ impl TodoDialog {
         self.entries = load_todos(TODO_FILE).unwrap_or_default();
         self.open = true;
         self.text.clear();
+        self.priority = 0;
+        self.tags.clear();
     }
 
     fn save(&mut self, app: &mut LauncherApp) {
@@ -39,10 +43,33 @@ impl TodoDialog {
                 ui.horizontal(|ui| {
                     ui.label("New");
                     ui.text_edit_singleline(&mut self.text);
+                    ui.label("Priority");
+                    if ui
+                        .add(egui::DragValue::new(&mut self.priority).clamp_range(0..=255))
+                        .changed()
+                    {
+                        // no action
+                    }
+                    ui.label("Tags");
+                    ui.text_edit_singleline(&mut self.tags);
                     if ui.button("Add").clicked() {
                         if !self.text.trim().is_empty() {
-                            self.entries.push(TodoEntry { text: self.text.clone(), done: false });
+                            let tag_list: Vec<String> = self
+                                .tags
+                                .split(',')
+                                .map(|t| t.trim())
+                                .filter(|t| !t.is_empty())
+                                .map(|t| t.to_string())
+                                .collect();
+                            self.entries.push(TodoEntry {
+                                text: self.text.clone(),
+                                done: false,
+                                priority: self.priority,
+                                tags: tag_list,
+                            });
                             self.text.clear();
+                            self.priority = 0;
+                            self.tags.clear();
                             save_now = true;
                         }
                     }
@@ -65,7 +92,20 @@ impl TodoDialog {
                                 save_now = true;
                             }
                             ui.label(entry.text.replace('\n', " "));
-                            if ui.button("Remove").clicked() { remove = Some(idx); }
+                            ui.add(egui::DragValue::new(&mut entry.priority).clamp_range(0..=255));
+                            let mut tag_str = entry.tags.join(", ");
+                            if ui.text_edit_singleline(&mut tag_str).changed() {
+                                entry.tags = tag_str
+                                    .split(',')
+                                    .map(|t| t.trim())
+                                    .filter(|t| !t.is_empty())
+                                    .map(|t| t.to_string())
+                                    .collect();
+                                save_now = true;
+                            }
+                            if ui.button("Remove").clicked() {
+                                remove = Some(idx);
+                            }
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- extend `TodoEntry` with `priority` and `tags`
- support editing priority and tags in the todo dialog
- add helpers to update priority and tags
- adapt launcher and tests for the new API

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687baa0165888332a440e99332625c72