### PR TITLE
Fix volume dialog default level

### DIFF
--- a/src/gui/volume_dialog.rs
+++ b/src/gui/volume_dialog.rs
@@ -71,8 +71,7 @@ fn get_system_volume() -> Option<u8> {
         {
             if let Ok(device) = enm.GetDefaultAudioEndpoint(eRender, eMultimedia) {
                 if let Ok(vol) = device.Activate::<IAudioEndpointVolume>(CLSCTX_ALL, None) {
-                    let mut val = 0f32;
-                    if vol.GetMasterVolumeLevelScalar(&mut val).is_ok() {
+                    if let Ok(val) = vol.GetMasterVolumeLevelScalar() {
                         percent = Some((val * 100.0).round() as u8);
                     }
                 }

--- a/src/gui/volume_dialog.rs
+++ b/src/gui/volume_dialog.rs
@@ -12,7 +12,7 @@ pub struct VolumeDialog {
 impl VolumeDialog {
     pub fn open(&mut self) {
         self.open = true;
-        self.value = 50;
+        self.value = get_system_volume().unwrap_or(50);
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
@@ -51,4 +51,39 @@ impl VolumeDialog {
             });
         if close { self.open = false; }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn get_system_volume() -> Option<u8> {
+    use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
+    use windows::Win32::Media::Audio::{
+        eMultimedia, eRender, IMMDeviceEnumerator, MMDeviceEnumerator,
+    };
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
+    };
+
+    unsafe {
+        let mut percent = None;
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        if let Ok(enm) =
+            CoCreateInstance::<_, IMMDeviceEnumerator>(&MMDeviceEnumerator, None, CLSCTX_ALL)
+        {
+            if let Ok(device) = enm.GetDefaultAudioEndpoint(eRender, eMultimedia) {
+                if let Ok(vol) = device.Activate::<IAudioEndpointVolume>(CLSCTX_ALL, None) {
+                    let mut val = 0f32;
+                    if vol.GetMasterVolumeLevelScalar(&mut val).is_ok() {
+                        percent = Some((val * 100.0).round() as u8);
+                    }
+                }
+            }
+        }
+        CoUninitialize();
+        percent
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_system_volume() -> Option<u8> {
+    None
 }

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -2,8 +2,6 @@ use crate::gui::LauncherApp;
 use crate::plugin::PluginManager;
 use crate::settings::Settings;
 use eframe::egui;
-#[cfg(target_os = "windows")]
-use rfd::FileDialog;
 use std::collections::HashMap;
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- show system volume level when opening the volume dialog
- provide a helper to retrieve the current volume on Windows

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880241207548332a671a43fe22d0ca9