### PR TITLE
Handle trailing commas in todo tags

### DIFF
--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -61,9 +61,14 @@ impl TodoDialog {
         let tag_list: Vec<String> = self
             .tags
             .split(',')
-            .map(|t| t.trim())
-            .filter(|t| !t.is_empty())
-            .map(|t| t.to_string())
+            .filter_map(|t| {
+                let t = t.trim();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_owned())
+                }
+            })
             .collect();
         tracing::debug!("Adding todo: '{}' tags={:?}", self.text, tag_list);
         self.entries.push(TodoEntry {
@@ -78,6 +83,22 @@ impl TodoDialog {
             self.tags.clear();
         }
         true
+    }
+
+    pub fn test_set_text(&mut self, text: &str) {
+        self.text = text.to_owned();
+    }
+
+    pub fn test_set_tags(&mut self, tags: &str) {
+        self.tags = tags.to_owned();
+    }
+
+    pub fn test_entries(&self) -> &Vec<TodoEntry> {
+        &self.entries
+    }
+
+    pub fn test_add_todo(&mut self) -> bool {
+        self.add_todo()
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {

--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -31,3 +31,31 @@ fn empty_filter_returns_all() {
     assert_eq!(idx, vec![0, 1]);
 }
 
+#[test]
+fn add_todo_parses_multiple_tags() {
+    let mut dlg = TodoDialog::default();
+    dlg.test_set_text("task");
+    dlg.test_set_tags("alpha, beta, gamma");
+    assert!(dlg.test_add_todo());
+    assert_eq!(
+        dlg.test_entries()[0].tags,
+        vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "gamma".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn add_todo_ignores_trailing_comma() {
+    let mut dlg = TodoDialog::default();
+    dlg.test_set_text("task");
+    dlg.test_set_tags("alpha, beta,");
+    assert!(dlg.test_add_todo());
+    assert_eq!(
+        dlg.test_entries()[0].tags,
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+}
+


### PR DESCRIPTION
## Summary
- robustly parse comma-separated tags in the todo dialog, trimming whitespace and skipping empties
- add test helpers and cover multiple tag and trailing-comma scenarios

## Testing
- `cargo test --test todo_dialog`


------
https://chatgpt.com/codex/tasks/task_e_688c19721ed883329b5b1433a1fb4e92