### PR TITLE
Add screenshot_dir helper

### DIFF
--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -1,6 +1,11 @@
+#[cfg(target_os = "windows")]
 use chrono::Local;
+#[cfg(target_os = "windows")]
 use std::borrow::Cow;
 use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]
+use crate::plugins::screenshot::screenshot_dir;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Mode {
@@ -11,9 +16,12 @@ pub enum Mode {
 
 #[cfg(target_os = "windows")]
 pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
-    let dir = dirs_next::picture_dir().unwrap_or_else(|| std::env::current_dir().unwrap());
+    let dir = screenshot_dir();
     std::fs::create_dir_all(&dir)?;
-    let filename = format!("multi_launcher_{}.png", Local::now().format("%Y%m%d_%H%M%S"));
+    let filename = format!(
+        "multi_launcher_{}.png",
+        Local::now().format("%Y%m%d_%H%M%S")
+    );
     let path = dir.join(filename);
     let path_str = path.to_string_lossy().to_string();
     match mode {

--- a/src/plugins/screenshot.rs
+++ b/src/plugins/screenshot.rs
@@ -1,5 +1,18 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use std::path::PathBuf;
+
+/// Return the directory used to store screenshots.
+///
+/// The directory is created inside the folder of the current executable if
+/// possible, otherwise a temporary directory is used.
+pub fn screenshot_dir() -> PathBuf {
+    let base = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_else(std::env::temp_dir);
+    base.join("screenshots")
+}
 
 pub struct ScreenshotPlugin;
 


### PR DESCRIPTION
## Summary
- create `screenshot_dir()` helper for screenshots
- save screenshots under this directory

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d465dfd208332832ca1fb4f17ff3b