### PR TITLE
Add todo export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Built-in commands:
 | `note` | `note add <text>` | Quick notes |
 | `todo` | `todo add <task>` | Todo items |
 | `todo edit` | `todo edit` | Edit todos |
+| `todo export` | `todo export` | Export todos |
 | `cs` | `cs add <alias> <text>` | Text snippets |
 | `rec` | `rec` | Recycle Bin cleanup |
 | `tmp` | `tmp new [name]` | Temporary files |

--- a/src/actions/todo.rs
+++ b/src/actions/todo.rs
@@ -40,3 +40,26 @@ pub fn clear_done() -> anyhow::Result<()> {
     crate::plugins::todo::clear_done(crate::plugins::todo::TODO_FILE)?;
     Ok(())
 }
+
+pub fn export() -> anyhow::Result<std::path::PathBuf> {
+    use std::fmt::Write as _;
+
+    let list = crate::plugins::todo::load_todos(crate::plugins::todo::TODO_FILE)?;
+
+    let mut content = String::new();
+    for entry in list {
+        let done = if entry.done { "[x]" } else { "[ ]" };
+        write!(content, "{done} {}", entry.text)?;
+        if !entry.tags.is_empty() {
+            write!(content, " #{}", entry.tags.join(" #"))?;
+        }
+        if entry.priority > 0 {
+            write!(content, " p={}", entry.priority)?;
+        }
+        writeln!(content)?;
+    }
+
+    let path = crate::plugins::tempfile::create_named_file("todo_export", &content)?;
+    open::that(&path)?;
+    Ok(path)
+}

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -192,6 +192,7 @@ enum ActionKind<'a> {
     TodoRemove(usize),
     TodoDone(usize),
     TodoClear,
+    TodoExport,
     SnippetRemove(&'a str),
     SnippetAdd { alias: &'a str, text: &'a str },
     BrightnessSet(u32),
@@ -370,6 +371,9 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
     if s == "todo:clear" {
         return ActionKind::TodoClear;
     }
+    if s == "todo:export" {
+        return ActionKind::TodoExport;
+    }
     if let Some(alias) = s.strip_prefix("snippet:remove:") {
         return ActionKind::SnippetRemove(alias);
     }
@@ -514,6 +518,10 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         ActionKind::TodoRemove(i) => todo::remove(i),
         ActionKind::TodoDone(i) => todo::mark_done(i),
         ActionKind::TodoClear => todo::clear_done(),
+        ActionKind::TodoExport => {
+            todo::export()?;
+            Ok(())
+        }
         ActionKind::SnippetRemove(alias) => snippets::remove(alias),
         ActionKind::SnippetAdd { alias, text } => snippets::add(alias, text),
         ActionKind::BrightnessSet(v) => {

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -198,6 +198,15 @@ impl Plugin for TodoPlugin {
             }];
         }
 
+        if trimmed.eq_ignore_ascii_case("todo export") {
+            return vec![Action {
+                label: "Export todo list".into(),
+                desc: "Todo".into(),
+                action: "todo:export".into(),
+                args: None,
+            }];
+        }
+
         if trimmed.eq_ignore_ascii_case("todo clear") {
             return vec![Action {
                 label: "Clear completed todos".into(),
@@ -413,6 +422,12 @@ impl Plugin for TodoPlugin {
                 label: "todo view".into(),
                 desc: "Todo".into(),
                 action: "query:todo view ".into(),
+                args: None,
+            },
+            Action {
+                label: "todo export".into(),
+                desc: "Todo".into(),
+                action: "query:todo export".into(),
                 args: None,
             },
         ]

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -210,3 +210,12 @@ fn search_view_opens_dialog() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "todo:view");
 }
+
+#[test]
+fn search_export_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TodoPlugin::default();
+    let results = plugin.search("todo export");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "todo:export");
+}


### PR DESCRIPTION
## Summary
- add `todo export` query to todo plugin
- implement `todo::export` action
- parse `todo:export` action in launcher
- document todo export command
- test todo export query

## Testing
- `cargo test --quiet -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6882b75b7348833291f270da5cbd0f56