### PR TITLE
Add network usage plugin

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -8,5 +8,6 @@
     "enable_toasts": true,
     "show_examples": false,
     "preserve_command": false,
-    "history_limit": 100
+    "history_limit": 100,
+    "net_refresh": 1.0
 }

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -119,6 +119,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),
         "sysinfo" => Some(&["info", "info cpu", "info cpu list 5"]),
+        "network" => Some(&["net"]),
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
         "timer" => Some(&[

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -86,7 +86,7 @@ impl PluginManager {
         self.register(Box::new(SystemPlugin));
         self.register(Box::new(ProcessesPlugin));
         self.register(Box::new(SysInfoPlugin));
-        self.register(Box::new(NetworkPlugin));
+        self.register(Box::new(NetworkPlugin::default()));
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(NotesPlugin::default()));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::processes::ProcessesPlugin;
 use crate::plugins::sysinfo::SysInfoPlugin;
+use crate::plugins::network::NetworkPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::reddit::RedditPlugin;
@@ -85,6 +86,7 @@ impl PluginManager {
         self.register(Box::new(SystemPlugin));
         self.register(Box::new(ProcessesPlugin));
         self.register(Box::new(SysInfoPlugin));
+        self.register(Box::new(NetworkPlugin));
         self.register(Box::new(ShellPlugin));
         self.register(Box::new(HistoryPlugin));
         self.register(Box::new(NotesPlugin::default()));

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -122,6 +122,7 @@ impl PluginEditor {
                         s.static_size,
                         Some(s.hide_after_run),
                         Some(s.timer_refresh),
+                        Some(s.net_refresh),
                         Some(s.disable_timer_updates),
                         Some(s.preserve_command),
                     );

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,7 @@ pub mod reddit;
 pub mod wikipedia;
 pub mod processes;
 pub mod sysinfo;
+pub mod network;
 pub mod weather;
 pub mod notes;
 pub mod todo;

--- a/src/plugins/network.rs
+++ b/src/plugins/network.rs
@@ -1,0 +1,51 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use sysinfo::Networks;
+
+/// Display network usage per interface using the `net` prefix.
+pub struct NetworkPlugin;
+
+impl Plugin for NetworkPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "net";
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        if !rest.trim().is_empty() {
+            return Vec::new();
+        }
+        let mut nets = Networks::new_with_refreshed_list();
+        // refresh to get current values and generate diff
+        nets.refresh(true);
+        nets
+            .iter()
+            .map(|(name, data)| {
+                let rx = data.total_received();
+                let tx = data.total_transmitted();
+                Action {
+                    label: format!("{name} Rx {} B Tx {} B", rx, tx),
+                    desc: "Network".into(),
+                    action: format!("net:{name}"),
+                    args: None,
+                }
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "network"
+    }
+
+    fn description(&self) -> &str {
+        "Show network usage per interface (prefix: `net`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action { label: "net".into(), desc: "Network".into(), action: "query:net".into(), args: None }]
+    }
+}

--- a/src/plugins/network.rs
+++ b/src/plugins/network.rs
@@ -4,6 +4,18 @@ use sysinfo::Networks;
 use std::sync::Mutex;
 use std::time::Instant;
 
+fn fmt_speed(bytes_per_sec: f64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    if bytes_per_sec >= MB {
+        format!("{:.2} MB/s", bytes_per_sec / MB)
+    } else if bytes_per_sec >= KB {
+        format!("{:.1} kB/s", bytes_per_sec / KB)
+    } else {
+        format!("{:.0} B/s", bytes_per_sec)
+    }
+}
+
 /// Display network usage per interface using the `net` prefix.
 pub struct NetworkPlugin {
     state: Mutex<(Networks, Instant)>,
@@ -39,10 +51,10 @@ impl Plugin for NetworkPlugin {
         nets
             .iter()
             .map(|(name, data)| {
-                let rx = data.received() as f64 / dt / 1_048_576.0;
-                let tx = data.transmitted() as f64 / dt / 1_048_576.0;
+                let rx = data.received() as f64 / dt;
+                let tx = data.transmitted() as f64 / dt;
                 Action {
-                    label: format!("{name} Rx {:.1} MB/s Tx {:.1} MB/s", rx, tx),
+                    label: format!("{name} Rx {} Tx {}", fmt_speed(rx), fmt_speed(tx)),
                     desc: "Network".into(),
                     action: format!("net:{name}"),
                     args: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -70,6 +70,9 @@ pub struct Settings {
     /// Interval in seconds to refresh the timer list.
     #[serde(default = "default_timer_refresh")]
     pub timer_refresh: f32,
+    /// Interval in seconds to refresh the network usage display.
+    #[serde(default = "default_net_refresh")]
+    pub net_refresh: f32,
     /// When true, the timer list will not refresh automatically.
     #[serde(default)]
     pub disable_timer_updates: bool,
@@ -93,6 +96,8 @@ fn default_usage_weight() -> f32 { 1.0 }
 fn default_follow_mouse() -> bool { true }
 
 fn default_timer_refresh() -> f32 { 1.0 }
+
+fn default_net_refresh() -> f32 { 1.0 }
 
 impl Default for Settings {
     fn default() -> Self {
@@ -120,6 +125,7 @@ impl Default for Settings {
             static_size: None,
             hide_after_run: false,
             timer_refresh: default_timer_refresh(),
+            net_refresh: default_net_refresh(),
             disable_timer_updates: false,
             preserve_command: false,
             show_examples: false,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -41,6 +41,7 @@ pub struct SettingsEditor {
     static_h: i32,
     hide_after_run: bool,
     timer_refresh: f32,
+    net_refresh: f32,
     disable_timer_updates: bool,
     preserve_command: bool,
 }
@@ -113,6 +114,7 @@ impl SettingsEditor {
             static_h: settings.static_size.unwrap_or((400, 220)).1,
             hide_after_run: settings.hide_after_run,
             timer_refresh: settings.timer_refresh,
+            net_refresh: settings.net_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,
         }
@@ -159,6 +161,7 @@ impl SettingsEditor {
             static_size: Some((self.static_w, self.static_h)),
             hide_after_run: self.hide_after_run,
             timer_refresh: self.timer_refresh,
+            net_refresh: self.net_refresh,
             disable_timer_updates: self.disable_timer_updates,
             preserve_command: self.preserve_command,
             show_examples: current.show_examples,
@@ -257,6 +260,10 @@ impl SettingsEditor {
                 ui.add_enabled_ui(!self.disable_timer_updates, |ui| {
                     ui.add(egui::DragValue::new(&mut self.timer_refresh).clamp_range(0.1..=60.0).speed(0.1));
                 });
+            });
+            ui.horizontal(|ui| {
+                ui.label("Network refresh rate (s)");
+                ui.add(egui::DragValue::new(&mut self.net_refresh).clamp_range(0.1..=60.0).speed(0.1));
             });
 
             ui.horizontal(|ui| {
@@ -404,6 +411,7 @@ impl SettingsEditor {
                                     new_settings.static_size,
                                     Some(new_settings.hide_after_run),
                                     Some(new_settings.timer_refresh),
+                                    Some(new_settings.net_refresh),
                                     Some(new_settings.disable_timer_updates),
                                     Some(new_settings.preserve_command),
                                 );

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -62,6 +62,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -1,0 +1,9 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::network::NetworkPlugin;
+
+#[test]
+fn search_returns_actions() {
+    let plugin = NetworkPlugin;
+    let results = plugin.search("net");
+    assert!(!results.is_empty());
+}

--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -1,9 +1,11 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::network::NetworkPlugin;
+use std::{thread, time::Duration};
 
 #[test]
 fn search_returns_actions() {
-    let plugin = NetworkPlugin;
+    let plugin = NetworkPlugin::default();
+    thread::sleep(Duration::from_millis(10));
     let results = plugin.search("net");
     assert!(!results.is_empty());
 }


### PR DESCRIPTION
## Summary
- implement `NetworkPlugin` using sysinfo to show per-interface Rx/Tx data
- register the plugin and add module entry
- document `net` examples in the help window
- include basic plugin tests

## Testing
- `cargo test --test network_plugin --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687cfc5957a48332ad28bd964157999d