### PR TITLE
Add base_convert plugin

### DIFF
--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -124,6 +124,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
             "conv ff hex to bin",
             "conv \"hello\" text to hex",
             "conv 48656c6c6f hex to text",
+            "conv 42 dec to bin",
         ]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com", "bm rm", "bm list"]),

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -119,6 +119,12 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
             "conv 30 mpg to kpl",
             "conv 180 deg to rad",
         ]),
+        "base_convert" => Some(&[
+            "conv 1010 bin to hex",
+            "conv ff hex to bin",
+            "conv \"hello\" text to hex",
+            "conv 48656c6c6f hex to text",
+        ]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com", "bm rm", "bm list"]),
         "folders" => Some(&["f add C:/path", "f rm docs"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -30,6 +30,7 @@ use crate::plugins::tempfile::TempfilePlugin;
 use crate::plugins::timer::TimerPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::unit_convert::UnitConvertPlugin;
+use crate::plugins::base_convert::BaseConvertPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 use crate::plugins::weather::WeatherPlugin;
@@ -109,6 +110,7 @@ impl PluginManager {
         self.register_with_settings(WebSearchPlugin, plugin_settings);
         self.register_with_settings(CalculatorPlugin, plugin_settings);
         self.register_with_settings(UnitConvertPlugin, plugin_settings);
+        self.register_with_settings(BaseConvertPlugin, plugin_settings);
         self.register_with_settings(DropCalcPlugin, plugin_settings);
         self.register_with_settings(RunescapeSearchPlugin, plugin_settings);
         self.register_with_settings(YoutubePlugin, plugin_settings);

--- a/src/plugins/base_convert.rs
+++ b/src/plugins/base_convert.rs
@@ -9,6 +9,7 @@ fn normalize(base: &str) -> Option<&'static str> {
         "bin" | "binary" => Some("bin"),
         "hex" | "hexadecimal" => Some("hex"),
         "oct" | "octal" => Some("oct"),
+        "dec" | "decimal" => Some("dec"),
         "text" | "string" => Some("text"),
         _ => None,
     }
@@ -42,6 +43,18 @@ fn bin_to_oct(s: &str) -> Option<String> {
 
 fn oct_to_bin(s: &str) -> Option<String> {
     u128::from_str_radix(s, 8).ok().map(|n| format!("{:b}", n))
+}
+
+fn dec_to_bin(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 10).ok().map(|n| format!("{:b}", n))
+}
+
+fn dec_to_hex(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 10).ok().map(|n| format!("{:x}", n))
+}
+
+fn dec_to_oct(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 10).ok().map(|n| format!("{:o}", n))
 }
 
 fn text_to_hex(s: &str) -> Option<String> {
@@ -82,6 +95,9 @@ fn convert(value: &str, from: &str, to: &str) -> Option<String> {
         ("hex", "bin") => hex_to_bin(value),
         ("bin", "oct") => bin_to_oct(value),
         ("oct", "bin") => oct_to_bin(value),
+        ("dec", "bin") => dec_to_bin(value),
+        ("dec", "hex") => dec_to_hex(value),
+        ("dec", "oct") => dec_to_oct(value),
         ("hex", "text") => hex_to_text(value),
         ("text", "hex") => text_to_hex(value),
         ("text", "bin") => text_to_bin(value),

--- a/src/plugins/base_convert.rs
+++ b/src/plugins/base_convert.rs
@@ -1,0 +1,137 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use shlex;
+
+pub struct BaseConvertPlugin;
+
+fn normalize(base: &str) -> Option<&'static str> {
+    match base.to_lowercase().as_str() {
+        "bin" | "binary" => Some("bin"),
+        "hex" | "hexadecimal" => Some("hex"),
+        "oct" | "octal" => Some("oct"),
+        "text" | "string" => Some("text"),
+        _ => None,
+    }
+}
+
+fn parse_query(query: &str) -> Option<(String, String, String)> {
+    let tokens = shlex::split(query.trim())?;
+    if tokens.len() < 4 {
+        return None;
+    }
+    if !tokens[tokens.len() - 2].eq_ignore_ascii_case("to") {
+        return None;
+    }
+    let value = tokens[0].to_string();
+    let from = normalize(&tokens[1])?.to_string();
+    let to = normalize(&tokens[3])?.to_string();
+    Some((value, from, to))
+}
+
+fn bin_to_hex(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 2).ok().map(|n| format!("{:x}", n))
+}
+
+fn hex_to_bin(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 16).ok().map(|n| format!("{:b}", n))
+}
+
+fn bin_to_oct(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 2).ok().map(|n| format!("{:o}", n))
+}
+
+fn oct_to_bin(s: &str) -> Option<String> {
+    u128::from_str_radix(s, 8).ok().map(|n| format!("{:b}", n))
+}
+
+fn text_to_hex(s: &str) -> Option<String> {
+    Some(hex::encode(s.as_bytes()))
+}
+
+fn hex_to_text(s: &str) -> Option<String> {
+    let bytes = hex::decode(s).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+fn text_to_bin(s: &str) -> Option<String> {
+    Some(
+        s.as_bytes()
+            .iter()
+            .map(|b| format!("{:08b}", b))
+            .collect::<Vec<_>>()
+            .join(" "),
+    )
+}
+
+fn bin_to_text(s: &str) -> Option<String> {
+    let clean = s.replace(' ', "");
+    if clean.len() % 8 != 0 {
+        return None;
+    }
+    let bytes: Option<Vec<u8>> = (0..clean.len())
+        .step_by(8)
+        .map(|i| u8::from_str_radix(&clean[i..i + 8], 2).ok())
+        .collect();
+    let bytes = bytes?;
+    String::from_utf8(bytes).ok()
+}
+
+fn convert(value: &str, from: &str, to: &str) -> Option<String> {
+    match (from, to) {
+        ("bin", "hex") => bin_to_hex(value),
+        ("hex", "bin") => hex_to_bin(value),
+        ("bin", "oct") => bin_to_oct(value),
+        ("oct", "bin") => oct_to_bin(value),
+        ("hex", "text") => hex_to_text(value),
+        ("text", "hex") => text_to_hex(value),
+        ("text", "bin") => text_to_bin(value),
+        ("bin", "text") => bin_to_text(value),
+        _ => None,
+    }
+}
+
+impl Plugin for BaseConvertPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const CONV_PREFIX: &str = "conv ";
+        const CONVERT_PREFIX: &str = "convert ";
+        let rest = if let Some(r) = crate::common::strip_prefix_ci(query.trim_start(), CONV_PREFIX) {
+            r
+        } else if let Some(r) = crate::common::strip_prefix_ci(query.trim_start(), CONVERT_PREFIX) {
+            r
+        } else {
+            return Vec::new();
+        };
+        if let Some((value, from, to)) = parse_query(rest) {
+            if let Some(res) = convert(&value, &from, &to) {
+                let label = format!("{value} {from} = {res} {to}");
+                return vec![Action {
+                    label,
+                    desc: "Base Convert".into(),
+                    action: format!("clipboard:{res}"),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "base_convert"
+    }
+
+    fn description(&self) -> &str {
+        "Convert between bases (prefix: `conv` or `convert`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action { label: "conv".into(), desc: "Base Convert".into(), action: "query:conv ".into(), args: None },
+            Action { label: "convert".into(), desc: "Base Convert".into(), action: "query:convert ".into(), args: None },
+        ]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -21,6 +21,7 @@ pub mod media;
 pub mod volume;
 pub mod brightness;
 pub mod unit_convert;
+pub mod base_convert;
 pub mod dropcalc;
 pub mod recycle;
 pub mod tempfile;

--- a/tests/base_convert_plugin.rs
+++ b/tests/base_convert_plugin.rs
@@ -55,3 +55,30 @@ fn hex_to_bin() {
     assert_eq!(results[0].action, "clipboard:11111111");
 }
 
+#[test]
+fn dec_to_bin() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 10 dec to bin");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "10 dec = 1010 bin");
+    assert_eq!(results[0].action, "clipboard:1010");
+}
+
+#[test]
+fn dec_to_hex() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 15 dec to hex");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "15 dec = f hex");
+    assert_eq!(results[0].action, "clipboard:f");
+}
+
+#[test]
+fn dec_to_oct() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 8 dec to oct");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "8 dec = 10 oct");
+    assert_eq!(results[0].action, "clipboard:10");
+}
+

--- a/tests/base_convert_plugin.rs
+++ b/tests/base_convert_plugin.rs
@@ -1,0 +1,57 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::base_convert::BaseConvertPlugin;
+
+#[test]
+fn bin_to_hex() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 1010 bin to hex");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "1010 bin = a hex");
+    assert_eq!(results[0].action, "clipboard:a");
+}
+
+#[test]
+fn bin_to_oct() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 111 bin to oct");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "111 bin = 7 oct");
+    assert_eq!(results[0].action, "clipboard:7");
+}
+
+#[test]
+fn text_to_bin() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv \"A\" text to bin");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "A text = 01000001 bin");
+    assert_eq!(results[0].action, "clipboard:01000001");
+}
+
+#[test]
+fn text_to_hex() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv \"hi\" text to hex");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "hi text = 6869 hex");
+    assert_eq!(results[0].action, "clipboard:6869");
+}
+
+#[test]
+fn hex_to_text() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv 41 hex to text");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "41 hex = A text");
+    assert_eq!(results[0].action, "clipboard:A");
+}
+
+#[test]
+fn hex_to_bin() {
+    let plugin = BaseConvertPlugin;
+    let results = plugin.search("conv ff hex to bin");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "ff hex = 11111111 bin");
+    assert_eq!(results[0].action, "clipboard:11111111");
+}
+


### PR DESCRIPTION
## Summary
- add new `base_convert` plugin for common base conversions
- register plugin
- document usage in help window
- test base conversions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6888020736708332af391824fb3900ca