### PR TITLE
Fix timer list refresh detection

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -918,6 +918,24 @@ impl LauncherApp {
         self.focus_query = true;
     }
 
+    pub fn handle_auto_refresh(&mut self) {
+        let trimmed = self.query.trim().to_string();
+        let tlc = trimmed.to_ascii_lowercase();
+        if (tlc.starts_with("timer list") || tlc.starts_with("alarm list"))
+            && !self.disable_timer_updates
+            && self.last_timer_update.elapsed().as_secs_f32() >= self.timer_refresh
+        {
+            self.search();
+            self.last_timer_update = Instant::now();
+        }
+        if trimmed.eq_ignore_ascii_case("net")
+            && self.last_net_update.elapsed().as_secs_f32() >= self.net_refresh
+        {
+            self.search();
+            self.last_net_update = Instant::now();
+        }
+    }
+
     fn any_panel_open(&self) -> bool {
         self.alias_dialog.open
             || self.bookmark_alias_dialog.open
@@ -1213,20 +1231,7 @@ impl eframe::App for LauncherApp {
             }
         }
 
-        let trimmed = self.query.trim().to_string();
-        if (trimmed.starts_with("timer list") || trimmed.starts_with("alarm list"))
-            && !self.disable_timer_updates
-            && self.last_timer_update.elapsed().as_secs_f32() >= self.timer_refresh
-        {
-            self.search();
-            self.last_timer_update = Instant::now();
-        }
-        if trimmed.eq_ignore_ascii_case("net")
-            && self.last_net_update.elapsed().as_secs_f32() >= self.net_refresh
-        {
-            self.search();
-            self.last_net_update = Instant::now();
-        }
+        self.handle_auto_refresh();
 
         CentralPanel::default().show(ctx, |ui| {
             ui.heading("🚀 LNCHR");

--- a/tests/auto_refresh.rs
+++ b/tests/auto_refresh.rs
@@ -1,0 +1,49 @@
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::actions::Action;
+use multi_launcher::settings::Settings;
+use once_cell::sync::Lazy;
+use std::sync::{Arc, Mutex, atomic::AtomicBool};
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
+    let mut settings = Settings::default();
+    settings.timer_refresh = 0.0;
+    let custom_len = 0usize;
+    LauncherApp::new(
+        ctx,
+        Vec::<Action>::new(),
+        custom_len,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn auto_refresh_case_insensitive() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let ctx = eframe::egui::Context::default();
+    let mut app = new_app(&ctx);
+
+    let initial_len = app.results.len();
+
+    app.query = "TiMeR LiSt".into();
+    app.handle_auto_refresh();
+    assert_ne!(app.results.len(), initial_len);
+
+    let after_timer = app.results.clone();
+
+    app.query = "AlArM LiSt".into();
+    app.handle_auto_refresh();
+    assert_ne!(app.results, after_timer);
+}


### PR DESCRIPTION
## Summary
- allow auto refresh to match `timer list` or `alarm list` regardless of case
- expose a helper for performing the refresh
- add regression test for mixed‐case queries

## Testing
- `cargo check` *(fails: could not run full tests in time)*

 