### PR TITLE
Add favorites plugin

### DIFF
--- a/src/actions/fav.rs
+++ b/src/actions/fav.rs
@@ -1,0 +1,17 @@
+pub fn add(label: &str, action: &str, args: Option<&str>) -> anyhow::Result<()> {
+    crate::plugins::fav::set_fav(
+        crate::plugins::fav::FAV_FILE,
+        label,
+        action,
+        args,
+    )?;
+    Ok(())
+}
+
+pub fn remove(label: &str) -> anyhow::Result<()> {
+    crate::plugins::fav::remove_fav(
+        crate::plugins::fav::FAV_FILE,
+        label,
+    )?;
+    Ok(())
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -34,4 +34,5 @@ pub mod tempfiles;
 pub mod media;
 pub mod system;
 pub mod exec;
+pub mod fav;
 pub mod screenshot;

--- a/src/gui/fav_dialog.rs
+++ b/src/gui/fav_dialog.rs
@@ -1,0 +1,221 @@
+use crate::gui::LauncherApp;
+use crate::plugins::fav::{load_favs, save_favs, FavEntry, FAV_FILE};
+use eframe::egui;
+
+#[derive(Default)]
+pub struct FavDialog {
+    pub open: bool,
+    entries: Vec<FavEntry>,
+    edit_idx: Option<usize>,
+    label: String,
+    command: String,
+    args: String,
+    add_plugin: String,
+    add_filter: String,
+}
+
+impl FavDialog {
+    pub fn open(&mut self) {
+        self.entries = load_favs(FAV_FILE).unwrap_or_default();
+        self.open = true;
+        self.edit_idx = None;
+        self.label.clear();
+        self.command.clear();
+        self.args.clear();
+        self.add_plugin.clear();
+        self.add_filter.clear();
+    }
+
+    pub fn open_edit(&mut self, label: &str) {
+        self.entries = load_favs(FAV_FILE).unwrap_or_default();
+        if let Some(pos) = self.entries.iter().position(|e| e.label == label) {
+            self.edit_idx = Some(pos);
+            let entry = &self.entries[pos];
+            self.label = entry.label.clone();
+            self.command = entry.action.clone();
+            self.args = entry.args.clone().unwrap_or_default();
+        } else {
+            self.edit_idx = Some(self.entries.len());
+            self.label = label.to_string();
+            self.command.clear();
+            self.args.clear();
+        }
+        self.open = true;
+    }
+
+    fn save(&mut self, app: &mut LauncherApp) {
+        if let Err(e) = save_favs(FAV_FILE, &self.entries) {
+            app.set_error(format!("Failed to save favorites: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+        }
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut close = false;
+        let mut save_now = false;
+        egui::Window::new("Favorites")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                if let Some(idx) = self.edit_idx {
+                    ui.horizontal(|ui| {
+                        ui.label("Label");
+                        ui.text_edit_singleline(&mut self.label);
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Command");
+                        ui.text_edit_singleline(&mut self.command);
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Args");
+                        ui.text_edit_singleline(&mut self.args);
+                    });
+                    ui.separator();
+                    ui.horizontal(|ui| {
+                        ui.label("Category");
+                        egui::ComboBox::from_id_source("fav_cat")
+                            .selected_text(if self.add_plugin.is_empty() {
+                                "Select".to_string()
+                            } else {
+                                self.add_plugin.clone()
+                            })
+                            .show_ui(ui, |ui| {
+                                for p in app.plugins.iter() {
+                                    let name = p.name();
+                                    ui.selectable_value(&mut self.add_plugin, name.to_string(), name);
+                                }
+                            });
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Filter");
+                        ui.text_edit_singleline(&mut self.add_filter);
+                    });
+                    if let Some(plugin) = app.plugins.iter().find(|p| p.name() == self.add_plugin) {
+                        let filter = self.add_filter.trim().to_lowercase();
+                        let mut actions = if plugin.name() == "folders" {
+                            plugin.search(&format!("f {}", self.add_filter))
+                        } else if plugin.name() == "bookmarks" {
+                            plugin.search(&format!("bm {}", self.add_filter))
+                        } else {
+                            plugin.commands()
+                        };
+                        egui::ScrollArea::vertical()
+                            .max_height(80.0)
+                            .show(ui, |ui| {
+                                for act in actions.drain(..) {
+                                    if !filter.is_empty()
+                                        && !act.label.to_lowercase().contains(&filter)
+                                        && !act.desc.to_lowercase().contains(&filter)
+                                        && !act.action.to_lowercase().contains(&filter)
+                                    {
+                                        continue;
+                                    }
+                                    if ui.button(format!("{} - {}", act.label, act.desc)).clicked() {
+                                        let mut cmd = act.action.clone();
+                                        let mut args = if self.args.trim().is_empty() {
+                                            None
+                                        } else {
+                                            Some(self.args.clone())
+                                        };
+                                        if let Some(q) = cmd.strip_prefix("query:") {
+                                            let mut q = q.to_string();
+                                            if let Some(ref a) = args {
+                                                q.push_str(a);
+                                            }
+                                            if let Some(res) = plugin.search(&q).into_iter().next() {
+                                                cmd = res.action;
+                                                args = res.args;
+                                            } else {
+                                                cmd = q;
+                                                args = None;
+                                            }
+                                        }
+                                        self.command = cmd;
+                                        self.args = args.unwrap_or_default();
+                                    }
+                                }
+                            });
+                    }
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            if self.label.trim().is_empty() || self.command.trim().is_empty() {
+                                app.set_error("Label and command required".into());
+                            } else {
+                                if idx == self.entries.len() {
+                                    self.entries.push(FavEntry {
+                                        label: self.label.clone(),
+                                        action: self.command.clone(),
+                                        args: if self.args.trim().is_empty() {
+                                            None
+                                        } else {
+                                            Some(self.args.clone())
+                                        },
+                                    });
+                                } else if let Some(e) = self.entries.get_mut(idx) {
+                                    e.label = self.label.clone();
+                                    e.action = self.command.clone();
+                                    e.args = if self.args.trim().is_empty() {
+                                        None
+                                    } else {
+                                        Some(self.args.clone())
+                                    };
+                                }
+                                self.edit_idx = None;
+                                self.label.clear();
+                                self.command.clear();
+                                self.args.clear();
+                                self.add_plugin.clear();
+                                self.add_filter.clear();
+                                save_now = true;
+                            }
+                        }
+                        if ui.button("Cancel").clicked() {
+                            self.edit_idx = None;
+                            self.add_plugin.clear();
+                            self.add_filter.clear();
+                        }
+                    });
+                } else {
+                    let mut remove: Option<usize> = None;
+                    egui::ScrollArea::vertical()
+                        .max_height(200.0)
+                        .show(ui, |ui| {
+                            for idx in 0..self.entries.len() {
+                                let entry = self.entries[idx].clone();
+                                ui.horizontal(|ui| {
+                                    ui.label(format!("{} - {}", entry.label, entry.action));
+                                    if ui.button("Edit").clicked() {
+                                        self.edit_idx = Some(idx);
+                                        self.label = entry.label.clone();
+                                        self.command = entry.action.clone();
+                                        self.args = entry.args.clone().unwrap_or_default();
+                                    }
+                                    if ui.button("Remove").clicked() {
+                                        remove = Some(idx);
+                                    }
+                                });
+                            }
+                        });
+                    if let Some(idx) = remove {
+                        self.entries.remove(idx);
+                        save_now = true;
+                    }
+                    if ui.button("Add Fav").clicked() {
+                        self.edit_idx = Some(self.entries.len());
+                        self.label.clear();
+                        self.command.clear();
+                        self.args.clear();
+                        self.add_plugin.clear();
+                        self.add_filter.clear();
+                    }
+                    if ui.button("Close").clicked() { close = true; }
+                }
+            });
+        if save_now { self.save(app); }
+        if close { self.open = false; }
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -10,6 +10,7 @@ mod notes_dialog;
 mod shell_cmd_dialog;
 mod snippet_dialog;
 mod macro_dialog;
+mod fav_dialog;
 mod tempfile_alias_dialog;
 mod tempfile_dialog;
 mod timer_dialog;
@@ -29,6 +30,7 @@ pub use notes_dialog::NotesDialog;
 pub use shell_cmd_dialog::ShellCmdDialog;
 pub use snippet_dialog::SnippetDialog;
 pub use macro_dialog::MacroDialog;
+pub use fav_dialog::FavDialog;
 pub use tempfile_alias_dialog::TempfileAliasDialog;
 pub use tempfile_dialog::TempfileDialog;
 pub use timer_dialog::{TimerCompletionDialog, TimerDialog};
@@ -162,6 +164,7 @@ enum Panel {
     ShellCmdDialog,
     SnippetDialog,
     MacroDialog,
+    FavDialog,
     NotesDialog,
     TodoDialog,
     TodoViewDialog,
@@ -189,6 +192,7 @@ struct PanelStates {
     shell_cmd_dialog: bool,
     snippet_dialog: bool,
     macro_dialog: bool,
+    fav_dialog: bool,
     notes_dialog: bool,
     todo_dialog: bool,
     todo_view_dialog: bool,
@@ -255,6 +259,7 @@ pub struct LauncherApp {
     shell_cmd_dialog: ShellCmdDialog,
     snippet_dialog: SnippetDialog,
     macro_dialog: MacroDialog,
+    fav_dialog: FavDialog,
     notes_dialog: NotesDialog,
     todo_dialog: TodoDialog,
     todo_view_dialog: TodoViewDialog,
@@ -567,6 +572,7 @@ impl LauncherApp {
             shell_cmd_dialog: ShellCmdDialog::default(),
             snippet_dialog: SnippetDialog::default(),
             macro_dialog: MacroDialog::default(),
+            fav_dialog: FavDialog::default(),
             notes_dialog: NotesDialog::default(),
             todo_dialog: TodoDialog::default(),
             todo_view_dialog: TodoViewDialog::default(),
@@ -1032,6 +1038,7 @@ impl LauncherApp {
             Panel::ShellCmdDialog => { self.shell_cmd_dialog.open = false; self.panel_states.shell_cmd_dialog = false; }
             Panel::SnippetDialog => { self.snippet_dialog.open = false; self.panel_states.snippet_dialog = false; }
             Panel::MacroDialog => { self.macro_dialog.open = false; self.panel_states.macro_dialog = false; }
+            Panel::FavDialog => { self.fav_dialog.open = false; self.panel_states.fav_dialog = false; }
             Panel::NotesDialog => { self.notes_dialog.open = false; self.panel_states.notes_dialog = false; }
             Panel::TodoDialog => { self.todo_dialog.open = false; self.panel_states.todo_dialog = false; }
             Panel::TodoViewDialog => { self.todo_view_dialog.open = false; self.panel_states.todo_view_dialog = false; }
@@ -1073,6 +1080,7 @@ impl LauncherApp {
         check!(self.shell_cmd_dialog.open, shell_cmd_dialog, Panel::ShellCmdDialog);
         check!(self.snippet_dialog.open, snippet_dialog, Panel::SnippetDialog);
         check!(self.macro_dialog.open, macro_dialog, Panel::MacroDialog);
+        check!(self.fav_dialog.open, fav_dialog, Panel::FavDialog);
         check!(self.notes_dialog.open, notes_dialog, Panel::NotesDialog);
         check!(self.todo_dialog.open, todo_dialog, Panel::TodoDialog);
         check!(self.todo_view_dialog.open, todo_view_dialog, Panel::TodoViewDialog);
@@ -1372,6 +1380,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "macro:dialog" {
                             self.macro_dialog.open();
+                        } else if let Some(label) = a.action.strip_prefix("fav:dialog:") {
+                            self.fav_dialog.open_edit(label);
                         } else if let Some(alias) = a.action.strip_prefix("snippet:edit:") {
                             self.snippet_dialog.open_edit(alias);
                         } else if a.action == "todo:dialog" {
@@ -1932,6 +1942,8 @@ impl eframe::App for LauncherApp {
                             self.snippet_dialog.open();
                         } else if a.action == "macro:dialog" {
                             self.macro_dialog.open();
+                        } else if let Some(label) = a.action.strip_prefix("fav:dialog:") {
+                            self.fav_dialog.open_edit(label);
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
                         } else if a.action == "todo:view" {
@@ -2214,6 +2226,9 @@ impl eframe::App for LauncherApp {
         let mut macro_dlg = std::mem::take(&mut self.macro_dialog);
         macro_dlg.ui(ctx, self);
         self.macro_dialog = macro_dlg;
+        let mut fav_dlg = std::mem::take(&mut self.fav_dialog);
+        fav_dlg.ui(ctx, self);
+        self.fav_dialog = fav_dlg;
         let mut notes_dlg = std::mem::take(&mut self.notes_dialog);
         notes_dlg.ui(ctx, self);
         self.notes_dialog = notes_dlg;

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -166,6 +166,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
             "tsm 01:00:00.500",
         ]),
         "snippets" => Some(&["cs hello"]),
+        "favorites" => Some(&["fav add mycmd", "fav list"]),
         "todo" => Some(&["todo add buy milk", "todo list"]),
         "wikipedia" => Some(&["wiki rust"]),
         "help" => Some(&["help"]),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,6 +20,7 @@ use crate::plugins::reddit::RedditPlugin;
 use crate::plugins::runescape::RunescapeSearchPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
+use crate::plugins::fav::FavPlugin;
 use crate::plugins::macros::MacrosPlugin;
 use crate::plugins::omni_search::OmniSearchPlugin;
 use crate::plugins::sysinfo::SysInfoPlugin;
@@ -132,6 +133,7 @@ impl PluginManager {
         self.register_with_settings(TodoPlugin::default(), plugin_settings);
         self.register_with_settings(SnippetsPlugin::default(), plugin_settings);
         self.register_with_settings(MacrosPlugin::default(), plugin_settings);
+        self.register_with_settings(FavPlugin::default(), plugin_settings);
         self.register_with_settings(RecyclePlugin, plugin_settings);
         self.register_with_settings(TempfilePlugin, plugin_settings);
         self.register_with_settings(MediaPlugin, plugin_settings);

--- a/src/plugins/fav.rs
+++ b/src/plugins/fav.rs
@@ -1,0 +1,224 @@
+use crate::actions::Action;
+use crate::common::json_watch::{watch_json, JsonWatcher};
+use crate::launcher::launch_action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+pub const FAV_FILE: &str = "fav.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FavEntry {
+    pub label: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<String>,
+}
+
+pub fn load_favs(path: &str) -> anyhow::Result<Vec<FavEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<FavEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+pub fn save_favs(path: &str, favs: &[FavEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(favs)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn set_fav(path: &str, label: &str, action: &str, args: Option<&str>) -> anyhow::Result<()> {
+    let mut list = load_favs(path).unwrap_or_default();
+    if let Some(item) = list.iter_mut().find(|e| e.label.eq_ignore_ascii_case(label)) {
+        item.action = action.to_string();
+        item.args = args.map(|s| s.to_string());
+    } else {
+        list.push(FavEntry {
+            label: label.to_string(),
+            action: action.to_string(),
+            args: args.map(|s| s.to_string()),
+        });
+    }
+    save_favs(path, &list)
+}
+
+pub fn remove_fav(path: &str, label: &str) -> anyhow::Result<()> {
+    let mut list = load_favs(path).unwrap_or_default();
+    if let Some(pos) = list.iter().position(|e| e.label.eq_ignore_ascii_case(label)) {
+        list.remove(pos);
+        save_favs(path, &list)?;
+    }
+    Ok(())
+}
+
+pub fn run_fav(label: &str) -> anyhow::Result<()> {
+    let list = load_favs(FAV_FILE).unwrap_or_default();
+    if let Some(entry) = list.iter().find(|e| e.label.eq_ignore_ascii_case(label)) {
+        let act = Action {
+            label: entry.label.clone(),
+            desc: String::new(),
+            action: entry.action.clone(),
+            args: entry.args.clone(),
+        };
+        launch_action(&act)?;
+    }
+    Ok(())
+}
+
+pub struct FavPlugin {
+    matcher: SkimMatcherV2,
+    data: Arc<Mutex<Vec<FavEntry>>>,
+    #[allow(dead_code)]
+    watcher: Option<JsonWatcher>,
+}
+
+impl FavPlugin {
+    pub fn new() -> Self {
+        let data = Arc::new(Mutex::new(load_favs(FAV_FILE).unwrap_or_default()));
+        let data_clone = data.clone();
+        let path = FAV_FILE.to_string();
+        let watch_path = path.clone();
+        let watcher = watch_json(&watch_path, {
+            let watch_path = watch_path.clone();
+            move || {
+                if let Ok(list) = load_favs(&watch_path) {
+                    if let Ok(mut lock) = data_clone.lock() {
+                        *lock = list;
+                    }
+                }
+            }
+        })
+        .ok();
+        Self {
+            matcher: SkimMatcherV2::default(),
+            data,
+            watcher,
+        }
+    }
+
+    fn list(&self, filter: &str) -> Vec<Action> {
+        let guard = match self.data.lock() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        guard
+            .iter()
+            .filter(|f| self.matcher.fuzzy_match(&f.label, filter).is_some())
+            .map(|f| Action {
+                label: f.label.clone(),
+                desc: "Fav".into(),
+                action: f.action.clone(),
+                args: f.args.clone(),
+            })
+            .collect()
+    }
+}
+
+impl Default for FavPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for FavPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("fav") {
+            return vec![Action {
+                label: "fav add".into(),
+                desc: "Fav".into(),
+                action: "query:fav add ".into(),
+                args: None,
+            }];
+        }
+
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "fav add") {
+            let label = rest.trim();
+            return vec![Action {
+                label: if label.is_empty() {
+                    "fav: add".into()
+                } else {
+                    format!("Add fav {label}")
+                },
+                desc: "Fav".into(),
+                action: format!("fav:dialog:{label}"),
+                args: None,
+            }];
+        }
+
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "fav rm") {
+            let filter = rest.trim();
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
+                .filter(|f| self.matcher.fuzzy_match(&f.label, filter).is_some())
+                .map(|f| Action {
+                    label: format!("Remove fav {}", f.label),
+                    desc: "Fav".into(),
+                    action: format!("fav:remove:{}", f.label),
+                    args: None,
+                })
+                .collect();
+        }
+
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "fav list") {
+            return self.list(rest.trim());
+        }
+
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "fav ") {
+            return self.list(rest.trim());
+        }
+
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "favorites"
+    }
+
+    fn description(&self) -> &str {
+        "Run saved favorite commands (prefix: `fav`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "fav".into(),
+                desc: "Fav".into(),
+                action: "query:fav ".into(),
+                args: None,
+            },
+            Action {
+                label: "fav add".into(),
+                desc: "Fav".into(),
+                action: "query:fav add ".into(),
+                args: None,
+            },
+            Action {
+                label: "fav rm".into(),
+                desc: "Fav".into(),
+                action: "query:fav rm ".into(),
+                args: None,
+            },
+            Action {
+                label: "fav list".into(),
+                desc: "Fav".into(),
+                action: "query:fav list".into(),
+                args: None,
+            },
+        ]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -33,6 +33,7 @@ pub mod screenshot;
 pub mod ip;
 pub mod omni_search;
 pub mod macros;
+pub mod fav;
 pub mod text_case;
 pub mod timestamp;
 pub mod random;

--- a/tests/fav_plugin.rs
+++ b/tests/fav_plugin.rs
@@ -1,0 +1,49 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::fav::{save_favs, FavEntry, FavPlugin, FAV_FILE};
+use multi_launcher::plugins::bookmarks::{load_bookmarks, save_bookmarks, BOOKMARKS_FILE};
+use multi_launcher::launcher::launch_action;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn list_returns_entries() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![FavEntry { label: "one".into(), action: "noop".into(), args: None }];
+    save_favs(FAV_FILE, &entries).unwrap();
+
+    let plugin = FavPlugin::default();
+    let results = plugin.search("fav list");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].label, "one");
+    assert_eq!(results[0].action, "noop");
+}
+
+#[test]
+fn launch_runs_command() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    save_favs(
+        FAV_FILE,
+        &[FavEntry {
+            label: "bm".into(),
+            action: "bookmark:add:https://example.com".into(),
+            args: None,
+        }],
+    )
+    .unwrap();
+    save_bookmarks(BOOKMARKS_FILE, &[]).unwrap();
+
+    let plugin = FavPlugin::default();
+    let action = plugin.search("fav list")[0].clone();
+    launch_action(&action).unwrap();
+    let list = load_bookmarks(BOOKMARKS_FILE).unwrap();
+    assert_eq!(list.len(), 1);
+}


### PR DESCRIPTION
## Summary
- add `FavPlugin` for saving frequently used commands
- support editing favorites via new GUI dialog
- register plugin and describe usage in help
- handle favorites actions in launcher
- test listing and execution

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688974bed7948332911f877fa4e2388d