### PR TITLE
Add Task Manager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Built-in plugins and their command prefixes are:
 - Saved apps (`app <filter>` or just `app`)
 - Volume control (`vol 50`) *(Windows only)*
 - Brightness control (`bright 50`) *(Windows only)*
+- Task Manager (`tm`) *(Windows only)*
 - Command overview (`help`)
 - Timers and alarms (`timer add 5m tea`, `timer add 1:30`, `alarm 07:30`). Use `timer list` to view
    remaining time or `timer rm` to remove timers. Pending alarms are saved to `alarms.json` and resume after

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -28,6 +28,8 @@ use crate::plugins::asciiart::AsciiArtPlugin;
 use crate::plugins::volume::VolumePlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
+#[cfg(target_os = "windows")]
+use crate::plugins::task_manager::TaskManagerPlugin;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -93,6 +95,7 @@ impl PluginManager {
         {
             self.register(Box::new(VolumePlugin));
             self.register(Box::new(BrightnessPlugin));
+            self.register(Box::new(TaskManagerPlugin));
         }
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -23,3 +23,4 @@ pub mod dropcalc;
 pub mod recycle;
 pub mod tempfile;
 pub mod asciiart;
+pub mod task_manager;

--- a/src/plugins/task_manager.rs
+++ b/src/plugins/task_manager.rs
@@ -1,0 +1,47 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct TaskManagerPlugin;
+
+impl Plugin for TaskManagerPlugin {
+    #[cfg(target_os = "windows")]
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim_start();
+        if crate::common::strip_prefix_ci(trimmed, "tm").is_some() {
+            return vec![Action {
+                label: "Open Task Manager".into(),
+                desc: "Task Manager".into(),
+                action: "shell:taskmgr".into(),
+                args: None,
+            }];
+        }
+        Vec::new()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "task_manager"
+    }
+
+    fn description(&self) -> &str {
+        "Open the Windows Task Manager (prefix: `tm`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "tm".into(),
+            desc: "Task Manager".into(),
+            action: "query:tm".into(),
+            args: None,
+        }]
+    }
+}
+

--- a/tests/task_manager_plugin.rs
+++ b/tests/task_manager_plugin.rs
@@ -1,0 +1,14 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::task_manager::TaskManagerPlugin;
+
+#[test]
+fn search_returns_action() {
+    let plugin = TaskManagerPlugin;
+    let results = plugin.search("tm");
+    if cfg!(target_os = "windows") {
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action, "shell:taskmgr");
+    } else {
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- implement a Task Manager plugin for Windows
- expose the plugin via `tm` prefix
- register the plugin in the plugin manager
- document the new plugin in README
- add regression test

## Testing
- `cargo test`
 