### PR TITLE
Handle Enter key to add todo

### DIFF
--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -1,5 +1,29 @@
-use multi_launcher::gui::TodoDialog;
+use eframe::egui;
+use multi_launcher::gui::{LauncherApp, TodoDialog};
+use multi_launcher::plugin::PluginManager;
 use multi_launcher::plugins::todo::TodoEntry;
+use multi_launcher::settings::Settings;
+use std::sync::{atomic::AtomicBool, Arc};
+use tempfile::tempdir;
+
+fn new_app(ctx: &egui::Context) -> LauncherApp {
+    LauncherApp::new(
+        ctx,
+        Vec::new(),
+        0,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
 
 #[test]
 fn filter_by_text() {
@@ -29,4 +53,31 @@ fn empty_filter_returns_all() {
     ];
     let idx = TodoDialog::filtered_indices(&entries, "");
     assert_eq!(idx, vec![0, 1]);
+}
+
+#[test]
+fn enter_adds_todo_without_focus() {
+    let _dir = tempdir().unwrap();
+    std::env::set_current_dir(&_dir.path()).unwrap();
+
+    let ctx = egui::Context::default();
+    let mut app = new_app(&ctx);
+    let mut dialog = TodoDialog::default();
+    dialog.open();
+    dialog.set_fields("demo", 0, "");
+
+    let mut input = egui::RawInput::default();
+    input.events.push(egui::Event::Key {
+        key: egui::Key::Enter,
+        physical_key: None,
+        pressed: true,
+        repeat: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    ctx.begin_frame(input);
+    dialog.ui(&ctx, &mut app);
+    ctx.end_frame();
+
+    assert_eq!(dialog.entry_count(), 1);
+    assert_eq!(dialog.entry_text(0), "demo");
 }


### PR DESCRIPTION
## Summary
- add helper methods in `TodoDialog` for tests
- allow Enter key to add a todo when dialog is open
- add regression test for adding by pressing Enter

## Testing
- `cargo test --quiet` *(fails: environment build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6884e945d3d4833294153c4c917e3960