### PR TITLE
test: verify tempfile removal refreshes results

### DIFF
--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -104,6 +104,22 @@ fn launch_action_remove_deletes_file() {
 }
 
 #[test]
+fn rm_refreshes_results() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let file = create_file().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp rm");
+    assert_eq!(results.len(), 1);
+    launch_action(&results[0]).unwrap();
+    let results = plugin.search("tmp rm");
+    assert!(results.is_empty());
+    assert!(!file.exists());
+}
+
+#[test]
 fn set_alias_renames_file() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- ensure tempfile removal results trigger a refresh and search update
- add regression test asserting `tmp rm` removes file from results

## Testing
- `cargo test rm_refreshes_results --test tempfile_plugin`
- `cargo test` *(fails: actions_watcher_sends_event, bookmarks_watcher_sends_event, folders_watcher_sends_event)*

------
https://chatgpt.com/codex/tasks/task_e_688c196aa424833287f2dd76e64e44a3