### PR TITLE
Handle invalid timestamps gracefully

### DIFF
--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -53,12 +53,16 @@ pub fn remove_note(path: &str, index: usize) -> anyhow::Result<()> {
 }
 
 fn format_ts(ts: u64) -> String {
-    Local
-        .timestamp_opt(ts as i64, 0)
-        .single()
-        .unwrap_or_else(|| Local.timestamp_opt(0, 0).single().unwrap())
-        .format("%Y-%m-%d %H:%M")
-        .to_string()
+    match Local.timestamp_opt(ts as i64, 0).single() {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M").to_string(),
+        None => {
+            tracing::warn!("invalid timestamp {ts}");
+            match Local.timestamp_opt(0, 0).single() {
+                Some(fallback) => fallback.format("%Y-%m-%d %H:%M").to_string(),
+                None => "1970-01-01 00:00".to_string(),
+            }
+        }
+    }
 }
 
 pub struct NotesPlugin {

--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -378,12 +378,16 @@ fn format_duration(dur: Duration) -> String {
 
 pub fn format_ts(ts: u64) -> String {
     use chrono::{Local, TimeZone};
-    Local
-        .timestamp_opt(ts as i64, 0)
-        .single()
-        .unwrap_or_else(|| Local.timestamp_opt(0, 0).single().unwrap())
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string()
+    match Local.timestamp_opt(ts as i64, 0).single() {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+        None => {
+            tracing::warn!("invalid timestamp {ts}");
+            match Local.timestamp_opt(0, 0).single() {
+                Some(fallback) => fallback.format("%Y-%m-%d %H:%M:%S").to_string(),
+                None => "1970-01-01 00:00:00".to_string(),
+            }
+        }
+    }
 }
 
 fn start_entry(

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -252,3 +252,17 @@ fn search_timer_hms_format() {
     assert_eq!(results.len(), 1);
     assert!(results[0].action.starts_with("timer:start:1:30"));
 }
+
+#[test]
+fn format_ts_invalid_timestamp() {
+    use multi_launcher::plugins::timer::format_ts;
+    use chrono::{Local, TimeZone};
+    let invalid_ts = 10_000_000_000_000u64;
+    let expected = Local
+        .timestamp_opt(0, 0)
+        .single()
+        .unwrap()
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    assert_eq!(format_ts(invalid_ts), expected);
+}


### PR DESCRIPTION
## Summary
- make `format_ts` robust for notes/timer plugins
- log warning when timestamp conversion fails
- cover invalid timestamps with new tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687eb7c4463883329b4e89a3f7ec8c3e