### PR TITLE
Add tests for missing plugins

### DIFF
--- a/tests/help_plugin.rs
+++ b/tests/help_plugin.rs
@@ -1,0 +1,10 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::help::HelpPlugin;
+
+#[test]
+fn search_returns_help_action() {
+    let plugin = HelpPlugin;
+    let results = plugin.search("help");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "help:show");
+}

--- a/tests/runescape_plugin.rs
+++ b/tests/runescape_plugin.rs
@@ -1,0 +1,18 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::runescape::RunescapeSearchPlugin;
+
+#[test]
+fn rs_search_returns_action() {
+    let plugin = RunescapeSearchPlugin;
+    let results = plugin.search("rs boots of lightness");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://runescape.wiki/?search=boots of lightness");
+}
+
+#[test]
+fn osrs_search_returns_action() {
+    let plugin = RunescapeSearchPlugin;
+    let results = plugin.search("osrs agility");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "https://oldschool.runescape.wiki/?search=agility");
+}


### PR DESCRIPTION
## Summary
- test that the help plugin shows the command list
- test RuneScape wiki search plugin

## Testing
- `cargo test --quiet`
 