### PR TITLE
Extend timer alarms beyond a day

### DIFF
--- a/src/actions/timer.rs
+++ b/src/actions/timer.rs
@@ -21,11 +21,11 @@ pub fn start(dur: &str, name: &str) {
 }
 
 pub fn set_alarm(time: &str, name: &str) {
-    if let Some((h, m)) = crate::plugins::timer::parse_hhmm(time) {
+    if let Some((h, m, date)) = crate::plugins::timer::parse_hhmm(time) {
         if name.is_empty() {
-            crate::plugins::timer::start_alarm(h, m, "None".to_string());
+            crate::plugins::timer::start_alarm(h, m, date, "None".to_string());
         } else {
-            crate::plugins::timer::start_alarm_named(h, m, Some(name.to_string()), "None".to_string());
+            crate::plugins::timer::start_alarm_named(h, m, date, Some(name.to_string()), "None".to_string());
         }
     }
 }

--- a/src/gui/timer_dialog.rs
+++ b/src/gui/timer_dialog.rs
@@ -58,7 +58,7 @@ impl TimerDialog {
                 }
                 Mode::Alarm => {
                     ui.horizontal(|ui| {
-                        ui.label("Time (HH:MM)");
+                        ui.label("Time (HH:MM, Nd HH:MM or YYYY-MM-DD HH:MM)");
                         ui.text_edit_singleline(&mut self.time);
                     });
                 }
@@ -113,10 +113,11 @@ impl TimerDialog {
                             }
                         }
                         Mode::Alarm => {
-                            if let Some((h, m)) = parse_hhmm(&self.time) {
+                            if let Some((h, m, date)) = parse_hhmm(&self.time) {
                                 start_alarm_named(
                                     h,
                                     m,
+                                    date,
                                     if self.label.is_empty() {
                                         None
                                     } else {


### PR DESCRIPTION
## Summary
- support relative or absolute dates in `parse_hhmm`
- allow scheduling alarms more than 24h ahead
- update timer dialog to describe and use the new format
- adjust timer actions for the new parameters
- test multi-day alarm parsing and scheduling

## Testing
- `cargo check`
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_6882afcc2e7c8332a54e6ea5b393c44e