### PR TITLE
Add Enter key handler for todos

### DIFF
--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -58,6 +58,29 @@ impl TodoDialog {
         if !self.open {
             return;
         }
+        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.text.trim().is_empty() {
+            let modifiers = ctx.input(|i| i.modifiers);
+            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+            let tag_list: Vec<String> = self
+                .tags
+                .split(',')
+                .map(|t| t.trim())
+                .filter(|t| !t.is_empty())
+                .map(|t| t.to_string())
+                .collect();
+            self.entries.push(TodoEntry {
+                text: self.text.clone(),
+                done: false,
+                priority: self.priority,
+                tags: tag_list,
+            });
+            self.text.clear();
+            self.priority = 0;
+            if !self.persist_tags {
+                self.tags.clear();
+            }
+            self.save(app, false);
+        }
         let mut save_now = false;
         egui::Window::new("Todos")
             .open(&mut self.open)
@@ -180,32 +203,6 @@ impl TodoDialog {
                     save_now = true;
                 }
             });
-        if self.open
-            && ctx.input(|i| i.key_pressed(egui::Key::Enter))
-            && !self.text.trim().is_empty()
-        {
-            let modifiers = ctx.input(|i| i.modifiers);
-            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
-            let tag_list: Vec<String> = self
-                .tags
-                .split(',')
-                .map(|t| t.trim())
-                .filter(|t| !t.is_empty())
-                .map(|t| t.to_string())
-                .collect();
-            self.entries.push(TodoEntry {
-                text: self.text.clone(),
-                done: false,
-                priority: self.priority,
-                tags: tag_list,
-            });
-            self.text.clear();
-            self.priority = 0;
-            if !self.persist_tags {
-                self.tags.clear();
-            }
-            self.save(app, false);
-        }
         if save_now {
             self.save(app, false);
         }

--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -58,29 +58,6 @@ impl TodoDialog {
         if !self.open {
             return;
         }
-        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.text.trim().is_empty() {
-            let modifiers = ctx.input(|i| i.modifiers);
-            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
-            let tag_list: Vec<String> = self
-                .tags
-                .split(',')
-                .map(|t| t.trim())
-                .filter(|t| !t.is_empty())
-                .map(|t| t.to_string())
-                .collect();
-            self.entries.push(TodoEntry {
-                text: self.text.clone(),
-                done: false,
-                priority: self.priority,
-                tags: tag_list,
-            });
-            self.text.clear();
-            self.priority = 0;
-            if !self.persist_tags {
-                self.tags.clear();
-            }
-            self.save(app, false);
-        }
         let mut save_now = false;
         egui::Window::new("Todos")
             .open(&mut self.open)
@@ -203,6 +180,29 @@ impl TodoDialog {
                     save_now = true;
                 }
             });
+        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) && !self.text.trim().is_empty() {
+            let modifiers = ctx.input(|i| i.modifiers);
+            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+            let tag_list: Vec<String> = self
+                .tags
+                .split(',')
+                .map(|t| t.trim())
+                .filter(|t| !t.is_empty())
+                .map(|t| t.to_string())
+                .collect();
+            self.entries.push(TodoEntry {
+                text: self.text.clone(),
+                done: false,
+                priority: self.priority,
+                tags: tag_list,
+            });
+            self.text.clear();
+            self.priority = 0;
+            if !self.persist_tags {
+                self.tags.clear();
+            }
+            save_now = true;
+        }
         if save_now {
             self.save(app, false);
         }

--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -180,8 +180,56 @@ impl TodoDialog {
                     save_now = true;
                 }
             });
+        if self.open
+            && ctx.input(|i| i.key_pressed(egui::Key::Enter))
+            && !self.text.trim().is_empty()
+        {
+            let modifiers = ctx.input(|i| i.modifiers);
+            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+            let tag_list: Vec<String> = self
+                .tags
+                .split(',')
+                .map(|t| t.trim())
+                .filter(|t| !t.is_empty())
+                .map(|t| t.to_string())
+                .collect();
+            self.entries.push(TodoEntry {
+                text: self.text.clone(),
+                done: false,
+                priority: self.priority,
+                tags: tag_list,
+            });
+            self.text.clear();
+            self.priority = 0;
+            if !self.persist_tags {
+                self.tags.clear();
+            }
+            self.save(app, false);
+        }
         if save_now {
             self.save(app, false);
         }
+    }
+}
+
+impl TodoDialog {
+    pub fn set_text(&mut self, text: &str) {
+        self.text = text.into();
+    }
+
+    pub fn set_tags(&mut self, tags: &str) {
+        self.tags = tags.into();
+    }
+
+    pub fn set_priority(&mut self, priority: u8) {
+        self.priority = priority;
+    }
+
+    pub fn set_filter(&mut self, filter: &str) {
+        self.filter = filter.into();
+    }
+
+    pub fn entries_len(&self) -> usize {
+        self.entries.len()
     }
 }

--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -1,5 +1,31 @@
+use eframe::egui;
 use multi_launcher::gui::TodoDialog;
 use multi_launcher::plugins::todo::TodoEntry;
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::settings::Settings;
+use multi_launcher::actions::Action;
+use tempfile::tempdir;
+use std::sync::{Arc, atomic::AtomicBool};
+
+fn new_app(ctx: &egui::Context) -> LauncherApp {
+    LauncherApp::new(
+        ctx,
+        Vec::<Action>::new(),
+        0,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
 
 #[test]
 fn filter_by_text() {
@@ -29,4 +55,35 @@ fn empty_filter_returns_all() {
     ];
     let idx = TodoDialog::filtered_indices(&entries, "");
     assert_eq!(idx, vec![0, 1]);
+}
+
+#[test]
+fn enter_adds_todo_without_focus() {
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let ctx = egui::Context::default();
+    ctx.run(Default::default(), |_| {});
+    let mut app = new_app(&ctx);
+    let mut dlg = TodoDialog::default();
+    dlg.open();
+    dlg.set_text("task");
+    dlg.set_tags("a,b");
+    dlg.set_priority(3);
+
+    ctx.input_mut(|i| i.events.push(egui::Event::Key {
+        key: egui::Key::Enter,
+        physical_key: None,
+        pressed: true,
+        repeat: false,
+        modifiers: egui::Modifiers::default(),
+    }));
+
+    dlg.ui(&ctx, &mut app);
+
+    let todos = multi_launcher::plugins::todo::load_todos(multi_launcher::plugins::todo::TODO_FILE).unwrap();
+    assert_eq!(todos.len(), 1);
+    assert_eq!(todos[0].text, "task");
+    assert_eq!(todos[0].priority, 3);
+    assert_eq!(todos[0].tags, vec!["a", "b"]);
 }

--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -63,7 +63,7 @@ fn enter_adds_todo_without_focus() {
     std::env::set_current_dir(dir.path()).unwrap();
 
     let ctx = egui::Context::default();
-    ctx.run(Default::default(), |_| {});
+    let _ = ctx.run(Default::default(), |_| {});
     let mut app = new_app(&ctx);
     let mut dlg = TodoDialog::default();
     dlg.open();


### PR DESCRIPTION
## Summary
- consume Enter key globally when TodoDialog is open and add the todo
- expose setter helpers on `TodoDialog` for tests
- add regression test covering Enter key behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68841e48b9c08332bc41f8870069165a