### PR TITLE
Add screenshot action support

### DIFF
--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Mode {
     Window,
     Region,


### PR DESCRIPTION
## Summary
- support screenshot actions emitted from the screenshot plugin
- parse screenshot action strings in the launcher
- invoke screenshot capture with specified mode
- derive required traits for `screenshot::Mode`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d359375d88332aa7c901c91ef7a31