### PR TITLE
Add expanded emoji list

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Built-in commands:
 | `rec` | `rec` | Recycle Bin cleanup |
 | `tmp` | `tmp new [name]` | Temporary files |
 | `ascii` | `ascii text` | ASCII art |
+| `emoji` | `emoji smile` | Emoji search |
 | `app` | `app <filter>` | Saved apps |
 | `vol` | `vol 50` | Volume control |
 | `media` | `media play` | Media controls |

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,6 @@
 use crate::actions::Action;
 use crate::plugins::asciiart::AsciiArtPlugin;
+use crate::plugins::emoji::EmojiPlugin;
 use crate::plugins::screenshot::ScreenshotPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
 #[cfg(target_os = "windows")]
@@ -128,6 +129,7 @@ impl PluginManager {
         self.register_with_settings(TempfilePlugin, plugin_settings);
         self.register_with_settings(MediaPlugin, plugin_settings);
         self.register_with_settings(AsciiArtPlugin::default(), plugin_settings);
+        self.register_with_settings(EmojiPlugin::default(), plugin_settings);
         self.register_with_settings(ScreenshotPlugin, plugin_settings);
         #[cfg(target_os = "windows")]
         {

--- a/src/plugins/emoji.rs
+++ b/src/plugins/emoji.rs
@@ -1,0 +1,148 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+
+pub struct EmojiPlugin {
+    matcher: SkimMatcherV2,
+}
+
+impl EmojiPlugin {
+    pub fn new() -> Self {
+        Self {
+            matcher: SkimMatcherV2::default(),
+        }
+    }
+}
+
+impl Default for EmojiPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const EMOJIS: &[(&str, &str)] = &[
+    // Common emoji shortcuts
+    ("😀", "grinning"),
+    ("😃", "smile"),
+    ("😄", "happy"),
+    ("😉", "wink"),
+    ("😍", "love"),
+    ("😂", "lol"),
+    ("🤣", "rofl"),
+    ("😎", "cool"),
+    ("🥳", "party"),
+    ("🤔", "thinking"),
+    ("🤗", "hug"),
+    ("🙃", "upside"),
+    ("😭", "cry"),
+    ("😅", "sweat_smile"),
+    ("😇", "angel"),
+    ("😡", "angry"),
+    ("👍", "thumbs up"),
+    ("🙏", "pray"),
+    ("🎉", "celebrate"),
+    ("❤", "heart"),
+    ("💔", "broken heart"),
+    ("✨", "sparkles"),
+    ("🔥", "fire"),
+    ("🤯", "mind blown"),
+    ("🥺", "pleading"),
+    ("🤓", "nerd"),
+    ("🤩", "star struck"),
+    ("🤡", "clown"),
+    ("🥶", "cold"),
+    ("🥴", "woozy"),
+    ("🤪", "crazy"),
+    ("😤", "frustrated"),
+    ("🤮", "vomit"),
+    ("👀", "eyes"),
+    // Kaomojis
+    ("¯\\_(ツ)_/¯", "shrug"),
+    ("(╯°□°）╯︵ ┻━┻", "table flip"),
+    ("(ᵔᴥᵔ)", "bear"),
+    ("(ง'̀-'́)ง", "fight"),
+    ("( ͡° ͜ʖ ͡°)", "lenny"),
+    ("(ಥ﹏ಥ)", "cry kaomoji"),
+    ("(^_^)", "happy kaomoji"),
+    ("o_O", "confused"),
+    ("(>_<)", "annoyed"),
+    ("(¬_¬)", "unamused"),
+    ("(☞ﾟヮﾟ)☞", "point"),
+    ("(づ｡◕‿‿◕｡)づ", "hug kaomoji"),
+    ("(╯︵╰,)", "sad"),
+    ("(ღ˘⌣˘ღ)", "love kaomoji"),
+    ("ヽ(•‿•)ノ", "excited"),
+    ("≧◡≦", "smile kaomoji"),
+    ("(｡◕‿◕｡)", "cute"),
+];
+
+impl Plugin for EmojiPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const LIST_PREFIX: &str = "emoji list";
+        let trimmed = query.trim();
+
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
+            let filter = rest.trim().to_lowercase();
+            return EMOJIS
+                .iter()
+                .filter(|(_, name)| {
+                    filter.is_empty() || self.matcher.fuzzy_match(name, &filter).is_some()
+                })
+                .map(|(emoji, _)| Action {
+                    label: (*emoji).into(),
+                    desc: "Emoji".into(),
+                    action: format!("clipboard:{emoji}"),
+                    args: None,
+                })
+                .collect();
+        }
+
+        const PREFIX: &str = "emoji ";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            let filter = rest.trim().to_lowercase();
+            if !filter.is_empty() {
+                return EMOJIS
+                    .iter()
+                    .filter(|(_, name)| self.matcher.fuzzy_match(name, &filter).is_some())
+                    .map(|(emoji, _)| Action {
+                        label: (*emoji).into(),
+                        desc: "Emoji".into(),
+                        action: format!("clipboard:{emoji}"),
+                        args: None,
+                    })
+                    .collect();
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "emoji"
+    }
+
+    fn description(&self) -> &str {
+        "Emoji search (prefix: `emoji`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "emoji".into(),
+                desc: "Emoji".into(),
+                action: "query:emoji ".into(),
+                args: None,
+            },
+            Action {
+                label: "emoji list".into(),
+                desc: "Emoji".into(),
+                action: "query:emoji list".into(),
+                args: None,
+            },
+        ]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -25,6 +25,7 @@ pub mod dropcalc;
 pub mod recycle;
 pub mod tempfile;
 pub mod asciiart;
+pub mod emoji;
 pub mod task_manager;
 pub mod windows;
 pub mod screenshot;

--- a/tests/emoji_plugin.rs
+++ b/tests/emoji_plugin.rs
@@ -1,0 +1,9 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::emoji::EmojiPlugin;
+
+#[test]
+fn search_returns_clipboard_action() {
+    let plugin = EmojiPlugin::default();
+    let results = plugin.search("emoji smile");
+    assert!(results.iter().any(|a| a.action.starts_with("clipboard:")));
+}


### PR DESCRIPTION
## Summary
- expand emoji and kaomoji coverage for the EmojiPlugin

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68867ae5c7888332a695ec5b68d4fb44