### PR TITLE
Remove index paths UI and plugin directory manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ value as shown below:
   "hotkey": "F2",
   "quit_hotkey": "Shift+Escape",
   "help_hotkey": "F1",
-  "index_paths": ["C:/ProgramData/Microsoft/Windows/Start Menu/Programs"],
-  "plugin_dirs": ["./plugins"],
+  
   "enabled_plugins": [
     "web_search",
     "calculator",
@@ -173,10 +172,7 @@ flowchart LR
 ```mermaid
 graph TD
     S[Startup] --> B1[Register built-in plugins]
-    S --> B2[Load plugin_dirs]
-    B2 --> L[Load dynamic plugins]
     B1 --> PM[Plugin manager ready]
-    L --> PM
 ```
 
 Built-in commands:
@@ -264,7 +260,7 @@ Place the resulting library file in one of the directories listed under
 
 Plugins can be enabled or disabled from the **Settings** window. The list of
 active plugins is stored in the `enabled_plugins` section of `settings.json`.
-The **Plugin Settings** dialog provides a graphical way to manage plugin directories, enable or disable plugins and toggle capabilities like `show_full_path`.
+The **Plugin Settings** dialog lets you enable or disable plugins and toggle capabilities like `show_full_path`.
 
 Changes take effect immediately once the dialog is closed. Use this window to
 enable additional plugins, such as a dynamic `envvar` plugin that exposes

--- a/settings.json
+++ b/settings.json
@@ -2,8 +2,6 @@
     "hotkey": "F2",
     "quit_hotkey": "Shift+Escape",
     "help_hotkey": "F1",
-    "index_paths": null,
-    "plugin_dirs": null,
     "debug_logging": false,
     "enable_toasts": true,
     "show_examples": false,

--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -29,7 +29,6 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
         Local::now().format("%Y%m%d_%H%M%S")
     );
     let path = dir.join(filename);
-    let path_str = path.to_string_lossy().to_string();
     match mode {
         Mode::Desktop => {
             let screen = Screen::from_point(0, 0)?;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -117,7 +117,6 @@ pub struct LauncherApp {
     rx: Receiver<WatchEvent>,
     folder_aliases: HashMap<String, Option<String>>,
     bookmark_aliases: HashMap<String, Option<String>>,
-    plugin_dirs: Option<Vec<String>>,
     index_paths: Option<Vec<String>>,
     enabled_plugins: Option<Vec<String>>,
     enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
@@ -200,8 +199,6 @@ impl LauncherApp {
     }
     pub fn update_paths(
         &mut self,
-        plugin_dirs: Option<Vec<String>>,
-        index_paths: Option<Vec<String>>,
         enabled_plugins: Option<Vec<String>>,
         enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
         offscreen_pos: Option<(i32, i32)>,
@@ -221,8 +218,6 @@ impl LauncherApp {
         screenshot_dir: Option<String>,
         screenshot_save_file: Option<bool>,
     ) {
-        self.plugin_dirs = plugin_dirs;
-        self.index_paths = index_paths;
         self.enabled_plugins = enabled_plugins;
         self.enabled_capabilities = enabled_capabilities;
         if let Some((x, y)) = offscreen_pos {
@@ -283,7 +278,6 @@ impl LauncherApp {
         actions_path: String,
         settings_path: String,
         settings: Settings,
-        plugin_dirs: Option<Vec<String>>,
         index_paths: Option<Vec<String>>,
         enabled_plugins: Option<Vec<String>>,
         enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
@@ -433,7 +427,6 @@ impl LauncherApp {
             rx,
             folder_aliases,
             bookmark_aliases,
-            plugin_dirs,
             index_paths,
             enabled_plugins,
             enabled_capabilities,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ fn spawn_gui(
 
     let actions_path = "actions.json".to_string();
     let settings_path_for_window = settings_path.clone();
-    let plugin_dirs = settings.plugin_dirs.clone();
     let index_paths = settings.index_paths.clone();
     let enabled_plugins = settings.enabled_plugins.clone();
     let visible_flag = Arc::new(AtomicBool::new(true));
@@ -101,7 +100,6 @@ fn spawn_gui(
                     actions_path,
                     settings_path_for_window,
                     settings.clone(),
-                    plugin_dirs,
                     index_paths,
                     enabled_plugins,
                     enabled_capabilities,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -19,8 +19,6 @@ pub struct SettingsEditor {
     help_hotkey: String,
     help_hotkey_valid: bool,
     last_valid_help_hotkey: String,
-    index_paths: Vec<String>,
-    index_input: String,
     debug_logging: bool,
     show_toasts: bool,
     offscreen_x: i32,
@@ -98,8 +96,6 @@ impl SettingsEditor {
             help_hotkey,
             help_hotkey_valid,
             last_valid_help_hotkey,
-            index_paths: settings.index_paths.clone().unwrap_or_default(),
-            index_input: String::new(),
             debug_logging: settings.debug_logging,
             show_toasts: settings.enable_toasts,
             offscreen_x: settings.offscreen_pos.unwrap_or((2000, 2000)).0,
@@ -174,11 +170,7 @@ impl SettingsEditor {
             } else {
                 Some(self.help_hotkey.clone())
             },
-            index_paths: if self.index_paths.is_empty() {
-                None
-            } else {
-                Some(self.index_paths.clone())
-            },
+            index_paths: current.index_paths.clone(),
             plugin_dirs: current.plugin_dirs.clone(),
             enabled_plugins: current.enabled_plugins.clone(),
             enabled_capabilities: current.enabled_capabilities.clone(),
@@ -359,34 +351,6 @@ impl SettingsEditor {
                         }
 
                         ui.separator();
-                        ui.label("Index paths:");
-                        let mut remove: Option<usize> = None;
-                        for (idx, path) in self.index_paths.iter().enumerate() {
-                            ui.horizontal(|ui| {
-                                ui.label(path);
-                                if ui.button("Remove").clicked() {
-                                    remove = Some(idx);
-                                }
-                            });
-                        }
-                        if let Some(i) = remove {
-                            self.index_paths.remove(i);
-                        }
-                        ui.horizontal(|ui| {
-                            ui.text_edit_singleline(&mut self.index_input);
-                            if ui.button("Browse").clicked() {
-                                #[cfg(target_os = "windows")]
-                                if let Some(dir) = FileDialog::new().pick_folder() {
-                                    self.index_input = dir.display().to_string();
-                                }
-                            }
-                            if ui.button("Add").clicked() {
-                                if !self.index_input.is_empty() {
-                                    self.index_paths.push(self.index_input.clone());
-                                    self.index_input.clear();
-                                }
-                            }
-                        });
 
                         ui.separator();
                         ui.horizontal(|ui| {
@@ -498,8 +462,6 @@ impl SettingsEditor {
                                             app.error = Some(format!("Failed to save: {e}"));
                                         } else {
                                             app.update_paths(
-                                                new_settings.plugin_dirs.clone(),
-                                                new_settings.index_paths.clone(),
                                                 new_settings.enabled_plugins.clone(),
                                                 new_settings.enabled_capabilities.clone(),
                                                 new_settings.offscreen_pos,

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -27,7 +27,6 @@ fn new_app_with_settings(
             None,
             None,
             None,
-            None,
             visible.clone(),
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
@@ -46,8 +45,6 @@ fn run_action(action: &str) -> bool {
     }];
     let (mut app, flag) = new_app_with_settings(&ctx, actions, Settings::default());
     app.update_paths(
-        None,
-        None,
         None,
         None,
         None,

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -27,7 +27,6 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -32,7 +32,6 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),

--- a/tests/preserve_command.rs
+++ b/tests/preserve_command.rs
@@ -20,7 +20,6 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>, preserve: bool) -> Launche
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),

--- a/tests/ranking.rs
+++ b/tests/ranking.rs
@@ -18,7 +18,6 @@ fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Se
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -18,7 +18,6 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -27,7 +27,6 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
         None,
         None,
         None,
-        None,
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),
         Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
## Summary
- remove unused index path UI code from settings panel
- stop exposing plugin directories in plugin settings
- tweak README and sample settings
- fix unused variable warning in screenshot action

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d8650a85083328bc1797083d09cd5