### PR TITLE
Remove index paths and plugin directory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Place the resulting library file in one of the directories listed under
 
 Plugins can be enabled or disabled from the **Settings** window. The list of
 active plugins is stored in the `enabled_plugins` section of `settings.json`.
-The **Plugin Settings** dialog provides a graphical way to manage plugin directories, enable or disable plugins and toggle capabilities like `show_full_path`.
+The **Plugin Settings** dialog provides a graphical way to enable or disable plugins and toggle capabilities like `show_full_path`.
 
 Changes take effect immediately once the dialog is closed. Use this window to
 enable additional plugins, such as a dynamic `envvar` plugin that exposes

--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -29,7 +29,6 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
         Local::now().format("%Y%m%d_%H%M%S")
     );
     let path = dir.join(filename);
-    let path_str = path.to_string_lossy().to_string();
     match mode {
         Mode::Desktop => {
             let screen = Screen::from_point(0, 0)?;
@@ -60,9 +59,10 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
 
             // Wait for the snipping tool to provide a new clipboard image
             let mut cb = arboard::Clipboard::new()?;
-            let old = cb.get_image().ok().map(|img| {
-                (img.width, img.height, img.bytes.into_owned())
-            });
+            let old = cb
+                .get_image()
+                .ok()
+                .map(|img| (img.width, img.height, img.bytes.into_owned()));
 
             let _ = Command::new("explorer").arg("ms-screenclip:").status();
 

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -9,10 +9,8 @@ use std::collections::HashMap;
 #[derive(Default)]
 
 pub struct PluginEditor {
-    plugin_dirs: Vec<String>,
     enabled_plugins: Vec<String>,
     enabled_capabilities: HashMap<String, Vec<String>>,
-    plugin_input: String,
     available: Vec<(String, String, Vec<String>)>,
     filter: String,
 }
@@ -40,10 +38,8 @@ impl PluginEditor {
         };
 
         Self {
-            plugin_dirs,
             enabled_plugins,
             enabled_capabilities,
-            plugin_input: String::new(),
             available: info,
             filter: String::new(),
         }
@@ -64,14 +60,9 @@ impl PluginEditor {
     }
 
     fn save_settings(&mut self, app: &mut LauncherApp) {
-        tracing::debug!(?self.plugin_dirs, ?self.enabled_plugins, "saving plugin settings");
+        tracing::debug!(?self.enabled_plugins, "saving plugin settings");
         match Settings::load(&app.settings_path) {
             Ok(mut s) => {
-                s.plugin_dirs = if self.plugin_dirs.is_empty() {
-                    None
-                } else {
-                    Some(self.plugin_dirs.clone())
-                };
                 let all_plugins_enabled = self.enabled_plugins.len() == self.available.len()
                     && self
                         .available
@@ -133,15 +124,16 @@ impl PluginEditor {
                         s.screenshot_dir.clone(),
                         Some(s.screenshot_save_file),
                     );
+                    let dirs = s.plugin_dirs.clone().unwrap_or_default();
                     app.plugins.reload_from_dirs(
-                        &self.plugin_dirs,
+                        &dirs,
                         app.clipboard_limit,
                         app.net_unit,
                         false,
                         &s.plugin_settings,
                     );
                     tracing::debug!(available=?app.plugins.plugin_names(), "plugins reloaded");
-                    self.available = Self::gather_available(&self.plugin_dirs);
+                    self.available = Self::gather_available(&dirs);
                     app.search();
 
                     crate::request_hotkey_restart(s);
@@ -157,37 +149,6 @@ impl PluginEditor {
         egui::Window::new("Plugin Settings")
             .open(&mut open)
             .show(ctx, |ui| {
-                ui.label("Plugin directories:");
-                let mut remove: Option<usize> = None;
-                for (idx, path) in self.plugin_dirs.iter().enumerate() {
-                    ui.horizontal(|ui| {
-                        ui.label(path);
-                        if ui.button("Remove").clicked() {
-                            remove = Some(idx);
-                        }
-                    });
-                }
-                if let Some(i) = remove {
-                    self.plugin_dirs.remove(i);
-                    changed = true;
-                }
-                ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut self.plugin_input);
-                    if ui.button("Browse").clicked() {
-                        #[cfg(target_os = "windows")]
-                        if let Some(dir) = FileDialog::new().pick_folder() {
-                            self.plugin_input = dir.display().to_string();
-                        }
-                    }
-                    if ui.button("Add").clicked() {
-                        if !self.plugin_input.is_empty() {
-                            self.plugin_dirs.push(self.plugin_input.clone());
-                            self.plugin_input.clear();
-                            changed = true;
-                        }
-                    }
-                });
-
                 ui.separator();
                 ui.label("Plugins:");
                 ui.horizontal(|ui| {


### PR DESCRIPTION
## Summary
- drop index path configuration from settings UI
- remove plugin directory controls from plugin settings
- fix unused variable warning in screenshot action
- document updated plugin settings behavior

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d8650a85083328bc1797083d09cd5