### PR TITLE
Add WindowsPlugin

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -208,6 +208,8 @@ enum ActionKind<'a> {
     VolumeSet(u32),
     VolumeMuteActive,
     RecycleClean,
+    WindowSwitch(usize),
+    WindowClose(usize),
     TempfileNew(Option<&'a str>),
     TempfileOpen,
     TempfileClear,
@@ -274,6 +276,16 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
     if let Some(pid) = s.strip_prefix("process:switch:") {
         if let Ok(p) = pid.parse::<u32>() {
             return ActionKind::ProcessSwitch(p);
+        }
+    }
+    if let Some(hwnd) = s.strip_prefix("window:switch:") {
+        if let Ok(h) = hwnd.parse::<usize>() {
+            return ActionKind::WindowSwitch(h);
+        }
+    }
+    if let Some(hwnd) = s.strip_prefix("window:close:") {
+        if let Ok(h) = hwnd.parse::<usize>() {
+            return ActionKind::WindowClose(h);
         }
     }
     if let Some(id) = s.strip_prefix("timer:cancel:") {
@@ -527,6 +539,20 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
             #[cfg(target_os = "windows")]
             {
                 crate::window_manager::activate_process(pid);
+            }
+            Ok(())
+        }
+        ActionKind::WindowSwitch(hwnd) => {
+            #[cfg(target_os = "windows")]
+            {
+                crate::window_manager::activate_window(hwnd);
+            }
+            Ok(())
+        }
+        ActionKind::WindowClose(hwnd) => {
+            #[cfg(target_os = "windows")]
+            {
+                crate::window_manager::close_window(hwnd);
             }
             Ok(())
         }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,6 +25,8 @@ use crate::plugins::recycle::RecyclePlugin;
 use crate::plugins::tempfile::TempfilePlugin;
 use crate::plugins::asciiart::AsciiArtPlugin;
 #[cfg(target_os = "windows")]
+use crate::plugins::windows::WindowsPlugin;
+#[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
@@ -96,6 +98,7 @@ impl PluginManager {
             self.register(Box::new(VolumePlugin));
             self.register(Box::new(BrightnessPlugin));
             self.register(Box::new(TaskManagerPlugin));
+            self.register(Box::new(WindowsPlugin));
         }
         self.register(Box::new(HelpPlugin));
         self.register(Box::new(TimerPlugin));

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -24,3 +24,4 @@ pub mod recycle;
 pub mod tempfile;
 pub mod asciiart;
 pub mod task_manager;
+pub mod windows;

--- a/src/plugins/windows.rs
+++ b/src/plugins/windows.rs
@@ -36,13 +36,13 @@ impl Plugin for WindowsPlugin {
                         ctx.out.push(Action {
                             label: format!("Switch to {title}"),
                             desc: "Windows".into(),
-                            action: format!("window:switch:{}", hwnd.0),
+                            action: format!("window:switch:{}", hwnd.0 as usize),
                             args: None,
                         });
                         ctx.out.push(Action {
                             label: format!("Close {title}"),
                             desc: "Windows".into(),
-                            action: format!("window:close:{}", hwnd.0),
+                            action: format!("window:close:{}", hwnd.0 as usize),
                             args: None,
                         });
                     }

--- a/src/plugins/windows.rs
+++ b/src/plugins/windows.rs
@@ -1,0 +1,82 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct WindowsPlugin;
+
+impl Plugin for WindowsPlugin {
+    #[cfg(target_os = "windows")]
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "win";
+        let trimmed = query.trim();
+        let rest = match crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            Some(r) => r.trim(),
+            None => return Vec::new(),
+        };
+        let filter = rest.to_lowercase();
+        use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
+        use windows::Win32::UI::WindowsAndMessaging::{
+            EnumWindows, GetWindowTextW, IsWindowVisible, GetWindow, GetWindowTextLengthW,
+            GW_OWNER,
+        };
+        struct Ctx {
+            filter: String,
+            out: Vec<Action>,
+        }
+        unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+            let ctx = &mut *(lparam.0 as *mut Ctx);
+            if IsWindowVisible(hwnd).as_bool()
+                && GetWindow(hwnd, GW_OWNER).unwrap_or_default().0.is_null()
+            {
+                let len = GetWindowTextLengthW(hwnd);
+                if len > 0 {
+                    let mut buf = vec![0u16; len as usize + 1];
+                    let read = GetWindowTextW(hwnd, &mut buf);
+                    let title = String::from_utf16_lossy(&buf[..read as usize]);
+                    if title.to_lowercase().contains(&ctx.filter) {
+                        ctx.out.push(Action {
+                            label: format!("Switch to {title}"),
+                            desc: "Windows".into(),
+                            action: format!("window:switch:{}", hwnd.0),
+                            args: None,
+                        });
+                        ctx.out.push(Action {
+                            label: format!("Close {title}"),
+                            desc: "Windows".into(),
+                            action: format!("window:close:{}", hwnd.0),
+                            args: None,
+                        });
+                    }
+                }
+            }
+            BOOL(1)
+        }
+        let mut ctx = Ctx { filter, out: Vec::new() };
+        unsafe {
+            let ctx_ptr = &mut ctx as *mut Ctx;
+            let _ = EnumWindows(Some(enum_cb), LPARAM(ctx_ptr as isize));
+        }
+        ctx.out
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "windows"
+    }
+
+    fn description(&self) -> &str {
+        "Switch or close windows (prefix: `win`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "win".into(), desc: "Windows".into(), action: "query:win ".into(), args: None }]
+    }
+}
+

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -268,6 +268,21 @@ pub fn activate_process(pid: u32) {
 }
 
 #[cfg(target_os = "windows")]
+pub fn activate_window(hwnd: usize) {
+    use windows::Win32::Foundation::HWND;
+    crate::window_manager::force_restore_and_foreground(HWND(hwnd as *mut _));
+}
+
+#[cfg(target_os = "windows")]
+pub fn close_window(hwnd: usize) {
+    use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+    unsafe {
+        let _ = PostMessageW(HWND(hwnd as *mut _), WM_CLOSE, WPARAM(0), LPARAM(0));
+    }
+}
+
+#[cfg(target_os = "windows")]
 pub fn send_end_key() {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,


### PR DESCRIPTION
## Summary
- implement WindowsPlugin for switching and closing windows
- expose new module in plugin registry
- register WindowsPlugin alongside other builtins

## Testing
- `cargo test --quiet`
 