### PR TITLE
Enhance text case plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arboard",
+ "base64",
  "chrono",
  "criterion",
  "dirs-next",
@@ -2905,6 +2906,7 @@ dependencies = [
  "exmex",
  "figlet-rs",
  "fuzzy-matcher",
+ "hex",
  "image 0.24.9",
  "ipconfig",
  "libloading 0.8.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ image = { version = "0.24", default-features = false, features = ["png"] }
 notify-rust = { version = "4", optional = true }
 ipconfig = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
+base64 = "0.21"
+hex = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = { version = "0.15.3", default-features = false, features = ["common-controls-v6"] }

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Built-in commands:
 | `tmp` | `tmp new [name]` | Temporary files |
 | `ascii` | `ascii text` | ASCII art |
 | `emoji` | `emoji smile` | Emoji search |
-| `case` | `case hello world` | Case conversions |
+| `case` | `case hello world` | Text and encoding conversions |
 | `ts` | `ts 0` | Timestamp conversion |
 | `tsm` | `tsm 3600000` | Midnight timestamp |
 | `app` | `app <filter>` | Saved apps |
@@ -281,7 +281,12 @@ Convert text to different cases. Example:
 case Hello World
 ```
 
-The plugin shows uppercase, lowercase, title case and snake_case variants. Select one to copy it.
+The plugin shows many variations including uppercase, lowercase, capitalized,
+camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE, kebab-case,
+Train-Case, dot.case and space case. It also offers alternating, mocking,
+inverse and backwards cases, acronym and initial forms, sentence and title
+case, Base64/hex/binary encodings, ROT13, clap and emoji text, custom
+delimiters and Morse code. Select any variant to copy it to the clipboard.
 
 ### Macros Plugin
 The macros plugin runs a saved sequence of launcher commands. Macros are stored in `macros.json` and can be edited by typing `macro` to open the editor.

--- a/src/plugins/text_case.rs
+++ b/src/plugins/text_case.rs
@@ -1,5 +1,8 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use base64::{engine::general_purpose, Engine as _};
+use hex;
+use std::collections::HashMap;
 
 pub struct TextCasePlugin;
 
@@ -9,53 +12,265 @@ impl Plugin for TextCasePlugin {
         if let Some(rest) = crate::common::strip_prefix_ci(query.trim_start(), PREFIX) {
             let text = rest.trim();
             if !text.is_empty() {
+                let words: Vec<&str> = text.split_whitespace().collect();
+
+                fn cap(w: &str) -> String {
+                    let mut c = w.chars();
+                    match c.next() {
+                        Some(f) => {
+                            let mut s = f.to_uppercase().to_string();
+                            s.push_str(&c.as_str().to_lowercase());
+                            s
+                        }
+                        None => String::new(),
+                    }
+                }
+
                 let upper = text.to_uppercase();
                 let lower = text.to_lowercase();
-                let title = text
-                    .split_whitespace()
-                    .map(|w| {
-                        let mut c = w.chars();
-                        match c.next() {
-                            Some(first) => {
-                                let mut s = first.to_uppercase().to_string();
-                                s.push_str(&c.as_str().to_lowercase());
-                                s
+                let capitalized = words.iter().map(|w| cap(w)).collect::<Vec<_>>().join(" ");
+
+                let camel = if let Some((first, rest)) = words.split_first() {
+                    let mut s = first.to_lowercase();
+                    for w in rest {
+                        s.push_str(&cap(w));
+                    }
+                    s
+                } else {
+                    String::new()
+                };
+
+                let pascal = words.iter().map(|w| cap(w)).collect::<String>();
+                let snake = words.iter().map(|w| w.to_lowercase()).collect::<Vec<_>>().join("_");
+                let screaming = words.iter().map(|w| w.to_uppercase()).collect::<Vec<_>>().join("_");
+                let kebab = words.iter().map(|w| w.to_lowercase()).collect::<Vec<_>>().join("-");
+                let train = words.iter().map(|w| cap(w)).collect::<Vec<_>>().join("-");
+                let dot = words.iter().map(|w| w.to_lowercase()).collect::<Vec<_>>().join(".");
+
+                let alt_case = {
+                    let mut upper_flag = true;
+                    text.chars()
+                        .map(|c| {
+                            if c.is_ascii_alphabetic() {
+                                let out = if upper_flag {
+                                    c.to_ascii_uppercase()
+                                } else {
+                                    c.to_ascii_lowercase()
+                                };
+                                upper_flag = !upper_flag;
+                                out
+                            } else {
+                                c
                             }
-                            None => String::new(),
+                        })
+                        .collect::<String>()
+                };
+
+                let mocking = {
+                    let mut upper_flag = false;
+                    text.chars()
+                        .map(|c| {
+                            if c.is_ascii_alphabetic() {
+                                let out = if upper_flag {
+                                    c.to_ascii_uppercase()
+                                } else {
+                                    c.to_ascii_lowercase()
+                                };
+                                upper_flag = !upper_flag;
+                                out
+                            } else {
+                                c
+                            }
+                        })
+                        .collect::<String>()
+                };
+
+                let inverse = text
+                    .chars()
+                    .map(|c| {
+                        if c.is_ascii_lowercase() {
+                            c.to_ascii_uppercase()
+                        } else if c.is_ascii_uppercase() {
+                            c.to_ascii_lowercase()
+                        } else {
+                            c
+                        }
+                    })
+                    .collect::<String>();
+
+                let backwards = text.chars().rev().collect::<String>();
+
+                let acronym = words
+                    .iter()
+                    .filter_map(|w| w.chars().next())
+                    .map(|c| c.to_ascii_uppercase())
+                    .collect::<String>();
+
+                let initial_caps = words
+                    .iter()
+                    .filter_map(|w| w.chars().next())
+                    .map(|c| format!("{}.", c.to_ascii_uppercase()))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                let small_words = [
+                    "a", "an", "and", "or", "the", "in", "on", "of", "for", "to",
+                    "at", "by", "with", "without",
+                ];
+                let small_set: std::collections::HashSet<&str> =
+                    small_words.iter().cloned().collect();
+                let title_case = words
+                    .iter()
+                    .enumerate()
+                    .map(|(i, w)| {
+                        if i > 0 && small_set.contains(&w.to_lowercase().as_str()) {
+                            w.to_lowercase()
+                        } else {
+                            cap(w)
                         }
                     })
                     .collect::<Vec<_>>()
                     .join(" ");
-                let snake = text
-                    .split_whitespace()
+
+                let sentence = {
+                    let mut chars = lower.chars();
+                    match chars.next() {
+                        Some(f) => {
+                            let mut s = f.to_ascii_uppercase().to_string();
+                            s.push_str(chars.as_str());
+                            s
+                        }
+                        None => String::new(),
+                    }
+                };
+
+                let b64 = general_purpose::STANDARD.encode(text);
+                let hex_enc = hex::encode(text);
+                let binary = text
+                    .as_bytes()
+                    .iter()
+                    .map(|b| format!("{:08b}", b))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                let rot13 = text
+                    .chars()
+                    .map(|c| match c {
+                        'a'..='z' => (((c as u8 - b'a' + 13) % 26) + b'a') as char,
+                        'A'..='Z' => (((c as u8 - b'A' + 13) % 26) + b'A') as char,
+                        _ => c,
+                    })
+                    .collect::<String>();
+
+                let clap = words
+                    .iter()
                     .map(|w| w.to_lowercase())
                     .collect::<Vec<_>>()
-                    .join("_");
+                    .join(" \u{1F44F} ");
+
+                let emoji_map: HashMap<&str, &str> = [
+                    ("world", "\u{1F30D}"),
+                    ("love", "\u{2764}\u{FE0F}"),
+                    ("fire", "\u{1F525}"),
+                    ("smile", "\u{1F604}"),
+                ]
+                .iter()
+                .cloned()
+                .collect();
+                let emoji_case = words
+                    .iter()
+                    .map(|w| emoji_map.get(&w.to_lowercase().as_str()).copied().unwrap_or(*w))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                let custom = words
+                    .iter()
+                    .map(|w| w.chars().map(|c| c.to_string()).collect::<Vec<_>>().join("-"))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                let morse_map: HashMap<char, &str> = [
+                    ('a', ".-"),
+                    ('b', "-..."),
+                    ('c', "-.-."),
+                    ('d', "-.."),
+                    ('e', "."),
+                    ('f', "..-."),
+                    ('g', "--."),
+                    ('h', "...."),
+                    ('i', ".."),
+                    ('j', ".---"),
+                    ('k', "-.-"),
+                    ('l', ".-.."),
+                    ('m', "--"),
+                    ('n', "-."),
+                    ('o', "---"),
+                    ('p', ".--."),
+                    ('q', "--.-"),
+                    ('r', ".-."),
+                    ('s', "..."),
+                    ('t', "-"),
+                    ('u', "..-"),
+                    ('v', "...-"),
+                    ('w', ".--"),
+                    ('x', "-..-"),
+                    ('y', "-.--"),
+                    ('z', "--.."),
+                    ('0', "-----"),
+                    ('1', ".----"),
+                    ('2', "..---"),
+                    ('3', "...--"),
+                    ('4', "....-"),
+                    ('5', "....."),
+                    ('6', "-...."),
+                    ('7', "--..."),
+                    ('8', "---.."),
+                    ('9', "----."),
+                ]
+                .iter()
+                .cloned()
+                .collect();
+
+                let morse = text
+                    .to_lowercase()
+                    .chars()
+                    .map(|c| {
+                        if c == ' ' {
+                            "/".to_string()
+                        } else {
+                            morse_map.get(&c).unwrap_or(&"?").to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
                 return vec![
-                    Action {
-                        label: upper.clone(),
-                        desc: "Text Case".into(),
-                        action: format!("clipboard:{}", upper),
-                        args: None,
-                    },
-                    Action {
-                        label: lower.clone(),
-                        desc: "Text Case".into(),
-                        action: format!("clipboard:{}", lower),
-                        args: None,
-                    },
-                    Action {
-                        label: title.clone(),
-                        desc: "Text Case".into(),
-                        action: format!("clipboard:{}", title),
-                        args: None,
-                    },
-                    Action {
-                        label: snake.clone(),
-                        desc: "Text Case".into(),
-                        action: format!("clipboard:{}", snake),
-                        args: None,
-                    },
+                    Action { label: upper.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", upper), args: None },
+                    Action { label: lower.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", lower), args: None },
+                    Action { label: capitalized.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", capitalized), args: None },
+                    Action { label: camel.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", camel), args: None },
+                    Action { label: pascal.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", pascal), args: None },
+                    Action { label: snake.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", snake), args: None },
+                    Action { label: screaming.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", screaming), args: None },
+                    Action { label: kebab.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", kebab), args: None },
+                    Action { label: train.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", train), args: None },
+                    Action { label: dot.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", dot), args: None },
+                    Action { label: alt_case.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", alt_case), args: None },
+                    Action { label: mocking.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", mocking), args: None },
+                    Action { label: inverse.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", inverse), args: None },
+                    Action { label: backwards.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", backwards), args: None },
+                    Action { label: acronym.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", acronym), args: None },
+                    Action { label: initial_caps.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", initial_caps), args: None },
+                    Action { label: title_case.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", title_case), args: None },
+                    Action { label: sentence.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", sentence), args: None },
+                    Action { label: b64.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", b64), args: None },
+                    Action { label: hex_enc.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", hex_enc), args: None },
+                    Action { label: binary.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", binary), args: None },
+                    Action { label: rot13.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", rot13), args: None },
+                    Action { label: clap.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", clap), args: None },
+                    Action { label: emoji_case.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", emoji_case), args: None },
+                    Action { label: custom.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", custom), args: None },
+                    Action { label: morse.clone(), desc: "Text Case".into(), action: format!("clipboard:{}", morse), args: None },
                 ];
             }
         }

--- a/tests/text_case_plugin.rs
+++ b/tests/text_case_plugin.rs
@@ -5,13 +5,31 @@ use multi_launcher::plugins::text_case::TextCasePlugin;
 fn converts_text_cases() {
     let plugin = TextCasePlugin;
     let results = plugin.search("case Rust Test");
-    assert_eq!(results.len(), 4);
+    assert_eq!(results.len(), 26);
+    // original cases
     assert_eq!(results[0].label, "RUST TEST");
     assert_eq!(results[0].action, "clipboard:RUST TEST");
     assert_eq!(results[1].label, "rust test");
     assert_eq!(results[1].action, "clipboard:rust test");
     assert_eq!(results[2].label, "Rust Test");
     assert_eq!(results[2].action, "clipboard:Rust Test");
-    assert_eq!(results[3].label, "rust_test");
-    assert_eq!(results[3].action, "clipboard:rust_test");
+    assert_eq!(results[5].label, "rust_test");
+    assert_eq!(results[5].action, "clipboard:rust_test");
+    assert_eq!(results[3].label, "rustTest"); // camelCase
+    assert_eq!(results[4].label, "RustTest"); // PascalCase
+    assert_eq!(results[6].label, "RUST_TEST"); // SCREAMING_SNAKE_CASE
+    assert_eq!(results[7].label, "rust-test"); // kebab-case
+    assert_eq!(results[9].label, "rust.test"); // dot.case
+    assert_eq!(results[10].label, "RuSt TeSt"); // Alternating case
+    assert_eq!(results[11].label, "rUsT tEsT"); // Mocking SpongeBob
+    assert_eq!(results[12].label, "rUST tEST"); // Inverse case
+    assert_eq!(results[13].label, "tseT tsuR"); // Backwards case
+    assert_eq!(results[14].label, "RT"); // Acronym
+    assert_eq!(results[15].label, "R. T."); // Initial Caps
+    assert_eq!(results[17].label, "Rust test"); // Sentence case
+    assert_eq!(results[18].label, "UnVzdCBUZXN0"); // Base64
+    assert_eq!(results[19].label, "527573742054657374"); // Hex
+    assert_eq!(results[21].label, "Ehfg Grfg"); // ROT13
+    assert_eq!(results[22].label, "rust 👏 test"); // Clap case
+    assert_eq!(results[24].label, "R-u-s-t T-e-s-t"); // Custom delimiter
 }


### PR DESCRIPTION
## Summary
- expand text case conversions (camel, Pascal, clap, emoji, Morse, etc.)
- extend tests for new conversions
- document additional formats in README
- add base64 and hex crates

## Testing
- `cargo test --test text_case_plugin -- --exact converts_text_cases --nocapture`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886c78203948332aa85bcf48a9d9edf