### PR TITLE
Add set_error helper

### DIFF
--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -82,7 +82,7 @@ impl ActionsEditor {
                 }
                 app.search();
                 if let Err(e) = save_actions(&app.actions_path, &app.actions[..app.custom_len]) {
-                    app.error = Some(format!("Failed to save: {e}"));
+                    app.set_error(format!("Failed to save: {e}"));
                 }
             }
 

--- a/src/gui/add_action_dialog.rs
+++ b/src/gui/add_action_dialog.rs
@@ -128,7 +128,7 @@ impl AddActionDialog {
                         if ui.button(button).clicked() {
                             use std::path::Path;
                             if self.path.is_empty() || !Path::new(&self.path).exists() {
-                                app.error = Some("Path does not exist".into());
+                                app.set_error("Path does not exist".into());
                             } else {
                                 match self.mode {
                                     DialogMode::Add => {
@@ -167,7 +167,7 @@ impl AddActionDialog {
                                 should_close = true;
                                 app.search();
                                 if let Err(e) = save_actions(&app.actions_path, &app.actions[..app.custom_len]) {
-                                    app.error = Some(format!("Failed to save: {e}"));
+                                    app.set_error(format!("Failed to save: {e}"));
                                 }
                             }
                         }

--- a/src/gui/add_bookmark_dialog.rs
+++ b/src/gui/add_bookmark_dialog.rs
@@ -45,13 +45,13 @@ impl AddBookmarkDialog {
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if self.url.trim().is_empty() {
-                            app.error = Some("URL required".into());
+                            app.set_error("URL required".into());
                         } else {
                             if let Err(e) = append_bookmark(BOOKMARKS_FILE, &self.url) {
-                                app.error = Some(format!("Failed to save: {e}"));
+                                app.set_error(format!("Failed to save: {e}"));
                             } else if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias)
                             {
-                                app.error = Some(format!("Failed to save alias: {e}"));
+                                app.set_error(format!("Failed to save alias: {e}"));
                             } else {
                                 close = true;
                                 if app.enable_toasts {

--- a/src/gui/alias_dialog.rs
+++ b/src/gui/alias_dialog.rs
@@ -43,7 +43,7 @@ impl AliasDialog {
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if let Err(e) = set_alias(FOLDERS_FILE, &self.path, &self.alias) {
-                            app.error = Some(format!("Failed to save alias: {e}"));
+                            app.set_error(format!("Failed to save alias: {e}"));
                         } else {
                             close = true;
                             app.search();

--- a/src/gui/bookmark_alias_dialog.rs
+++ b/src/gui/bookmark_alias_dialog.rs
@@ -42,7 +42,7 @@ impl BookmarkAliasDialog {
 
                 if ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
                     if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {
-                        app.error = Some(format!("Failed to save alias: {e}"));
+                        app.set_error(format!("Failed to save alias: {e}"));
                     } else {
                         close = true;
                         app.search();
@@ -55,7 +55,7 @@ impl BookmarkAliasDialog {
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if let Err(e) = set_alias(BOOKMARKS_FILE, &self.url, &self.alias) {
-                            app.error = Some(format!("Failed to save alias: {e}"));
+                            app.set_error(format!("Failed to save alias: {e}"));
                         } else {
                             close = true;
                             app.search();

--- a/src/gui/clipboard_dialog.rs
+++ b/src/gui/clipboard_dialog.rs
@@ -33,7 +33,7 @@ impl ClipboardDialog {
     fn save(&mut self, app: &mut LauncherApp) {
         let history: VecDeque<String> = self.entries.clone().into();
         if let Err(e) = save_history(CLIPBOARD_FILE, &history) {
-            app.error = Some(format!("Failed to save clipboard history: {e}"));
+            app.set_error(format!("Failed to save clipboard history: {e}"));
         } else {
             app.search();
             app.focus_input();
@@ -70,7 +70,7 @@ impl ClipboardDialog {
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.text.trim().is_empty() {
-                                app.error = Some("Text required".into());
+                                app.set_error("Text required".into());
                             } else {
                                 if idx < self.entries.len() {
                                     self.entries[idx] = self.text.clone();

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -257,6 +257,11 @@ impl LauncherApp {
     pub fn add_toast(&mut self, toast: Toast) {
         push_toast(&mut self.toasts, toast);
     }
+
+    pub fn set_error(&mut self, msg: String) {
+        self.error = Some(msg);
+        self.error_time = Some(Instant::now());
+    }
     pub fn update_paths(
         &mut self,
         plugin_dirs: Option<Vec<String>>,
@@ -998,7 +1003,7 @@ impl eframe::App for LauncherApp {
                     }
                     if ui.button("Open Toast Log").clicked() {
                         if let Err(e) = open::that(TOAST_LOG_FILE) {
-                            self.error = Some(format!("Failed to open log: {e}"));
+                            self.set_error(format!("Failed to open log: {e}"));
                         }
                     }
                     if ui.button("View Toast Log").clicked() {
@@ -1173,8 +1178,7 @@ impl eframe::App for LauncherApp {
                                 self.cpu_list_dialog.open(count);
                             }
                         } else if let Err(e) = launch_action(&a) {
-                            self.error = Some(format!("Failed: {e}"));
-                            self.error_time = Some(Instant::now());
+                            self.set_error(format!("Failed: {e}"));
                             if self.enable_toasts {
                                 push_toast(&mut self.toasts, Toast {
                                     text: format!("Failed: {e}").into(),

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -32,7 +32,7 @@ impl NotesDialog {
 
     fn save(&mut self, app: &mut LauncherApp) {
         if let Err(e) = save_notes(QUICK_NOTES_FILE, &self.entries) {
-            app.error = Some(format!("Failed to save notes: {e}"));
+            app.set_error(format!("Failed to save notes: {e}"));
         } else {
             app.search();
             app.focus_input();
@@ -66,7 +66,7 @@ impl NotesDialog {
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.text.trim().is_empty() {
-                                app.error = Some("Text required".into());
+                                app.set_error("Text required".into());
                             } else {
                                 if idx == self.entries.len() {
                                     self.entries.push(NoteEntry {

--- a/src/gui/shell_cmd_dialog.rs
+++ b/src/gui/shell_cmd_dialog.rs
@@ -22,7 +22,7 @@ impl ShellCmdDialog {
 
     fn save(&mut self, app: &mut LauncherApp) {
         if let Err(e) = save_shell_cmds(SHELL_CMDS_FILE, &self.entries) {
-            app.error = Some(format!("Failed to save commands: {e}"));
+            app.set_error(format!("Failed to save commands: {e}"));
         } else {
             app.search();
             app.focus_input();
@@ -48,7 +48,7 @@ impl ShellCmdDialog {
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.name.trim().is_empty() || self.args.trim().is_empty() {
-                                app.error = Some("Both fields required".into());
+                                app.set_error("Both fields required".into());
                             } else {
                                 if idx == self.entries.len() {
                                     self.entries.push(ShellCmdEntry { name: self.name.clone(), args: self.args.clone() });

--- a/src/gui/snippet_dialog.rs
+++ b/src/gui/snippet_dialog.rs
@@ -36,7 +36,7 @@ impl SnippetDialog {
 
     fn save(&mut self, app: &mut LauncherApp) {
         if let Err(e) = save_snippets(SNIPPETS_FILE, &self.entries) {
-            app.error = Some(format!("Failed to save snippets: {e}"));
+            app.set_error(format!("Failed to save snippets: {e}"));
         } else {
             app.search();
             app.focus_input();
@@ -60,7 +60,7 @@ impl SnippetDialog {
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
                             if self.alias.trim().is_empty() || self.text.trim().is_empty() {
-                                app.error = Some("Both fields required".into());
+                                app.set_error("Both fields required".into());
                             } else {
                                 if idx == self.entries.len() {
                                     self.entries.push(SnippetEntry { alias: self.alias.clone(), text: self.text.clone() });

--- a/src/gui/tempfile_alias_dialog.rs
+++ b/src/gui/tempfile_alias_dialog.rs
@@ -43,7 +43,7 @@ impl TempfileAliasDialog {
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if let Err(e) = set_alias(Path::new(&self.path), &self.alias) {
-                            app.error = Some(format!("Failed to rename: {e}"));
+                            app.set_error(format!("Failed to rename: {e}"));
                         } else {
                             close = true;
                             app.search();

--- a/src/gui/tempfile_dialog.rs
+++ b/src/gui/tempfile_dialog.rs
@@ -47,12 +47,12 @@ impl TempfileDialog {
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         if self.alias.trim().is_empty() {
-                            app.error = Some("Alias required".into());
+                            app.set_error("Alias required".into());
                         } else {
                             match create_named_file(&self.alias, &self.text) {
                                 Ok(path) => {
                                     if let Err(e) = open::that(&path) {
-                                        app.error = Some(format!("Failed to open: {e}"));
+                                        app.set_error(format!("Failed to open: {e}"));
                                     } else {
                                         if app.enable_toasts {
                                             app.add_toast(Toast {
@@ -73,7 +73,7 @@ impl TempfileDialog {
                                         app.focus_input();
                                     }
                                 }
-                                Err(e) => app.error = Some(format!("Failed to save: {e}")),
+                                Err(e) => app.set_error(format!("Failed to save: {e}")),
                             }
                         }
                     }

--- a/src/gui/timer_dialog.rs
+++ b/src/gui/timer_dialog.rs
@@ -109,7 +109,7 @@ impl TimerDialog {
                                 close = true;
                                 app.focus_input();
                             } else {
-                                app.error = Some("Invalid duration".into());
+                                app.set_error("Invalid duration".into());
                             }
                         }
                         Mode::Alarm => {
@@ -127,7 +127,7 @@ impl TimerDialog {
                                 );
                                 close = true;
                             } else {
-                                app.error = Some("Invalid time".into());
+                                app.set_error("Invalid time".into());
                             }
                         }
                     }

--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -25,7 +25,7 @@ impl TodoDialog {
 
     fn save(&mut self, app: &mut LauncherApp, focus: bool) {
         if let Err(e) = save_todos(TODO_FILE, &self.entries) {
-            app.error = Some(format!("Failed to save todos: {e}"));
+            app.set_error(format!("Failed to save todos: {e}"));
         } else {
             app.search();
             if focus {

--- a/src/gui/todo_view_dialog.rs
+++ b/src/gui/todo_view_dialog.rs
@@ -40,7 +40,7 @@ impl TodoViewDialog {
 
     fn save(&mut self, app: &mut LauncherApp) {
         if let Err(e) = save_todos(TODO_FILE, &self.entries) {
-            app.error = Some(format!("Failed to save todos: {e}"));
+            app.set_error(format!("Failed to save todos: {e}"));
         } else {
             app.search();
             app.focus_input();

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -97,7 +97,7 @@ impl PluginEditor {
                     s.enabled_capabilities = Some(self.enabled_capabilities.clone());
                 }
                 if let Err(e) = s.save(&app.settings_path) {
-                    app.error = Some(format!("Failed to save: {e}"));
+                    app.set_error(format!("Failed to save: {e}"));
                 } else {
                     app.update_paths(
                         s.plugin_dirs.clone(),
@@ -137,7 +137,7 @@ impl PluginEditor {
                     crate::request_hotkey_restart(s);
                 }
             }
-            Err(e) => app.error = Some(format!("Failed to read settings: {e}")),
+            Err(e) => app.set_error(format!("Failed to read settings: {e}")),
         }
     }
 

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -491,7 +491,7 @@ impl SettingsEditor {
                                     Ok(current) => {
                                         let new_settings = self.to_settings(&current);
                                         if let Err(e) = new_settings.save(&app.settings_path) {
-                                            app.error = Some(format!("Failed to save: {e}"));
+                                            app.set_error(format!("Failed to save: {e}"));
                                         } else {
                                             app.update_paths(
                                                 new_settings.plugin_dirs.clone(),
@@ -558,7 +558,7 @@ impl SettingsEditor {
                                         }
                                     }
                                     Err(e) => {
-                                        app.error = Some(format!("Failed to read settings: {e}"))
+                                        app.set_error(format!("Failed to read settings: {e}"))
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- add `LauncherApp::set_error` helper
- use `set_error` in dialogs when displaying errors

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68851dd59e088332bb487e7111c18ee1