### PR TITLE
Use HashSet for plugin filtering

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -35,6 +35,7 @@ use crate::plugins::windows::WindowsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
+use std::collections::HashSet;
 use libloading::Library;
 use serde_json::Value;
 use eframe::egui;
@@ -233,14 +234,14 @@ impl PluginManager {
     pub fn search_filtered(
         &self,
         query: &str,
-        enabled_plugins: Option<&Vec<String>>,
+        enabled_plugins: Option<&HashSet<String>>,
         enabled_caps: Option<&std::collections::HashMap<String, Vec<String>>>,
     ) -> Vec<Action> {
         let mut actions = Vec::new();
         for p in &self.plugins {
             let name = p.name();
             if let Some(list) = enabled_plugins {
-                if !list.contains(&name.to_string()) {
+                if !list.contains(name) {
                     continue;
                 }
             }

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -22,7 +22,7 @@ impl PluginEditor {
         // If settings don't specify enabled plugins, enable all gathered ones by
         // default.
         let enabled_plugins = match &settings.enabled_plugins {
-            Some(list) => list.clone(),
+            Some(set) => set.iter().cloned().collect(),
             None => info.iter().map(|(n, _, _)| n.clone()).collect(),
         };
 
@@ -70,7 +70,7 @@ impl PluginEditor {
                 s.enabled_plugins = if all_plugins_enabled {
                     None
                 } else {
-                    Some(self.enabled_plugins.clone())
+                    Some(self.enabled_plugins.iter().cloned().collect())
                 };
 
                 let mut default_caps = true;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@ use crate::hotkey::Key;
 
 use crate::hotkey::{parse_hotkey, Hotkey};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -37,9 +38,9 @@ pub struct Settings {
     pub help_hotkey: Option<String>,
     pub index_paths: Option<Vec<String>>,
     pub plugin_dirs: Option<Vec<String>>,
-    /// List of plugin names which should be enabled. If `None`, all loaded
+    /// Set of plugin names which should be enabled. If `None`, all loaded
     /// plugins are enabled.
-    pub enabled_plugins: Option<Vec<String>>,
+    pub enabled_plugins: Option<HashSet<String>>,
     /// Map of plugin capability identifiers enabled per plugin.
     pub enabled_capabilities: Option<std::collections::HashMap<String, Vec<String>>>,
     /// When enabled the application initialises the logger at debug level.


### PR DESCRIPTION
## Summary
- store enabled plugin names in a `HashSet` instead of `Vec`
- update plugin search filter to check membership via `HashSet`
- adjust plugin editor and GUI for new set type

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ed46ee6708332bc49175e712f35b9