### PR TITLE
Fix enter key save in todo view

### DIFF
--- a/src/gui/todo_view_dialog.rs
+++ b/src/gui/todo_view_dialog.rs
@@ -95,23 +95,46 @@ impl TodoViewDialog {
                         for idx in indices {
                             if Some(idx) == self.editing_idx {
                                 ui.vertical(|ui| {
+                                    let text_resp = ui
+                                        .horizontal(|ui| {
+                                            ui.label("Text:");
+                                            ui.text_edit_singleline(&mut self.editing_text)
+                                        })
+                                        .inner;
+
+                                    let prio_resp = ui
+                                        .horizontal(|ui| {
+                                            ui.label("Priority:");
+                                            ui.add(
+                                                egui::DragValue::new(&mut self.editing_priority)
+                                                    .clamp_range(0..=255),
+                                            )
+                                        })
+                                        .inner;
+
+                                    let tags_resp = ui
+                                        .horizontal(|ui| {
+                                            ui.label("Tags:");
+                                            ui.text_edit_singleline(&mut self.editing_tags)
+                                        })
+                                        .inner;
+
                                     ui.horizontal(|ui| {
-                                        ui.label("Text:");
-                                        ui.text_edit_singleline(&mut self.editing_text);
-                                    });
-                                    ui.horizontal(|ui| {
-                                        ui.label("Priority:");
-                                        ui.add(
-                                            egui::DragValue::new(&mut self.editing_priority)
-                                                .clamp_range(0..=255),
-                                        );
-                                    });
-                                    ui.horizontal(|ui| {
-                                        ui.label("Tags:");
-                                        ui.text_edit_singleline(&mut self.editing_tags);
-                                    });
-                                    ui.horizontal(|ui| {
-                                        if ui.button("Save").clicked() {
+                                        let mut save_clicked = ui.button("Save").clicked();
+                                        if !save_clicked
+                                            && (text_resp.has_focus()
+                                                || prio_resp.has_focus()
+                                                || tags_resp.has_focus())
+                                            && ctx.input(|i| i.key_pressed(egui::Key::Enter))
+                                        {
+                                            save_clicked = true;
+                                            let modifiers = ctx.input(|i| i.modifiers);
+                                            ctx.input_mut(|i| {
+                                                i.consume_key(modifiers, egui::Key::Enter)
+                                            });
+                                        }
+
+                                        if save_clicked {
                                             let tags: Vec<String> = self
                                                 .editing_tags
                                                 .split(',')
@@ -127,6 +150,7 @@ impl TodoViewDialog {
                                             self.editing_idx = None;
                                             save_now = true;
                                         }
+
                                         if ui.button("Cancel").clicked() {
                                             self.editing_idx = None;
                                         }


### PR DESCRIPTION
## Summary
- handle Enter key when saving edits in TodoViewDialog so users can press Enter to save changes

## Testing
- `cargo test --locked`

 