### PR TITLE
Add convert panel plugin and panel UI

### DIFF
--- a/src/gui/convert_panel.rs
+++ b/src/gui/convert_panel.rs
@@ -1,0 +1,75 @@
+use crate::gui::LauncherApp;
+use eframe::egui;
+
+const OPTIONS: &[&str] = &[
+    "meters",
+    "kilometers",
+    "miles",
+    "feet",
+    "inches",
+    "centimeters",
+    "millimeters",
+    "grams",
+    "kilograms",
+    "pounds",
+    "ounces",
+];
+
+#[derive(Default)]
+pub struct ConvertPanel {
+    pub open: bool,
+    text: String,
+    from_idx: usize,
+    to_idx: usize,
+    filter: String,
+}
+
+impl ConvertPanel {
+    pub fn open(&mut self) {
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, _app: &mut LauncherApp) {
+        if !self.open { return; }
+        let mut close = false;
+        egui::Window::new("Convert")
+            .open(&mut self.open)
+            .show(ctx, |ui| {
+                ui.text_edit_singleline(&mut self.text);
+                let filtered: Vec<&str> = OPTIONS
+                    .iter()
+                    .copied()
+                    .filter(|o| self.filter.is_empty() || o.contains(&self.filter))
+                    .collect();
+                ui.horizontal(|ui| {
+                    ui.label("From");
+                    let from_text = filtered.get(self.from_idx).copied().unwrap_or("");
+                    egui::ComboBox::from_id_source("convert_from")
+                        .selected_text(from_text)
+                        .show_ui(ui, |ui| {
+                            for (i, opt) in filtered.iter().enumerate() {
+                                ui.selectable_value(&mut self.from_idx, i, *opt);
+                            }
+                        });
+                    ui.label("To");
+                    let to_text = filtered.get(self.to_idx).copied().unwrap_or("");
+                    egui::ComboBox::from_id_source("convert_to")
+                        .selected_text(to_text)
+                        .show_ui(ui, |ui| {
+                            for (i, opt) in filtered.iter().enumerate() {
+                                ui.selectable_value(&mut self.to_idx, i, *opt);
+                            }
+                        });
+                });
+                ui.label("Filter");
+                ui.text_edit_singleline(&mut self.filter);
+                if ui.button("Close").clicked() {
+                    close = true;
+                }
+            });
+        if close {
+            self.open = false;
+        }
+    }
+}
+

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -17,6 +17,7 @@ mod toast_log_dialog;
 mod todo_dialog;
 mod todo_view_dialog;
 mod volume_dialog;
+mod convert_panel;
 
 pub use add_action_dialog::AddActionDialog;
 pub use add_bookmark_dialog::AddBookmarkDialog;
@@ -37,6 +38,7 @@ pub use toast_log_dialog::ToastLogDialog;
 pub use todo_dialog::TodoDialog;
 pub use todo_view_dialog::TodoViewDialog;
 pub use volume_dialog::VolumeDialog;
+pub use convert_panel::ConvertPanel;
 
 use crate::actions::folders;
 use crate::actions::{load_actions, Action};
@@ -172,6 +174,7 @@ enum Panel {
     VolumeDialog,
     BrightnessDialog,
     CpuListDialog,
+    ConvertPanel,
     ToastLogDialog,
     Editor,
     Settings,
@@ -200,6 +203,7 @@ struct PanelStates {
     volume_dialog: bool,
     brightness_dialog: bool,
     cpu_list_dialog: bool,
+    convert_panel: bool,
     toast_log_dialog: bool,
     editor: bool,
     settings: bool,
@@ -267,6 +271,7 @@ pub struct LauncherApp {
     volume_dialog: VolumeDialog,
     brightness_dialog: BrightnessDialog,
     cpu_list_dialog: CpuListDialog,
+    pub convert_panel: ConvertPanel,
     toast_log_dialog: ToastLogDialog,
     panel_stack: Vec<Panel>,
     panel_states: PanelStates,
@@ -585,6 +590,7 @@ impl LauncherApp {
             volume_dialog: VolumeDialog::default(),
             brightness_dialog: BrightnessDialog::default(),
             cpu_list_dialog: CpuListDialog::default(),
+            convert_panel: ConvertPanel::default(),
             toast_log_dialog: ToastLogDialog::default(),
             panel_stack: Vec::new(),
             panel_states: PanelStates::default(),
@@ -1144,6 +1150,10 @@ impl LauncherApp {
                 self.cpu_list_dialog.open = false;
                 self.panel_states.cpu_list_dialog = false;
             }
+            Panel::ConvertPanel => {
+                self.convert_panel.open = false;
+                self.panel_states.convert_panel = false;
+            }
             Panel::ToastLogDialog => {
                 self.toast_log_dialog.open = false;
                 self.panel_states.toast_log_dialog = false;
@@ -1245,6 +1255,11 @@ impl LauncherApp {
             self.cpu_list_dialog.open,
             cpu_list_dialog,
             Panel::CpuListDialog
+        );
+        check!(
+            self.convert_panel.open,
+            convert_panel,
+            Panel::ConvertPanel
         );
         check!(
             self.toast_log_dialog.open,
@@ -1575,6 +1590,8 @@ impl eframe::App for LauncherApp {
                             self.clipboard_dialog.open();
                         } else if a.action == "tempfile:dialog" {
                             self.tempfile_dialog.open();
+                        } else if a.action == "convert:panel" {
+                            self.convert_panel.open();
                         } else if a.action == "settings:dialog" {
                             self.show_settings = true;
                         } else if a.action == "volume:dialog" {
@@ -2229,6 +2246,8 @@ impl eframe::App for LauncherApp {
                             self.clipboard_dialog.open();
                         } else if a.action == "tempfile:dialog" {
                             self.tempfile_dialog.open();
+                        } else if a.action == "convert:panel" {
+                            self.convert_panel.open();
                         } else if a.action == "settings:dialog" {
                             self.show_settings = true;
                         } else if a.action == "volume:dialog" {
@@ -2528,6 +2547,9 @@ impl eframe::App for LauncherApp {
         let mut cpu_dlg = std::mem::take(&mut self.cpu_list_dialog);
         cpu_dlg.ui(ctx, self);
         self.cpu_list_dialog = cpu_dlg;
+        let mut convert_panel = std::mem::take(&mut self.convert_panel);
+        convert_panel.ui(ctx, self);
+        self.convert_panel = convert_panel;
         let mut toast_dlg = std::mem::take(&mut self.toast_log_dialog);
         toast_dlg.ui(ctx, self);
         self.toast_log_dialog = toast_dlg;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -34,6 +34,7 @@ use crate::plugins::stopwatch::StopwatchPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::unit_convert::UnitConvertPlugin;
 use crate::plugins::base_convert::BaseConvertPlugin;
+use crate::plugins::convert_panel::ConvertPanelPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 use crate::plugins::weather::WeatherPlugin;
@@ -142,6 +143,7 @@ impl PluginManager {
         self.register_with_settings(AsciiArtPlugin::default(), plugin_settings);
         self.register_with_settings(EmojiPlugin::default(), plugin_settings);
         self.register_with_settings(TextCasePlugin, plugin_settings);
+        self.register_with_settings(ConvertPanelPlugin, plugin_settings);
         self.register_with_settings(ScreenshotPlugin, plugin_settings);
         self.register_with_settings(TimestampPlugin, plugin_settings);
         self.register_with_settings(IpPlugin, plugin_settings);

--- a/src/plugins/convert_panel.rs
+++ b/src/plugins/convert_panel.rs
@@ -1,0 +1,53 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct ConvertPanelPlugin;
+
+impl Plugin for ConvertPanelPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let q = query.trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(q, "conv")
+            .or_else(|| crate::common::strip_prefix_ci(q, "convert"))
+        {
+            if rest.is_empty() || rest.starts_with(' ') {
+                return vec![Action {
+                    label: "Open convert panel".into(),
+                    desc: "Show convert panel".into(),
+                    action: "convert:panel".into(),
+                    args: None,
+                }];
+            }
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "convert_panel"
+    }
+
+    fn description(&self) -> &str {
+        "Open convert panel (prefix: `conv` or `convert`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "conv".into(),
+                desc: "Convert panel".into(),
+                action: "query:conv".into(),
+                args: None,
+            },
+            Action {
+                label: "convert".into(),
+                desc: "Convert panel".into(),
+                action: "query:convert".into(),
+                args: None,
+            },
+        ]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -40,3 +40,4 @@ pub mod text_case;
 pub mod timestamp;
 pub mod random;
 pub mod lorem;
+pub mod convert_panel;

--- a/tests/convert_panel_plugin.rs
+++ b/tests/convert_panel_plugin.rs
@@ -1,0 +1,61 @@
+use multi_launcher::actions::Action;
+use multi_launcher::gui::LauncherApp;
+use multi_launcher::plugin::{Plugin, PluginManager};
+use multi_launcher::plugins::convert_panel::ConvertPanelPlugin;
+use multi_launcher::settings::Settings;
+use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc};
+
+fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    plugins.reload_from_dirs(
+        &[],
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        &actions,
+    );
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn search_conv_opens_panel() {
+    let plugin = ConvertPanelPlugin;
+    let results = plugin.search("conv");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "convert:panel");
+
+    let ctx = egui::Context::default();
+    let actions: Vec<Action> = Vec::new();
+    let mut app = new_app(&ctx, actions);
+    app.query = "conv".into();
+    app.search();
+    let idx = app.results.iter().position(|a| a.action == "convert:panel").unwrap();
+    app.selected = Some(idx);
+    let launch_idx = app.handle_key(egui::Key::Enter);
+    assert_eq!(launch_idx, Some(idx));
+    if let Some(i) = launch_idx {
+        let a = app.results[i].clone();
+        if a.action == "convert:panel" {
+            app.convert_panel.open();
+        }
+    }
+    assert!(app.convert_panel.open);
+}


### PR DESCRIPTION
## Summary
- add `ConvertPanel` window with conversion fields
- add `convert_panel` plugin returning `convert:panel`
- wire convert panel into app and test prefix action

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688c00556e5c8332a0ef08f61920bc03