### PR TITLE
Display average network speed

### DIFF
--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -8,4 +8,5 @@ fn search_returns_actions() {
     thread::sleep(Duration::from_millis(10));
     let results = plugin.search("net");
     assert!(!results.is_empty());
+    assert!(results[0].label.contains("AvgRx"));
 }


### PR DESCRIPTION
## Summary
- track network totals across refreshes
- display 10 second average Tx/Rx speed
- assert average values shown in plugin tests

## Testing
- `cargo test --quiet --test network_plugin`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d2177bc48833284e8374369d67304