### PR TITLE
Fix network plugin empty history

### DIFF
--- a/tests/network_plugin.rs
+++ b/tests/network_plugin.rs
@@ -10,3 +10,11 @@ fn search_returns_actions() {
     assert!(!results.is_empty());
     assert!(results[0].label.contains("AvgRx"));
 }
+
+#[test]
+fn search_no_panic_with_empty_history() {
+    let plugin = NetworkPlugin::default();
+    plugin.clear_history();
+    thread::sleep(Duration::from_millis(10));
+    plugin.search("net");
+}


### PR DESCRIPTION
## Summary
- handle empty network history queue safely
- expose a method to clear network history for tests
- add regression test for clearing history

## Testing
- `cargo test --test network_plugin -- --nocapture --test-threads=1`
- `cargo test --quiet`
 