### PR TITLE
Fix timer overflow handling

### DIFF
--- a/src/plugins/timer.rs
+++ b/src/plugins/timer.rs
@@ -402,7 +402,17 @@ pub fn parse_hhmm(input: &str) -> Option<(u32, u32, Option<chrono::NaiveDate>)> 
         if let Some((h, m)) = parse_time(rest.trim()) {
             if let Some(days_str) = first.strip_suffix(['d', 'D']) {
                 if let Ok(offset) = days_str.parse::<i64>() {
-                    let date = Local::now().date_naive() + ChronoDuration::days(offset);
+                    let today = Local::now().date_naive();
+                    let max_off = chrono::NaiveDate::MAX
+                        .signed_duration_since(today)
+                        .num_days();
+                    let min_off = chrono::NaiveDate::MIN
+                        .signed_duration_since(today)
+                        .num_days();
+                    if offset > max_off || offset < min_off {
+                        return None;
+                    }
+                    let date = today + ChronoDuration::days(offset);
                     return Some((h, m, Some(date)));
                 }
             }

--- a/tests/timer_plugin.rs
+++ b/tests/timer_plugin.rs
@@ -310,6 +310,13 @@ fn parse_hhmm_with_absolute_date() {
 }
 
 #[test]
+fn parse_hhmm_large_day_offset() {
+    use multi_launcher::plugins::timer::parse_hhmm;
+    assert!(parse_hhmm("1000000000d 12:00").is_none());
+    assert!(parse_hhmm("-1000000000d 12:00").is_none());
+}
+
+#[test]
 fn start_alarm_multi_day() {
     use multi_launcher::plugins::timer::{
         cancel_timer, start_alarm_named, ACTIVE_TIMERS,


### PR DESCRIPTION
## Summary
- prevent date overflow in `parse_hhmm`
- add regression test for extremely large offsets

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886228835708332bdbd0742d3675ccf