### PR TITLE
Fix screenshot region selection and default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ value as shown below:
   "static_location_enabled": false,
   "static_pos": [0, 0],
   "static_size": [400, 220],
-  "screenshot_dir": "C:/Users/YourName/Pictures",
+  "screenshot_dir": "./MultiLauncher_Screenshots",
   "screenshot_save_file": true
 }
 ```
@@ -148,7 +148,7 @@ Example: typing `test` will only list entries containing `test`. If an alias mat
 `clipboard_limit` sets how many clipboard entries are persisted for the clipboard plugin.
 `preserve_command` keeps the typed command prefix (like `bm add` or `f add`) in the search field after running an action.
 `enabled_capabilities` maps plugin names to capability identifiers so features can be toggled individually. The folders plugin, for example, exposes `show_full_path`.
-`screenshot_dir` sets the directory used when saving screenshots. If omitted, the Pictures or home folder is used by default.
+`screenshot_dir` sets the directory used when saving screenshots. If omitted, screenshots are stored in a `MultiLauncher_Screenshots` folder in the current working directory.
 `screenshot_save_file` determines whether screenshots copied to the clipboard are also written to disk. The default is `true`.
 
 
@@ -220,7 +220,7 @@ Built-in plugins and their command prefixes are:
 
 ### Screenshot Plugin (Windows only)
 Use `ss` to capture the active window, a custom region or the whole desktop. Add `clip` to copy the result to the clipboard.
-Screenshots are saved in a `screenshots` folder next to the executable by default or the path set in `screenshot_dir`.
+Screenshots are saved in a `MultiLauncher_Screenshots` folder in the current working directory by default or the path set in `screenshot_dir`.
 Set `screenshot_save_file` to `true` to always keep a file when copying to the clipboard.
 
 When the search box is empty the launcher shows these shortcuts along with `app <alias>` entries for saved actions.

--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -26,7 +26,7 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
     std::fs::create_dir_all(&dir)?;
     let filename = format!(
         "multi_launcher_{}.png",
-        Local::now().format("%Y%m%d_%H%M%S")
+        Local::now().format("%Y%m%d_%H%M%S%.3f")
     );
     let path = dir.join(filename);
     let path_str = path.to_string_lossy().to_string();
@@ -35,6 +35,7 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
             let screen = Screen::from_point(0, 0)?;
             let image = screen.capture()?;
             image.save(&path)?;
+            std::fs::File::open(&path)?.sync_all()?;
         }
         Mode::Window => {
             let hwnd = unsafe { GetForegroundWindow() };
@@ -51,6 +52,7 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
                     height,
                 )?;
                 image.save(&path)?;
+                std::fs::File::open(&path)?.sync_all()?;
             }
         }
         Mode::Region => {
@@ -73,6 +75,7 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
             )
             .ok_or_else(|| anyhow::anyhow!("invalid clipboard image"))?;
             buf.save(&path)?;
+            std::fs::File::open(&path)?.sync_all()?;
         }
     }
     if clipboard {

--- a/src/plugins/screenshot.rs
+++ b/src/plugins/screenshot.rs
@@ -1,17 +1,22 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use crate::settings::Settings;
 use std::path::PathBuf;
 
 /// Return the directory used to store screenshots.
 ///
-/// The directory is created inside the folder of the current executable if
-/// possible, otherwise a temporary directory is used.
+/// The path is loaded from `settings.json` if available. When no directory is
+/// configured, a `MultiLauncher_Screenshots` folder in the current working
+/// directory is used.
 pub fn screenshot_dir() -> PathBuf {
-    let base = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-        .unwrap_or_else(std::env::temp_dir);
-    base.join("screenshots")
+    if let Ok(s) = Settings::load("settings.json") {
+        if let Some(dir) = s.screenshot_dir {
+            return PathBuf::from(dir);
+        }
+    }
+    std::env::current_dir()
+        .unwrap_or_else(|_| std::env::temp_dir())
+        .join("MultiLauncher_Screenshots")
 }
 
 pub struct ScreenshotPlugin;

--- a/src/plugins/screenshot.rs
+++ b/src/plugins/screenshot.rs
@@ -14,9 +14,10 @@ pub fn screenshot_dir() -> PathBuf {
             return PathBuf::from(dir);
         }
     }
-    std::env::current_dir()
+    let dir = std::env::current_dir()
         .unwrap_or_else(|_| std::env::temp_dir())
-        .join("MultiLauncher_Screenshots")
+        .join("MultiLauncher_Screenshots");
+    std::fs::canonicalize(&dir).unwrap_or(dir)
 }
 
 pub struct ScreenshotPlugin;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -181,9 +181,13 @@ impl Default for Settings {
             disable_timer_updates: false,
             preserve_command: false,
             show_examples: false,
-            screenshot_dir: dirs_next::picture_dir()
-                .or_else(dirs_next::home_dir)
-                .map(|p| p.to_string_lossy().to_string()),
+            screenshot_dir: Some(
+                std::env::current_dir()
+                    .unwrap_or_else(|_| std::env::temp_dir())
+                    .join("MultiLauncher_Screenshots")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
             screenshot_save_file: true,
         }
     }


### PR DESCRIPTION
## Summary
- allow capturing a user-selected region by invoking Windows snipping
- load screenshot directory from settings and default to `./MultiLauncher_Screenshots`
- document new screenshot directory behaviour

## Testing
- `cargo test --quiet`
 