### PR TITLE
Avoid cloning history during search

### DIFF
--- a/src/plugins/history.rs
+++ b/src/plugins/history.rs
@@ -1,5 +1,5 @@
 use crate::actions::Action;
-use crate::history::get_history;
+use crate::history::with_history;
 use crate::plugin::Plugin;
 use eframe::egui;
 
@@ -36,18 +36,20 @@ impl Plugin for HistoryPlugin {
             }
         }
         let filter = rest.trim().to_lowercase();
-        get_history()
-            .into_iter()
-            .enumerate()
-            .filter(|(_, entry)| entry.query_lc.contains(&filter))
-            .take(MAX_HISTORY_RESULTS)
-            .map(|(idx, entry)| Action {
-                label: entry.query,
-                desc: "History".into(),
-                action: format!("history:{idx}"),
-                args: None,
-            })
-            .collect()
+        with_history(|h| {
+            h.iter()
+                .enumerate()
+                .filter(|(_, entry)| entry.query_lc.contains(&filter))
+                .take(MAX_HISTORY_RESULTS)
+                .map(|(idx, entry)| Action {
+                    label: entry.query.clone(),
+                    desc: "History".into(),
+                    action: format!("history:{idx}"),
+                    args: None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
     }
 
     fn name(&self) -> &str {


### PR DESCRIPTION
## Summary
- add `with_history` helper to access history entries without cloning
- refactor HistoryPlugin to iterate over history directly
- expose a cloning `get_history` built on the new helper

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e75dda774833291240c80faf5b709