### PR TITLE
Fix timer list auto-refresh logic

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -292,6 +292,7 @@ pub struct LauncherApp {
     last_net_update: Instant,
     last_search_query: String,
     last_results_valid: bool,
+    last_timer_query: bool,
 }
 
 impl LauncherApp {
@@ -602,6 +603,7 @@ impl LauncherApp {
             last_net_update: Instant::now(),
             last_search_query: String::new(),
             last_results_valid: false,
+            last_timer_query: false,
             action_cache: Vec::new(),
         };
 
@@ -645,6 +647,7 @@ impl LauncherApp {
 
         let trimmed = self.query.trim();
         let trimmed_lc = trimmed.to_lowercase();
+        self.last_timer_query = trimmed.starts_with("timer list") || trimmed.starts_with("alarm list");
 
         let mut res: Vec<(Action, f32)> = Vec::new();
 
@@ -875,6 +878,21 @@ impl LauncherApp {
         }
     }
 
+    #[cfg_attr(test, allow(dead_code))]
+    pub fn maybe_refresh_timer_list(&mut self) {
+        let trimmed = self.query.trim();
+        if (
+            trimmed.starts_with("timer list")
+                || trimmed.starts_with("alarm list")
+                || self.last_timer_query
+        ) && !self.disable_timer_updates
+            && self.last_timer_update.elapsed().as_secs_f32() >= self.timer_refresh
+        {
+            self.search();
+            self.last_timer_update = Instant::now();
+        }
+    }
+
     /// Handle a keyboard navigation key. Returns the index of a selected
     /// action when `Enter` is pressed and a selection is available.
     pub fn handle_key(&mut self, key: egui::Key) -> Option<usize> {
@@ -916,6 +934,22 @@ impl LauncherApp {
 
     pub fn focus_input(&mut self) {
         self.focus_query = true;
+    }
+
+    pub fn set_last_search_query(&mut self, s: String) {
+        self.last_search_query = s;
+    }
+
+    pub fn set_last_timer_update(&mut self, t: Instant) {
+        self.last_timer_update = t;
+    }
+
+    pub fn get_last_search_query(&self) -> &str {
+        &self.last_search_query
+    }
+
+    pub fn last_timer_query_flag(&self) -> bool {
+        self.last_timer_query
     }
 
     fn any_panel_open(&self) -> bool {
@@ -1214,13 +1248,7 @@ impl eframe::App for LauncherApp {
         }
 
         let trimmed = self.query.trim().to_string();
-        if (trimmed.starts_with("timer list") || trimmed.starts_with("alarm list"))
-            && !self.disable_timer_updates
-            && self.last_timer_update.elapsed().as_secs_f32() >= self.timer_refresh
-        {
-            self.search();
-            self.last_timer_update = Instant::now();
-        }
+        self.maybe_refresh_timer_list();
         if trimmed.eq_ignore_ascii_case("net")
             && self.last_net_update.elapsed().as_secs_f32() >= self.net_refresh
         {
@@ -1312,6 +1340,8 @@ impl eframe::App for LauncherApp {
                         if let Some(new_q) = a.action.strip_prefix("query:") {
                             tracing::debug!("query action via Enter: {new_q}");
                             self.query = new_q.to_string();
+                            self.last_timer_query = new_q.starts_with("timer list")
+                                || new_q.starts_with("alarm list");
                             self.search();
                             set_focus = true;
                             tracing::debug!("move_cursor_end set via Enter key");

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -888,6 +888,7 @@ impl LauncherApp {
         ) && !self.disable_timer_updates
             && self.last_timer_update.elapsed().as_secs_f32() >= self.timer_refresh
         {
+            self.last_results_valid = false;
             self.search();
             self.last_timer_update = Instant::now();
         }
@@ -942,6 +943,11 @@ impl LauncherApp {
 
     pub fn set_last_timer_update(&mut self, t: Instant) {
         self.last_timer_update = t;
+    }
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub fn last_timer_update(&self) -> Instant {
+        self.last_timer_update
     }
 
     pub fn get_last_search_query(&self) -> &str {

--- a/tests/timer_refresh.rs
+++ b/tests/timer_refresh.rs
@@ -2,7 +2,6 @@ use multi_launcher::actions::Action;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::settings::Settings;
-use eframe::egui;
 use std::sync::{atomic::AtomicBool, Arc};
 use std::time::{Duration, Instant};
 
@@ -60,4 +59,17 @@ fn refresh_after_alarm_list_command() {
     app.set_last_timer_update(Instant::now() - Duration::from_secs_f32(app.timer_refresh + 1.0));
     app.maybe_refresh_timer_list();
     assert_eq!(app.get_last_search_query(), app.query);
+}
+
+#[test]
+fn refresh_while_timer_query_active() {
+    let ctx = eframe::egui::Context::default();
+    let mut app = new_app(&ctx);
+    app.query = "timer list".into();
+    app.search();
+    assert!(app.last_timer_query_flag());
+    app.set_last_timer_update(Instant::now() - Duration::from_secs_f32(app.timer_refresh + 1.0));
+    let prev = app.last_timer_update();
+    app.maybe_refresh_timer_list();
+    assert!(app.last_timer_update() > prev);
 }

--- a/tests/timer_refresh.rs
+++ b/tests/timer_refresh.rs
@@ -1,0 +1,63 @@
+use multi_launcher::actions::Action;
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::settings::Settings;
+use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc};
+use std::time::{Duration, Instant};
+
+fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
+    let actions: Vec<Action> = Vec::new();
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    plugins.reload_from_dirs(
+        &[],
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        &actions,
+    );
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn refresh_after_timer_list_command() {
+    let ctx = eframe::egui::Context::default();
+    let mut app = new_app(&ctx);
+    app.query = "timer list".into();
+    app.search();
+    assert!(app.last_timer_query_flag());
+    app.set_last_search_query("old".into());
+    app.set_last_timer_update(Instant::now() - Duration::from_secs_f32(app.timer_refresh + 1.0));
+    app.maybe_refresh_timer_list();
+    assert_eq!(app.get_last_search_query(), app.query);
+}
+
+#[test]
+fn refresh_after_alarm_list_command() {
+    let ctx = eframe::egui::Context::default();
+    let mut app = new_app(&ctx);
+    app.query = "alarm list".into();
+    app.search();
+    assert!(app.last_timer_query_flag());
+    app.set_last_search_query("old".into());
+    app.set_last_timer_update(Instant::now() - Duration::from_secs_f32(app.timer_refresh + 1.0));
+    app.maybe_refresh_timer_list();
+    assert_eq!(app.get_last_search_query(), app.query);
+}


### PR DESCRIPTION
## Summary
- keep refreshing timer list if results originated from timer or alarm list
- expose helper methods for tests to modify internal refresh state
- add regression tests covering automatic timer list refresh behavior

## Testing
- `cargo test --test timer_refresh -- --nocapture`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688945d7329c8332ac775c22eca5bc3a