### PR TITLE
Add optional file logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "walkdir",
  "windows 0.58.0",
@@ -4191,10 +4192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4202,6 +4205,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"
@@ -4309,6 +4322,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 walkdir = "2.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 exmex = "0.20"
 libloading = "0.8"
 notify = "6"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ option is active, you can further adjust the verbosity by setting the
 RUST_LOG=info cargo run --release --features unstable_grab
 ```
 
+Enable persistent log files by adding a `log_file` entry to `settings.json`.
+Set it to `true` to create `launcher.log` next to the executable or supply a
+custom path.
+
 If hotkeys do nothing, check the output for warnings starting with
 `Hotkey listener failed`. When using `CapsLock` as the hotkey you almost
 always need to build with `--features unstable_grab` so the listener can
@@ -91,6 +95,7 @@ value as shown below:
   "fuzzy_weight": 1.0,
   "usage_weight": 1.0,
   "debug_logging": false,
+  "log_file": true,
   "offscreen_pos": [2000, 2000],
   "window_size": [400, 220],
   "query_scale": 1.0,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,23 +1,44 @@
-use tracing_subscriber::EnvFilter;
+use std::path::PathBuf;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+static mut LOG_GUARD: Option<WorkerGuard> = None;
 
 /// Initialise logging. In debug builds the default level is `debug` while in
 /// release builds it falls back to `info`. The level can be overridden via the
-/// `RUST_LOG` environment variable.
-/// `debug` level can be explicitly enabled via the settings file.
-pub fn init(debug: bool) {
-    // When debug logging is disabled we force `info` level regardless of the
-    // `RUST_LOG` environment variable. This prevents accidental verbose output
-    // if the variable happens to be set in the user's environment.
+/// `RUST_LOG` environment variable. `debug` level can be explicitly enabled via
+/// the settings file. When `log_file` is `Some`, logs are also written to the
+/// given file path.
+pub fn init(debug: bool, log_file: Option<PathBuf>) {
     let level = if debug { "debug" } else { "info" };
 
     let filter = if debug {
-        // Allow `RUST_LOG` to override the level when debug logging is enabled.
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level))
     } else {
         EnvFilter::new(level)
     };
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
+    let console_layer = fmt::layer().with_writer(std::io::stderr);
+
+    if let Some(path) = log_file {
+        if let (Some(dir), Some(file)) = (path.parent(), path.file_name()) {
+            let file_appender = tracing_appender::rolling::never(dir, file);
+            let (nb, guard) = tracing_appender::non_blocking(file_appender);
+            unsafe {
+                LOG_GUARD = Some(guard);
+            }
+            let file_layer = fmt::layer().with_ansi(false).with_writer(nb);
+            let _ = tracing_subscriber::registry()
+                .with(filter)
+                .with(console_layer)
+                .with(file_layer)
+                .try_init();
+            return;
+        }
+    }
+
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(console_layer)
         .try_init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn spawn_gui(
 
 fn main() -> anyhow::Result<()> {
     let mut settings = Settings::load("settings.json").unwrap_or_default();
-    logging::init(settings.debug_logging);
+    logging::init(settings.debug_logging, settings.log_file_path());
     tracing::debug!(?settings, "settings loaded");
     let mut actions = load_actions("actions.json").unwrap_or_default();
     let custom_len = actions.len();

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -184,6 +184,7 @@ impl SettingsEditor {
             enabled_plugins: current.enabled_plugins.clone(),
             enabled_capabilities: current.enabled_capabilities.clone(),
             debug_logging: self.debug_logging,
+            log_file: current.log_file.clone(),
             enable_toasts: self.show_toasts,
             toast_duration: self.toast_duration,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),


### PR DESCRIPTION
## Summary
- support writing logs to an optional file via `tracing_appender`
- expose new `log_file` setting
- honour the setting in main at startup
- document log file usage in README

## Testing
- `cargo build --quiet`
- `cargo test --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688168e10e14833298375a5b8abdcf5d