### PR TITLE
Add case-insensitive prefix helper

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,7 @@
+pub fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod plugin;
 pub mod plugin_editor;
 pub mod plugins;
 pub mod plugins_builtin;
+pub mod common;
 pub mod sound;
 pub mod settings;
 pub mod settings_editor;

--- a/src/plugins/asciiart.rs
+++ b/src/plugins/asciiart.rs
@@ -22,10 +22,8 @@ impl Default for AsciiArtPlugin {
 impl Plugin for AsciiArtPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "ascii ";
-        if query.len() >= PREFIX.len()
-            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            let text = query[PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, PREFIX) {
+            let text = rest.trim();
             if !text.is_empty() {
                 if let Some(fig) = self.font.convert(text) {
                     let art = fig.to_string();

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -7,15 +7,15 @@ impl Plugin for BrightnessPlugin {
     #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed.eq_ignore_ascii_case("bright") {
-            return vec![Action {
-                label: "bright: edit brightness".into(),
-                desc: "Brightness".into(),
-                action: "brightness:dialog".into(),
-                args: None,
-            }];
-        }
-        if let Some(rest) = trimmed.strip_prefix("bright ") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "bright") {
+            if rest.trim().is_empty() {
+                return vec![Action {
+                    label: "bright: edit brightness".into(),
+                    desc: "Brightness".into(),
+                    action: "brightness:dialog".into(),
+                    args: None,
+                }];
+            }
             let rest = rest.trim();
             if let Ok(val) = rest.parse::<u8>() {
                 if val <= 100 {

--- a/src/plugins/dropcalc.rs
+++ b/src/plugins/dropcalc.rs
@@ -20,12 +20,9 @@ impl Plugin for DropCalcPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
         const PREFIX: &str = "drop ";
-        let rest = if trimmed.len() >= PREFIX.len()
-            && trimmed[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            trimmed[PREFIX.len()..].trim()
-        } else {
-            return Vec::new();
+        let rest = match crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            Some(r) => r.trim(),
+            None => return Vec::new(),
         };
         let parts: Vec<&str> = rest.split_whitespace().collect();
         if parts.len() != 2 {

--- a/src/plugins/folders.rs
+++ b/src/plugins/folders.rs
@@ -174,10 +174,8 @@ impl Default for FoldersPlugin {
 impl Plugin for FoldersPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const ADD_PREFIX: &str = "f add ";
-        if query.len() >= ADD_PREFIX.len()
-            && query[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
-        {
-            let path = query[ADD_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, ADD_PREFIX) {
+            let path = rest.trim();
             if !path.is_empty() {
                 return vec![Action {
                     label: format!("Add folder {path}"),
@@ -189,10 +187,8 @@ impl Plugin for FoldersPlugin {
         }
 
         const RM_PREFIX: &str = "f rm ";
-        if query.len() >= RM_PREFIX.len()
-            && query[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
-        {
-            let filter = query[RM_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, RM_PREFIX) {
+            let filter = rest.trim();
             let folders = self.data.lock().unwrap().clone();
             return folders
                 .into_iter()
@@ -214,10 +210,11 @@ impl Plugin for FoldersPlugin {
         }
 
         const PREFIX: &str = "f";
-        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-            return Vec::new();
-        }
-        let filter = query[PREFIX.len()..].trim();
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        let filter = rest.trim();
         let folders = self.data.lock().unwrap().clone();
         folders
             .into_iter()

--- a/src/plugins/help.rs
+++ b/src/plugins/help.rs
@@ -6,18 +6,15 @@ pub struct HelpPlugin;
 impl Plugin for HelpPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let q = query.trim();
-        const PREFIX: &str = "help";
-        const PREFIX_SPACE: &str = "help ";
-        if q.eq_ignore_ascii_case(PREFIX)
-            || (q.len() >= PREFIX_SPACE.len()
-                && q[..PREFIX_SPACE.len()].eq_ignore_ascii_case(PREFIX_SPACE))
-        {
+        if let Some(rest) = crate::common::strip_prefix_ci(q, "help") {
+            if rest.is_empty() || rest.starts_with(' ') {
             return vec![Action {
                 label: "Show command list".into(),
                 desc: "Display available command prefixes".into(),
                 action: "help:show".into(),
                 args: None,
             }];
+            }
         }
         Vec::new()
     }

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -9,18 +9,21 @@ pub struct HistoryPlugin;
 impl Plugin for HistoryPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "hi";
-        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-            return Vec::new();
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        if let Some(clear_rest) = crate::common::strip_prefix_ci(query.trim(), "hi clear") {
+            if clear_rest.is_empty() {
+                return vec![Action {
+                    label: "Clear history".into(),
+                    desc: "History".into(),
+                    action: "history:clear".into(),
+                    args: None,
+                }];
+            }
         }
-        if query.trim().eq_ignore_ascii_case("hi clear") {
-            return vec![Action {
-                label: "Clear history".into(),
-                desc: "History".into(),
-                action: "history:clear".into(),
-                args: None,
-            }];
-        }
-        let filter = query[PREFIX.len()..].trim().to_lowercase();
+        let filter = rest.trim().to_lowercase();
         get_history()
             .into_iter()
             .enumerate()

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -119,10 +119,8 @@ impl Default for NotesPlugin {
 impl Plugin for NotesPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const ADD_PREFIX: &str = "note add ";
-        if query.len() >= ADD_PREFIX.len()
-            && query[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
-        {
-            let text = query[ADD_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, ADD_PREFIX) {
+            let text = rest.trim();
             if !text.is_empty() {
                 return vec![Action {
                     label: format!("Add note {text}"),
@@ -134,10 +132,8 @@ impl Plugin for NotesPlugin {
         }
 
         const RM_PREFIX: &str = "note rm ";
-        if query.len() >= RM_PREFIX.len()
-            && query[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
-        {
-            let filter = query[RM_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, RM_PREFIX) {
+            let filter = rest.trim();
             let notes = self.data.lock().unwrap().clone();
             return notes
                 .into_iter()
@@ -153,10 +149,8 @@ impl Plugin for NotesPlugin {
         }
 
         const LIST_PREFIX: &str = "note list";
-        if query.len() >= LIST_PREFIX.len()
-            && query[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
-        {
-            let filter = query[LIST_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, LIST_PREFIX) {
+            let filter = rest.trim();
             let notes = self.data.lock().unwrap().clone();
             return notes
                 .into_iter()
@@ -171,13 +165,15 @@ impl Plugin for NotesPlugin {
                 .collect();
         }
 
-        if query.trim().eq_ignore_ascii_case("note") {
+        if let Some(rest) = crate::common::strip_prefix_ci(query.trim(), "note") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "note: edit notes".into(),
                 desc: "Note".into(),
                 action: "note:dialog".into(),
                 args: None,
             }];
+        }
         }
 
         Vec::new()

--- a/src/plugins/processes.rs
+++ b/src/plugins/processes.rs
@@ -7,10 +7,11 @@ pub struct ProcessesPlugin;
 impl Plugin for ProcessesPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "ps";
-        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-            return Vec::new();
-        }
-        let filter = query[PREFIX.len()..].trim().to_lowercase();
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        let filter = rest.trim().to_lowercase();
         let system = System::new_all();
         system
             .processes()

--- a/src/plugins/recycle.rs
+++ b/src/plugins/recycle.rs
@@ -8,7 +8,7 @@ impl Plugin for RecyclePlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "rec";
         let trimmed = query.trim_start();
-        if trimmed.len() >= PREFIX.len() && trimmed[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        if crate::common::strip_prefix_ci(trimmed, PREFIX).is_some() {
             return vec![Action {
                 label: "Clean Recycle Bin".into(),
                 desc: "Recycle Bin".into(),

--- a/src/plugins/reddit.rs
+++ b/src/plugins/reddit.rs
@@ -6,10 +6,8 @@ pub struct RedditPlugin;
 impl Plugin for RedditPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "red ";
-        if query.len() >= PREFIX.len()
-            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            let q = query[PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, PREFIX) {
+            let q = rest.trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search Reddit for {q}"),

--- a/src/plugins/runescape.rs
+++ b/src/plugins/runescape.rs
@@ -6,10 +6,8 @@ pub struct RunescapeSearchPlugin;
 impl Plugin for RunescapeSearchPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const RS_PREFIX: &str = "rs ";
-        if query.len() >= RS_PREFIX.len()
-            && query[..RS_PREFIX.len()].eq_ignore_ascii_case(RS_PREFIX)
-        {
-            let q = query[RS_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, RS_PREFIX) {
+            let q = rest.trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search RuneScape Wiki for {q}"),
@@ -20,10 +18,8 @@ impl Plugin for RunescapeSearchPlugin {
             }
         }
         const OSRS_PREFIX: &str = "osrs ";
-        if query.len() >= OSRS_PREFIX.len()
-            && query[..OSRS_PREFIX.len()].eq_ignore_ascii_case(OSRS_PREFIX)
-        {
-            let q = query[OSRS_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, OSRS_PREFIX) {
+            let q = rest.trim();
             if !q.is_empty() {
                 return vec![Action {
                     label: format!("Search Old School RuneScape Wiki for {q}"),

--- a/src/plugins/shell.rs
+++ b/src/plugins/shell.rs
@@ -57,20 +57,19 @@ pub struct ShellPlugin;
 impl Plugin for ShellPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed.eq_ignore_ascii_case("sh") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "sh") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "sh: edit saved commands".into(),
                 desc: "Shell".into(),
                 action: "shell:dialog".into(),
                 args: None,
             }];
+            }
         }
 
         const ADD_PREFIX: &str = "sh add ";
-        if trimmed.len() >= ADD_PREFIX.len()
-            && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
-        {
-            let rest = &trimmed[ADD_PREFIX.len()..];
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, ADD_PREFIX) {
             let mut parts = rest.trim().splitn(2, ' ');
             let name = parts.next().unwrap_or("").trim();
             let args = parts.next().unwrap_or("").trim();
@@ -85,10 +84,7 @@ impl Plugin for ShellPlugin {
         }
 
         const RM_PREFIX: &str = "sh rm";
-        if trimmed.len() >= RM_PREFIX.len()
-            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
-        {
-            let rest = &trimmed[RM_PREFIX.len()..];
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, RM_PREFIX) {
             let filter = rest.trim();
             if let Ok(list) = load_shell_cmds(SHELL_CMDS_FILE) {
                 let matcher = SkimMatcherV2::default();
@@ -110,10 +106,7 @@ impl Plugin for ShellPlugin {
         }
 
         const LIST_PREFIX: &str = "sh list";
-        if trimmed.len() >= LIST_PREFIX.len()
-            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
-        {
-            let rest = &trimmed[LIST_PREFIX.len()..];
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
             let filter = rest.trim();
             if let Ok(list) = load_shell_cmds(SHELL_CMDS_FILE) {
                 let matcher = SkimMatcherV2::default();
@@ -134,10 +127,7 @@ impl Plugin for ShellPlugin {
         }
 
         const CMD_PREFIX: &str = "sh ";
-        if trimmed.len() >= CMD_PREFIX.len()
-            && trimmed[..CMD_PREFIX.len()].eq_ignore_ascii_case(CMD_PREFIX)
-        {
-            let cmd = &trimmed[CMD_PREFIX.len()..];
+        if let Some(cmd) = crate::common::strip_prefix_ci(trimmed, CMD_PREFIX) {
             let arg = cmd.trim();
             if arg.is_empty() {
                 return Vec::new();

--- a/src/plugins/system.rs
+++ b/src/plugins/system.rs
@@ -6,10 +6,11 @@ pub struct SystemPlugin;
 impl Plugin for SystemPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "sys";
-        if query.len() < PREFIX.len() || !query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
-            return Vec::new();
-        }
-        let filter = query[PREFIX.len()..].trim();
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        let filter = rest.trim();
         const OPTIONS: [&str; 4] = ["shutdown", "reboot", "lock", "logoff"];
         OPTIONS
             .iter()

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -119,19 +119,19 @@ pub struct TempfilePlugin;
 impl Plugin for TempfilePlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed.eq_ignore_ascii_case("tmp") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "tmp: create".into(),
                 desc: "Tempfile".into(),
                 action: "tempfile:dialog".into(),
                 args: None,
             }];
+            }
         }
         const NEW_PREFIX: &str = "tmp new ";
-        if trimmed.len() >= NEW_PREFIX.len()
-            && trimmed[..NEW_PREFIX.len()].eq_ignore_ascii_case(NEW_PREFIX)
-        {
-            let alias = trimmed[NEW_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, NEW_PREFIX) {
+            let alias = rest.trim();
             if !alias.is_empty() && validate_alias(alias).is_ok() {
                 return vec![Action {
                     label: format!("Create temp file {alias}"),
@@ -140,35 +140,39 @@ impl Plugin for TempfilePlugin {
                     args: None,
                 }];
             }
-        } else if trimmed.eq_ignore_ascii_case("tmp new") {
+        } else if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp new") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "Create temp file".into(),
                 desc: "Tempfile".into(),
                 action: "tempfile:new".into(),
                 args: None,
             }];
+            }
         }
-        if trimmed.eq_ignore_ascii_case("tmp open") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp open") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "Open temp directory".into(),
                 desc: "Tempfile".into(),
                 action: "tempfile:open".into(),
                 args: None,
             }];
+            }
         }
-        if trimmed.eq_ignore_ascii_case("tmp clear") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp clear") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "Clear temp files".into(),
                 desc: "Tempfile".into(),
                 action: "tempfile:clear".into(),
                 args: None,
             }];
+            }
         }
         const RM_PREFIX: &str = "tmp rm";
-        if trimmed.len() >= RM_PREFIX.len()
-            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
-        {
-            let filter = trimmed[RM_PREFIX.len()..].trim().to_lowercase();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, RM_PREFIX) {
+            let filter = rest.trim().to_lowercase();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()
@@ -188,10 +192,7 @@ impl Plugin for TempfilePlugin {
                 .collect();
         }
         const ALIAS_PREFIX: &str = "tmp alias";
-        if trimmed.len() >= ALIAS_PREFIX.len()
-            && trimmed[..ALIAS_PREFIX.len()].eq_ignore_ascii_case(ALIAS_PREFIX)
-        {
-            let rest = &trimmed[ALIAS_PREFIX.len()..];
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, ALIAS_PREFIX) {
             let mut parts = rest.trim().splitn(2, ' ');
             if let (Some(file), Some(alias)) = (parts.next(), parts.next()) {
                 let file = file.trim();
@@ -216,10 +217,8 @@ impl Plugin for TempfilePlugin {
             }
         }
         const LIST_PREFIX: &str = "tmp list";
-        if trimmed.len() >= LIST_PREFIX.len()
-            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
-        {
-            let filter = trimmed[LIST_PREFIX.len()..].trim().to_lowercase();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
+            let filter = rest.trim().to_lowercase();
             let files = list_files().unwrap_or_default();
             return files
                 .into_iter()

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -445,23 +445,29 @@ pub struct TimerPlugin;
 impl Plugin for TimerPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed.eq_ignore_ascii_case("timer") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "timer") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "Open timer dialog".into(),
                 desc: "Timer".into(),
                 action: "timer:dialog:timer".into(),
                 args: None,
             }];
+            }
         }
-        if trimmed.eq_ignore_ascii_case("alarm") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "alarm") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "Open alarm dialog".into(),
                 desc: "Timer".into(),
                 action: "timer:dialog:alarm".into(),
                 args: None,
             }];
+            }
         }
-        if trimmed.starts_with("timer list") || trimmed.starts_with("alarm list") {
+        if crate::common::strip_prefix_ci(trimmed, "timer list").is_some()
+            || crate::common::strip_prefix_ci(trimmed, "alarm list").is_some()
+        {
             return active_timers()
                 .into_iter()
                 .map(|(id, label, rem, _start)| Action {
@@ -472,7 +478,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if trimmed.starts_with("timer cancel") {
+        if crate::common::strip_prefix_ci(trimmed, "timer cancel").is_some() {
             return active_timers()
                 .into_iter()
                 .map(|(id, label, _rem, _start)| Action {
@@ -483,7 +489,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if trimmed.starts_with("timer rm") {
+        if crate::common::strip_prefix_ci(trimmed, "timer rm").is_some() {
             return active_timers()
                 .into_iter()
                 .map(|(id, label, rem, _start)| Action {
@@ -494,7 +500,7 @@ impl Plugin for TimerPlugin {
                 })
                 .collect();
         }
-        if let Some(id_str) = trimmed.strip_prefix("timer pause") {
+        if let Some(id_str) = crate::common::strip_prefix_ci(trimmed, "timer pause") {
             let tail = id_str.trim();
             if tail.is_empty() {
                 return running_timers()
@@ -515,7 +521,7 @@ impl Plugin for TimerPlugin {
                 }];
             }
         }
-        if let Some(id_str) = trimmed.strip_prefix("timer resume") {
+        if let Some(id_str) = crate::common::strip_prefix_ci(trimmed, "timer resume") {
             let tail = id_str.trim();
             if tail.is_empty() {
                 return paused_timers()
@@ -536,7 +542,7 @@ impl Plugin for TimerPlugin {
                 }];
             }
         }
-        if let Some(arg) = trimmed.strip_prefix("timer add") {
+        if let Some(arg) = crate::common::strip_prefix_ci(trimmed, "timer add") {
             let arg = arg.trim();
             let mut parts = arg.splitn(2, ' ');
             let dur_part = parts.next().unwrap_or("");
@@ -560,7 +566,7 @@ impl Plugin for TimerPlugin {
                 }];
             }
         }
-        if let Some(arg) = trimmed.strip_prefix("alarm ") {
+        if let Some(arg) = crate::common::strip_prefix_ci(trimmed, "alarm ") {
             let arg = arg.trim();
             let mut parts = arg.splitn(2, ' ');
             let time_part = parts.next().unwrap_or("");

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -162,16 +162,18 @@ impl Plugin for TodoPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
 
-        if trimmed.eq_ignore_ascii_case("todo") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "todo") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "todo: edit todos".into(),
                 desc: "Todo".into(),
                 action: "todo:dialog".into(),
                 args: None,
             }];
+            }
         }
 
-        if trimmed.eq_ignore_ascii_case("todo view") {
+        if crate::common::strip_prefix_ci(trimmed, "todo view").is_some() {
             return vec![Action {
                 label: "todo: view list".into(),
                 desc: "Todo".into(),
@@ -180,7 +182,7 @@ impl Plugin for TodoPlugin {
             }];
         }
 
-        if trimmed.eq_ignore_ascii_case("todo clear") {
+        if crate::common::strip_prefix_ci(trimmed, "todo clear").is_some() {
             return vec![Action {
                 label: "Clear completed todos".into(),
                 desc: "Todo".into(),
@@ -189,7 +191,7 @@ impl Plugin for TodoPlugin {
             }];
         }
 
-        if trimmed.eq_ignore_ascii_case("todo add") {
+        if crate::common::strip_prefix_ci(trimmed, "todo add").is_some() {
             return vec![Action {
                 label: "todo: edit todos".into(),
                 desc: "Todo".into(),
@@ -199,10 +201,8 @@ impl Plugin for TodoPlugin {
         }
 
         const ADD_PREFIX: &str = "todo add ";
-        if trimmed.len() >= ADD_PREFIX.len()
-            && trimmed[..ADD_PREFIX.len()].eq_ignore_ascii_case(ADD_PREFIX)
-        {
-            let rest = trimmed[ADD_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, ADD_PREFIX) {
+            let rest = rest.trim();
             if !rest.is_empty() {
                 let mut priority: u8 = 0;
                 let mut tags: Vec<String> = Vec::new();
@@ -234,10 +234,8 @@ impl Plugin for TodoPlugin {
         }
 
         const PSET_PREFIX: &str = "todo pset ";
-        if trimmed.len() >= PSET_PREFIX.len()
-            && trimmed[..PSET_PREFIX.len()].eq_ignore_ascii_case(PSET_PREFIX)
-        {
-            let rest = trimmed[PSET_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, PSET_PREFIX) {
+            let rest = rest.trim();
             let mut parts = rest.split_whitespace();
             if let (Some(idx_str), Some(priority_str)) = (parts.next(), parts.next()) {
                 if let (Ok(idx), Ok(priority)) = (idx_str.parse::<usize>(), priority_str.parse::<u8>()) {
@@ -252,10 +250,8 @@ impl Plugin for TodoPlugin {
         }
 
         const TAG_PREFIX: &str = "todo tag ";
-        if trimmed.len() >= TAG_PREFIX.len()
-            && trimmed[..TAG_PREFIX.len()].eq_ignore_ascii_case(TAG_PREFIX)
-        {
-            let rest = trimmed[TAG_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, TAG_PREFIX) {
+            let rest = rest.trim();
             let mut parts = rest.split_whitespace();
             if let Some(idx_str) = parts.next() {
                 if let Ok(idx) = idx_str.parse::<usize>() {
@@ -279,10 +275,8 @@ impl Plugin for TodoPlugin {
         }
 
         const RM_PREFIX: &str = "todo rm ";
-        if trimmed.len() >= RM_PREFIX.len()
-            && trimmed[..RM_PREFIX.len()].eq_ignore_ascii_case(RM_PREFIX)
-        {
-            let filter = trimmed[RM_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, RM_PREFIX) {
+            let filter = rest.trim();
             let todos = self.data.lock().unwrap().clone();
             return todos
                 .into_iter()
@@ -298,10 +292,8 @@ impl Plugin for TodoPlugin {
         }
 
         const LIST_PREFIX: &str = "todo list";
-        if trimmed.len() >= LIST_PREFIX.len()
-            && trimmed[..LIST_PREFIX.len()].eq_ignore_ascii_case(LIST_PREFIX)
-        {
-            let filter = trimmed[LIST_PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
+            let filter = rest.trim();
             let todos = self.data.lock().unwrap().clone();
             let mut entries: Vec<(usize, TodoEntry)> = todos.into_iter().enumerate().collect();
 

--- a/src/plugins/unit_convert.rs
+++ b/src/plugins/unit_convert.rs
@@ -80,14 +80,10 @@ impl Plugin for UnitConvertPlugin {
         let trimmed = query.trim();
         const CONV_PREFIX: &str = "conv ";
         const CONVERT_PREFIX: &str = "convert ";
-        let rest = if trimmed.len() >= CONV_PREFIX.len()
-            && trimmed[..CONV_PREFIX.len()].eq_ignore_ascii_case(CONV_PREFIX)
-        {
-            &trimmed[CONV_PREFIX.len()..]
-        } else if trimmed.len() >= CONVERT_PREFIX.len()
-            && trimmed[..CONVERT_PREFIX.len()].eq_ignore_ascii_case(CONVERT_PREFIX)
-        {
-            &trimmed[CONVERT_PREFIX.len()..]
+        let rest = if let Some(r) = crate::common::strip_prefix_ci(trimmed, CONV_PREFIX) {
+            r
+        } else if let Some(r) = crate::common::strip_prefix_ci(trimmed, CONVERT_PREFIX) {
+            r
         } else {
             return Vec::new();
         };

--- a/src/plugins/volume.rs
+++ b/src/plugins/volume.rs
@@ -7,15 +7,17 @@ impl Plugin for VolumePlugin {
     #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
-        if trimmed.eq_ignore_ascii_case("vol") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "vol") {
+            if rest.is_empty() {
             return vec![Action {
                 label: "vol: edit volume".into(),
                 desc: "Volume".into(),
                 action: "volume:dialog".into(),
                 args: None,
             }];
+            }
         }
-        if let Some(rest) = trimmed.strip_prefix("vol ") {
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "vol ") {
             let rest = rest.trim();
             if rest.eq_ignore_ascii_case("ma") {
                 return vec![Action {

--- a/src/plugins/weather.rs
+++ b/src/plugins/weather.rs
@@ -7,10 +7,8 @@ pub struct WeatherPlugin;
 impl Plugin for WeatherPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "weather ";
-        if query.len() >= PREFIX.len()
-            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            let q = query[PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, PREFIX) {
+            let q = rest.trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {

--- a/src/plugins/wikipedia.rs
+++ b/src/plugins/wikipedia.rs
@@ -6,10 +6,8 @@ pub struct WikipediaPlugin;
 impl Plugin for WikipediaPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "wiki ";
-        if query.len() >= PREFIX.len()
-            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            let q = query[PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, PREFIX) {
+            let q = rest.trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {

--- a/src/plugins/youtube.rs
+++ b/src/plugins/youtube.rs
@@ -6,10 +6,8 @@ pub struct YoutubePlugin;
 impl Plugin for YoutubePlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "yt ";
-        if query.len() >= PREFIX.len()
-            && query[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-        {
-            let q = query[PREFIX.len()..].trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(query, PREFIX) {
+            let q = rest.trim();
             let q = q.trim();
             if !q.is_empty() {
                 return vec![Action {


### PR DESCRIPTION
## Summary
- add new `strip_prefix_ci` helper to `common` module
- update plugins to use the helper for command prefix detection
- expose the new module via `lib.rs`

## Testing
- `cargo test --quiet` *(fails: alsa-sys build script can't find `alsa.pc`)*

------
https://chatgpt.com/codex/tasks/task_e_687c010356a08332a1b71d5b7b473855