### PR TITLE
Add network usage unit configuration

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -170,6 +170,8 @@ pub struct LauncherApp {
     pub timer_refresh: f32,
     pub disable_timer_updates: bool,
     pub preserve_command: bool,
+    pub net_refresh: f32,
+    pub net_unit: crate::settings::NetUnit,
     last_timer_update: Instant,
 }
 
@@ -202,6 +204,8 @@ impl LauncherApp {
         timer_refresh: Option<f32>,
         disable_timer_updates: Option<bool>,
         preserve_command: Option<bool>,
+        net_refresh: Option<f32>,
+        net_unit: Option<crate::settings::NetUnit>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -242,6 +246,12 @@ impl LauncherApp {
         }
         if let Some(v) = preserve_command {
             self.preserve_command = v;
+        }
+        if let Some(v) = net_refresh {
+            self.net_refresh = v;
+        }
+        if let Some(v) = net_unit {
+            self.net_unit = v;
         }
     }
 
@@ -422,7 +432,10 @@ impl LauncherApp {
             tempfile_alias_dialog: TempfileAliasDialog::default(),
             tempfile_dialog: TempfileDialog::default(),
             add_bookmark_dialog: AddBookmarkDialog::default(),
-            help_window: HelpWindow { show_examples: settings.show_examples, ..Default::default() },
+            help_window: HelpWindow {
+                show_examples: settings.show_examples,
+                ..Default::default()
+            },
             timer_help: TimerHelpWindow::default(),
             timer_dialog: TimerDialog::default(),
             completion_dialog: TimerCompletionDialog::default(),
@@ -454,6 +467,8 @@ impl LauncherApp {
             timer_refresh: settings.timer_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,
+            net_refresh: settings.net_refresh,
+            net_unit: settings.net_unit,
             last_timer_update: Instant::now(),
             action_cache: Vec::new(),
         };

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -119,6 +119,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),
         "sysinfo" => Some(&["info", "info cpu", "info cpu list 5"]),
+        "network" => Some(&["net"]),
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
         "timer" => Some(&[

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
-    plugins.reload_from_dirs(dirs, settings.clipboard_limit, true);
+    plugins.reload_from_dirs(dirs, settings.clipboard_limit, settings.net_unit, true);
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();
@@ -61,8 +61,9 @@ fn spawn_gui(
 
     let handle = thread::spawn(move || {
         let (w, h) = settings.window_size.unwrap_or((400, 220));
-        let icon = icon_data::from_png_bytes(include_bytes!("../Resources/Green_MultiLauncher.png"))
-            .expect("invalid icon");
+        let icon =
+            icon_data::from_png_bytes(include_bytes!("../Resources/Green_MultiLauncher.png"))
+                .expect("invalid icon");
         let native_options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
                 .with_inner_size([w as f32, h as f32])

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,7 @@ pub mod reddit;
 pub mod wikipedia;
 pub mod processes;
 pub mod sysinfo;
+pub mod network;
 pub mod weather;
 pub mod notes;
 pub mod todo;

--- a/src/plugins/network.rs
+++ b/src/plugins/network.rs
@@ -1,0 +1,107 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use crate::settings::NetUnit;
+use std::sync::Mutex;
+use std::time::Instant;
+use sysinfo::Networks;
+
+fn fmt_speed(bytes_per_sec: f64, unit: NetUnit) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    match unit {
+        NetUnit::Auto => {
+            if bytes_per_sec >= MB {
+                format!("{:.2} MB/s", bytes_per_sec / MB)
+            } else if bytes_per_sec >= KB {
+                format!("{:.1} kB/s", bytes_per_sec / KB)
+            } else {
+                format!("{:.0} B/s", bytes_per_sec)
+            }
+        }
+        NetUnit::B => format!("{:.0} B/s", bytes_per_sec),
+        NetUnit::Kb => format!("{:.1} kB/s", bytes_per_sec / KB),
+        NetUnit::Mb => format!("{:.2} MB/s", bytes_per_sec / MB),
+    }
+}
+
+/// Display network usage per interface using the `net` prefix.
+pub struct NetworkPlugin {
+    state: Mutex<(Networks, Instant)>,
+    unit: NetUnit,
+}
+
+impl NetworkPlugin {
+    pub fn new(unit: NetUnit) -> Self {
+        let mut nets = Networks::new_with_refreshed_list();
+        nets.refresh(true);
+        Self {
+            state: Mutex::new((nets, Instant::now())),
+            unit,
+        }
+    }
+}
+
+impl Default for NetworkPlugin {
+    fn default() -> Self {
+        Self::new(NetUnit::Auto)
+    }
+}
+
+impl Plugin for NetworkPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "net";
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        if !rest.trim().is_empty() {
+            return Vec::new();
+        }
+        let mut guard = match self.state.lock() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        let (nets, last) = &mut *guard;
+        let now = Instant::now();
+        nets.refresh(true);
+        let dt = now.duration_since(*last).as_secs_f64().max(0.001);
+        *last = now;
+        nets.iter()
+            .map(|(name, data)| {
+                let rx = data.received() as f64 / dt;
+                let tx = data.transmitted() as f64 / dt;
+                Action {
+                    label: format!(
+                        "{name} Rx {} Tx {}",
+                        fmt_speed(rx, self.unit),
+                        fmt_speed(tx, self.unit)
+                    ),
+                    desc: "Network".into(),
+                    action: format!("net:{name}"),
+                    args: None,
+                }
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "network"
+    }
+
+    fn description(&self) -> &str {
+        "Show network usage per interface (prefix: `net`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "net".into(),
+            desc: "Network".into(),
+            action: "query:net".into(),
+            args: None,
+        }]
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,6 +3,32 @@ use crate::hotkey::Key;
 use crate::hotkey::{parse_hotkey, Hotkey};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetUnit {
+    Auto,
+    B,
+    Kb,
+    Mb,
+}
+
+impl Default for NetUnit {
+    fn default() -> Self {
+        NetUnit::Auto
+    }
+}
+
+impl std::fmt::Display for NetUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetUnit::Auto => write!(f, "Auto"),
+            NetUnit::B => write!(f, "B/s"),
+            NetUnit::Kb => write!(f, "kB/s"),
+            NetUnit::Mb => write!(f, "MB/s"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub hotkey: Option<String>,
@@ -76,23 +102,47 @@ pub struct Settings {
     /// Keep the command prefix in the query after running an action.
     #[serde(default)]
     pub preserve_command: bool,
+    #[serde(default = "default_net_refresh")]
+    pub net_refresh: f32,
+    #[serde(default)]
+    pub net_unit: NetUnit,
 }
 
-fn default_toasts() -> bool { true }
+fn default_toasts() -> bool {
+    true
+}
 
-fn default_scale() -> Option<f32> { Some(1.0) }
+fn default_scale() -> Option<f32> {
+    Some(1.0)
+}
 
-fn default_history_limit() -> usize { 100 }
+fn default_history_limit() -> usize {
+    100
+}
 
-fn default_clipboard_limit() -> usize { 20 }
+fn default_clipboard_limit() -> usize {
+    20
+}
 
-fn default_fuzzy_weight() -> f32 { 1.0 }
+fn default_fuzzy_weight() -> f32 {
+    1.0
+}
 
-fn default_usage_weight() -> f32 { 1.0 }
+fn default_usage_weight() -> f32 {
+    1.0
+}
 
-fn default_follow_mouse() -> bool { true }
+fn default_follow_mouse() -> bool {
+    true
+}
 
-fn default_timer_refresh() -> f32 { 1.0 }
+fn default_timer_refresh() -> f32 {
+    1.0
+}
+
+fn default_net_refresh() -> f32 {
+    1.0
+}
 
 impl Default for Settings {
     fn default() -> Self {
@@ -120,6 +170,8 @@ impl Default for Settings {
             static_size: None,
             hide_after_run: false,
             timer_refresh: default_timer_refresh(),
+            net_refresh: default_net_refresh(),
+            net_unit: NetUnit::Auto,
             disable_timer_updates: false,
             preserve_command: false,
             show_examples: false,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,6 +1,6 @@
-use crate::settings::Settings;
 use crate::gui::LauncherApp;
 use crate::hotkey::parse_hotkey;
+use crate::settings::Settings;
 use eframe::egui;
 use egui_toast::{Toast, ToastKind, ToastOptions};
 #[cfg(target_os = "windows")]
@@ -43,6 +43,8 @@ pub struct SettingsEditor {
     timer_refresh: f32,
     disable_timer_updates: bool,
     preserve_command: bool,
+    net_refresh: f32,
+    net_unit: crate::settings::NetUnit,
 }
 
 impl SettingsEditor {
@@ -115,6 +117,8 @@ impl SettingsEditor {
             timer_refresh: settings.timer_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,
+            net_refresh: settings.net_refresh,
+            net_unit: settings.net_unit,
         }
     }
 
@@ -161,6 +165,8 @@ impl SettingsEditor {
             timer_refresh: self.timer_refresh,
             disable_timer_updates: self.disable_timer_updates,
             preserve_command: self.preserve_command,
+            net_refresh: self.net_refresh,
+            net_unit: self.net_unit,
             show_examples: current.show_examples,
         }
     }
@@ -173,264 +179,317 @@ impl SettingsEditor {
                 egui::ScrollArea::vertical()
                     .max_height(300.0)
                     .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                ui.label("Launcher hotkey");
-                let resp = ui.text_edit_singleline(&mut self.hotkey);
-                if resp.changed() {
-                    self.hotkey_valid = parse_hotkey(&self.hotkey).is_some();
-                    if self.hotkey_valid {
-                        self.last_valid_hotkey = self.hotkey.clone();
-                    }
-                }
-                let color = if self.hotkey_valid {
-                    egui::Color32::GREEN
-                } else {
-                    egui::Color32::RED
-                };
-                ui.add(egui::Label::new(
-                    egui::RichText::new("●").color(color),
-                ));
-            });
-            ui.checkbox(&mut self.quit_hotkey_enabled, "Enable quit hotkey");
-            if self.quit_hotkey_enabled {
-                ui.horizontal(|ui| {
-                    ui.label("Quit hotkey");
-                    let resp = ui.text_edit_singleline(&mut self.quit_hotkey);
-                    if resp.changed() {
-                        self.quit_hotkey_valid = parse_hotkey(&self.quit_hotkey).is_some();
-                        if self.quit_hotkey_valid {
-                            self.last_valid_quit_hotkey = self.quit_hotkey.clone();
-                        }
-                    }
-                    let color = if self.quit_hotkey_valid {
-                        egui::Color32::GREEN
-                    } else {
-                        egui::Color32::RED
-                    };
-                    ui.add(egui::Label::new(
-                        egui::RichText::new("●").color(color),
-                    ));
-                });
-            }
-
-            ui.checkbox(&mut self.help_hotkey_enabled, "Enable help hotkey");
-            if self.help_hotkey_enabled {
-                ui.horizontal(|ui| {
-                    ui.label("Help hotkey");
-                    let resp = ui.text_edit_singleline(&mut self.help_hotkey);
-                    if resp.changed() {
-                        self.help_hotkey_valid = parse_hotkey(&self.help_hotkey).is_some();
-                        if self.help_hotkey_valid {
-                            self.last_valid_help_hotkey = self.help_hotkey.clone();
-                        }
-                    }
-                    let color = if self.help_hotkey_valid {
-                        egui::Color32::GREEN
-                    } else {
-                        egui::Color32::RED
-                    };
-                    ui.add(egui::Label::new(
-                        egui::RichText::new("●").color(color),
-                    ));
-                });
-            }
-
-            ui.horizontal(|ui| {
-                egui::ComboBox::from_label("Debug logging")
-                    .selected_text(if self.debug_logging {
-                        "Enabled"
-                    } else {
-                        "Disabled"
-                    })
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(&mut self.debug_logging, false, "Disabled");
-                        ui.selectable_value(&mut self.debug_logging, true, "Enabled");
-                    });
-            });
-
-            ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
-            ui.checkbox(&mut self.hide_after_run, "Hide window after running action");
-            ui.checkbox(&mut self.preserve_command, "Preserve command after run");
-            ui.checkbox(&mut self.disable_timer_updates, "Disable timer auto refresh");
-            ui.horizontal(|ui| {
-                ui.label("Timer refresh rate (s)");
-                ui.add_enabled_ui(!self.disable_timer_updates, |ui| {
-                    ui.add(egui::DragValue::new(&mut self.timer_refresh).clamp_range(0.1..=60.0).speed(0.1));
-                });
-            });
-
-            ui.horizontal(|ui| {
-                ui.label("Query scale");
-                ui.add(egui::Slider::new(&mut self.query_scale, 0.5..=5.0).text(""));
-            });
-            ui.horizontal(|ui| {
-                ui.label("List scale");
-                ui.add(egui::Slider::new(&mut self.list_scale, 0.5..=5.0).text(""));
-            });
-            ui.horizontal(|ui| {
-                ui.label("Fuzzy weight");
-                ui.add(egui::Slider::new(&mut self.fuzzy_weight, 0.0..=5.0).text(""));
-            });
-            ui.horizontal(|ui| {
-                ui.label("Usage weight");
-                ui.add(egui::Slider::new(&mut self.usage_weight, 0.0..=5.0).text(""));
-            });
-            ui.horizontal(|ui| {
-                ui.label("History limit");
-                ui.add(egui::Slider::new(&mut self.history_limit, 10..=500).text(""));
-            });
-            ui.horizontal(|ui| {
-                ui.label("Clipboard limit");
-                ui.add(egui::Slider::new(&mut self.clipboard_limit, 1..=100).text(""));
-            });
-
-            ui.horizontal(|ui| {
-                ui.label("Off-screen X");
-                ui.add(egui::DragValue::new(&mut self.offscreen_x));
-                ui.label("Y");
-                ui.add(egui::DragValue::new(&mut self.offscreen_y));
-            });
-
-            ui.checkbox(&mut self.follow_mouse, "Follow mouse");
-            ui.add_enabled_ui(!self.follow_mouse, |ui| {
-                ui.checkbox(&mut self.static_enabled, "Use static position");
-            });
-            if self.static_enabled {
-                ui.horizontal(|ui| {
-                    ui.label("X");
-                    ui.add(egui::DragValue::new(&mut self.static_x));
-                    ui.label("Y");
-                    ui.add(egui::DragValue::new(&mut self.static_y));
-                    ui.label("W");
-                    ui.add(egui::DragValue::new(&mut self.static_w));
-                    ui.label("H");
-                    ui.add(egui::DragValue::new(&mut self.static_h));
-                    if ui.button("Snapshot").clicked() {
-                        self.static_x = app.window_pos.0;
-                        self.static_y = app.window_pos.1;
-                        self.static_w = app.window_size.0;
-                        self.static_h = app.window_size.1;
-                    }
-                });
-            }
-
-            ui.separator();
-            ui.label("Index paths:");
-            let mut remove: Option<usize> = None;
-            for (idx, path) in self.index_paths.iter().enumerate() {
-                ui.horizontal(|ui| {
-                    ui.label(path);
-                    if ui.button("Remove").clicked() {
-                        remove = Some(idx);
-                    }
-                });
-            }
-            if let Some(i) = remove {
-                self.index_paths.remove(i);
-            }
-            ui.horizontal(|ui| {
-                ui.text_edit_singleline(&mut self.index_input);
-                if ui.button("Browse").clicked() {
-                    #[cfg(target_os = "windows")]
-                    if let Some(dir) = FileDialog::new().pick_folder() {
-                        self.index_input = dir.display().to_string();
-                    }
-                }
-                if ui.button("Add").clicked() {
-                    if !self.index_input.is_empty() {
-                        self.index_paths.push(self.index_input.clone());
-                        self.index_input.clear();
-                    }
-                }
-            });
-
-            if ui.button("Save").clicked() {
-                if parse_hotkey(&self.hotkey).is_none() {
-                    self.hotkey = self.last_valid_hotkey.clone();
-                    self.hotkey_valid = true;
-                    if app.enable_toasts {
-                        app.add_toast(Toast {
-                            text: "Failed to save settings: hotkey is invalid".into(),
-                            kind: ToastKind::Error,
-                            options: ToastOptions::default().duration_in_seconds(3.0),
-                        });
-                    }
-                } else if self.quit_hotkey_enabled && parse_hotkey(&self.quit_hotkey).is_none() {
-                    self.quit_hotkey = self.last_valid_quit_hotkey.clone();
-                    self.quit_hotkey_valid = true;
-                    if app.enable_toasts {
-                        app.add_toast(Toast {
-                            text: "Failed to save settings: quit hotkey is invalid".into(),
-                            kind: ToastKind::Error,
-                            options: ToastOptions::default().duration_in_seconds(3.0),
-                        });
-                    }
-                } else if self.help_hotkey_enabled && parse_hotkey(&self.help_hotkey).is_none() {
-                    self.help_hotkey = self.last_valid_help_hotkey.clone();
-                    self.help_hotkey_valid = true;
-                    if app.enable_toasts {
-                        app.add_toast(Toast {
-                            text: "Failed to save settings: help hotkey is invalid".into(),
-                            kind: ToastKind::Error,
-                            options: ToastOptions::default().duration_in_seconds(3.0),
-                        });
-                    }
-                } else {
-                    self.last_valid_hotkey = self.hotkey.clone();
-                    if self.quit_hotkey_enabled {
-                        self.last_valid_quit_hotkey = self.quit_hotkey.clone();
-                    }
-                    if self.help_hotkey_enabled {
-                        self.last_valid_help_hotkey = self.help_hotkey.clone();
-                    }
-                    match Settings::load(&app.settings_path) {
-                        Ok(current) => {
-                            let new_settings = self.to_settings(&current);
-                            if let Err(e) = new_settings.save(&app.settings_path) {
-                                app.error = Some(format!("Failed to save: {e}"));
+                        ui.horizontal(|ui| {
+                            ui.label("Launcher hotkey");
+                            let resp = ui.text_edit_singleline(&mut self.hotkey);
+                            if resp.changed() {
+                                self.hotkey_valid = parse_hotkey(&self.hotkey).is_some();
+                                if self.hotkey_valid {
+                                    self.last_valid_hotkey = self.hotkey.clone();
+                                }
+                            }
+                            let color = if self.hotkey_valid {
+                                egui::Color32::GREEN
                             } else {
-                                app.update_paths(
-                                    new_settings.plugin_dirs.clone(),
-                                    new_settings.index_paths.clone(),
-                                    new_settings.enabled_plugins.clone(),
-                                    new_settings.enabled_capabilities.clone(),
-                                    new_settings.offscreen_pos,
-                                    Some(new_settings.enable_toasts),
-                                    Some(new_settings.fuzzy_weight),
-                                    Some(new_settings.usage_weight),
-                                    Some(new_settings.follow_mouse),
-                                    Some(new_settings.static_location_enabled),
-                                    new_settings.static_pos,
-                                    new_settings.static_size,
-                                    Some(new_settings.hide_after_run),
-                                    Some(new_settings.timer_refresh),
-                                    Some(new_settings.disable_timer_updates),
-                                    Some(new_settings.preserve_command),
+                                egui::Color32::RED
+                            };
+                            ui.add(egui::Label::new(egui::RichText::new("●").color(color)));
+                        });
+                        ui.checkbox(&mut self.quit_hotkey_enabled, "Enable quit hotkey");
+                        if self.quit_hotkey_enabled {
+                            ui.horizontal(|ui| {
+                                ui.label("Quit hotkey");
+                                let resp = ui.text_edit_singleline(&mut self.quit_hotkey);
+                                if resp.changed() {
+                                    self.quit_hotkey_valid =
+                                        parse_hotkey(&self.quit_hotkey).is_some();
+                                    if self.quit_hotkey_valid {
+                                        self.last_valid_quit_hotkey = self.quit_hotkey.clone();
+                                    }
+                                }
+                                let color = if self.quit_hotkey_valid {
+                                    egui::Color32::GREEN
+                                } else {
+                                    egui::Color32::RED
+                                };
+                                ui.add(egui::Label::new(egui::RichText::new("●").color(color)));
+                            });
+                        }
+
+                        ui.checkbox(&mut self.help_hotkey_enabled, "Enable help hotkey");
+                        if self.help_hotkey_enabled {
+                            ui.horizontal(|ui| {
+                                ui.label("Help hotkey");
+                                let resp = ui.text_edit_singleline(&mut self.help_hotkey);
+                                if resp.changed() {
+                                    self.help_hotkey_valid =
+                                        parse_hotkey(&self.help_hotkey).is_some();
+                                    if self.help_hotkey_valid {
+                                        self.last_valid_help_hotkey = self.help_hotkey.clone();
+                                    }
+                                }
+                                let color = if self.help_hotkey_valid {
+                                    egui::Color32::GREEN
+                                } else {
+                                    egui::Color32::RED
+                                };
+                                ui.add(egui::Label::new(egui::RichText::new("●").color(color)));
+                            });
+                        }
+
+                        ui.horizontal(|ui| {
+                            egui::ComboBox::from_label("Debug logging")
+                                .selected_text(if self.debug_logging {
+                                    "Enabled"
+                                } else {
+                                    "Disabled"
+                                })
+                                .show_ui(ui, |ui| {
+                                    ui.selectable_value(&mut self.debug_logging, false, "Disabled");
+                                    ui.selectable_value(&mut self.debug_logging, true, "Enabled");
+                                });
+                        });
+
+                        ui.checkbox(&mut self.show_toasts, "Enable toast notifications");
+                        ui.checkbox(&mut self.hide_after_run, "Hide window after running action");
+                        ui.checkbox(&mut self.preserve_command, "Preserve command after run");
+                        ui.checkbox(
+                            &mut self.disable_timer_updates,
+                            "Disable timer auto refresh",
+                        );
+                        ui.horizontal(|ui| {
+                            ui.label("Timer refresh rate (s)");
+                            ui.add_enabled_ui(!self.disable_timer_updates, |ui| {
+                                ui.add(
+                                    egui::DragValue::new(&mut self.timer_refresh)
+                                        .clamp_range(0.1..=60.0)
+                                        .speed(0.1),
                                 );
-                                app.hotkey_str = new_settings.hotkey.clone();
-                                app.quit_hotkey_str = new_settings.quit_hotkey.clone();
-                                app.help_hotkey_str = new_settings.help_hotkey.clone();
-                                app.query_scale = new_settings.query_scale.unwrap_or(1.0).min(5.0);
-                                app.list_scale = new_settings.list_scale.unwrap_or(1.0).min(5.0);
-                                app.history_limit = new_settings.history_limit;
-                                app.clipboard_limit = new_settings.clipboard_limit;
-                                app.preserve_command = new_settings.preserve_command;
-                                crate::request_hotkey_restart(new_settings);
+                            });
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Net refresh rate (s)");
+                            ui.add(
+                                egui::DragValue::new(&mut self.net_refresh)
+                                    .clamp_range(0.1..=60.0)
+                                    .speed(0.1),
+                            );
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Net units");
+                            egui::ComboBox::from_id_source("net_units")
+                                .selected_text(self.net_unit.to_string())
+                                .show_ui(ui, |ui| {
+                                    ui.selectable_value(
+                                        &mut self.net_unit,
+                                        crate::settings::NetUnit::Auto,
+                                        "Auto",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.net_unit,
+                                        crate::settings::NetUnit::B,
+                                        "B/s",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.net_unit,
+                                        crate::settings::NetUnit::Kb,
+                                        "kB/s",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.net_unit,
+                                        crate::settings::NetUnit::Mb,
+                                        "MB/s",
+                                    );
+                                });
+                        });
+
+                        ui.horizontal(|ui| {
+                            ui.label("Query scale");
+                            ui.add(egui::Slider::new(&mut self.query_scale, 0.5..=5.0).text(""));
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("List scale");
+                            ui.add(egui::Slider::new(&mut self.list_scale, 0.5..=5.0).text(""));
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Fuzzy weight");
+                            ui.add(egui::Slider::new(&mut self.fuzzy_weight, 0.0..=5.0).text(""));
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Usage weight");
+                            ui.add(egui::Slider::new(&mut self.usage_weight, 0.0..=5.0).text(""));
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("History limit");
+                            ui.add(egui::Slider::new(&mut self.history_limit, 10..=500).text(""));
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Clipboard limit");
+                            ui.add(egui::Slider::new(&mut self.clipboard_limit, 1..=100).text(""));
+                        });
+
+                        ui.horizontal(|ui| {
+                            ui.label("Off-screen X");
+                            ui.add(egui::DragValue::new(&mut self.offscreen_x));
+                            ui.label("Y");
+                            ui.add(egui::DragValue::new(&mut self.offscreen_y));
+                        });
+
+                        ui.checkbox(&mut self.follow_mouse, "Follow mouse");
+                        ui.add_enabled_ui(!self.follow_mouse, |ui| {
+                            ui.checkbox(&mut self.static_enabled, "Use static position");
+                        });
+                        if self.static_enabled {
+                            ui.horizontal(|ui| {
+                                ui.label("X");
+                                ui.add(egui::DragValue::new(&mut self.static_x));
+                                ui.label("Y");
+                                ui.add(egui::DragValue::new(&mut self.static_y));
+                                ui.label("W");
+                                ui.add(egui::DragValue::new(&mut self.static_w));
+                                ui.label("H");
+                                ui.add(egui::DragValue::new(&mut self.static_h));
+                                if ui.button("Snapshot").clicked() {
+                                    self.static_x = app.window_pos.0;
+                                    self.static_y = app.window_pos.1;
+                                    self.static_w = app.window_size.0;
+                                    self.static_h = app.window_size.1;
+                                }
+                            });
+                        }
+
+                        ui.separator();
+                        ui.label("Index paths:");
+                        let mut remove: Option<usize> = None;
+                        for (idx, path) in self.index_paths.iter().enumerate() {
+                            ui.horizontal(|ui| {
+                                ui.label(path);
+                                if ui.button("Remove").clicked() {
+                                    remove = Some(idx);
+                                }
+                            });
+                        }
+                        if let Some(i) = remove {
+                            self.index_paths.remove(i);
+                        }
+                        ui.horizontal(|ui| {
+                            ui.text_edit_singleline(&mut self.index_input);
+                            if ui.button("Browse").clicked() {
+                                #[cfg(target_os = "windows")]
+                                if let Some(dir) = FileDialog::new().pick_folder() {
+                                    self.index_input = dir.display().to_string();
+                                }
+                            }
+                            if ui.button("Add").clicked() {
+                                if !self.index_input.is_empty() {
+                                    self.index_paths.push(self.index_input.clone());
+                                    self.index_input.clear();
+                                }
+                            }
+                        });
+
+                        if ui.button("Save").clicked() {
+                            if parse_hotkey(&self.hotkey).is_none() {
+                                self.hotkey = self.last_valid_hotkey.clone();
+                                self.hotkey_valid = true;
                                 if app.enable_toasts {
                                     app.add_toast(Toast {
-                                        text: "Settings saved".into(),
-                                        kind: ToastKind::Success,
+                                        text: "Failed to save settings: hotkey is invalid".into(),
+                                        kind: ToastKind::Error,
                                         options: ToastOptions::default().duration_in_seconds(3.0),
                                     });
                                 }
+                            } else if self.quit_hotkey_enabled
+                                && parse_hotkey(&self.quit_hotkey).is_none()
+                            {
+                                self.quit_hotkey = self.last_valid_quit_hotkey.clone();
+                                self.quit_hotkey_valid = true;
+                                if app.enable_toasts {
+                                    app.add_toast(Toast {
+                                        text: "Failed to save settings: quit hotkey is invalid"
+                                            .into(),
+                                        kind: ToastKind::Error,
+                                        options: ToastOptions::default().duration_in_seconds(3.0),
+                                    });
+                                }
+                            } else if self.help_hotkey_enabled
+                                && parse_hotkey(&self.help_hotkey).is_none()
+                            {
+                                self.help_hotkey = self.last_valid_help_hotkey.clone();
+                                self.help_hotkey_valid = true;
+                                if app.enable_toasts {
+                                    app.add_toast(Toast {
+                                        text: "Failed to save settings: help hotkey is invalid"
+                                            .into(),
+                                        kind: ToastKind::Error,
+                                        options: ToastOptions::default().duration_in_seconds(3.0),
+                                    });
+                                }
+                            } else {
+                                self.last_valid_hotkey = self.hotkey.clone();
+                                if self.quit_hotkey_enabled {
+                                    self.last_valid_quit_hotkey = self.quit_hotkey.clone();
+                                }
+                                if self.help_hotkey_enabled {
+                                    self.last_valid_help_hotkey = self.help_hotkey.clone();
+                                }
+                                match Settings::load(&app.settings_path) {
+                                    Ok(current) => {
+                                        let new_settings = self.to_settings(&current);
+                                        if let Err(e) = new_settings.save(&app.settings_path) {
+                                            app.error = Some(format!("Failed to save: {e}"));
+                                        } else {
+                                            app.update_paths(
+                                                new_settings.plugin_dirs.clone(),
+                                                new_settings.index_paths.clone(),
+                                                new_settings.enabled_plugins.clone(),
+                                                new_settings.enabled_capabilities.clone(),
+                                                new_settings.offscreen_pos,
+                                                Some(new_settings.enable_toasts),
+                                                Some(new_settings.fuzzy_weight),
+                                                Some(new_settings.usage_weight),
+                                                Some(new_settings.follow_mouse),
+                                                Some(new_settings.static_location_enabled),
+                                                new_settings.static_pos,
+                                                new_settings.static_size,
+                                                Some(new_settings.hide_after_run),
+                                                Some(new_settings.timer_refresh),
+                                                Some(new_settings.disable_timer_updates),
+                                                Some(new_settings.preserve_command),
+                                                Some(new_settings.net_refresh),
+                                                Some(new_settings.net_unit),
+                                            );
+                                            app.hotkey_str = new_settings.hotkey.clone();
+                                            app.quit_hotkey_str = new_settings.quit_hotkey.clone();
+                                            app.help_hotkey_str = new_settings.help_hotkey.clone();
+                                            app.query_scale =
+                                                new_settings.query_scale.unwrap_or(1.0).min(5.0);
+                                            app.list_scale =
+                                                new_settings.list_scale.unwrap_or(1.0).min(5.0);
+                                            app.history_limit = new_settings.history_limit;
+                                            app.clipboard_limit = new_settings.clipboard_limit;
+                                            app.preserve_command = new_settings.preserve_command;
+                                            app.net_refresh = new_settings.net_refresh;
+                                            app.net_unit = new_settings.net_unit;
+                                            crate::request_hotkey_restart(new_settings);
+                                            if app.enable_toasts {
+                                                app.add_toast(Toast {
+                                                    text: "Settings saved".into(),
+                                                    kind: ToastKind::Success,
+                                                    options: ToastOptions::default()
+                                                        .duration_in_seconds(3.0),
+                                                });
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        app.error = Some(format!("Failed to read settings: {e}"))
+                                    }
+                                }
                             }
                         }
-                        Err(e) => app.error = Some(format!("Failed to read settings: {e}")),
-                    }
-                }
-            }
+                    });
             });
-        });
         app.show_settings = open;
     }
 }

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -62,6 +62,8 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -1,0 +1,11 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::network::NetworkPlugin;
+use std::{thread, time::Duration};
+
+#[test]
+fn search_returns_actions() {
+    let plugin = NetworkPlugin::default();
+    thread::sleep(Duration::from_millis(10));
+    let results = plugin.search("net");
+    assert!(!results.is_empty());
+}

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -9,7 +9,12 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         actions,

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -14,7 +14,12 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
     let custom_len = 0;
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         Vec::new(),
@@ -83,7 +88,10 @@ fn snippet_edit_command_unfiltered() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
-    let entries = vec![SnippetEntry { alias: "foo".into(), text: "bar".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "foo".into(),
+        text: "bar".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
     let mut settings = Settings::default();
     settings.fuzzy_weight = 0.0;

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -1,15 +1,20 @@
+use eframe::egui;
+use multi_launcher::actions::Action;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
-use multi_launcher::actions::Action;
 use multi_launcher::settings::Settings;
-use std::sync::{Arc, atomic::AtomicBool};
-use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc};
 
 fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         actions,
@@ -31,10 +36,18 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
 #[test]
 fn g_prefix_filters_web_search() {
     let ctx = egui::Context::default();
-    let actions = vec![Action { label: "g hello".into(), desc: "test".into(), action: "custom".into(), args: None }];
+    let actions = vec![Action {
+        label: "g hello".into(),
+        desc: "test".into(),
+        action: "custom".into(),
+        args: None,
+    }];
     let mut app = new_app_with_plugins(&ctx, actions);
     app.query = "g hello".into();
     app.search();
     assert_eq!(app.results.len(), 1);
-    assert_eq!(app.results[0].action, "https://www.google.com/search?q=hello");
+    assert_eq!(
+        app.results[0].action,
+        "https://www.google.com/search?q=hello"
+    );
 }


### PR DESCRIPTION
## Summary
- support selecting a fixed unit for network speed output
- persist network refresh and unit in settings with defaults
- expose new options in the settings dialog
- pass unit to NetworkPlugin at plugin load time

## Testing
- `cargo test --test network_plugin --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687cfc5957a48332ad28bd964157999d