### PR TITLE
Fix warnings in watchers and quit_finished tests

### DIFF
--- a/tests/quit_finished.rs
+++ b/tests/quit_finished.rs
@@ -1,7 +1,6 @@
 use eframe::egui;
 use multi_launcher::hotkey::{Hotkey, HotkeyTrigger};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
 use std::thread;
@@ -24,7 +23,7 @@ fn run_quit_loop(
         }
 
         if quit_requested {
-            if let Ok(mut guard) = ctx_handle.lock() {
+            if let Ok(guard) = ctx_handle.lock() {
                 if let Some(c) = &*guard {
                     c.send_viewport_cmd(egui::ViewportCommand::Close);
                     c.request_repaint();

--- a/tests/watchers.rs
+++ b/tests/watchers.rs
@@ -50,7 +50,7 @@ fn actions_watcher_sends_event() {
     save_bookmarks(BOOKMARKS_FILE, &[]).unwrap();
 
     let ctx = egui::Context::default();
-    let mut app = new_app(&ctx, acts);
+    let app = new_app(&ctx, acts);
 
     save_actions("actions.json", &[]).unwrap();
     sleep(Duration::from_millis(200));
@@ -69,7 +69,7 @@ fn folders_watcher_sends_event() {
     save_bookmarks(BOOKMARKS_FILE, &[]).unwrap();
 
     let ctx = egui::Context::default();
-    let mut app = new_app(&ctx, Vec::new());
+    let app = new_app(&ctx, Vec::new());
 
     save_folders(
         FOLDERS_FILE,
@@ -96,7 +96,7 @@ fn bookmarks_watcher_sends_event() {
     save_bookmarks(BOOKMARKS_FILE, &[]).unwrap();
 
     let ctx = egui::Context::default();
-    let mut app = new_app(&ctx, Vec::new());
+    let app = new_app(&ctx, Vec::new());
 
     save_bookmarks(
         BOOKMARKS_FILE,


### PR DESCRIPTION
## Summary
- clean up unused imports in `quit_finished.rs`
- remove `mut` qualifiers from local variables in `watchers.rs`
- drop `mut` when locking in `quit_finished.rs`

## Testing
- `cargo test --no-run`

 