### PR TITLE
Add screenshot capture utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,7 @@ dependencies = [
  "exmex",
  "figlet-rs",
  "fuzzy-matcher",
+ "image 0.24.9",
  "libloading 0.8.8",
  "log",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ shlex = "1.3"
 sysinfo = "0.35"
 chrono = "0.4"
 screenshot = { package = "screenshot-rs", version = "0.1.5" }
+image = { version = "0.24", default-features = false, features = ["png"] }
 notify-rust = { version = "4", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -34,3 +34,4 @@ pub mod tempfiles;
 pub mod media;
 pub mod system;
 pub mod exec;
+pub mod screenshot;

--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -1,0 +1,42 @@
+use chrono::Local;
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+#[derive(Clone, Copy)]
+pub enum Mode {
+    Window,
+    Region,
+    Desktop,
+}
+
+#[cfg(target_os = "windows")]
+pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
+    let dir = dirs_next::picture_dir().unwrap_or_else(|| std::env::current_dir().unwrap());
+    std::fs::create_dir_all(&dir)?;
+    let filename = format!("multi_launcher_{}.png", Local::now().format("%Y%m%d_%H%M%S"));
+    let path = dir.join(filename);
+    let path_str = path.to_string_lossy().to_string();
+    match mode {
+        Mode::Window => screenshot::screenshot_window(path_str.clone()),
+        Mode::Region => screenshot::screenshot_area(path_str.clone(), false),
+        Mode::Desktop => screenshot::screenshot_full(path_str.clone()),
+    }
+    if clipboard {
+        let img = image::load_from_memory(&std::fs::read(&path)?)?.to_rgba8();
+        let (w, h) = img.dimensions();
+        let mut cb = arboard::Clipboard::new()?;
+        cb.set_image(arboard::ImageData {
+            width: w as usize,
+            height: h as usize,
+            bytes: Cow::Owned(img.into_raw()),
+        })?;
+    } else {
+        open::that(&path)?;
+    }
+    Ok(path)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn capture(_mode: Mode, _clipboard: bool) -> anyhow::Result<PathBuf> {
+    anyhow::bail!("screenshot not supported on this platform")
+}


### PR DESCRIPTION
## Summary
- implement screenshot capture helper module
- export new module in actions
- support PNG clipboard copy or open saved file
- add `image` crate for decoding PNGs

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d30ae403483329f3ed196ea769a22