### PR TITLE
Fix default hotkey handling in SettingsEditor

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -152,10 +152,18 @@ fn default_net_refresh() -> f32 {
     1.0
 }
 
+fn default_launcher_hotkey() -> Option<String> {
+    if std::env::var("ML_DEFAULT_HOTKEY_NONE").is_ok() {
+        None
+    } else {
+        Some("F2".into())
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            hotkey: Some("F2".into()),
+            hotkey: default_launcher_hotkey(),
             quit_hotkey: None,
             help_hotkey: Some("F1".into()),
             index_paths: None,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -54,7 +54,9 @@ impl SettingsEditor {
     pub fn new(settings: &Settings) -> Self {
         let hotkey = settings.hotkey.clone().unwrap_or_default();
         let hotkey_valid = parse_hotkey(&hotkey).is_some();
-        let default_hotkey = Settings::default().hotkey.unwrap();
+        let default_hotkey = Settings::default()
+            .hotkey
+            .unwrap_or_else(|| "F2".into());
         let last_valid_hotkey = if hotkey_valid {
             hotkey.clone()
         } else {

--- a/tests/settings_editor.rs
+++ b/tests/settings_editor.rs
@@ -1,0 +1,11 @@
+use multi_launcher::settings::Settings;
+use multi_launcher::settings_editor::SettingsEditor;
+
+#[test]
+fn new_handles_none_default_hotkey() {
+    std::env::set_var("ML_DEFAULT_HOTKEY_NONE", "1");
+    let settings = Settings::default();
+    assert!(settings.hotkey.is_none());
+    assert!(std::panic::catch_unwind(|| SettingsEditor::new(&settings)).is_ok());
+    std::env::remove_var("ML_DEFAULT_HOTKEY_NONE");
+}


### PR DESCRIPTION
## Summary
- prevent panic if `Settings::default().hotkey` is `None`
- allow overriding default hotkey via `ML_DEFAULT_HOTKEY_NONE` in tests
- add regression test for `SettingsEditor::new` when no default hotkey is set

## Testing
- `cargo test --test settings_editor -- --test-threads=1 -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ec91e43008332b455c8bdc54e77a7