### PR TITLE
Improve history mutex resilience

### DIFF
--- a/tests/resilience.rs
+++ b/tests/resilience.rs
@@ -1,6 +1,8 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::folders::{FoldersPlugin, FOLDERS_FILE};
-use multi_launcher::plugins::timer::{ACTIVE_TIMERS, active_timers};
+use multi_launcher::plugins::timer::{active_timers, ACTIVE_TIMERS};
+use multi_launcher::history::{append_history, clear_history, get_history, poison_history_lock, HistoryEntry};
+use multi_launcher::actions::Action;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 use tempfile::tempdir;
@@ -26,6 +28,29 @@ fn timer_poisoned_lock_does_not_panic() {
     });
     assert!(std::panic::catch_unwind(|| {
         active_timers();
+    })
+    .is_ok());
+}
+
+#[test]
+fn history_poisoned_lock_does_not_panic() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    poison_history_lock();
+    let action = Action {
+        label: "l".into(),
+        desc: "d".into(),
+        action: "a".into(),
+        args: None,
+    };
+    let entry = HistoryEntry {
+        query: "q".into(),
+        query_lc: String::new(),
+        action,
+    };
+    assert!(std::panic::catch_unwind(|| {
+        let _ = append_history(entry.clone(), 10);
+        let _ = get_history();
+        let _ = clear_history();
     })
     .is_ok());
 }


### PR DESCRIPTION
## Summary
- prevent panics when the history mutex is poisoned by using `lock().ok()`
- provide helper `poison_history_lock` for tests
- add a test verifying history operations remain safe after poisoning

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687ec595b824833288d8e90eeaeb3c82