### PR TITLE
Fix macro URL steps with empty args

### DIFF
--- a/src/actions/exec.rs
+++ b/src/actions/exec.rs
@@ -7,13 +7,18 @@ pub fn launch(path: &str, args: Option<&str>) -> anyhow::Result<()> {
         .map(|e| e.eq_ignore_ascii_case("exe"))
         .unwrap_or(false);
 
-    if is_exe || args.is_some() {
+    let has_args = args.map(|a| !a.trim().is_empty()).unwrap_or(false);
+
+    if is_exe || has_args {
         let mut command = std::process::Command::new(path);
         if let Some(arg_str) = args {
-            if let Some(list) = shlex::split(arg_str) {
-                command.args(list);
-            } else {
-                command.args(arg_str.split_whitespace());
+            let arg_str = arg_str.trim();
+            if !arg_str.is_empty() {
+                if let Some(list) = shlex::split(arg_str) {
+                    command.args(list);
+                } else {
+                    command.args(arg_str.split_whitespace());
+                }
             }
         }
         command.spawn().map(|_| ()).map_err(|e| e.into())

--- a/src/gui/macro_dialog.rs
+++ b/src/gui/macro_dialog.rs
@@ -230,6 +230,13 @@ impl MacroDialog {
                             if self.label.trim().is_empty() {
                                 app.set_error("Label required".into());
                             } else {
+                                for step in &mut self.steps {
+                                    if let Some(a) = &step.args {
+                                        if a.trim().is_empty() {
+                                            step.args = None;
+                                        }
+                                    }
+                                }
                                 if idx == self.entries.len() {
                                     self.entries.push(MacroEntry {
                                         label: self.label.clone(),

--- a/src/plugins/macros.rs
+++ b/src/plugins/macros.rs
@@ -100,6 +100,11 @@ pub fn run_macro(name: &str) -> anyhow::Result<()> {
         for (i, step) in entry.steps.iter().enumerate() {
             let mut command = step.command.trim().to_string();
             let mut args = step.args.clone();
+            if let Some(ref s) = args {
+                if s.trim().is_empty() {
+                    args = None;
+                }
+            }
 
             let mut query = if let Some(q) = command.strip_prefix("query:") {
                 q.to_string()


### PR DESCRIPTION
## Summary
- handle empty argument strings in macro steps
- strip whitespace from argument strings before launching actions
- clean up empty args when saving macros

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6887f65a51d0833291c6ed6ce6179243