### PR TITLE
Support per-plugin settings

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -184,6 +184,17 @@ impl LauncherApp {
             .map(|a| (a.label.to_lowercase(), a.desc.to_lowercase()))
             .collect();
     }
+
+    pub fn plugin_enabled(&self, name: &str) -> bool {
+        match &self.enabled_plugins {
+            Some(list) => list.contains(&name.to_string()),
+            None => true,
+        }
+    }
+
+    pub fn enabled_plugins_list(&self) -> Option<Vec<String>> {
+        self.enabled_plugins.clone()
+    }
     pub fn add_toast(&mut self, toast: Toast) {
         self.toasts.add(toast);
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -407,7 +407,7 @@ impl LauncherApp {
         let follow_mouse = settings.follow_mouse;
         let static_enabled = settings.static_location_enabled;
 
-        let settings_editor = SettingsEditor::new(&settings);
+        let settings_editor = SettingsEditor::new_with_plugins(&settings);
         let plugin_editor = PluginEditor::new(&settings);
         let mut app = Self {
             actions: actions.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,13 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
-    plugins.reload_from_dirs(dirs, settings.clipboard_limit, settings.net_unit, true);
+    plugins.reload_from_dirs(
+        dirs,
+        settings.clipboard_limit,
+        settings.net_unit,
+        true,
+        &settings.plugin_settings,
+    );
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -56,6 +56,7 @@ impl PluginEditor {
             Settings::default().clipboard_limit,
             Settings::default().net_unit,
             false,
+            &std::collections::HashMap::new(),
         );
         let mut infos = pm.plugin_infos();
         infos.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
@@ -137,6 +138,7 @@ impl PluginEditor {
                         app.clipboard_limit,
                         app.net_unit,
                         false,
+                        &s.plugin_settings,
                     );
                     tracing::debug!(available=?app.plugins.plugin_names(), "plugins reloaded");
                     self.available = Self::gather_available(&self.plugin_dirs);

--- a/src/plugins/clipboard.rs
+++ b/src/plugins/clipboard.rs
@@ -270,7 +270,7 @@ impl Plugin for ClipboardPlugin {
     fn settings_ui(&mut self, ui: &mut egui::Ui, value: &mut serde_json::Value) {
         let mut cfg: ClipboardPluginSettings = serde_json::from_value(value.clone()).unwrap_or_default();
         ui.horizontal(|ui| {
-            ui.label("Max history entries");
+            ui.label("Clipboard limit");
             ui.add(egui::DragValue::new(&mut cfg.max_entries).clamp_range(1..=200));
         });
         *value = serde_json::to_value(&cfg).unwrap();

--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -1,10 +1,22 @@
 use crate::actions::Action;
 use crate::history::get_history;
 use crate::plugin::Plugin;
+use eframe::egui;
 
 const MAX_HISTORY_RESULTS: usize = 10;
 
 pub struct HistoryPlugin;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+pub struct HistoryPluginSettings {
+    pub max_entries: usize,
+}
+
+impl Default for HistoryPluginSettings {
+    fn default() -> Self {
+        Self { max_entries: 100 }
+    }
+}
 
 impl Plugin for HistoryPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
@@ -55,5 +67,20 @@ impl Plugin for HistoryPlugin {
             Action { label: "hi".into(), desc: "History".into(), action: "query:hi".into(), args: None },
             Action { label: "hi clear".into(), desc: "History".into(), action: "query:hi clear".into(), args: None },
         ]
+    }
+
+    fn default_settings(&self) -> Option<serde_json::Value> {
+        Some(serde_json::to_value(HistoryPluginSettings::default()).unwrap())
+    }
+
+    fn apply_settings(&mut self, _value: &serde_json::Value) {}
+
+    fn settings_ui(&mut self, ui: &mut egui::Ui, value: &mut serde_json::Value) {
+        let mut cfg: HistoryPluginSettings = serde_json::from_value(value.clone()).unwrap_or_default();
+        ui.horizontal(|ui| {
+            ui.label("History limit");
+            ui.add(egui::Slider::new(&mut cfg.max_entries, 10..=500).text(""));
+        });
+        *value = serde_json::to_value(&cfg).unwrap();
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -112,6 +112,8 @@ pub struct Settings {
     /// When capturing screenshots to the clipboard, also save them to disk.
     #[serde(default)]
     pub screenshot_save_file: bool,
+    #[serde(default)]
+    pub plugin_settings: std::collections::HashMap<String, serde_json::Value>,
 }
 
 fn default_toasts() -> bool {
@@ -189,6 +191,7 @@ impl Default for Settings {
                     .to_string(),
             ),
             screenshot_save_file: true,
+            plugin_settings: std::collections::HashMap::new(),
         }
     }
 }

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -14,6 +14,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
+        &std::collections::HashMap::new(),
     );
     LauncherApp::new(
         ctx,

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -19,6 +19,7 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
+        &std::collections::HashMap::new(),
     );
     LauncherApp::new(
         ctx,

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -14,6 +14,7 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
+        &std::collections::HashMap::new(),
     );
     LauncherApp::new(
         ctx,


### PR DESCRIPTION
## Summary
- allow plugins to provide configuration UIs
- persist plugin settings in `settings.json`
- implement settings for the clipboard plugin
- hide plugin sections when disabled
- update tests for new plugin API

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d7280992883328dd7d8c73b019d7f