### PR TITLE
Add random plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "notify-rust",
  "once_cell",
  "open",
+ "rand",
  "raw-window-handle 0.6.2",
  "rdev",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ipconfig = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 base64 = "0.21"
 hex = "0.4"
+rand = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = { version = "0.15.3", default-features = false, features = ["common-controls-v6"] }

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Built-in commands:
 | `case` | `case hello world` | Text and encoding conversions |
 | `ts` | `ts 0` | Timestamp conversion |
 | `tsm` | `tsm 3600000` | Midnight timestamp |
+| `rand` | `rand number 10` | Random numbers, dice and passwords |
 | `app` | `app <filter>` | Saved apps |
 | `vol` | `vol 50` | Volume control (`vol pid <pid> <level>`; dialog lists processes on Windows) |
 | `media` | `media play` | Media controls |
@@ -319,6 +320,15 @@ The macros plugin runs a saved sequence of launcher commands. Macros are stored 
 ```text
 macro list
 macro example
+```
+
+### Random Plugin
+Generate random numbers, dice rolls or passwords with the `rand` prefix. Examples:
+
+```text
+rand number 10
+rand dice
+rand pw 8
 ```
 
 ### IP Plugin

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -40,6 +40,7 @@ use crate::plugins::windows::WindowsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::ip::IpPlugin;
 use crate::plugins::timestamp::TimestampPlugin;
+use crate::plugins::random::RandomPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
 use std::collections::HashSet;
@@ -139,6 +140,7 @@ impl PluginManager {
         self.register_with_settings(ScreenshotPlugin, plugin_settings);
         self.register_with_settings(TimestampPlugin, plugin_settings);
         self.register_with_settings(IpPlugin, plugin_settings);
+        self.register_with_settings(RandomPlugin::default(), plugin_settings);
         #[cfg(target_os = "windows")]
         {
             self.register_with_settings(VolumePlugin, plugin_settings);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -35,3 +35,4 @@ pub mod omni_search;
 pub mod macros;
 pub mod text_case;
 pub mod timestamp;
+pub mod random;

--- a/src/plugins/random.rs
+++ b/src/plugins/random.rs
@@ -1,0 +1,128 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use rand::distributions::Alphanumeric;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::sync::Mutex;
+
+pub struct RandomPlugin {
+    rng: Mutex<StdRng>,
+}
+
+impl RandomPlugin {
+    /// Create a new plugin using randomness from the operating system.
+    pub fn new() -> Self {
+        Self { rng: Mutex::new(StdRng::from_entropy()) }
+    }
+
+    /// Create a plugin with a fixed seed (useful for deterministic tests).
+    pub fn from_seed(seed: u64) -> Self {
+        Self { rng: Mutex::new(StdRng::seed_from_u64(seed)) }
+    }
+}
+
+impl Default for RandomPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for RandomPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        let rest = if let Some(r) = crate::common::strip_prefix_ci(trimmed, "rand ") {
+            r
+        } else if let Some(r) = crate::common::strip_prefix_ci(trimmed, "random ") {
+            r
+        } else {
+            return Vec::new();
+        };
+        let parts: Vec<&str> = rest.split_whitespace().collect();
+        if parts.is_empty() {
+            return Vec::new();
+        }
+        match parts[0] {
+            "number" | "num" => {
+                if parts.len() != 2 {
+                    return Vec::new();
+                }
+                if let Ok(max) = parts[1].parse::<u64>() {
+                    let mut rng = self.rng.lock().unwrap();
+                    let value = rng.gen_range(0..=max).to_string();
+                    return vec![Action {
+                        label: value.clone(),
+                        desc: "Random number".into(),
+                        action: format!("clipboard:{value}"),
+                        args: None,
+                    }];
+                }
+            }
+            "dice" => {
+                let mut rng = self.rng.lock().unwrap();
+                let value = rng.gen_range(1..=6).to_string();
+                return vec![Action {
+                    label: value.clone(),
+                    desc: "Dice roll".into(),
+                    action: format!("clipboard:{value}"),
+                    args: None,
+                }];
+            }
+            "pw" | "password" => {
+                if parts.len() != 2 {
+                    return Vec::new();
+                }
+                if let Ok(len) = parts[1].parse::<usize>() {
+                    let mut rng = self.rng.lock().unwrap();
+                    let pw: String = (&mut *rng)
+                        .sample_iter(&Alphanumeric)
+                        .take(len)
+                        .map(char::from)
+                        .collect();
+                    return vec![Action {
+                        label: pw.clone(),
+                        desc: "Random password".into(),
+                        action: format!("clipboard:{pw}"),
+                        args: None,
+                    }];
+                }
+            }
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "random"
+    }
+
+    fn description(&self) -> &str {
+        "Generate random numbers, dice rolls and passwords (prefix: `rand`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "rand number <max>".into(),
+                desc: "Random number".into(),
+                action: "query:rand number ".into(),
+                args: None,
+            },
+            Action {
+                label: "rand dice".into(),
+                desc: "Dice".into(),
+                action: "query:rand dice".into(),
+                args: None,
+            },
+            Action {
+                label: "rand pw <len>".into(),
+                desc: "Random password".into(),
+                action: "query:rand pw ".into(),
+                args: None,
+            },
+        ]
+    }
+}

--- a/tests/random_plugin.rs
+++ b/tests/random_plugin.rs
@@ -1,0 +1,20 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::random::RandomPlugin;
+
+#[test]
+fn generate_number() {
+    let plugin = RandomPlugin::from_seed(1);
+    let results = plugin.search("rand number 10");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "7");
+    assert_eq!(results[0].action, "clipboard:7");
+}
+
+#[test]
+fn generate_password() {
+    let plugin = RandomPlugin::from_seed(1);
+    let results = plugin.search("rand pw 8");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "0zsMbNLx");
+    assert_eq!(results[0].action, "clipboard:0zsMbNLx");
+}


### PR DESCRIPTION
## Summary
- add `rand` dependency
- implement a new `random` plugin supporting numbers, dice rolls and passwords
- register the plugin
- document usage in README
- add tests for deterministic output

## Testing
- `cargo test --test random_plugin -- --nocapture`

 