### PR TITLE
Add media control plugin

### DIFF
--- a/src/actions/media.rs
+++ b/src/actions/media.rs
@@ -1,0 +1,100 @@
+#[cfg(target_os = "windows")]
+fn send_key(vk: windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY) {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+    };
+    unsafe {
+        let mut input = INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: vk,
+                    wScan: 0,
+                    dwFlags: KEYBD_EVENT_FLAGS(0),
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        };
+        let _ = SendInput(&[input], std::mem::size_of::<INPUT>() as i32);
+        input.Anonymous.ki.dwFlags = KEYEVENTF_KEYUP;
+        let _ = SendInput(&[input], std::mem::size_of::<INPUT>() as i32);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn playerctl(cmd: &str) {
+    let _ = std::process::Command::new("playerctl").arg(cmd).spawn();
+}
+
+#[cfg(target_os = "windows")]
+pub fn play() -> anyhow::Result<()> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::VK_MEDIA_PLAY_PAUSE;
+    send_key(VK_MEDIA_PLAY_PAUSE);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn play() -> anyhow::Result<()> {
+    playerctl("play");
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn play() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn pause() -> anyhow::Result<()> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::VK_MEDIA_PLAY_PAUSE;
+    send_key(VK_MEDIA_PLAY_PAUSE);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn pause() -> anyhow::Result<()> {
+    playerctl("pause");
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn pause() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn next() -> anyhow::Result<()> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::VK_MEDIA_NEXT_TRACK;
+    send_key(VK_MEDIA_NEXT_TRACK);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn next() -> anyhow::Result<()> {
+    playerctl("next");
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn next() -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn prev() -> anyhow::Result<()> {
+    use windows::Win32::UI::Input::KeyboardAndMouse::VK_MEDIA_PREV_TRACK;
+    send_key(VK_MEDIA_PREV_TRACK);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn prev() -> anyhow::Result<()> {
+    playerctl("previous");
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn prev() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -31,5 +31,6 @@ pub mod notes;
 pub mod todo;
 pub mod snippets;
 pub mod tempfiles;
+pub mod media;
 pub mod system;
 pub mod exec;

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -197,6 +197,10 @@ enum ActionKind<'a> {
     BrightnessSet(u32),
     VolumeSet(u32),
     VolumeMuteActive,
+    MediaPlay,
+    MediaPause,
+    MediaNext,
+    MediaPrev,
     RecycleClean,
     WindowSwitch(isize),
     WindowClose(isize),
@@ -386,6 +390,18 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
     if s == "volume:mute_active" {
         return ActionKind::VolumeMuteActive;
     }
+    if s == "media:play" {
+        return ActionKind::MediaPlay;
+    }
+    if s == "media:pause" {
+        return ActionKind::MediaPause;
+    }
+    if s == "media:next" {
+        return ActionKind::MediaNext;
+    }
+    if s == "media:prev" {
+        return ActionKind::MediaPrev;
+    }
     if s == "recycle:clean" {
         return ActionKind::RecycleClean;
     }
@@ -497,6 +513,22 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         }
         ActionKind::VolumeMuteActive => {
             system::mute_active_window();
+            Ok(())
+        }
+        ActionKind::MediaPlay => {
+            crate::actions::media::play()?;
+            Ok(())
+        }
+        ActionKind::MediaPause => {
+            crate::actions::media::pause()?;
+            Ok(())
+        }
+        ActionKind::MediaNext => {
+            crate::actions::media::next()?;
+            Ok(())
+        }
+        ActionKind::MediaPrev => {
+            crate::actions::media::prev()?;
             Ok(())
         }
         ActionKind::RecycleClean => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,6 +8,7 @@ use crate::plugins::dropcalc::DropCalcPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::history::HistoryPlugin;
+use crate::plugins::media::MediaPlugin;
 use crate::plugins::network::NetworkPlugin;
 use crate::plugins::notes::NotesPlugin;
 use crate::plugins::processes::ProcessesPlugin;
@@ -101,6 +102,7 @@ impl PluginManager {
         self.register(Box::new(SnippetsPlugin::default()));
         self.register(Box::new(RecyclePlugin));
         self.register(Box::new(TempfilePlugin));
+        self.register(Box::new(MediaPlugin));
         self.register(Box::new(AsciiArtPlugin::default()));
         #[cfg(target_os = "windows")]
         {

--- a/src/plugins/media.rs
+++ b/src/plugins/media.rs
@@ -1,0 +1,66 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct MediaPlugin;
+
+impl Plugin for MediaPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "media";
+        let rest = match crate::common::strip_prefix_ci(query, PREFIX) {
+            Some(r) => r,
+            None => return Vec::new(),
+        };
+        let filter = rest.trim();
+        const OPS: [&str; 4] = ["play", "pause", "next", "prev"];
+        OPS.iter()
+            .filter(|op| filter.is_empty() || op.starts_with(filter))
+            .map(|op| Action {
+                label: format!("Media {}", op),
+                desc: "Media".into(),
+                action: format!("media:{}", op),
+                args: None,
+            })
+            .collect()
+    }
+
+    fn name(&self) -> &str {
+        "media"
+    }
+
+    fn description(&self) -> &str {
+        "Control media playback (prefix: `media`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "media play".into(),
+                desc: "Media".into(),
+                action: "query:media play".into(),
+                args: None,
+            },
+            Action {
+                label: "media pause".into(),
+                desc: "Media".into(),
+                action: "query:media pause".into(),
+                args: None,
+            },
+            Action {
+                label: "media next".into(),
+                desc: "Media".into(),
+                action: "query:media next".into(),
+                args: None,
+            },
+            Action {
+                label: "media prev".into(),
+                desc: "Media".into(),
+                action: "query:media prev".into(),
+                args: None,
+            },
+        ]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -17,6 +17,7 @@ pub mod notes;
 pub mod todo;
 pub mod timer;
 pub mod snippets;
+pub mod media;
 pub mod volume;
 pub mod brightness;
 pub mod unit_convert;

--- a/tests/media_plugin.rs
+++ b/tests/media_plugin.rs
@@ -1,0 +1,45 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::media::MediaPlugin;
+
+#[test]
+fn search_play_returns_action() {
+    let plugin = MediaPlugin;
+    let results = plugin.search("media play");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "media:play");
+}
+
+#[test]
+fn search_pause_returns_action() {
+    let plugin = MediaPlugin;
+    let results = plugin.search("media pause");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "media:pause");
+}
+
+#[test]
+fn search_next_returns_action() {
+    let plugin = MediaPlugin;
+    let results = plugin.search("media next");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "media:next");
+}
+
+#[test]
+fn search_prev_returns_action() {
+    let plugin = MediaPlugin;
+    let results = plugin.search("media prev");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "media:prev");
+}
+
+#[test]
+fn search_plain_lists_all() {
+    let plugin = MediaPlugin;
+    let results = plugin.search("media");
+    assert_eq!(results.len(), 4);
+    assert!(results.iter().any(|a| a.action == "media:play"));
+    assert!(results.iter().any(|a| a.action == "media:pause"));
+    assert!(results.iter().any(|a| a.action == "media:next"));
+    assert!(results.iter().any(|a| a.action == "media:prev"));
+}


### PR DESCRIPTION
## Summary
- implement `MediaPlugin` with play/pause/next/prev actions
- add OS-specific media control helpers
- register the plugin in plugin manager
- expose `media` actions module
- test media plugin behaviour

## Testing
- `cargo test --quiet`
 