### PR TITLE
Add 10s average network rate display

### DIFF
--- a/src/plugins/network.rs
+++ b/src/plugins/network.rs
@@ -1,9 +1,12 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 use crate::settings::NetUnit;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 use std::time::Instant;
 use sysinfo::Networks;
+
+const AVG_WINDOW: f64 = 10.0;
 
 fn fmt_speed(bytes_per_sec: f64, unit: NetUnit) -> String {
     const KB: f64 = 1024.0;
@@ -26,7 +29,7 @@ fn fmt_speed(bytes_per_sec: f64, unit: NetUnit) -> String {
 
 /// Display network usage per interface using the `net` prefix.
 pub struct NetworkPlugin {
-    state: Mutex<(Networks, Instant)>,
+    state: Mutex<(Networks, Instant, HashMap<String, VecDeque<(Instant, u64, u64, f64)>>)>,
     unit: NetUnit,
 }
 
@@ -35,7 +38,7 @@ impl NetworkPlugin {
         let mut nets = Networks::new_with_refreshed_list();
         nets.refresh(true);
         Self {
-            state: Mutex::new((nets, Instant::now())),
+            state: Mutex::new((nets, Instant::now(), HashMap::new())),
             unit,
         }
     }
@@ -61,20 +64,39 @@ impl Plugin for NetworkPlugin {
             Ok(g) => g,
             Err(_) => return Vec::new(),
         };
-        let (nets, last) = &mut *guard;
+        let (nets, last, history) = &mut *guard;
         let now = Instant::now();
         nets.refresh(true);
         let dt = now.duration_since(*last).as_secs_f64().max(0.001);
         *last = now;
         nets.iter()
             .map(|(name, data)| {
-                let rx = data.received() as f64 / dt;
-                let tx = data.transmitted() as f64 / dt;
+                let rx_bytes = data.received();
+                let tx_bytes = data.transmitted();
+                let rx = rx_bytes as f64 / dt;
+                let tx = tx_bytes as f64 / dt;
+
+                let hist = history.entry(name.to_string()).or_default();
+                hist.push_back((now, rx_bytes, tx_bytes, dt));
+                while let Some((t, _, _, _)) = hist.front() {
+                    if now.duration_since(*t).as_secs_f64() > AVG_WINDOW {
+                        hist.pop_front();
+                    } else {
+                        break;
+                    }
+                }
+                let total_dt: f64 = hist.iter().map(|(_, _, _, d)| *d).sum::<f64>().max(dt);
+                let total_rx: u64 = hist.iter().map(|(_, r, _, _)| *r).sum();
+                let total_tx: u64 = hist.iter().map(|(_, _, t, _)| *t).sum();
+                let avg_rx = total_rx as f64 / total_dt;
+                let avg_tx = total_tx as f64 / total_dt;
                 Action {
                     label: format!(
-                        "{name} Rx {} Tx {}",
+                        "{name} Rx {} Tx {} (10s avg Rx {} Tx {})",
                         fmt_speed(rx, self.unit),
-                        fmt_speed(tx, self.unit)
+                        fmt_speed(tx, self.unit),
+                        fmt_speed(avg_rx, self.unit),
+                        fmt_speed(avg_tx, self.unit)
                     ),
                     desc: "Network".into(),
                     action: format!("net:{name}"),


### PR DESCRIPTION
## Summary
- extend `NetworkPlugin` to track network history
- display average 10-second receive and transmit rates

## Testing
- `cargo check`
- `cargo test --quiet` *(fails: did not produce output)*

 