### PR TITLE
Fix macro plugin error handling

### DIFF
--- a/tests/macros_plugin.rs
+++ b/tests/macros_plugin.rs
@@ -81,3 +81,14 @@ fn macros_file_change_reload() {
     assert_eq!(results[0].label, "two");
 }
 
+#[test]
+fn run_macro_missing_returns_err() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    save_macros(MACROS_FILE, &[]).unwrap();
+    let err = run_macro("none").unwrap_err();
+    assert!(format!("{err}").contains("not found"));
+}
+


### PR DESCRIPTION
## Summary
- improve error handling when loading macros
- propagate errors for missing macro entries
- log macro loading failures
- add a unit test covering missing macro execution

## Testing
- `cargo test --test macros_plugin -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6887da4742fc8332859621883507a769