### PR TITLE
Add text case conversion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Built-in commands:
 | `tmp` | `tmp new [name]` | Temporary files |
 | `ascii` | `ascii text` | ASCII art |
 | `emoji` | `emoji smile` | Emoji search |
+| `case` | `case hello world` | Case conversions |
 | `app` | `app <filter>` | Saved apps |
 | `vol` | `vol 50` | Volume control |
 | `media` | `media play` | Media controls |
@@ -259,6 +260,15 @@ sequenceDiagram
     P-->>L: image path
     L->>U: save/copy
 ```
+
+### Text Case Plugin
+Convert text to different cases. Example:
+
+```text
+case Hello World
+```
+
+The plugin shows uppercase, lowercase, title case and snake_case variants. Select one to copy it.
 
 ### Macros Plugin
 The macros plugin runs a saved sequence of launcher commands. Macros are stored in `macros.json` and can be edited by typing `macro` to open the editor.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,6 +2,7 @@ use crate::actions::Action;
 use crate::plugins::asciiart::AsciiArtPlugin;
 use crate::plugins::emoji::EmojiPlugin;
 use crate::plugins::screenshot::ScreenshotPlugin;
+use crate::plugins::text_case::TextCasePlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
@@ -130,6 +131,7 @@ impl PluginManager {
         self.register_with_settings(MediaPlugin, plugin_settings);
         self.register_with_settings(AsciiArtPlugin::default(), plugin_settings);
         self.register_with_settings(EmojiPlugin::default(), plugin_settings);
+        self.register_with_settings(TextCasePlugin, plugin_settings);
         self.register_with_settings(ScreenshotPlugin, plugin_settings);
         #[cfg(target_os = "windows")]
         {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -31,3 +31,4 @@ pub mod windows;
 pub mod screenshot;
 pub mod omni_search;
 pub mod macros;
+pub mod text_case;

--- a/src/plugins/text_case.rs
+++ b/src/plugins/text_case.rs
@@ -1,0 +1,85 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct TextCasePlugin;
+
+impl Plugin for TextCasePlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "case ";
+        if let Some(rest) = crate::common::strip_prefix_ci(query.trim_start(), PREFIX) {
+            let text = rest.trim();
+            if !text.is_empty() {
+                let upper = text.to_uppercase();
+                let lower = text.to_lowercase();
+                let title = text
+                    .split_whitespace()
+                    .map(|w| {
+                        let mut c = w.chars();
+                        match c.next() {
+                            Some(first) => {
+                                let mut s = first.to_uppercase().to_string();
+                                s.push_str(&c.as_str().to_lowercase());
+                                s
+                            }
+                            None => String::new(),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let snake = text
+                    .split_whitespace()
+                    .map(|w| w.to_lowercase())
+                    .collect::<Vec<_>>()
+                    .join("_");
+                return vec![
+                    Action {
+                        label: upper.clone(),
+                        desc: "Text Case".into(),
+                        action: format!("clipboard:{}", upper),
+                        args: None,
+                    },
+                    Action {
+                        label: lower.clone(),
+                        desc: "Text Case".into(),
+                        action: format!("clipboard:{}", lower),
+                        args: None,
+                    },
+                    Action {
+                        label: title.clone(),
+                        desc: "Text Case".into(),
+                        action: format!("clipboard:{}", title),
+                        args: None,
+                    },
+                    Action {
+                        label: snake.clone(),
+                        desc: "Text Case".into(),
+                        action: format!("clipboard:{}", snake),
+                        args: None,
+                    },
+                ];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "text_case"
+    }
+
+    fn description(&self) -> &str {
+        "Convert text cases (prefix: `case`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "case <text>".into(),
+            desc: "Text Case".into(),
+            action: "query:case ".into(),
+            args: None,
+        }]
+    }
+}

--- a/tests/text_case_plugin.rs
+++ b/tests/text_case_plugin.rs
@@ -1,0 +1,17 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::text_case::TextCasePlugin;
+
+#[test]
+fn converts_text_cases() {
+    let plugin = TextCasePlugin;
+    let results = plugin.search("case Rust Test");
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[0].label, "RUST TEST");
+    assert_eq!(results[0].action, "clipboard:RUST TEST");
+    assert_eq!(results[1].label, "rust test");
+    assert_eq!(results[1].action, "clipboard:rust test");
+    assert_eq!(results[2].label, "Rust Test");
+    assert_eq!(results[2].action, "clipboard:Rust Test");
+    assert_eq!(results[3].label, "rust_test");
+    assert_eq!(results[3].action, "clipboard:rust_test");
+}


### PR DESCRIPTION
## Summary
- add new `text_case` plugin providing case conversions via `case` prefix
- register the plugin in the plugin manager
- document usage in README and extend built‑in commands table
- include tests for new plugin

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688686daba308332bd6f71eb9eb0500e