### PR TITLE
Improve watcher error handling

### DIFF
--- a/tests/watcher_failures.rs
+++ b/tests/watcher_failures.rs
@@ -1,0 +1,50 @@
+use eframe::egui;
+use multi_launcher::actions::Action;
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::plugins::bookmarks::{save_bookmarks, BOOKMARKS_FILE};
+use multi_launcher::plugins::folders::{save_folders, FOLDERS_FILE};
+use multi_launcher::settings::Settings;
+use once_cell::sync::Lazy;
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn new_app(actions_path: &str, ctx: &egui::Context) -> LauncherApp {
+    LauncherApp::new(
+        ctx,
+        Vec::new(),
+        0,
+        PluginManager::new(),
+        actions_path.into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn invalid_actions_watcher_logs_error() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    // create other files so the app initializes
+    save_folders(FOLDERS_FILE, &[]).unwrap();
+    save_bookmarks(BOOKMARKS_FILE, &[]).unwrap();
+
+    let ctx = egui::Context::default();
+    let invalid_path = "missing_dir/actions.json";
+    let _app = new_app(invalid_path, &ctx);
+
+    // toast log should contain an entry after initialization
+    let log = std::fs::read_to_string(multi_launcher::toast_log::TOAST_LOG_FILE).unwrap();
+    assert!(!log.trim().is_empty());
+}


### PR DESCRIPTION
## Summary
- return a `notify::Result` from `watch_file`
- push toast notifications when watcher creation fails
- test watcher failures using temporary directories

## Testing
- `cargo test --test watcher_failures`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68829d219318833294d02e7c46757a7e