### PR TITLE
Handle missing toast log gracefully

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1379,7 +1379,14 @@ impl eframe::App for LauncherApp {
                         self.help_window.open = true;
                     }
                     if ui.button("Open Toast Log").clicked() {
-                        if let Err(e) = open::that(TOAST_LOG_FILE) {
+                        if std::fs::OpenOptions::new()
+                            .create(true)
+                            .write(true)
+                            .open(TOAST_LOG_FILE)
+                            .is_err()
+                        {
+                            self.set_error("Failed to create log".into());
+                        } else if let Err(e) = open::that(TOAST_LOG_FILE) {
                             self.set_error(format!("Failed to open log: {e}"));
                         }
                     }

--- a/src/gui/toast_log_dialog.rs
+++ b/src/gui/toast_log_dialog.rs
@@ -14,15 +14,12 @@ impl ToastLogDialog {
     }
 
     fn read_last_lines(path: &str, count: usize) -> Vec<String> {
-        if let Ok(content) = std::fs::read_to_string(path) {
-            let mut lines: Vec<String> = content.lines().map(|s| s.to_owned()).collect();
-            if lines.len() > count {
-                lines.drain(0..lines.len() - count);
-            }
-            lines
-        } else {
-            Vec::new()
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        let mut lines: Vec<String> = content.lines().map(|s| s.to_owned()).collect();
+        if lines.len() > count {
+            lines.drain(0..lines.len() - count);
         }
+        lines
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, _app: &mut crate::gui::LauncherApp) {

--- a/tests/toast_log.rs
+++ b/tests/toast_log.rs
@@ -1,0 +1,34 @@
+use multi_launcher::gui::ToastLogDialog;
+use multi_launcher::toast_log::TOAST_LOG_FILE;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn open_action_missing_file_does_not_panic() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    assert!(std::panic::catch_unwind(|| {
+        if std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(TOAST_LOG_FILE)
+            .is_ok()
+        {
+            let _ = open::that(TOAST_LOG_FILE);
+        }
+    })
+    .is_ok());
+}
+
+#[test]
+fn toast_log_dialog_open_missing_file_does_not_panic() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+    let mut dialog = ToastLogDialog::default();
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dialog.open())).is_ok());
+}


### PR DESCRIPTION
## Summary
- Ensure `Open Toast Log` creates the log file before attempting to open it
- Make toast log dialog ignore missing/invalid log files
- Add regression tests covering toast log behaviors when the log file is absent

## Testing
- `cargo test`

------
 