### PR TITLE
Add global JSON watcher helper and refactor plugins

### DIFF
--- a/src/common/json_watch.rs
+++ b/src/common/json_watch.rs
@@ -1,0 +1,86 @@
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{atomic::{AtomicUsize, Ordering}, Arc, Mutex};
+
+/// Handle to a registered JSON file watcher.
+/// Dropping the handle removes the associated callback.
+pub struct JsonWatcher {
+    path: PathBuf,
+    id: usize,
+}
+
+struct WatchEntry {
+    #[allow(dead_code)]
+    watcher: RecommendedWatcher,
+    callbacks: Arc<Mutex<HashMap<usize, Box<dyn FnMut() + Send>>>>,
+}
+
+static WATCHERS: Lazy<Mutex<HashMap<PathBuf, WatchEntry>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+impl Drop for JsonWatcher {
+    fn drop(&mut self) {
+        if let Ok(mut map) = WATCHERS.lock() {
+            if let Some(entry) = map.get_mut(&self.path) {
+                let mut cbs = entry.callbacks.lock().unwrap();
+                cbs.remove(&self.id);
+            }
+        }
+    }
+}
+
+/// Watch a JSON file and invoke `callback` whenever it changes.
+///
+/// Returns a handle that must be kept alive for the callbacks to trigger.
+pub fn watch_json<F, P>(path: P, callback: F) -> notify::Result<JsonWatcher>
+where
+    F: FnMut() + Send + 'static,
+    P: AsRef<Path>,
+{
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let path_buf = path.as_ref().to_path_buf();
+
+    let mut map = WATCHERS.lock().unwrap();
+    if let Some(entry) = map.get_mut(&path_buf) {
+        entry.callbacks.lock().unwrap().insert(id, Box::new(callback));
+        return Ok(JsonWatcher { path: path_buf, id });
+    }
+
+    let callbacks: Arc<Mutex<HashMap<usize, Box<dyn FnMut() + Send>>>> = Arc::new(Mutex::new(HashMap::new()));
+    callbacks.lock().unwrap().insert(id, Box::new(callback));
+    let callbacks_clone = callbacks.clone();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: notify::Result<notify::Event>| {
+            match res {
+                Ok(event) => {
+                    if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)) {
+                        let mut cbs = callbacks_clone.lock().unwrap();
+                        for cb in cbs.values_mut() {
+                            cb();
+                        }
+                    }
+                }
+                Err(e) => tracing::error!("watch error: {:?}", e),
+            }
+        },
+        Config::default(),
+    )?;
+
+    if watcher.watch(&path_buf, RecursiveMode::NonRecursive).is_err() {
+        let parent = path_buf.parent().unwrap_or_else(|| Path::new("."));
+        watcher.watch(parent, RecursiveMode::NonRecursive)?;
+    }
+
+    map.insert(
+        path_buf.clone(),
+        WatchEntry {
+            watcher,
+            callbacks,
+        },
+    );
+
+    Ok(JsonWatcher { path: path_buf, id })
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,3 +5,5 @@ pub fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
         None
     }
 }
+
+pub mod json_watch;


### PR DESCRIPTION
## Summary
- move `common.rs` to module directory so helpers can be extended
- implement a global notify helper to watch JSON files
- refactor clipboard and todo plugins to use new helper

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6882ab0780308332bc9449645fd8c553