### PR TITLE
Handle trailing commas in todo tags

### DIFF
--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -60,15 +60,12 @@ impl TodoDialog {
         }
         let tag_list: Vec<String> = self
             .tags
+            .trim()
+            .trim_end_matches(',')
             .split(',')
-            .filter_map(|t| {
-                let t = t.trim();
-                if t.is_empty() {
-                    None
-                } else {
-                    Some(t.to_owned())
-                }
-            })
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_owned())
             .collect();
         tracing::debug!("Adding todo: '{}' tags={:?}", self.text, tag_list);
         self.entries.push(TodoEntry {

--- a/tests/todo_dialog.rs
+++ b/tests/todo_dialog.rs
@@ -35,7 +35,7 @@ fn empty_filter_returns_all() {
 fn add_todo_parses_multiple_tags() {
     let mut dlg = TodoDialog::default();
     dlg.test_set_text("task");
-    dlg.test_set_tags("alpha, beta, gamma");
+    dlg.test_set_tags("alpha, beta, gamma, delta");
     assert!(dlg.test_add_todo());
     assert_eq!(
         dlg.test_entries()[0].tags,
@@ -43,6 +43,7 @@ fn add_todo_parses_multiple_tags() {
             "alpha".to_string(),
             "beta".to_string(),
             "gamma".to_string(),
+            "delta".to_string(),
         ]
     );
 }
@@ -51,11 +52,16 @@ fn add_todo_parses_multiple_tags() {
 fn add_todo_ignores_trailing_comma() {
     let mut dlg = TodoDialog::default();
     dlg.test_set_text("task");
-    dlg.test_set_tags("alpha, beta,");
+    dlg.test_set_tags("alpha, beta, gamma, delta,");
     assert!(dlg.test_add_todo());
     assert_eq!(
         dlg.test_entries()[0].tags,
-        vec!["alpha".to_string(), "beta".to_string()]
+        vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+            "gamma".to_string(),
+            "delta".to_string(),
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary
- trim todo tag input, drop trailing commas, and ignore empty values
- expand todo dialog tests for multiple tags and trailing comma cases

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e600ece5c8332b0942dbed3a8b8c1