### PR TITLE
Add network auto refresh & unit reload

### DIFF
--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -119,6 +119,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),
         "sysinfo" => Some(&["info", "info cpu", "info cpu list 5"]),
+        "network" => Some(&["net"]),
         "weather" => Some(&["weather Berlin"]),
         "history" => Some(&["hi"]),
         "timer" => Some(&[

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
-    plugins.reload_from_dirs(dirs, settings.clipboard_limit, true);
+    plugins.reload_from_dirs(dirs, settings.clipboard_limit, settings.net_unit, true);
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();
@@ -61,8 +61,9 @@ fn spawn_gui(
 
     let handle = thread::spawn(move || {
         let (w, h) = settings.window_size.unwrap_or((400, 220));
-        let icon = icon_data::from_png_bytes(include_bytes!("../Resources/Green_MultiLauncher.png"))
-            .expect("invalid icon");
+        let icon =
+            icon_data::from_png_bytes(include_bytes!("../Resources/Green_MultiLauncher.png"))
+                .expect("invalid icon");
         let native_options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
                 .with_inner_size([w as f32, h as f32])

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,7 @@ pub mod reddit;
 pub mod wikipedia;
 pub mod processes;
 pub mod sysinfo;
+pub mod network;
 pub mod weather;
 pub mod notes;
 pub mod todo;

--- a/src/plugins/network.rs
+++ b/src/plugins/network.rs
@@ -1,0 +1,107 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use crate::settings::NetUnit;
+use std::sync::Mutex;
+use std::time::Instant;
+use sysinfo::Networks;
+
+fn fmt_speed(bytes_per_sec: f64, unit: NetUnit) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+    match unit {
+        NetUnit::Auto => {
+            if bytes_per_sec >= MB {
+                format!("{:.2} MB/s", bytes_per_sec / MB)
+            } else if bytes_per_sec >= KB {
+                format!("{:.1} kB/s", bytes_per_sec / KB)
+            } else {
+                format!("{:.0} B/s", bytes_per_sec)
+            }
+        }
+        NetUnit::B => format!("{:.0} B/s", bytes_per_sec),
+        NetUnit::Kb => format!("{:.1} kB/s", bytes_per_sec / KB),
+        NetUnit::Mb => format!("{:.2} MB/s", bytes_per_sec / MB),
+    }
+}
+
+/// Display network usage per interface using the `net` prefix.
+pub struct NetworkPlugin {
+    state: Mutex<(Networks, Instant)>,
+    unit: NetUnit,
+}
+
+impl NetworkPlugin {
+    pub fn new(unit: NetUnit) -> Self {
+        let mut nets = Networks::new_with_refreshed_list();
+        nets.refresh(true);
+        Self {
+            state: Mutex::new((nets, Instant::now())),
+            unit,
+        }
+    }
+}
+
+impl Default for NetworkPlugin {
+    fn default() -> Self {
+        Self::new(NetUnit::Auto)
+    }
+}
+
+impl Plugin for NetworkPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "net";
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        if !rest.trim().is_empty() {
+            return Vec::new();
+        }
+        let mut guard = match self.state.lock() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        let (nets, last) = &mut *guard;
+        let now = Instant::now();
+        nets.refresh(true);
+        let dt = now.duration_since(*last).as_secs_f64().max(0.001);
+        *last = now;
+        nets.iter()
+            .map(|(name, data)| {
+                let rx = data.received() as f64 / dt;
+                let tx = data.transmitted() as f64 / dt;
+                Action {
+                    label: format!(
+                        "{name} Rx {} Tx {}",
+                        fmt_speed(rx, self.unit),
+                        fmt_speed(tx, self.unit)
+                    ),
+                    desc: "Network".into(),
+                    action: format!("net:{name}"),
+                    args: None,
+                }
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "network"
+    }
+
+    fn description(&self) -> &str {
+        "Show network usage per interface (prefix: `net`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "net".into(),
+            desc: "Network".into(),
+            action: "query:net".into(),
+            args: None,
+        }]
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,6 +3,32 @@ use crate::hotkey::Key;
 use crate::hotkey::{parse_hotkey, Hotkey};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetUnit {
+    Auto,
+    B,
+    Kb,
+    Mb,
+}
+
+impl Default for NetUnit {
+    fn default() -> Self {
+        NetUnit::Auto
+    }
+}
+
+impl std::fmt::Display for NetUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NetUnit::Auto => write!(f, "Auto"),
+            NetUnit::B => write!(f, "B/s"),
+            NetUnit::Kb => write!(f, "kB/s"),
+            NetUnit::Mb => write!(f, "MB/s"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub hotkey: Option<String>,
@@ -76,23 +102,47 @@ pub struct Settings {
     /// Keep the command prefix in the query after running an action.
     #[serde(default)]
     pub preserve_command: bool,
+    #[serde(default = "default_net_refresh")]
+    pub net_refresh: f32,
+    #[serde(default)]
+    pub net_unit: NetUnit,
 }
 
-fn default_toasts() -> bool { true }
+fn default_toasts() -> bool {
+    true
+}
 
-fn default_scale() -> Option<f32> { Some(1.0) }
+fn default_scale() -> Option<f32> {
+    Some(1.0)
+}
 
-fn default_history_limit() -> usize { 100 }
+fn default_history_limit() -> usize {
+    100
+}
 
-fn default_clipboard_limit() -> usize { 20 }
+fn default_clipboard_limit() -> usize {
+    20
+}
 
-fn default_fuzzy_weight() -> f32 { 1.0 }
+fn default_fuzzy_weight() -> f32 {
+    1.0
+}
 
-fn default_usage_weight() -> f32 { 1.0 }
+fn default_usage_weight() -> f32 {
+    1.0
+}
 
-fn default_follow_mouse() -> bool { true }
+fn default_follow_mouse() -> bool {
+    true
+}
 
-fn default_timer_refresh() -> f32 { 1.0 }
+fn default_timer_refresh() -> f32 {
+    1.0
+}
+
+fn default_net_refresh() -> f32 {
+    1.0
+}
 
 impl Default for Settings {
     fn default() -> Self {
@@ -120,6 +170,8 @@ impl Default for Settings {
             static_size: None,
             hide_after_run: false,
             timer_refresh: default_timer_refresh(),
+            net_refresh: default_net_refresh(),
+            net_unit: NetUnit::Auto,
             disable_timer_updates: false,
             preserve_command: false,
             show_examples: false,

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -62,6 +62,8 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -1,0 +1,11 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::network::NetworkPlugin;
+use std::{thread, time::Duration};
+
+#[test]
+fn search_returns_actions() {
+    let plugin = NetworkPlugin::default();
+    thread::sleep(Duration::from_millis(10));
+    let results = plugin.search("net");
+    assert!(!results.is_empty());
+}

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -9,7 +9,12 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         actions,

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -14,7 +14,12 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
     let custom_len = 0;
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         Vec::new(),
@@ -83,7 +88,10 @@ fn snippet_edit_command_unfiltered() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let dir = tempdir().unwrap();
     std::env::set_current_dir(dir.path()).unwrap();
-    let entries = vec![SnippetEntry { alias: "foo".into(), text: "bar".into() }];
+    let entries = vec![SnippetEntry {
+        alias: "foo".into(),
+        text: "bar".into(),
+    }];
     save_snippets(SNIPPETS_FILE, &entries).unwrap();
     let mut settings = Settings::default();
     settings.fuzzy_weight = 0.0;

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -1,15 +1,20 @@
+use eframe::egui;
+use multi_launcher::actions::Action;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
-use multi_launcher::actions::Action;
 use multi_launcher::settings::Settings;
-use std::sync::{Arc, atomic::AtomicBool};
-use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc};
 
 fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    plugins.reload_from_dirs(&dirs, Settings::default().clipboard_limit, false);
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+    );
     LauncherApp::new(
         ctx,
         actions,
@@ -31,10 +36,18 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
 #[test]
 fn g_prefix_filters_web_search() {
     let ctx = egui::Context::default();
-    let actions = vec![Action { label: "g hello".into(), desc: "test".into(), action: "custom".into(), args: None }];
+    let actions = vec![Action {
+        label: "g hello".into(),
+        desc: "test".into(),
+        action: "custom".into(),
+        args: None,
+    }];
     let mut app = new_app_with_plugins(&ctx, actions);
     app.query = "g hello".into();
     app.search();
     assert_eq!(app.results.len(), 1);
-    assert_eq!(app.results[0].action, "https://www.google.com/search?q=hello");
+    assert_eq!(
+        app.results[0].action,
+        "https://www.google.com/search?q=hello"
+    );
 }


### PR DESCRIPTION
## Summary
- keep last network update time and refresh automatically while viewing `net`
- reload plugins when network unit is changed in settings

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687cfc5957a48332ad28bd964157999d