### PR TITLE
Add screenshot directory settings

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -170,6 +170,8 @@ pub struct LauncherApp {
     pub preserve_command: bool,
     pub net_refresh: f32,
     pub net_unit: crate::settings::NetUnit,
+    pub screenshot_dir: Option<String>,
+    pub screenshot_save_file: bool,
     last_timer_update: Instant,
     last_net_update: Instant,
 }
@@ -205,6 +207,8 @@ impl LauncherApp {
         preserve_command: Option<bool>,
         net_refresh: Option<f32>,
         net_unit: Option<crate::settings::NetUnit>,
+        screenshot_dir: Option<String>,
+        screenshot_save_file: Option<bool>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -251,6 +255,12 @@ impl LauncherApp {
         }
         if let Some(v) = net_unit {
             self.net_unit = v;
+        }
+        if screenshot_dir.is_some() {
+            self.screenshot_dir = screenshot_dir;
+        }
+        if let Some(v) = screenshot_save_file {
+            self.screenshot_save_file = v;
         }
     }
 
@@ -467,6 +477,8 @@ impl LauncherApp {
             preserve_command: settings.preserve_command,
             net_refresh: settings.net_refresh,
             net_unit: settings.net_unit,
+            screenshot_dir: settings.screenshot_dir.clone(),
+            screenshot_save_file: settings.screenshot_save_file,
             last_timer_update: Instant::now(),
             last_net_update: Instant::now(),
             action_cache: Vec::new(),

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -129,6 +129,8 @@ impl PluginEditor {
                         Some(s.preserve_command),
                         Some(s.net_refresh),
                         Some(s.net_unit),
+                        s.screenshot_dir.clone(),
+                        Some(s.screenshot_save_file),
                     );
                     app.plugins.reload_from_dirs(
                         &self.plugin_dirs,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -106,6 +106,12 @@ pub struct Settings {
     pub net_refresh: f32,
     #[serde(default)]
     pub net_unit: NetUnit,
+    /// Directory used for saving screenshots. If `None`, a platform default is
+    /// used.
+    pub screenshot_dir: Option<String>,
+    /// When capturing screenshots to the clipboard, also save them to disk.
+    #[serde(default)]
+    pub screenshot_save_file: bool,
 }
 
 fn default_toasts() -> bool {
@@ -175,6 +181,10 @@ impl Default for Settings {
             disable_timer_updates: false,
             preserve_command: false,
             show_examples: false,
+            screenshot_dir: dirs_next::picture_dir()
+                .or_else(dirs_next::home_dir)
+                .map(|p| p.to_string_lossy().to_string()),
+            screenshot_save_file: true,
         }
     }
 }

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -45,6 +45,8 @@ pub struct SettingsEditor {
     preserve_command: bool,
     net_refresh: f32,
     net_unit: crate::settings::NetUnit,
+    screenshot_dir: String,
+    screenshot_save_file: bool,
 }
 
 impl SettingsEditor {
@@ -119,6 +121,8 @@ impl SettingsEditor {
             preserve_command: settings.preserve_command,
             net_refresh: settings.net_refresh,
             net_unit: settings.net_unit,
+            screenshot_dir: settings.screenshot_dir.clone().unwrap_or_default(),
+            screenshot_save_file: settings.screenshot_save_file,
         }
     }
 
@@ -167,6 +171,12 @@ impl SettingsEditor {
             preserve_command: self.preserve_command,
             net_refresh: self.net_refresh,
             net_unit: self.net_unit,
+            screenshot_dir: if self.screenshot_dir.trim().is_empty() {
+                None
+            } else {
+                Some(self.screenshot_dir.clone())
+            },
+            screenshot_save_file: self.screenshot_save_file,
             show_examples: current.show_examples,
         }
     }
@@ -388,6 +398,22 @@ impl SettingsEditor {
                             }
                         });
 
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            ui.label("Screenshot dir");
+                            ui.text_edit_singleline(&mut self.screenshot_dir);
+                            if ui.button("Browse").clicked() {
+                                #[cfg(target_os = "windows")]
+                                if let Some(dir) = FileDialog::new().pick_folder() {
+                                    self.screenshot_dir = dir.display().to_string();
+                                }
+                            }
+                        });
+                        ui.checkbox(
+                            &mut self.screenshot_save_file,
+                            "Save file when copying screenshot",
+                        );
+
                         if ui.button("Save").clicked() {
                             if parse_hotkey(&self.hotkey).is_none() {
                                 self.hotkey = self.last_valid_hotkey.clone();
@@ -458,6 +484,8 @@ impl SettingsEditor {
                                                 Some(new_settings.preserve_command),
                                                 Some(new_settings.net_refresh),
                                                 Some(new_settings.net_unit),
+                                                new_settings.screenshot_dir.clone(),
+                                                Some(new_settings.screenshot_save_file),
                                             );
                                             app.hotkey_str = new_settings.hotkey.clone();
                                             app.quit_hotkey_str = new_settings.quit_hotkey.clone();
@@ -471,6 +499,8 @@ impl SettingsEditor {
                                             app.preserve_command = new_settings.preserve_command;
                                             app.net_refresh = new_settings.net_refresh;
                                             app.net_unit = new_settings.net_unit;
+                                            app.screenshot_dir = new_settings.screenshot_dir.clone();
+                                            app.screenshot_save_file = new_settings.screenshot_save_file;
                                             let dirs = new_settings
                                                 .plugin_dirs
                                                 .clone()

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -64,6 +64,8 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();


### PR DESCRIPTION
## Summary
- add screenshot settings with screenshot_dir and screenshot_save_file fields
- support editing new settings via SettingsEditor
- propagate screenshot settings through LauncherApp
- update tests for new API

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d381ca0e883329dfb508ebd37addd