### PR TITLE
Add timestamp conversion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Built-in commands:
 | `ascii` | `ascii text` | ASCII art |
 | `emoji` | `emoji smile` | Emoji search |
 | `case` | `case hello world` | Case conversions |
+| `ts` | `ts 0` | Timestamp conversion |
+| `tsm` | `tsm 3600000` | Midnight timestamp |
 | `app` | `app <filter>` | Saved apps |
 | `vol` | `vol 50` | Volume control |
 | `media` | `media play` | Media controls |

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -146,6 +146,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "dropcalc" => Some(&["drop 1/128 25"]),
         "recycle" => Some(&["rec"]),
         "tempfile" => Some(&["tmp new"]),
+        "timestamp" => Some(&["ts 0", "tsm 3600000"]),
         "snippets" => Some(&["cs hello"]),
         "todo" => Some(&["todo add buy milk", "todo list"]),
         "wikipedia" => Some(&["wiki rust"]),

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -146,7 +146,12 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "dropcalc" => Some(&["drop 1/128 25"]),
         "recycle" => Some(&["rec"]),
         "tempfile" => Some(&["tmp new"]),
-        "timestamp" => Some(&["ts 0", "tsm 3600000"]),
+        "timestamp" => Some(&[
+            "ts 0",
+            "ts 2024-05-01 12:00",
+            "tsm 3600000",
+            "tsm 01:00:00.500",
+        ]),
         "snippets" => Some(&["cs hello"]),
         "todo" => Some(&["todo add buy milk", "todo list"]),
         "wikipedia" => Some(&["wiki rust"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -38,6 +38,7 @@ use crate::plugins::wikipedia::WikipediaPlugin;
 use crate::plugins::windows::WindowsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::ip::IpPlugin;
+use crate::plugins::timestamp::TimestampPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
 use std::collections::HashSet;
@@ -134,6 +135,7 @@ impl PluginManager {
         self.register_with_settings(EmojiPlugin::default(), plugin_settings);
         self.register_with_settings(TextCasePlugin, plugin_settings);
         self.register_with_settings(ScreenshotPlugin, plugin_settings);
+        self.register_with_settings(TimestampPlugin, plugin_settings);
         self.register_with_settings(IpPlugin, plugin_settings);
         #[cfg(target_os = "windows")]
         {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -33,3 +33,4 @@ pub mod ip;
 pub mod omni_search;
 pub mod macros;
 pub mod text_case;
+pub mod timestamp;

--- a/src/plugins/timestamp.rs
+++ b/src/plugins/timestamp.rs
@@ -25,12 +25,15 @@ impl TimestampPlugin {
     }
 
     fn string_to_ms(s: &str) -> Option<i64> {
-        for fmt in ["%H:%M:%S", "%H:%M"] {
+        for fmt in ["%H:%M:%S%.f", "%H:%M:%S", "%H:%M"] {
             if let Ok(t) = NaiveTime::parse_from_str(s, fmt) {
-                return Some((t.num_seconds_from_midnight() as i64) * 1000);
+                return Some(
+                    (t.num_seconds_from_midnight() as i64) * 1000
+                        + (t.nanosecond() / 1_000_000) as i64,
+                );
             }
         }
-        for fmt in ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"] {
+        for fmt in ["%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"] {
             if let Ok(dt) = NaiveDateTime::parse_from_str(s, fmt) {
                 let midnight = dt.date().and_hms_opt(0, 0, 0)?;
                 return Some((dt - midnight).num_milliseconds());

--- a/src/plugins/timestamp.rs
+++ b/src/plugins/timestamp.rs
@@ -1,0 +1,135 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use chrono::{Local, NaiveDateTime, NaiveTime, TimeZone, Timelike};
+
+pub struct TimestampPlugin;
+
+impl TimestampPlugin {
+    fn ms_to_string(ms: i64) -> Option<String> {
+        if ms < 0 {
+            return None;
+        }
+        if ms < 86_400_000 {
+            let secs = ms / 1000;
+            let nanos = (ms % 1000) as u32 * 1_000_000;
+            if let Some(t) = NaiveTime::from_num_seconds_from_midnight_opt(secs as u32, nanos) {
+                return Some(t.format("%H:%M:%S").to_string());
+            }
+        }
+        let secs = ms / 1000;
+        let nanos = (ms % 1000) as u32 * 1_000_000;
+        Local
+            .timestamp_opt(secs, nanos)
+            .single()
+            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
+    }
+
+    fn string_to_ms(s: &str) -> Option<i64> {
+        for fmt in ["%H:%M:%S", "%H:%M"] {
+            if let Ok(t) = NaiveTime::parse_from_str(s, fmt) {
+                return Some((t.num_seconds_from_midnight() as i64) * 1000);
+            }
+        }
+        for fmt in ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"] {
+            if let Ok(dt) = NaiveDateTime::parse_from_str(s, fmt) {
+                let midnight = dt.date().and_hms_opt(0, 0, 0)?;
+                return Some((dt - midnight).num_milliseconds());
+            }
+        }
+        None
+    }
+}
+
+impl Plugin for TimestampPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "ts ";
+        const MS_PREFIX: &str = "tsm ";
+        let trimmed = query.trim_start();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, MS_PREFIX) {
+            let arg = rest.trim();
+            if arg.is_empty() {
+                return Vec::new();
+            }
+            if let Ok(num) = arg.parse::<i64>() {
+                if let Some(out) = Self::ms_to_string(num) {
+                    return vec![Action {
+                        label: out.clone(),
+                        desc: "Midnight TS".into(),
+                        action: format!("clipboard:{out}"),
+                        args: None,
+                    }];
+                }
+            } else if let Some(ms) = Self::string_to_ms(arg) {
+                let out = ms.to_string();
+                return vec![Action {
+                    label: out.clone(),
+                    desc: "Midnight TS".into(),
+                    action: format!("clipboard:{out}"),
+                    args: None,
+                }];
+            }
+        } else if let Some(rest) = crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            let arg = rest.trim();
+            if arg.is_empty() {
+                return Vec::new();
+            }
+            if let Ok(num) = arg.parse::<i64>() {
+                let dt = Local.timestamp_opt(num, 0).single().or_else(|| Local.timestamp_opt(0, 0).single());
+                if let Some(dt) = dt {
+                    let out = dt.format("%Y-%m-%d %H:%M:%S").to_string();
+                    return vec![Action {
+                        label: out.clone(),
+                        desc: "Timestamp".into(),
+                        action: format!("clipboard:{out}"),
+                        args: None,
+                    }];
+                }
+            } else {
+                let parsed = NaiveDateTime::parse_from_str(arg, "%Y-%m-%d %H:%M:%S")
+                    .or_else(|_| NaiveDateTime::parse_from_str(arg, "%Y-%m-%d %H:%M"));
+                if let Ok(naive) = parsed {
+                    if let Some(dt) = Local.from_local_datetime(&naive).single() {
+                        let ts = dt.timestamp().to_string();
+                        return vec![Action {
+                            label: ts.clone(),
+                            desc: "Timestamp".into(),
+                            action: format!("clipboard:{ts}"),
+                            args: None,
+                        }];
+                    }
+                }
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "timestamp"
+    }
+
+    fn description(&self) -> &str {
+        "Convert timestamps (prefix: `ts`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "ts <value>".into(),
+                desc: "Timestamp".into(),
+                action: "query:ts ".into(),
+                args: None,
+            },
+            Action {
+                label: "tsm <value>".into(),
+                desc: "Midnight TS".into(),
+                action: "query:tsm ".into(),
+                args: None,
+            },
+        ]
+    }
+}
+

--- a/tests/timestamp_plugin.rs
+++ b/tests/timestamp_plugin.rs
@@ -48,3 +48,12 @@ fn time_to_ms() {
     assert_eq!(results[0].label, "3600000");
     assert_eq!(results[0].action, "clipboard:3600000");
 }
+
+#[test]
+fn time_with_ms_to_ms() {
+    let plugin = TimestampPlugin;
+    let results = plugin.search("tsm 01:00:00.500");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "3600500");
+    assert_eq!(results[0].action, "clipboard:3600500");
+}

--- a/tests/timestamp_plugin.rs
+++ b/tests/timestamp_plugin.rs
@@ -1,0 +1,50 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::timestamp::TimestampPlugin;
+use chrono::{Local, TimeZone};
+
+#[test]
+fn unix_to_date() {
+    let plugin = TimestampPlugin;
+    let results = plugin.search("ts 0");
+    let expected = Local
+        .timestamp_opt(0, 0)
+        .single()
+        .unwrap()
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, expected);
+    assert_eq!(results[0].action, format!("clipboard:{expected}"));
+}
+
+#[test]
+fn date_to_unix() {
+    let plugin = TimestampPlugin;
+    let query = "ts 2024-05-01 12:00";
+    let dt = Local
+        .with_ymd_and_hms(2024, 5, 1, 12, 0, 0)
+        .unwrap();
+    let ts = dt.timestamp().to_string();
+    let results = plugin.search(query);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, ts);
+    assert_eq!(results[0].action, format!("clipboard:{}", ts));
+}
+
+#[test]
+fn ms_to_time() {
+    let plugin = TimestampPlugin;
+    let results = plugin.search("tsm 3600000");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "01:00:00");
+    assert_eq!(results[0].action, "clipboard:01:00:00");
+}
+
+#[test]
+fn time_to_ms() {
+    let plugin = TimestampPlugin;
+    let results = plugin.search("tsm 01:00");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "3600000");
+    assert_eq!(results[0].action, "clipboard:3600000");
+}


### PR DESCRIPTION
## Summary
- add a timestamp converter plugin
- register the plugin
- document the new `ts` command
- test timestamp conversions
- support midnight timestamp conversions

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6886902bf6088332ac4ba02b2d7eee11