### PR TITLE
Add todo view dialog

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -17,6 +17,7 @@ use crate::tempfile_dialog::TempfileDialog;
 use crate::timer_dialog::{TimerCompletionDialog, TimerDialog};
 use crate::timer_help_window::TimerHelpWindow;
 use crate::todo_dialog::TodoDialog;
+use crate::todo_view_dialog::TodoViewDialog;
 use crate::usage::{self, USAGE_FILE};
 use crate::visibility::apply_visibility;
 use eframe::egui;
@@ -118,6 +119,7 @@ pub struct LauncherApp {
     snippet_dialog: SnippetDialog,
     notes_dialog: NotesDialog,
     todo_dialog: TodoDialog,
+    todo_view_dialog: TodoViewDialog,
     clipboard_dialog: ClipboardDialog,
     volume_dialog: crate::volume_dialog::VolumeDialog,
     brightness_dialog: crate::brightness_dialog::BrightnessDialog,
@@ -402,6 +404,7 @@ impl LauncherApp {
             snippet_dialog: SnippetDialog::default(),
             notes_dialog: NotesDialog::default(),
             todo_dialog: TodoDialog::default(),
+            todo_view_dialog: TodoViewDialog::default(),
             clipboard_dialog: ClipboardDialog::default(),
             volume_dialog: crate::volume_dialog::VolumeDialog::default(),
             brightness_dialog: crate::brightness_dialog::BrightnessDialog::default(),
@@ -717,6 +720,7 @@ impl LauncherApp {
             || self.snippet_dialog.open
             || self.notes_dialog.open
             || self.todo_dialog.open
+            || self.todo_view_dialog.open
             || self.clipboard_dialog.open
             || self.volume_dialog.open
             || self.brightness_dialog.open
@@ -990,6 +994,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open_edit(alias);
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
+                        } else if a.action == "todo:view" {
+                            self.todo_view_dialog.open();
                         } else if a.action == "clipboard:dialog" {
                             self.clipboard_dialog.open();
                         } else if a.action == "tempfile:dialog" {
@@ -1526,14 +1532,16 @@ impl eframe::App for LauncherApp {
                                     self.notes_dialog.open();
                                 } else if a.action == "bookmark:dialog" {
                                     self.add_bookmark_dialog.open();
-                                } else if a.action == "snippet:dialog" {
-                                    self.snippet_dialog.open();
-                                } else if a.action == "todo:dialog" {
-                                    self.todo_dialog.open();
-                                } else if a.action == "clipboard:dialog" {
-                                    self.clipboard_dialog.open();
-                                } else if a.action == "tempfile:dialog" {
-                                    self.tempfile_dialog.open();
+                        } else if a.action == "snippet:dialog" {
+                            self.snippet_dialog.open();
+                        } else if a.action == "todo:dialog" {
+                            self.todo_dialog.open();
+                        } else if a.action == "todo:view" {
+                            self.todo_view_dialog.open();
+                        } else if a.action == "clipboard:dialog" {
+                            self.clipboard_dialog.open();
+                        } else if a.action == "tempfile:dialog" {
+                            self.tempfile_dialog.open();
                                 } else if a.action == "volume:dialog" {
                                     self.volume_dialog.open();
                                 } else if a.action == "brightness:dialog" {
@@ -1809,6 +1817,9 @@ impl eframe::App for LauncherApp {
         let mut todo_dlg = std::mem::take(&mut self.todo_dialog);
         todo_dlg.ui(ctx, self);
         self.todo_dialog = todo_dlg;
+        let mut todo_view = std::mem::take(&mut self.todo_view_dialog);
+        todo_view.ui(ctx, self);
+        self.todo_view_dialog = todo_view;
         let mut cb_dlg = std::mem::take(&mut self.clipboard_dialog);
         cb_dlg.ui(ctx, self);
         self.clipboard_dialog = cb_dlg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod tempfile_dialog;
 pub mod timer_dialog;
 pub mod timer_help_window;
 pub mod todo_dialog;
+pub mod todo_view_dialog;
 pub mod usage;
 pub mod visibility;
 pub mod volume_dialog;

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -171,6 +171,15 @@ impl Plugin for TodoPlugin {
             }];
         }
 
+        if trimmed.eq_ignore_ascii_case("todo view") {
+            return vec![Action {
+                label: "todo: view list".into(),
+                desc: "Todo".into(),
+                action: "todo:view".into(),
+                args: None,
+            }];
+        }
+
         if trimmed.eq_ignore_ascii_case("todo clear") {
             return vec![Action {
                 label: "Clear completed todos".into(),

--- a/src/todo_view_dialog.rs
+++ b/src/todo_view_dialog.rs
@@ -1,0 +1,114 @@
+use crate::gui::LauncherApp;
+use crate::plugins::todo::{load_todos, save_todos, TodoEntry, TODO_FILE};
+use eframe::egui;
+
+#[derive(Default)]
+pub struct TodoViewDialog {
+    pub open: bool,
+    entries: Vec<TodoEntry>,
+    filter: String,
+    sort_by_priority: bool,
+}
+
+impl TodoViewDialog {
+    pub fn open(&mut self) {
+        self.entries = load_todos(TODO_FILE).unwrap_or_default();
+        self.open = true;
+        self.filter.clear();
+        self.sort_by_priority = true;
+    }
+
+    fn save(&mut self, app: &mut LauncherApp) {
+        if let Err(e) = save_todos(TODO_FILE, &self.entries) {
+            app.error = Some(format!("Failed to save todos: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut close = false;
+        let mut save_now = false;
+        egui::Window::new("View Todos")
+            .open(&mut self.open)
+            .resizable(true)
+            .default_size((360.0, 240.0))
+            .min_width(200.0)
+            .min_height(150.0)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.checkbox(&mut self.sort_by_priority, "Sort by priority");
+                    ui.label("Filter");
+                    ui.text_edit_singleline(&mut self.filter);
+                });
+                ui.separator();
+                let filter = self.filter.trim().trim_start_matches('#').to_lowercase();
+                let mut indices: Vec<usize> = self
+                    .entries
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, e)| {
+                        filter.is_empty()
+                            || e.tags
+                                .iter()
+                                .any(|t| t.eq_ignore_ascii_case(&filter))
+                    })
+                    .map(|(i, _)| i)
+                    .collect();
+                if self.sort_by_priority {
+                    indices.sort_by(|a, b| self.entries[*b].priority.cmp(&self.entries[*a].priority));
+                }
+                let mut remove: Option<usize> = None;
+                let area_height = ui.available_height();
+                egui::ScrollArea::both().max_height(area_height).show(ui, |ui| {
+                    for idx in indices {
+                        let entry = &mut self.entries[idx];
+                        ui.horizontal(|ui| {
+                            if ui.text_edit_singleline(&mut entry.text).changed() {
+                                save_now = true;
+                            }
+                            if ui
+                                .add(egui::DragValue::new(&mut entry.priority).clamp_range(0..=255))
+                                .changed()
+                            {
+                                save_now = true;
+                            }
+                            let mut tag_str = entry.tags.join(", ");
+                            if ui.text_edit_singleline(&mut tag_str).changed() {
+                                entry.tags = tag_str
+                                    .split(',')
+                                    .map(|t| t.trim())
+                                    .filter(|t| !t.is_empty())
+                                    .map(|t| t.to_string())
+                                    .collect();
+                                save_now = true;
+                            }
+                            if ui.button("Remove").clicked() {
+                                remove = Some(idx);
+                            }
+                        });
+                    }
+                });
+                if let Some(idx) = remove {
+                    self.entries.remove(idx);
+                    save_now = true;
+                }
+                ui.horizontal(|ui| {
+                    if ui.button("Close").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        if save_now {
+            self.save(app);
+        }
+        if close {
+            self.open = false;
+        }
+    }
+}
+

--- a/src/todo_view_dialog.rs
+++ b/src/todo_view_dialog.rs
@@ -41,7 +41,7 @@ impl TodoViewDialog {
         egui::Window::new("View Todos")
             .open(&mut self.open)
             .resizable(true)
-            .default_size((360.0, 240.0))
+            .default_size((320.0, 240.0))
             .min_width(200.0)
             .min_height(150.0)
             .show(ctx, |ui| {
@@ -79,39 +79,47 @@ impl TodoViewDialog {
                     .show(ui, |ui| {
                         for idx in indices {
                             if Some(idx) == self.editing_idx {
-                                ui.horizontal(|ui| {
-                                    ui.label("Text:");
-                                    ui.text_edit_singleline(&mut self.editing_text);
-                                    ui.label("Priority:");
-                                    ui.add(
-                                        egui::DragValue::new(&mut self.editing_priority)
-                                            .clamp_range(0..=255),
-                                    );
-                                    ui.label("Tags:");
-                                    ui.text_edit_singleline(&mut self.editing_tags);
-                                    if ui.button("Save").clicked() {
-                                        let tags: Vec<String> = self
-                                            .editing_tags
-                                            .split(',')
-                                            .map(|t| t.trim())
-                                            .filter(|t| !t.is_empty())
-                                            .map(|t| t.to_string())
-                                            .collect();
-                                        if let Some(e) = self.entries.get_mut(idx) {
-                                            e.text = self.editing_text.clone();
-                                            e.priority = self.editing_priority;
-                                            e.tags = tags;
+                                ui.vertical(|ui| {
+                                    ui.horizontal(|ui| {
+                                        ui.label("Text:");
+                                        ui.text_edit_singleline(&mut self.editing_text);
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Priority:");
+                                        ui.add(
+                                            egui::DragValue::new(&mut self.editing_priority)
+                                                .clamp_range(0..=255),
+                                        );
+                                    });
+                                    ui.horizontal(|ui| {
+                                        ui.label("Tags:");
+                                        ui.text_edit_singleline(&mut self.editing_tags);
+                                    });
+                                    ui.horizontal(|ui| {
+                                        if ui.button("Save").clicked() {
+                                            let tags: Vec<String> = self
+                                                .editing_tags
+                                                .split(',')
+                                                .map(|t| t.trim())
+                                                .filter(|t| !t.is_empty())
+                                                .map(|t| t.to_string())
+                                                .collect();
+                                            if let Some(e) = self.entries.get_mut(idx) {
+                                                e.text = self.editing_text.clone();
+                                                e.priority = self.editing_priority;
+                                                e.tags = tags;
+                                            }
+                                            self.editing_idx = None;
+                                            save_now = true;
                                         }
-                                        self.editing_idx = None;
-                                        save_now = true;
-                                    }
-                                    if ui.button("Cancel").clicked() {
-                                        self.editing_idx = None;
-                                    }
+                                        if ui.button("Cancel").clicked() {
+                                            self.editing_idx = None;
+                                        }
+                                    });
                                 });
                             } else {
                                 let entry = &mut self.entries[idx];
-                                ui.horizontal(|ui| {
+                                ui.horizontal_wrapped(|ui| {
                                     if ui.checkbox(&mut entry.done, "").changed() {
                                         save_now = true;
                                     }

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -160,3 +160,11 @@ fn list_filters_by_tag() {
     assert_eq!(results.len(), 1);
     assert!(results[0].label.contains("alpha"));
 }
+#[test]
+fn search_view_opens_dialog() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo view");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "todo:view");
+}


### PR DESCRIPTION
## Summary
- create `TodoViewDialog` panel
- open it in GUI when action `todo:view` is triggered
- return `todo:view` action when typing `todo view`
- test that the plugin outputs the new action

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_687bb7e79b508332b831160e3453eae2