### PR TITLE
Fix macro plugin dialog handling

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1087,6 +1087,9 @@ impl eframe::App for LauncherApp {
         for err in crate::plugins::macros::take_error_messages() {
             self.macro_dialog.push_debug(err);
         }
+        if crate::plugins::macros::take_dialog_request() {
+            self.macro_dialog.open();
+        }
         if let Some(rect) = ctx.input(|i| i.viewport().inner_rect) {
             self.window_size = (rect.width() as i32, rect.height() as i32);
         }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -691,8 +691,13 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         ActionKind::TempfileRemove(path) => tempfiles::remove(path),
         ActionKind::TempfileAlias { path, alias } => tempfiles::set_alias(path, alias),
         ActionKind::Macro(name) => {
-            crate::plugins::macros::run_macro(name)?;
-            Ok(())
+            if name.eq_ignore_ascii_case("dialog") {
+                crate::plugins::macros::request_dialog();
+                Ok(())
+            } else {
+                crate::plugins::macros::run_macro(name)?;
+                Ok(())
+            }
         }
         ActionKind::ExecPath { path, args } => exec::launch(path, args),
     }

--- a/src/plugins/macros.rs
+++ b/src/plugins/macros.rs
@@ -7,11 +7,12 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex};
 
 pub const MACROS_FILE: &str = "macros.json";
 pub static STEP_MESSAGES: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
 pub static ERROR_MESSAGES: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
+pub static DIALOG_REQUEST: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct MacroStep {
@@ -70,6 +71,14 @@ pub fn take_error_messages() -> Vec<String> {
     } else {
         Vec::new()
     }
+}
+
+pub fn request_dialog() {
+    DIALOG_REQUEST.store(true, Ordering::SeqCst);
+}
+
+pub fn take_dialog_request() -> bool {
+    DIALOG_REQUEST.swap(false, Ordering::SeqCst)
 }
 
 fn search_first_action(query: &str) -> Option<Action> {


### PR DESCRIPTION
## Summary
- track when the macro dialog should open via a new flag
- request opening the macro dialog if the `macro:dialog` action is executed
- show the macro dialog in the GUI when requested

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6887da4742fc8332859621883507a769