### PR TITLE
Filter disabled plugin commands

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -543,7 +543,10 @@ impl LauncherApp {
         let mut res: Vec<(Action, f32)> = Vec::new();
 
         if trimmed.is_empty() {
-            for cmd in self.plugins.commands() {
+            for cmd in self
+                .plugins
+                .commands_filtered(self.enabled_plugins.as_ref())
+            {
                 res.push((cmd, 0.0));
             }
             for a in &self.actions {
@@ -679,7 +682,10 @@ impl LauncherApp {
         );
 
         if plugin_results.is_empty() && !trimmed.is_empty() {
-            for a in self.plugins.commands() {
+            for a in self
+                .plugins
+                .commands_filtered(self.enabled_plugins.as_ref())
+            {
                 let label_lc = a.label.to_lowercase();
                 let desc_lc = a.desc.to_lowercase();
                 if self.fuzzy_weight <= 0.0 {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -177,13 +177,23 @@ impl PluginManager {
             .collect()
     }
 
-    /// Collect command shortcuts from all plugins.
-    pub fn commands(&self) -> Vec<Action> {
+    /// Collect command shortcuts from plugins filtered by `enabled_plugins`.
+    pub fn commands_filtered(&self, enabled_plugins: Option<&HashSet<String>>) -> Vec<Action> {
         let mut out = Vec::new();
         for p in &self.plugins {
+            if let Some(set) = enabled_plugins {
+                if !set.contains(p.name()) {
+                    continue;
+                }
+            }
             out.extend(p.commands());
         }
         out
+    }
+
+    /// Collect command shortcuts from all plugins.
+    pub fn commands(&self) -> Vec<Action> {
+        self.commands_filtered(None)
     }
 
     pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Box<dyn Plugin>> {

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -34,6 +34,41 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     )
 }
 
+fn new_app_with_settings(
+    ctx: &egui::Context,
+    actions: Vec<Action>,
+    settings: Settings,
+) -> LauncherApp {
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    let dirs: Vec<String> = Vec::new();
+    let plugin_settings = settings.plugin_settings.clone();
+    plugins.reload_from_dirs(
+        &dirs,
+        settings.clipboard_limit,
+        settings.net_unit,
+        false,
+        &plugin_settings,
+    );
+    let enabled_plugins = settings.enabled_plugins.clone();
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        enabled_plugins,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
 #[test]
 fn empty_query_lists_commands() {
     let ctx = egui::Context::default();
@@ -58,4 +93,16 @@ fn query_matches_commands_when_plugins_empty() {
     app.query = "hel".into();
     app.search();
     assert!(app.results.iter().any(|a| a.label == "help"));
+}
+
+#[test]
+fn disabled_plugin_commands_hidden() {
+    let ctx = egui::Context::default();
+    let actions: Vec<Action> = Vec::new();
+    let mut settings = Settings::default();
+    settings.enabled_plugins = Some(std::collections::HashSet::from(["web_search".to_string()]));
+    let mut app = new_app_with_settings(&ctx, actions, settings);
+    app.query.clear();
+    app.search();
+    assert!(!app.results.iter().any(|a| a.label == "help"));
 }


### PR DESCRIPTION
## Summary
- avoid showing commands from disabled plugins
- handle filtered commands in LauncherApp
- test disabled plugins stay hidden

## Testing
- `cargo test --quiet --test plugin_commands`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688027f85df48332a41c06709af16de7