### PR TITLE
Refine todo dialog layout

### DIFF
--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -55,111 +55,120 @@ impl TodoDialog {
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
-        if !self.open { return; }
-        let mut close = false;
+        if !self.open {
+            return;
+        }
         let mut save_now = false;
         egui::Window::new("Todos")
             .open(&mut self.open)
             .resizable(true)
-            .default_size((360.0, 240.0))
+            .default_size((320.0, 200.0))
             .min_width(200.0)
             .min_height(150.0)
             .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label("New");
-                    let text_resp = ui.text_edit_singleline(&mut self.text);
-                    ui.label("Priority");
-                    let prio_resp = ui
-                        .add(egui::DragValue::new(&mut self.priority).clamp_range(0..=255));
-                    ui.label("Tags");
-                    let tags_resp = ui.text_edit_singleline(&mut self.tags);
-                    ui.checkbox(&mut self.persist_tags, "Persist Tags");
+                ui.spacing_mut().item_spacing = egui::vec2(4.0, 2.0);
+                ui.checkbox(&mut self.persist_tags, "Persist Tags");
+                egui::Grid::new("todo_add_grid")
+                    .spacing([4.0, 2.0])
+                    .show(ui, |ui| {
+                        ui.label(egui::RichText::new("New Todo").strong());
+                        let text_resp = ui.text_edit_singleline(&mut self.text);
+                        ui.end_row();
 
-                    let mut add_clicked = ui.button("Add").clicked();
-                    if !add_clicked
-                        && (text_resp.has_focus()
-                            || tags_resp.has_focus()
-                            || prio_resp.has_focus())
-                        && ctx.input(|i| i.key_pressed(egui::Key::Enter))
-                    {
-                        add_clicked = true;
-                        let modifiers = ctx.input(|i| i.modifiers);
-                        ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
-                    }
+                        ui.label("Tags");
+                        let tags_resp = ui.text_edit_singleline(&mut self.tags);
+                        ui.end_row();
 
-                    if add_clicked {
-                        if !self.text.trim().is_empty() {
-                            let tag_list: Vec<String> = self
-                                .tags
-                                .split(',')
-                                .map(|t| t.trim())
-                                .filter(|t| !t.is_empty())
-                                .map(|t| t.to_string())
-                                .collect();
-                            self.entries.push(TodoEntry {
-                                text: self.text.clone(),
-                                done: false,
-                                priority: self.priority,
-                                tags: tag_list,
-                            });
-                            self.text.clear();
-                            self.priority = 0;
-                            if !self.persist_tags {
-                                self.tags.clear();
-                            }
-                            save_now = true;
+                        ui.label("Priority");
+                        let prio_resp =
+                            ui.add(egui::DragValue::new(&mut self.priority).clamp_range(0..=255));
+                        let mut add_clicked = ui.button("Add").clicked();
+                        if !add_clicked
+                            && (text_resp.has_focus()
+                                || tags_resp.has_focus()
+                                || prio_resp.has_focus())
+                            && ctx.input(|i| i.key_pressed(egui::Key::Enter))
+                        {
+                            add_clicked = true;
+                            let modifiers = ctx.input(|i| i.modifiers);
+                            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
                         }
-                    }
-                });
-                ui.horizontal(|ui| {
-                    if ui.button("Clear Completed").clicked() {
-                        self.entries.retain(|e| !e.done);
-                        save_now = true;
-                    }
-                    if ui.button("Close").clicked() { close = true; }
-                });
-                ui.horizontal(|ui| {
-                    ui.label("Filter");
-                    ui.text_edit_singleline(&mut self.filter);
-                });
-                ui.separator();
-                let mut remove: Option<usize> = None;
-                let area_height = ui.available_height();
-                let indices = Self::filtered_indices(&self.entries, &self.filter);
-                egui::ScrollArea::both().max_height(area_height).show(ui, |ui| {
-                    for idx in indices {
-                        ui.horizontal(|ui| {
-                            let entry = &mut self.entries[idx];
-                            if ui.checkbox(&mut entry.done, "").changed() {
-                                save_now = true;
-                            }
-                            ui.label(entry.text.replace('\n', " "));
-                            ui.add(egui::DragValue::new(&mut entry.priority).clamp_range(0..=255));
-                            let mut tag_str = entry.tags.join(", ");
-                            if ui.text_edit_singleline(&mut tag_str).changed() {
-                                entry.tags = tag_str
+
+                        if add_clicked {
+                            if !self.text.trim().is_empty() {
+                                let tag_list: Vec<String> = self
+                                    .tags
                                     .split(',')
                                     .map(|t| t.trim())
                                     .filter(|t| !t.is_empty())
                                     .map(|t| t.to_string())
                                     .collect();
+                                self.entries.push(TodoEntry {
+                                    text: self.text.clone(),
+                                    done: false,
+                                    priority: self.priority,
+                                    tags: tag_list,
+                                });
+                                self.text.clear();
+                                self.priority = 0;
+                                if !self.persist_tags {
+                                    self.tags.clear();
+                                }
                                 save_now = true;
                             }
-                            if ui.button("Remove").clicked() {
-                                remove = Some(idx);
-                            }
-                        });
+                        }
+                        ui.end_row();
+                    });
+                ui.horizontal(|ui| {
+                    if ui.button("Clear Completed").clicked() {
+                        self.entries.retain(|e| !e.done);
+                        save_now = true;
                     }
                 });
+                ui.separator();
+                ui.horizontal(|ui| {
+                    ui.label("Filter");
+                    ui.text_edit_singleline(&mut self.filter);
+                });
+                let mut remove: Option<usize> = None;
+                let area_height = ui.available_height();
+                let indices = Self::filtered_indices(&self.entries, &self.filter);
+                egui::ScrollArea::both()
+                    .max_height(area_height)
+                    .show(ui, |ui| {
+                        for idx in indices {
+                            ui.horizontal(|ui| {
+                                let entry = &mut self.entries[idx];
+                                if ui.checkbox(&mut entry.done, "").changed() {
+                                    save_now = true;
+                                }
+                                ui.label(entry.text.replace('\n', " "));
+                                ui.add(
+                                    egui::DragValue::new(&mut entry.priority).clamp_range(0..=255),
+                                );
+                                let mut tag_str = entry.tags.join(", ");
+                                if ui.text_edit_singleline(&mut tag_str).changed() {
+                                    entry.tags = tag_str
+                                        .split(',')
+                                        .map(|t| t.trim())
+                                        .filter(|t| !t.is_empty())
+                                        .map(|t| t.to_string())
+                                        .collect();
+                                    save_now = true;
+                                }
+                                if ui.button("Remove").clicked() {
+                                    remove = Some(idx);
+                                }
+                            });
+                        }
+                    });
                 if let Some(idx) = remove {
                     self.entries.remove(idx);
                     save_now = true;
                 }
             });
-        if save_now { self.save(app, false); }
-        if close {
-            self.open = false;
-            app.focus_input();
+        if save_now {
+            self.save(app, false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- move persist checkbox to a separate row
- emphasize `New Todo` entry and add label for tags below it
- drop `Close` button and reorder filter section

## Testing
- `cargo test --quiet`
 