### PR TITLE
Add basic convert panel plugin and GUI

### DIFF
--- a/src/gui/convert_panel.rs
+++ b/src/gui/convert_panel.rs
@@ -1,0 +1,139 @@
+use crate::gui::LauncherApp;
+use eframe::egui;
+
+struct Category {
+    name: &'static str,
+    units: &'static [&'static str],
+}
+
+const CATEGORIES: &[Category] = &[
+    Category {
+        name: "Distance",
+        units: &["m", "km", "cm", "mm", "mi", "ft", "in", "yd", "nm"],
+    },
+    Category {
+        name: "Mass",
+        units: &["kg", "g", "lb", "oz"],
+    },
+    Category {
+        name: "Temperature",
+        units: &["c", "f", "k"],
+    },
+    Category {
+        name: "Volume",
+        units: &["l", "ml", "gal"],
+    },
+    Category {
+        name: "Base",
+        units: &["dec", "hex", "bin", "oct"],
+    },
+];
+
+/// Simple conversion panel with an input box and two combo boxes.
+pub struct ConvertPanel {
+    pub open: bool,
+    input: String,
+    filter: String,
+    category: String,
+    from: String,
+    to: String,
+    focus_input: bool,
+}
+
+impl Default for ConvertPanel {
+    fn default() -> Self {
+        Self {
+            open: false,
+            input: String::new(),
+            filter: String::new(),
+            category: CATEGORIES[0].name.to_string(),
+            from: String::new(),
+            to: String::new(),
+            focus_input: false,
+        }
+    }
+}
+
+impl ConvertPanel {
+    /// Open the panel.
+    pub fn open(&mut self) {
+        self.open = true;
+        self.focus_input = true;
+    }
+
+    /// Draw the panel UI when open.
+    pub fn ui(&mut self, ctx: &egui::Context, _app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut open = self.open;
+        let units = CATEGORIES
+            .iter()
+            .find(|c| c.name == self.category)
+            .map(|c| c.units)
+            .unwrap_or_default();
+        let filtered: Vec<&str> = units
+            .iter()
+            .copied()
+            .filter(|u| self.filter.is_empty() || u.contains(&self.filter))
+            .collect();
+        if (self.from.is_empty() || !units.contains(&self.from.as_str())) && !filtered.is_empty() {
+            self.from = filtered[0].to_string();
+        }
+        if (self.to.is_empty() || !units.contains(&self.to.as_str())) && !filtered.is_empty() {
+            self.to = filtered[0].to_string();
+        }
+        egui::Window::new("Convert")
+            .open(&mut open)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label("Value");
+                let val_edit = ui.text_edit_singleline(&mut self.input);
+                if self.focus_input {
+                    val_edit.request_focus();
+                    self.focus_input = false;
+                }
+                ui.label("Type");
+                let mut cat_changed = false;
+                egui::ComboBox::from_id_source("convert_category")
+                    .selected_text(&self.category)
+                    .show_ui(ui, |ui| {
+                        for cat in CATEGORIES {
+                            if ui
+                                .selectable_value(
+                                    &mut self.category,
+                                    cat.name.to_string(),
+                                    cat.name,
+                                )
+                                .changed()
+                            {
+                                cat_changed = true;
+                            }
+                        }
+                    });
+                if cat_changed {
+                    self.from.clear();
+                    self.to.clear();
+                }
+                ui.label("Filter");
+                ui.text_edit_singleline(&mut self.filter);
+                ui.horizontal(|ui| {
+                    egui::ComboBox::from_label("From")
+                        .selected_text(&self.from)
+                        .show_ui(ui, |ui| {
+                            for opt in &filtered {
+                                ui.selectable_value(&mut self.from, (*opt).to_string(), *opt);
+                            }
+                        });
+                    egui::ComboBox::from_label("To")
+                        .selected_text(&self.to)
+                        .show_ui(ui, |ui| {
+                            for opt in &filtered {
+                                ui.selectable_value(&mut self.to, (*opt).to_string(), *opt);
+                            }
+                        });
+                });
+            });
+        self.open = open;
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -16,6 +16,7 @@ mod timer_dialog;
 mod toast_log_dialog;
 mod todo_dialog;
 mod todo_view_dialog;
+mod convert_panel;
 mod volume_dialog;
 
 pub use add_action_dialog::AddActionDialog;
@@ -36,6 +37,7 @@ pub use timer_dialog::{TimerCompletionDialog, TimerDialog};
 pub use toast_log_dialog::ToastLogDialog;
 pub use todo_dialog::TodoDialog;
 pub use todo_view_dialog::TodoViewDialog;
+pub use convert_panel::ConvertPanel;
 pub use volume_dialog::VolumeDialog;
 
 use crate::actions::folders;
@@ -169,6 +171,7 @@ enum Panel {
     TodoDialog,
     TodoViewDialog,
     ClipboardDialog,
+    ConvertPanel,
     VolumeDialog,
     BrightnessDialog,
     CpuListDialog,
@@ -197,6 +200,7 @@ struct PanelStates {
     todo_dialog: bool,
     todo_view_dialog: bool,
     clipboard_dialog: bool,
+    convert_panel: bool,
     volume_dialog: bool,
     brightness_dialog: bool,
     cpu_list_dialog: bool,
@@ -264,6 +268,7 @@ pub struct LauncherApp {
     todo_dialog: TodoDialog,
     todo_view_dialog: TodoViewDialog,
     clipboard_dialog: ClipboardDialog,
+    convert_panel: ConvertPanel,
     volume_dialog: VolumeDialog,
     brightness_dialog: BrightnessDialog,
     cpu_list_dialog: CpuListDialog,
@@ -582,6 +587,7 @@ impl LauncherApp {
             todo_dialog: TodoDialog::default(),
             todo_view_dialog: TodoViewDialog::default(),
             clipboard_dialog: ClipboardDialog::default(),
+            convert_panel: ConvertPanel::default(),
             volume_dialog: VolumeDialog::default(),
             brightness_dialog: BrightnessDialog::default(),
             cpu_list_dialog: CpuListDialog::default(),
@@ -1132,6 +1138,10 @@ impl LauncherApp {
                 self.clipboard_dialog.open = false;
                 self.panel_states.clipboard_dialog = false;
             }
+            Panel::ConvertPanel => {
+                self.convert_panel.open = false;
+                self.panel_states.convert_panel = false;
+            }
             Panel::VolumeDialog => {
                 self.volume_dialog.open = false;
                 self.panel_states.volume_dialog = false;
@@ -1235,6 +1245,7 @@ impl LauncherApp {
             clipboard_dialog,
             Panel::ClipboardDialog
         );
+        check!(self.convert_panel.open, convert_panel, Panel::ConvertPanel);
         check!(self.volume_dialog.open, volume_dialog, Panel::VolumeDialog);
         check!(
             self.brightness_dialog.open,
@@ -1573,6 +1584,8 @@ impl eframe::App for LauncherApp {
                             }
                         } else if a.action == "clipboard:dialog" {
                             self.clipboard_dialog.open();
+                        } else if a.action == "convert:panel" {
+                            self.convert_panel.open();
                         } else if a.action == "tempfile:dialog" {
                             self.tempfile_dialog.open();
                         } else if a.action == "settings:dialog" {
@@ -2227,6 +2240,8 @@ impl eframe::App for LauncherApp {
                             }
                         } else if a.action == "clipboard:dialog" {
                             self.clipboard_dialog.open();
+                        } else if a.action == "convert:panel" {
+                            self.convert_panel.open();
                         } else if a.action == "tempfile:dialog" {
                             self.tempfile_dialog.open();
                         } else if a.action == "settings:dialog" {
@@ -2519,6 +2534,9 @@ impl eframe::App for LauncherApp {
         let mut cb_dlg = std::mem::take(&mut self.clipboard_dialog);
         cb_dlg.ui(ctx, self);
         self.clipboard_dialog = cb_dlg;
+        let mut conv_panel = std::mem::take(&mut self.convert_panel);
+        conv_panel.ui(ctx, self);
+        self.convert_panel = conv_panel;
         let mut vol_dlg = std::mem::take(&mut self.volume_dialog);
         vol_dlg.ui(ctx, self);
         self.volume_dialog = vol_dlg;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -45,6 +45,7 @@ use crate::plugins::ip::IpPlugin;
 use crate::plugins::timestamp::TimestampPlugin;
 use crate::plugins::random::RandomPlugin;
 use crate::plugins::lorem::LoremPlugin;
+use crate::plugins::convert_panel::ConvertPanelPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
 use std::collections::HashSet;
@@ -147,6 +148,7 @@ impl PluginManager {
         self.register_with_settings(IpPlugin, plugin_settings);
         self.register_with_settings(RandomPlugin::default(), plugin_settings);
         self.register_with_settings(LoremPlugin, plugin_settings);
+        self.register_with_settings(ConvertPanelPlugin, plugin_settings);
         #[cfg(target_os = "windows")]
         {
             self.register_with_settings(VolumePlugin, plugin_settings);

--- a/src/plugins/convert_panel.rs
+++ b/src/plugins/convert_panel.rs
@@ -1,0 +1,52 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+/// Plugin exposing the interactive convert panel.
+pub struct ConvertPanelPlugin;
+
+impl Plugin for ConvertPanelPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if crate::common::strip_prefix_ci(trimmed, "convert").is_some()
+            || crate::common::strip_prefix_ci(trimmed, "conv").is_some()
+        {
+            return vec![Action {
+                label: "conv: open convert panel".into(),
+                desc: "Convert".into(),
+                action: "convert:panel".into(),
+                args: None,
+            }];
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "convert_panel"
+    }
+
+    fn description(&self) -> &str {
+        "Open the conversion panel (prefix: `conv` or `convert`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "conv".into(),
+                desc: "Convert".into(),
+                action: "query:conv ".into(),
+                args: None,
+            },
+            Action {
+                label: "convert".into(),
+                desc: "Convert".into(),
+                action: "query:convert ".into(),
+                args: None,
+            },
+        ]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -40,3 +40,4 @@ pub mod text_case;
 pub mod timestamp;
 pub mod random;
 pub mod lorem;
+pub mod convert_panel;

--- a/tests/convert_panel_plugin.rs
+++ b/tests/convert_panel_plugin.rs
@@ -1,0 +1,19 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::convert_panel::ConvertPanelPlugin;
+
+#[test]
+fn search_conv_prefix() {
+    let plugin = ConvertPanelPlugin;
+    let results = plugin.search("conv");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "convert:panel");
+}
+
+#[test]
+fn search_convert_prefix() {
+    let plugin = ConvertPanelPlugin;
+    let results = plugin.search("convert");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "convert:panel");
+}
+


### PR DESCRIPTION
## Summary
- add simple conversion panel UI with filterable from/to combos
- support `conv`/`convert` prefix opening panel via new plugin
- wire convert panel into launcher and plugin manager with tests
- filter conversion units by category and include bases like hex/bin
- ensure convert panel input gets focus when opened

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688c00556e5c8332a0ef08f61920bc03