### PR TITLE
Fix text_case plugin encoding cases

### DIFF
--- a/tests/text_case_plugin.rs
+++ b/tests/text_case_plugin.rs
@@ -33,3 +33,16 @@ fn converts_text_cases() {
     assert_eq!(results[22].label, "rust 👏 test"); // Clap case
     assert_eq!(results[24].label, "R-u-s-t T-e-s-t"); // Custom delimiter
 }
+
+#[test]
+fn converts_specific_cases() {
+    let plugin = TextCasePlugin;
+    let hex = plugin.search("case hex Rust");
+    assert_eq!(hex.len(), 1);
+    assert_eq!(hex[0].label, "52757374");
+
+    let bin = plugin.search("case binary A");
+    assert_eq!(bin.len(), 1);
+    assert_eq!(bin[0].label, "01000001");
+}
+


### PR DESCRIPTION
## Summary
- add ability to specify a single text case to convert to (e.g. `case hex foo`)
- extend unit tests to check specific case conversions

## Testing
- `cargo test --test text_case_plugin --quiet`
- `cargo test --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_6887e2cda2908332bb24a5ff7e5ac69b