### PR TITLE
Add always-on-top window option

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -287,6 +287,7 @@ pub struct LauncherApp {
     pub static_pos: Option<(i32, i32)>,
     pub static_size: Option<(i32, i32)>,
     pub hide_after_run: bool,
+    pub always_on_top: bool,
     pub timer_refresh: f32,
     pub disable_timer_updates: bool,
     pub preserve_command: bool,
@@ -356,6 +357,7 @@ impl LauncherApp {
         net_unit: Option<crate::settings::NetUnit>,
         screenshot_dir: Option<String>,
         screenshot_save_file: Option<bool>,
+        always_on_top: Option<bool>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -411,6 +413,9 @@ impl LauncherApp {
         }
         if let Some(v) = screenshot_save_file {
             self.screenshot_save_file = v;
+        }
+        if let Some(v) = always_on_top {
+            self.always_on_top = v;
         }
     }
 
@@ -599,6 +604,7 @@ impl LauncherApp {
             static_pos,
             static_size,
             hide_after_run: settings.hide_after_run,
+            always_on_top: settings.always_on_top,
             timer_refresh: settings.timer_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,13 +78,16 @@ fn spawn_gui(
         let icon =
             icon_data::from_png_bytes(include_bytes!("../Resources/Green_MultiLauncher.png"))
                 .expect("invalid icon");
+        let mut viewport = egui::ViewportBuilder::default()
+            .with_inner_size([w as f32, h as f32])
+            .with_min_inner_size([320.0, 160.0])
+            .with_visible(true)
+            .with_icon(icon);
+        if settings.always_on_top {
+            viewport = viewport.with_always_on_top();
+        }
         let native_options = eframe::NativeOptions {
-            viewport: egui::ViewportBuilder::default()
-                .with_inner_size([w as f32, h as f32])
-                .with_min_inner_size([320.0, 160.0])
-                .with_always_on_top()
-                .with_visible(true)
-                .with_icon(icon),
+            viewport,
             event_loop_builder: Some(Box::new(|_builder| {
                 #[cfg(target_os = "windows")]
                 {

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -122,6 +122,8 @@ impl PluginEditor {
                         Some(s.net_unit),
                         s.screenshot_dir.clone(),
                         Some(s.screenshot_save_file),
+        
+                        None,
                     );
                     let dirs = s.plugin_dirs.clone().unwrap_or_default();
                     app.plugins.reload_from_dirs(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -110,6 +110,9 @@ pub struct Settings {
     /// Hide the main window automatically after successfully launching an action.
     #[serde(default)]
     pub hide_after_run: bool,
+    /// Keep the window always on top of other windows.
+    #[serde(default = "default_always_on_top")]
+    pub always_on_top: bool,
     /// Interval in seconds to refresh the timer list.
     #[serde(default = "default_timer_refresh")]
     pub timer_refresh: f32,
@@ -165,6 +168,10 @@ fn default_follow_mouse() -> bool {
     true
 }
 
+fn default_always_on_top() -> bool {
+    true
+}
+
 fn default_timer_refresh() -> f32 {
     1.0
 }
@@ -215,6 +222,7 @@ impl Default for Settings {
             static_pos: None,
             static_size: None,
             hide_after_run: false,
+            always_on_top: default_always_on_top(),
             timer_refresh: default_timer_refresh(),
             net_refresh: default_net_refresh(),
             net_unit: NetUnit::Auto,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -39,6 +39,7 @@ pub struct SettingsEditor {
     static_w: i32,
     static_h: i32,
     hide_after_run: bool,
+    pub always_on_top: bool,
     timer_refresh: f32,
     disable_timer_updates: bool,
     preserve_command: bool,
@@ -117,6 +118,7 @@ impl SettingsEditor {
             static_w: settings.static_size.unwrap_or((400, 220)).0,
             static_h: settings.static_size.unwrap_or((400, 220)).1,
             hide_after_run: settings.hide_after_run,
+            always_on_top: settings.always_on_top,
             timer_refresh: settings.timer_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,
@@ -162,7 +164,7 @@ impl SettingsEditor {
         }
     }
 
-    fn to_settings(&self, current: &Settings) -> Settings {
+    pub fn to_settings(&self, current: &Settings) -> Settings {
         Settings {
             hotkey: if self.hotkey.trim().is_empty() {
                 None
@@ -200,6 +202,7 @@ impl SettingsEditor {
             static_pos: Some((self.static_x, self.static_y)),
             static_size: Some((self.static_w, self.static_h)),
             hide_after_run: self.hide_after_run,
+            always_on_top: self.always_on_top,
             timer_refresh: self.timer_refresh,
             disable_timer_updates: self.disable_timer_updates,
             preserve_command: self.preserve_command,
@@ -305,6 +308,7 @@ impl SettingsEditor {
                             });
                         }
                         ui.checkbox(&mut self.hide_after_run, "Hide window after running action");
+                        ui.checkbox(&mut self.always_on_top, "Always on top");
                         ui.checkbox(&mut self.preserve_command, "Preserve command after run");
                         ui.checkbox(
                             &mut self.disable_timer_updates,
@@ -515,7 +519,15 @@ impl SettingsEditor {
                                                 Some(new_settings.net_unit),
                                                 new_settings.screenshot_dir.clone(),
                                                 Some(new_settings.screenshot_save_file),
+                                                Some(new_settings.always_on_top),
                                             );
+                                            ctx.send_viewport_cmd(egui::ViewportCommand::WindowLevel(
+                                                if new_settings.always_on_top {
+                                                    egui::WindowLevel::AlwaysOnTop
+                                                } else {
+                                                    egui::WindowLevel::Normal
+                                                },
+                                            ));
                                             app.hotkey_str = new_settings.hotkey.clone();
                                             app.quit_hotkey_str = new_settings.quit_hotkey.clone();
                                             app.help_hotkey_str = new_settings.help_hotkey.clone();

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -67,6 +67,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/settings_editor.rs
+++ b/tests/settings_editor.rs
@@ -9,3 +9,13 @@ fn new_handles_none_default_hotkey() {
     assert!(std::panic::catch_unwind(|| SettingsEditor::new(&settings)).is_ok());
     std::env::remove_var("ML_DEFAULT_HOTKEY_NONE");
 }
+
+#[test]
+fn always_on_top_persists() {
+    let settings = Settings::default();
+    let mut editor = SettingsEditor::new(&settings);
+    assert!(editor.always_on_top);
+    editor.always_on_top = false;
+    let new_settings = editor.to_settings(&settings);
+    assert!(!new_settings.always_on_top);
+}


### PR DESCRIPTION
## Summary
- add `always_on_top` setting with default enabled
- expose checkbox in settings editor and toggle viewport at runtime
- apply always-on-top only when enabled

## Testing
- `cargo test`
 