### PR TITLE
Use Arc for OmniSearchPlugin actions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,13 +50,14 @@ fn spawn_gui(
     let mut plugins = PluginManager::new();
     let empty_dirs = Vec::new();
     let dirs = settings.plugin_dirs.as_ref().unwrap_or(&empty_dirs);
+    let actions_arc = Arc::new(actions_for_window.clone());
     plugins.reload_from_dirs(
         dirs,
         settings.clipboard_limit,
         settings.net_unit,
         true,
         &settings.plugin_settings,
-        &actions_for_window,
+        actions_arc,
     );
 
     let actions_path = "actions.json".to_string();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -49,6 +49,7 @@ use crate::plugins::convert_panel::ConvertPanelPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
 use std::collections::HashSet;
+use std::sync::Arc;
 use libloading::Library;
 use serde_json::Value;
 use eframe::egui;
@@ -107,7 +108,7 @@ impl PluginManager {
         net_unit: NetUnit,
         reset_alarm: bool,
         plugin_settings: &std::collections::HashMap<String, Value>,
-        actions: &[Action],
+        actions: Arc<Vec<Action>>,
     ) {
         self.clear_plugins();
         // Drop previously loaded dynamic libraries to avoid accumulating
@@ -125,7 +126,7 @@ impl PluginManager {
         self.register_with_settings(ClipboardPlugin::new(clipboard_limit), plugin_settings);
         self.register_with_settings(BookmarksPlugin::default(), plugin_settings);
         self.register_with_settings(FoldersPlugin::default(), plugin_settings);
-        self.register_with_settings(OmniSearchPlugin::new(actions.to_vec()), plugin_settings);
+        self.register_with_settings(OmniSearchPlugin::new(actions.clone()), plugin_settings);
         self.register_with_settings(SystemPlugin, plugin_settings);
         self.register_with_settings(ProcessesPlugin, plugin_settings);
         self.register_with_settings(SysInfoPlugin, plugin_settings);

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -3,6 +3,7 @@ use crate::plugin::PluginManager;
 use crate::settings::Settings;
 use eframe::egui;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Default)]
 
@@ -50,7 +51,7 @@ impl PluginEditor {
             Settings::default().net_unit,
             false,
             &std::collections::HashMap::new(),
-            &[],
+            Arc::new(Vec::new()),
         );
         let mut infos = pm.plugin_infos();
         infos.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
@@ -126,13 +127,14 @@ impl PluginEditor {
                         None,
                     );
                     let dirs = s.plugin_dirs.clone().unwrap_or_default();
+                    let actions_arc = Arc::new(app.actions.clone());
                     app.plugins.reload_from_dirs(
                         &dirs,
                         app.clipboard_limit,
                         app.net_unit,
                         false,
                         &s.plugin_settings,
-                        &app.actions,
+                        actions_arc,
                     );
                     tracing::debug!(available=?app.plugins.plugin_names(), "plugins reloaded");
                     self.available = Self::gather_available(&dirs);

--- a/src/plugins/macros.rs
+++ b/src/plugins/macros.rs
@@ -77,13 +77,14 @@ fn search_first_action(query: &str) -> Option<Action> {
     let actions = load_actions("actions.json").unwrap_or_default();
     let mut pm = PluginManager::new();
     let dirs = settings.plugin_dirs.unwrap_or_default();
+    let actions_arc = Arc::new(actions);
     pm.reload_from_dirs(
         &dirs,
         settings.clipboard_limit,
         settings.net_unit,
         false,
         &settings.plugin_settings,
-        &actions,
+        actions_arc,
     );
     pm.search_filtered(
         query,

--- a/src/plugins/omni_search.rs
+++ b/src/plugins/omni_search.rs
@@ -4,16 +4,17 @@ use crate::plugins::bookmarks::BookmarksPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use std::sync::Arc;
 
 pub struct OmniSearchPlugin {
     folders: FoldersPlugin,
     bookmarks: BookmarksPlugin,
-    actions: Vec<Action>,
+    actions: Arc<Vec<Action>>,
     matcher: SkimMatcherV2,
 }
 
 impl OmniSearchPlugin {
-    pub fn new(actions: Vec<Action>) -> Self {
+    pub fn new(actions: Arc<Vec<Action>>) -> Self {
         Self {
             folders: FoldersPlugin::default(),
             bookmarks: BookmarksPlugin::default(),
@@ -81,7 +82,7 @@ impl OmniSearchPlugin {
         if q.is_empty() {
             out.extend(self.actions.iter().cloned());
         } else {
-            for a in &self.actions {
+            for a in self.actions.iter() {
                 if self.matcher.fuzzy_match(&a.label, q).is_some()
                     || self.matcher.fuzzy_match(&a.desc, q).is_some()
                 {

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,6 +1,7 @@
 use crate::gui::LauncherApp;
 use crate::hotkey::parse_hotkey;
 use crate::settings::Settings;
+use std::sync::Arc;
 use eframe::egui;
 use egui_toast::{Toast, ToastKind, ToastOptions};
 #[cfg(target_os = "windows")]
@@ -549,13 +550,14 @@ impl SettingsEditor {
                                                 .plugin_dirs
                                                 .clone()
                                                 .unwrap_or_default();
+                                            let actions_arc = Arc::new(app.actions.clone());
                                             app.plugins.reload_from_dirs(
                                                 &dirs,
                                                 app.clipboard_limit,
                                                 app.net_unit,
                                                 false,
                                                 &new_settings.plugin_settings,
-                                                &app.actions,
+                                                actions_arc,
                                             );
                                             crate::request_hotkey_restart(new_settings);
                                             if app.enable_toasts {

--- a/tests/omni_search_plugin.rs
+++ b/tests/omni_search_plugin.rs
@@ -1,5 +1,6 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::omni_search::OmniSearchPlugin;
+use std::sync::Arc;
 use multi_launcher::plugins::bookmarks::{save_bookmarks, BookmarkEntry, BOOKMARKS_FILE};
 use multi_launcher::plugins::folders::{save_folders, FolderEntry, FOLDERS_FILE};
 use multi_launcher::actions::Action;
@@ -18,7 +19,7 @@ fn o_list_combines_all_sources() {
     save_bookmarks(BOOKMARKS_FILE, &[BookmarkEntry { url: "https://example.com".into(), alias: None }]).unwrap();
     save_folders(FOLDERS_FILE, &[FolderEntry { label: "Foo".into(), path: "/foo".into(), alias: None }]).unwrap();
 
-    let actions = vec![Action { label: "myapp".into(), desc: "app".into(), action: "myapp".into(), args: None }];
+    let actions = Arc::new(vec![Action { label: "myapp".into(), desc: "app".into(), action: "myapp".into(), args: None }]);
     let plugin = OmniSearchPlugin::new(actions);
 
     let results = plugin.search("o list");
@@ -37,7 +38,7 @@ fn o_list_filters_results() {
     save_bookmarks(BOOKMARKS_FILE, &[BookmarkEntry { url: "https://example.com".into(), alias: None }]).unwrap();
     save_folders(FOLDERS_FILE, &[FolderEntry { label: "Foo".into(), path: "/foo".into(), alias: None }]).unwrap();
 
-    let actions = vec![Action { label: "barapp".into(), desc: "app".into(), action: "bar".into(), args: None }];
+    let actions = Arc::new(vec![Action { label: "barapp".into(), desc: "app".into(), action: "bar".into(), args: None }]);
     let plugin = OmniSearchPlugin::new(actions);
 
     let results = plugin.search("o list bar");

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -9,13 +9,14 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,
@@ -44,13 +45,14 @@ fn new_app_with_settings(
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
     let plugin_settings = settings.plugin_settings.clone();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &dirs,
         settings.clipboard_limit,
         settings.net_unit,
         false,
         &plugin_settings,
-        &actions,
+        actions_arc,
     );
     let enabled_plugins = settings.enabled_plugins.clone();
     LauncherApp::new(

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -1,4 +1,5 @@
 use eframe::egui;
+use multi_launcher::actions::Action;
 use multi_launcher::gui::LauncherApp;
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::plugins::bookmarks::{save_bookmarks, BookmarkEntry, BOOKMARKS_FILE};
@@ -14,13 +15,14 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
     let custom_len = 0;
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
+    let actions_arc: Arc<Vec<Action>> = Arc::new(Vec::new());
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &[],
+        actions_arc,
     );
     LauncherApp::new(
         ctx,

--- a/tests/settings_plugin.rs
+++ b/tests/settings_plugin.rs
@@ -7,13 +7,14 @@ use eframe::egui;
 fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,

--- a/tests/stopwatch_refresh.rs
+++ b/tests/stopwatch_refresh.rs
@@ -10,13 +10,14 @@ fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
     let actions: Vec<Action> = Vec::new();
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,

--- a/tests/timer_refresh.rs
+++ b/tests/timer_refresh.rs
@@ -9,13 +9,14 @@ fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
     let actions: Vec<Action> = Vec::new();
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,

--- a/tests/tmp_rm_refresh.rs
+++ b/tests/tmp_rm_refresh.rs
@@ -13,13 +13,14 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -9,13 +9,14 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
+    let actions_arc = Arc::new(actions.clone());
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        &actions,
+        actions_arc,
     );
     LauncherApp::new(
         ctx,


### PR DESCRIPTION
## Summary
- store actions in `Arc<Vec<Action>>` in `OmniSearchPlugin`
- take `Arc` in `PluginManager::reload_from_dirs` and forward clone to plugin
- update call sites and tests to pass shared action lists

## Testing
- `cargo test --test plugin_commands -q`
- `cargo test --test settings_plugin -q`
- `cargo test --test tmp_rm_refresh -q`
- `cargo test --test web_search_prefix -q`
- `cargo test --test plugin_exact_match -q`
- `cargo test --test stopwatch_refresh -q`
- `cargo test --test timer_refresh -q`


------
https://chatgpt.com/codex/tasks/task_e_688e874205dc8332a00969998a20a25f