### PR TITLE
Add Enter key shortcut to Todo dialog

### DIFF
--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -180,8 +180,89 @@ impl TodoDialog {
                     save_now = true;
                 }
             });
+        if self.open && ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
+            let modifiers = ctx.input(|i| i.modifiers);
+            ctx.input_mut(|i| i.consume_key(modifiers, egui::Key::Enter));
+            if !self.text.trim().is_empty() {
+                let tag_list: Vec<String> = self
+                    .tags
+                    .split(',')
+                    .map(|t| t.trim())
+                    .filter(|t| !t.is_empty())
+                    .map(|t| t.to_string())
+                    .collect();
+                self.entries.push(TodoEntry {
+                    text: self.text.clone(),
+                    done: false,
+                    priority: self.priority,
+                    tags: tag_list,
+                });
+                self.text.clear();
+                self.priority = 0;
+                if !self.persist_tags {
+                    self.tags.clear();
+                }
+                save_now = true;
+            }
+        }
         if save_now {
             self.save(app, false);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::PluginManager;
+    use crate::settings::Settings;
+    use std::sync::{Arc, atomic::AtomicBool};
+    use tempfile::tempdir;
+
+    fn new_app(ctx: &egui::Context) -> LauncherApp {
+        LauncherApp::new(
+            ctx,
+            Vec::new(),
+            0,
+            PluginManager::new(),
+            "actions.json".into(),
+            "settings.json".into(),
+            Settings::default(),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    #[test]
+    fn enter_adds_todo_with_filter_focus() {
+        let dir = tempdir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        let mut dlg = TodoDialog::default();
+        dlg.open();
+        dlg.text = "task".into();
+        dlg.filter = "something".into();
+
+        ctx.begin_frame(egui::RawInput {
+            events: vec![egui::Event::Key {
+                key: egui::Key::Enter,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+            ..Default::default()
+        });
+        dlg.ui(&ctx, &mut app);
+        let _ = ctx.end_frame();
+
+        assert_eq!(dlg.entries.len(), 1);
+        assert_eq!(dlg.entries[0].text, "task");
     }
 }

--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -30,3 +30,4 @@ fn empty_filter_returns_all() {
     let idx = TodoDialog::filtered_indices(&entries, "");
     assert_eq!(idx, vec![0, 1]);
 }
+


### PR DESCRIPTION
## Summary
- allow pressing Enter anywhere in `TodoDialog` to add an item
- unit test for adding a todo via Enter key
- keep existing filtering tests

## Testing
- `cargo test --quiet`
 