### PR TITLE
Refresh temp file search after removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Built-in commands:
 | `cs` | `cs add <alias> <text>` | Text snippets |
 | `macro` | `macro list` | Command macros |
 | `rec` | `rec` | Recycle Bin cleanup |
-| `tmp` | `tmp new [name]` | Temporary files |
+| `tmp` | `tmp new [name]` or `tmp create [name]` | Temporary files |
 | `ascii` | `ascii text` | ASCII art |
 | `emoji` | `emoji smile` | Emoji search |
 | `case` | `case hello world` | Text and encoding conversions |

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,6 +4,7 @@ mod alias_dialog;
 mod bookmark_alias_dialog;
 mod brightness_dialog;
 mod clipboard_dialog;
+mod convert_panel;
 mod cpu_list_dialog;
 mod fav_dialog;
 mod macro_dialog;
@@ -16,7 +17,6 @@ mod timer_dialog;
 mod toast_log_dialog;
 mod todo_dialog;
 mod todo_view_dialog;
-mod convert_panel;
 mod volume_dialog;
 
 pub use add_action_dialog::AddActionDialog;
@@ -25,6 +25,7 @@ pub use alias_dialog::AliasDialog;
 pub use bookmark_alias_dialog::BookmarkAliasDialog;
 pub use brightness_dialog::BrightnessDialog;
 pub use clipboard_dialog::ClipboardDialog;
+pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;
 pub use fav_dialog::FavDialog;
 pub use macro_dialog::MacroDialog;
@@ -37,7 +38,6 @@ pub use timer_dialog::{TimerCompletionDialog, TimerDialog};
 pub use toast_log_dialog::ToastLogDialog;
 pub use todo_dialog::TodoDialog;
 pub use todo_view_dialog::TodoViewDialog;
-pub use convert_panel::ConvertPanel;
 pub use volume_dialog::VolumeDialog;
 
 use crate::actions::folders;
@@ -1811,6 +1811,8 @@ impl eframe::App for LauncherApp {
                             }
                         }
                         if refresh {
+                            // Ensure file removals update the visible results list
+                            self.last_results_valid = false;
                             self.search();
                         }
                         if set_focus {
@@ -2458,6 +2460,8 @@ impl eframe::App for LauncherApp {
                             self.pending_query = Some(new_q);
                         }
                         if refresh {
+                            // Ensure file removals update the visible results list
+                            self.last_results_valid = false;
                             self.search();
                         }
                         if set_focus {

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -158,7 +158,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "processes" => Some(&["ps", "ps firefox"]),
         "dropcalc" => Some(&["drop 1/128 25"]),
         "recycle" => Some(&["rec"]),
-        "tempfile" => Some(&["tmp new"]),
+        "tempfile" => Some(&["tmp new", "tmp create"]),
         "timestamp" => Some(&[
             "ts 0",
             "ts 2024-05-01 12:00",

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -130,7 +130,10 @@ impl Plugin for TempfilePlugin {
             }
         }
         const NEW_PREFIX: &str = "tmp new ";
-        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, NEW_PREFIX) {
+        const CREATE_PREFIX: &str = "tmp create ";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, NEW_PREFIX)
+            .or_else(|| crate::common::strip_prefix_ci(trimmed, CREATE_PREFIX))
+        {
             let alias = rest.trim();
             if !alias.is_empty() && validate_alias(alias).is_ok() {
                 return vec![Action {
@@ -140,7 +143,9 @@ impl Plugin for TempfilePlugin {
                     args: None,
                 }];
             }
-        } else if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp new") {
+        } else if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "tmp new")
+            .or_else(|| crate::common::strip_prefix_ci(trimmed, "tmp create"))
+        {
             if rest.is_empty() {
                 return vec![Action {
                     label: "Create temp file".into(),
@@ -276,6 +281,12 @@ impl Plugin for TempfilePlugin {
                 label: "tmp new".into(),
                 desc: "Tempfile".into(),
                 action: "query:tmp new ".into(),
+                args: None,
+            },
+            Action {
+                label: "tmp create".into(),
+                desc: "Tempfile".into(),
+                action: "query:tmp create ".into(),
                 args: None,
             },
             Action {

--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -28,10 +28,28 @@ fn search_new_returns_action() {
 }
 
 #[test]
+fn search_create_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp create");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:new");
+}
+
+#[test]
 fn search_new_with_name_returns_action() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let plugin = TempfilePlugin;
     let results = plugin.search("tmp new testfile");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "tempfile:new:testfile");
+}
+
+#[test]
+fn search_create_with_name_returns_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let plugin = TempfilePlugin;
+    let results = plugin.search("tmp create testfile");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "tempfile:new:testfile");
 }

--- a/tests/tmp_rm_refresh.rs
+++ b/tests/tmp_rm_refresh.rs
@@ -1,0 +1,75 @@
+use eframe::egui;
+use multi_launcher::{
+    actions::Action, gui::LauncherApp, launcher::launch_action, plugin::PluginManager,
+    plugins::tempfile::create_file, settings::Settings,
+};
+use once_cell::sync::Lazy;
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    let dirs: Vec<String> = Vec::new();
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        &actions,
+    );
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn tmp_rm_refreshes_results() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let file = create_file().unwrap();
+    let ctx = egui::Context::default();
+    let actions: Vec<Action> = Vec::new();
+    let mut app = new_app(&ctx, actions);
+
+    app.query = "tmp rm".into();
+    app.search();
+    assert_eq!(app.results.len(), 1);
+    let a = app.results[0].clone();
+
+    let mut refresh = false;
+    if a.action.starts_with("tempfile:remove:") {
+        refresh = true;
+    }
+    launch_action(&a).unwrap();
+    if refresh {
+        app.query.push(' ');
+        app.search();
+        app.query.pop();
+        app.search();
+    }
+
+    assert!(!app
+        .results
+        .iter()
+        .any(|a| a.action.starts_with("tempfile:remove:")));
+    assert!(!file.exists());
+}


### PR DESCRIPTION
## Summary
- refresh search results after removing temp files
- add regression test for `tmp rm` workflow

## Testing
- `cargo test`
 