### PR TITLE
Fix timestamp command with millisecond input

### DIFF
--- a/src/plugins/timestamp.rs
+++ b/src/plugins/timestamp.rs
@@ -77,7 +77,8 @@ impl Plugin for TimestampPlugin {
                 return Vec::new();
             }
             if let Ok(num) = arg.parse::<i64>() {
-                let dt = Local.timestamp_opt(num, 0).single().or_else(|| Local.timestamp_opt(0, 0).single());
+                let ts_sec = if num.abs() > 1_000_000_000_000 { num / 1000 } else { num };
+                let dt = Local.timestamp_opt(ts_sec, 0).single().or_else(|| Local.timestamp_opt(0, 0).single());
                 if let Some(dt) = dt {
                     let out = dt.format("%Y-%m-%d %H:%M:%S").to_string();
                     return vec![Action {

--- a/tests/timestamp_plugin.rs
+++ b/tests/timestamp_plugin.rs
@@ -57,3 +57,18 @@ fn time_with_ms_to_ms() {
     assert_eq!(results[0].label, "3600500");
     assert_eq!(results[0].action, "clipboard:3600500");
 }
+
+#[test]
+fn unix_ms_to_date() {
+    let plugin = TimestampPlugin;
+    let dt = Local
+        .with_ymd_and_hms(2024, 5, 1, 12, 0, 0)
+        .unwrap();
+    let ts_ms = dt.timestamp_millis();
+    let query = format!("ts {ts_ms}");
+    let results = plugin.search(&query);
+    let expected = dt.format("%Y-%m-%d %H:%M:%S").to_string();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, expected);
+    assert_eq!(results[0].action, format!("clipboard:{expected}"));
+}


### PR DESCRIPTION
## Summary
- handle millisecond timestamps in `ts` plugin
- add regression test for millisecond timestamps

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6887d61e429c833286d3635f1760ab6b