### PR TITLE
Borrow plugin vectors directly

### DIFF
--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -196,14 +196,12 @@ impl Plugin for BookmarksPlugin {
         const RM_PREFIX: &str = "bm rm";
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, RM_PREFIX) {
             let filter = rest.trim();
-            let bookmarks = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return bookmarks
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|b| {
                     self.matcher.fuzzy_match(&b.url, filter).is_some()
                         || b.alias
@@ -212,9 +210,9 @@ impl Plugin for BookmarksPlugin {
                             .unwrap_or(false)
                 })
                 .map(|b| Action {
-                    label: format!("Remove bookmark {}", b.url),
+                    label: format!("Remove bookmark {}", b.url.clone()),
                     desc: "Bookmark".into(),
-                    action: format!("bookmark:remove:{}", b.url),
+                    action: format!("bookmark:remove:{}", b.url.clone()),
                     args: None,
                 })
                 .collect();
@@ -222,14 +220,12 @@ impl Plugin for BookmarksPlugin {
         const LIST_PREFIX: &str = "bm list";
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
             let filter = rest.trim();
-            let bookmarks = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return bookmarks
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|b| {
                     self.matcher.fuzzy_match(&b.url, filter).is_some()
                         || b.alias
@@ -242,7 +238,7 @@ impl Plugin for BookmarksPlugin {
                     Action {
                         label,
                         desc: "Bookmark".into(),
-                        action: b.url,
+                        action: b.url.clone(),
                         args: None,
                     }
                 })
@@ -254,14 +250,12 @@ impl Plugin for BookmarksPlugin {
             None => return Vec::new(),
         };
         let filter = rest.trim();
-        let bookmarks = self
-            .data
-            .lock()
-            .ok()
-            .map(|g| g.clone())
-            .unwrap_or_default();
-        bookmarks
-            .into_iter()
+        let guard = match self.data.lock() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        guard
+            .iter()
             .filter(|b| {
                 self.matcher.fuzzy_match(&b.url, filter).is_some()
                     || b.alias
@@ -274,7 +268,7 @@ impl Plugin for BookmarksPlugin {
                 Action {
                     label,
                     desc: "Bookmark".into(),
-                    action: b.url,
+                    action: b.url.clone(),
                     args: None,
                 }
             })

--- a/src/plugins/notes.rs
+++ b/src/plugins/notes.rs
@@ -138,18 +138,16 @@ impl Plugin for NotesPlugin {
         const RM_PREFIX: &str = "note rm ";
         if let Some(rest) = crate::common::strip_prefix_ci(query, RM_PREFIX) {
             let filter = rest.trim();
-            let notes = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return notes
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .enumerate()
                 .filter(|(_, n)| self.matcher.fuzzy_match(&n.text, filter).is_some())
                 .map(|(idx, n)| Action {
-                    label: format!("Remove note {} - {}", format_ts(n.ts), n.text),
+                    label: format!("Remove note {} - {}", format_ts(n.ts), n.text.clone()),
                     desc: "Note".into(),
                     action: format!("note:remove:{idx}"),
                     args: None,
@@ -160,18 +158,16 @@ impl Plugin for NotesPlugin {
         const LIST_PREFIX: &str = "note list";
         if let Some(rest) = crate::common::strip_prefix_ci(query, LIST_PREFIX) {
             let filter = rest.trim();
-            let notes = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return notes
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .enumerate()
                 .filter(|(_, n)| self.matcher.fuzzy_match(&n.text, filter).is_some())
                 .map(|(idx, n)| Action {
-                    label: format!("{} - {}", format_ts(n.ts), n.text),
+                    label: format!("{} - {}", format_ts(n.ts), n.text.clone()),
                     desc: "Note".into(),
                     action: format!("note:copy:{idx}"),
                     args: None,
@@ -181,13 +177,13 @@ impl Plugin for NotesPlugin {
 
         if let Some(rest) = crate::common::strip_prefix_ci(query.trim(), "note") {
             if rest.is_empty() {
-            return vec![Action {
-                label: "note: edit notes".into(),
-                desc: "Note".into(),
-                action: "note:dialog".into(),
-                args: None,
-            }];
-        }
+                return vec![Action {
+                    label: "note: edit notes".into(),
+                    desc: "Note".into(),
+                    action: "note:dialog".into(),
+                    args: None,
+                }];
+            }
         }
 
         Vec::new()
@@ -207,10 +203,30 @@ impl Plugin for NotesPlugin {
 
     fn commands(&self) -> Vec<Action> {
         vec![
-            Action { label: "note".into(), desc: "Note".into(), action: "query:note".into(), args: None },
-            Action { label: "note add".into(), desc: "Note".into(), action: "query:note add ".into(), args: None },
-            Action { label: "note list".into(), desc: "Note".into(), action: "query:note list".into(), args: None },
-            Action { label: "note rm".into(), desc: "Note".into(), action: "query:note rm ".into(), args: None },
+            Action {
+                label: "note".into(),
+                desc: "Note".into(),
+                action: "query:note".into(),
+                args: None,
+            },
+            Action {
+                label: "note add".into(),
+                desc: "Note".into(),
+                action: "query:note add ".into(),
+                args: None,
+            },
+            Action {
+                label: "note list".into(),
+                desc: "Note".into(),
+                action: "query:note list".into(),
+                args: None,
+            },
+            Action {
+                label: "note rm".into(),
+                desc: "Note".into(),
+                action: "query:note rm ".into(),
+                args: None,
+            },
         ]
     }
 }

--- a/src/plugins/snippets.rs
+++ b/src/plugins/snippets.rs
@@ -115,33 +115,31 @@ impl Plugin for SnippetsPlugin {
         let trimmed = query.trim();
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "cs") {
             if rest.is_empty() {
-            return vec![Action {
-                label: "cs: edit snippets".into(),
-                desc: "Snippet".into(),
-                action: "snippet:dialog".into(),
-                args: None,
-            }];
+                return vec![Action {
+                    label: "cs: edit snippets".into(),
+                    desc: "Snippet".into(),
+                    action: "snippet:dialog".into(),
+                    args: None,
+                }];
             }
         }
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "cs rm") {
             let filter = rest.trim();
-            let list = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return list
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|s| {
                     filter.is_empty()
                         || self.matcher.fuzzy_match(&s.alias, filter).is_some()
                         || self.matcher.fuzzy_match(&s.text, filter).is_some()
                 })
                 .map(|s| Action {
-                    label: format!("Remove snippet {}", s.alias),
+                    label: format!("Remove snippet {}", s.alias.clone()),
                     desc: "Snippet".into(),
-                    action: format!("snippet:remove:{}", s.alias),
+                    action: format!("snippet:remove:{}", s.alias.clone()),
                     args: None,
                 })
                 .collect();
@@ -163,23 +161,21 @@ impl Plugin for SnippetsPlugin {
 
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "cs edit") {
             let filter = rest.trim();
-            let list = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return list
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|s| {
                     filter.is_empty()
                         || self.matcher.fuzzy_match(&s.alias, filter).is_some()
                         || self.matcher.fuzzy_match(&s.text, filter).is_some()
                 })
                 .map(|s| Action {
-                    label: format!("Edit snippet {}", s.alias),
+                    label: format!("Edit snippet {}", s.alias.clone()),
                     desc: "Snippet".into(),
-                    action: format!("snippet:edit:{}", s.alias),
+                    action: format!("snippet:edit:{}", s.alias.clone()),
                     args: None,
                 })
                 .collect();
@@ -187,22 +183,20 @@ impl Plugin for SnippetsPlugin {
 
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "cs list") {
             let filter = rest.trim();
-            let list = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return list
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|s| {
                     self.matcher.fuzzy_match(&s.alias, filter).is_some()
                         || self.matcher.fuzzy_match(&s.text, filter).is_some()
                 })
                 .map(|s| Action {
-                    label: s.alias,
+                    label: s.alias.clone(),
                     desc: "Snippet".into(),
-                    action: format!("clipboard:{}", s.text),
+                    action: format!("clipboard:{}", s.text.clone()),
                     args: None,
                 })
                 .collect();
@@ -210,22 +204,20 @@ impl Plugin for SnippetsPlugin {
 
         if let Some(filter) = crate::common::strip_prefix_ci(trimmed, "cs") {
             let filter = filter.trim();
-            let list = self
-                .data
-                .lock()
-                .ok()
-                .map(|g| g.clone())
-                .unwrap_or_default();
-            return list
-                .into_iter()
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
                 .filter(|s| {
                     self.matcher.fuzzy_match(&s.alias, filter).is_some()
                         || self.matcher.fuzzy_match(&s.text, filter).is_some()
                 })
                 .map(|s| Action {
-                    label: s.alias,
+                    label: s.alias.clone(),
                     desc: "Snippet".into(),
-                    action: format!("clipboard:{}", s.text),
+                    action: format!("clipboard:{}", s.text.clone()),
                     args: None,
                 })
                 .collect();
@@ -247,11 +239,36 @@ impl Plugin for SnippetsPlugin {
 
     fn commands(&self) -> Vec<Action> {
         vec![
-            Action { label: "cs".into(), desc: "Snippet".into(), action: "query:cs".into(), args: None },
-            Action { label: "cs add".into(), desc: "Snippet".into(), action: "query:cs add ".into(), args: None },
-            Action { label: "cs rm".into(), desc: "Snippet".into(), action: "query:cs rm ".into(), args: None },
-            Action { label: "cs list".into(), desc: "Snippet".into(), action: "query:cs list".into(), args: None },
-            Action { label: "cs edit".into(), desc: "Snippet".into(), action: "query:cs edit".into(), args: None },
+            Action {
+                label: "cs".into(),
+                desc: "Snippet".into(),
+                action: "query:cs".into(),
+                args: None,
+            },
+            Action {
+                label: "cs add".into(),
+                desc: "Snippet".into(),
+                action: "query:cs add ".into(),
+                args: None,
+            },
+            Action {
+                label: "cs rm".into(),
+                desc: "Snippet".into(),
+                action: "query:cs rm ".into(),
+                args: None,
+            },
+            Action {
+                label: "cs list".into(),
+                desc: "Snippet".into(),
+                action: "query:cs list".into(),
+                args: None,
+            },
+            Action {
+                label: "cs edit".into(),
+                desc: "Snippet".into(),
+                action: "query:cs edit".into(),
+                args: None,
+            },
         ]
     }
 }


### PR DESCRIPTION
## Summary
- avoid cloning the vectors in plugin search functions
- hold a lock while iterating and clone only fields needed for the Action

## Testing
- `cargo test`
 