### PR TITLE
Implement priority and tag support for todo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Built-in plugins and their command prefixes are:
 - Shell commands (`sh echo hi`)
 - Search history (`hi`)
 - Quick notes (`note add <text>`, `note list`, `note rm <pattern>`)
-- Todo items (`todo add <task>`, `todo list`, `todo rm <pattern>`, `todo clear`)
+- Todo items (`todo add <task> p=<n> #tag`, `todo list`, `todo rm <pattern>`, `todo pset <idx> <n>`, `todo tag <idx> #tag`, `todo clear`)
 - Text snippets (`cs`, `cs list`, `cs rm`, `cs add <alias> <text>`, `cs edit`)
 - Recycle Bin cleanup (`rec`)
 - Temporary files (`tmp`, `tmp new [name]`, `tmp open`, `tmp clear`, `tmp list`, `tmp rm`)

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1069,12 +1069,15 @@ impl eframe::App for LauncherApp {
                                 refresh = true;
                                 set_focus = true;
                                 if self.enable_toasts {
-                                    if let Some(text) = a.action.strip_prefix("todo:add:") {
+                                    if let Some(text) = a
+                                        .action
+                                        .strip_prefix("todo:add:")
+                                        .and_then(|r| r.split('|').next())
+                                    {
                                         self.toasts.add(Toast {
                                             text: format!("Added todo {text}").into(),
                                             kind: ToastKind::Success,
-                                            options: ToastOptions::default()
-                                                .duration_in_seconds(3.0),
+                                            options: ToastOptions::default().duration_in_seconds(3.0),
                                         });
                                     }
                                 }
@@ -1100,6 +1103,26 @@ impl eframe::App for LauncherApp {
                                         .trim_start_matches("[ ] ");
                                     self.toasts.add(Toast {
                                         text: format!("Toggled todo {label}").into(),
+                                        kind: ToastKind::Success,
+                                        options: ToastOptions::default().duration_in_seconds(3.0),
+                                    });
+                                }
+                            } else if a.action.starts_with("todo:pset:") {
+                                refresh = true;
+                                set_focus = true;
+                                if self.enable_toasts {
+                                    self.toasts.add(Toast {
+                                        text: "Updated todo priority".into(),
+                                        kind: ToastKind::Success,
+                                        options: ToastOptions::default().duration_in_seconds(3.0),
+                                    });
+                                }
+                            } else if a.action.starts_with("todo:tag:") {
+                                refresh = true;
+                                set_focus = true;
+                                if self.enable_toasts {
+                                    self.toasts.add(Toast {
+                                        text: "Updated todo tags".into(),
                                         kind: ToastKind::Success,
                                         options: ToastOptions::default().duration_in_seconds(3.0),
                                     });
@@ -1588,12 +1611,15 @@ impl eframe::App for LauncherApp {
                                         refresh = true;
                                         set_focus = true;
                                         if self.enable_toasts {
-                                            if let Some(text) = a.action.strip_prefix("todo:add:") {
+                                            if let Some(text) = a
+                                                .action
+                                                .strip_prefix("todo:add:")
+                                                .and_then(|r| r.split('|').next())
+                                            {
                                                 self.toasts.add(Toast {
                                                     text: format!("Added todo {text}").into(),
                                                     kind: ToastKind::Success,
-                                                    options: ToastOptions::default()
-                                                        .duration_in_seconds(3.0),
+                                                    options: ToastOptions::default().duration_in_seconds(3.0),
                                                 });
                                             }
                                         }
@@ -1625,6 +1651,26 @@ impl eframe::App for LauncherApp {
                                                 kind: ToastKind::Success,
                                                 options: ToastOptions::default()
                                                     .duration_in_seconds(3.0),
+                                            });
+                                        }
+                                    } else if a.action.starts_with("todo:pset:") {
+                                        refresh = true;
+                                        set_focus = true;
+                                        if self.enable_toasts {
+                                            self.toasts.add(Toast {
+                                                text: "Updated todo priority".into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default().duration_in_seconds(3.0),
+                                            });
+                                        }
+                                    } else if a.action.starts_with("todo:tag:") {
+                                        refresh = true;
+                                        set_focus = true;
+                                        if self.enable_toasts {
+                                            self.toasts.add(Toast {
+                                                text: "Updated todo tags".into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default().duration_in_seconds(3.0),
                                             });
                                         }
                                     } else if a.action == "todo:clear" {

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -341,6 +341,8 @@ impl Plugin for TodoPlugin {
             Action { label: "todo list".into(), desc: "Todo".into(), action: "query:todo list".into(), args: None },
             Action { label: "todo rm".into(), desc: "Todo".into(), action: "query:todo rm ".into(), args: None },
             Action { label: "todo clear".into(), desc: "Todo".into(), action: "query:todo clear".into(), args: None },
+            Action { label: "todo pset".into(), desc: "Todo".into(), action: "query:todo pset ".into(), args: None },
+            Action { label: "todo tag".into(), desc: "Todo".into(), action: "query:todo tag ".into(), args: None },
         ]
     }
 }

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -193,14 +193,79 @@ impl Plugin for TodoPlugin {
         if trimmed.len() >= ADD_PREFIX.len()
             && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
         {
-            let text = trimmed[ADD_PREFIX.len()..].trim();
-            if !text.is_empty() {
-                return vec![Action {
-                    label: format!("Add todo {text}"),
-                    desc: "Todo".into(),
-                    action: format!("todo:add:{text}"),
-                    args: None,
-                }];
+            let rest = trimmed[ADD_PREFIX.len()..].trim();
+            if !rest.is_empty() {
+                let mut priority: u8 = 0;
+                let mut tags: Vec<String> = Vec::new();
+                let mut words: Vec<String> = Vec::new();
+                for part in rest.split_whitespace() {
+                    if let Some(p) = part.strip_prefix("p=") {
+                        if let Ok(n) = p.parse::<u8>() {
+                            priority = n;
+                        }
+                    } else if let Some(tag) = part.strip_prefix('#') {
+                        if !tag.is_empty() {
+                            tags.push(tag.to_string());
+                        }
+                    } else {
+                        words.push(part.to_string());
+                    }
+                }
+                let text = words.join(" ");
+                if !text.is_empty() {
+                    let tag_str = tags.join(",");
+                    return vec![Action {
+                        label: format!("Add todo {text}"),
+                        desc: "Todo".into(),
+                        action: format!("todo:add:{text}|{priority}|{tag_str}"),
+                        args: None,
+                    }];
+                }
+            }
+        }
+
+        const PSET_PREFIX: &str = "todo pset ";
+        if trimmed.len() >= PSET_PREFIX.len()
+            && trimmed[..PSET_PREFIX.len()].eq_ignore_ascii_case(PSET_PREFIX)
+        {
+            let rest = trimmed[PSET_PREFIX.len()..].trim();
+            let mut parts = rest.split_whitespace();
+            if let (Some(idx_str), Some(priority_str)) = (parts.next(), parts.next()) {
+                if let (Ok(idx), Ok(priority)) = (idx_str.parse::<usize>(), priority_str.parse::<u8>()) {
+                    return vec![Action {
+                        label: format!("Set priority {priority} for todo {idx}"),
+                        desc: "Todo".into(),
+                        action: format!("todo:pset:{idx}|{priority}"),
+                        args: None,
+                    }];
+                }
+            }
+        }
+
+        const TAG_PREFIX: &str = "todo tag ";
+        if trimmed.len() >= TAG_PREFIX.len()
+            && trimmed[..TAG_PREFIX.len()].eq_ignore_ascii_case(TAG_PREFIX)
+        {
+            let rest = trimmed[TAG_PREFIX.len()..].trim();
+            let mut parts = rest.split_whitespace();
+            if let Some(idx_str) = parts.next() {
+                if let Ok(idx) = idx_str.parse::<usize>() {
+                    let mut tags: Vec<String> = Vec::new();
+                    for t in parts {
+                        if let Some(tag) = t.strip_prefix('#') {
+                            if !tag.is_empty() {
+                                tags.push(tag.to_string());
+                            }
+                        }
+                    }
+                    let tag_str = tags.join(",");
+                    return vec![Action {
+                        label: format!("Set tags for todo {idx}"),
+                        desc: "Todo".into(),
+                        action: format!("todo:tag:{idx}|{tag_str}"),
+                        args: None,
+                    }];
+                }
             }
         }
 

--- a/tests/preserve_command.rs
+++ b/tests/preserve_command.rs
@@ -101,7 +101,7 @@ fn todo_add_preserves_prefix() {
     let actions = vec![Action {
         label: "todo".into(),
         desc: "".into(),
-        action: "todo:add:test".into(),
+        action: "todo:add:test|0|".into(),
         args: None,
     }];
     let mut app = new_app(&ctx, actions, true);

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -15,7 +15,16 @@ fn search_add_returns_action() {
     let plugin = TodoPlugin::default();
     let results = plugin.search("todo add task   ");
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0].action, "todo:add:task");
+    assert_eq!(results[0].action, "todo:add:task|0|");
+}
+
+#[test]
+fn search_add_with_priority_and_tags() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo add task p=3 #a #b");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "todo:add:task|3|a,b");
 }
 
 #[test]
@@ -107,6 +116,18 @@ fn set_priority_and_tags_update_entry() {
     let todos = load_todos(TODO_FILE).unwrap();
     assert_eq!(todos[0].priority, 5);
     assert_eq!(todos[0].tags, vec!["a", "b"]);
+}
+
+#[test]
+fn search_pset_and_tag_actions() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let res = plugin.search("todo pset 1 4");
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].action, "todo:pset:1|4");
+    let res = plugin.search("todo tag 2 #x #y");
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].action, "todo:tag:2|x,y");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse `pset` and `tag` subcommands in `TodoPlugin::search`
- support priority and tags when adding todos
- handle new todo actions in GUI event loop
- update launcher action handlers
- extend todo plugin tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687bafa54d9c8332a283da8c0f44ac2e