### PR TITLE
Refresh todo list after toggling items

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1706,6 +1706,9 @@ impl eframe::App for LauncherApp {
                             } else if a.action.starts_with("todo:done:") {
                                 refresh = true;
                                 set_focus = true;
+                                // Re-run the current query so the todo list reflects the
+                                // updated completion state immediately.
+                                self.pending_query = Some(current.clone());
                                 if self.enable_toasts {
                                     let label = a
                                         .label
@@ -2294,7 +2297,7 @@ impl eframe::App for LauncherApp {
                                     if a.action != "help:show" {
                                         let _ = history::append_history(
                                             HistoryEntry {
-                                                query: current,
+                                                query: current.clone(),
                                                 query_lc: String::new(),
                                                 action: a.clone(),
                                             },
@@ -2370,6 +2373,9 @@ impl eframe::App for LauncherApp {
                                     } else if a.action.starts_with("todo:done:") {
                                         refresh = true;
                                         set_focus = true;
+                                        // Re-run the current query so the visible list refreshes
+                                        // with the toggled completion state.
+                                        clicked_query = Some(current.clone());
                                         if self.enable_toasts {
                                             let label = a
                                                 .label

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -4,6 +4,7 @@ use crate::plugin::Plugin;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use serde::{Deserialize, Serialize};
+use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
 
 pub const TODO_FILE: &str = "todo.json";
@@ -17,6 +18,9 @@ pub struct TodoEntry {
     #[serde(default)]
     pub tags: Vec<String>,
 }
+
+pub static TODO_DATA: Lazy<Arc<Mutex<Vec<TodoEntry>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(load_todos(TODO_FILE).unwrap_or_default())));
 
 /// Sort todo entries by priority descending (highest priority first).
 pub fn sort_by_priority_desc(entries: &mut Vec<TodoEntry>) {
@@ -40,6 +44,12 @@ pub fn save_todos(path: &str, todos: &[TodoEntry]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn update_cache(list: Vec<TodoEntry>) {
+    if let Ok(mut lock) = TODO_DATA.lock() {
+        *lock = list;
+    }
+}
+
 /// Append a new todo entry with `text`, `priority` and `tags`.
 pub fn append_todo(path: &str, text: &str, priority: u8, tags: &[String]) -> anyhow::Result<()> {
     let mut list = load_todos(path).unwrap_or_default();
@@ -49,7 +59,9 @@ pub fn append_todo(path: &str, text: &str, priority: u8, tags: &[String]) -> any
         priority,
         tags: tags.to_vec(),
     });
-    save_todos(path, &list)
+    save_todos(path, &list)?;
+    update_cache(list);
+    Ok(())
 }
 
 /// Remove the todo at `index` from the list stored at `path`.
@@ -58,6 +70,7 @@ pub fn remove_todo(path: &str, index: usize) -> anyhow::Result<()> {
     if index < list.len() {
         list.remove(index);
         save_todos(path, &list)?;
+        update_cache(list);
     }
     Ok(())
 }
@@ -68,6 +81,7 @@ pub fn mark_done(path: &str, index: usize) -> anyhow::Result<()> {
     if let Some(entry) = list.get_mut(index) {
         entry.done = !entry.done;
         save_todos(path, &list)?;
+        update_cache(list);
     }
     Ok(())
 }
@@ -78,6 +92,7 @@ pub fn set_priority(path: &str, index: usize, priority: u8) -> anyhow::Result<()
     if let Some(entry) = list.get_mut(index) {
         entry.priority = priority;
         save_todos(path, &list)?;
+        update_cache(list);
     }
     Ok(())
 }
@@ -88,6 +103,7 @@ pub fn set_tags(path: &str, index: usize, tags: &[String]) -> anyhow::Result<()>
     if let Some(entry) = list.get_mut(index) {
         entry.tags = tags.to_vec();
         save_todos(path, &list)?;
+        update_cache(list);
     }
     Ok(())
 }
@@ -99,6 +115,7 @@ pub fn clear_done(path: &str) -> anyhow::Result<()> {
     list.retain(|e| !e.done);
     if list.len() != orig_len {
         save_todos(path, &list)?;
+        update_cache(list);
     }
     Ok(())
 }
@@ -113,12 +130,11 @@ pub struct TodoPlugin {
 impl TodoPlugin {
     /// Create a new todo plugin with a fuzzy matcher.
     pub fn new() -> Self {
-        let data = Arc::new(Mutex::new(load_todos(TODO_FILE).unwrap_or_default()));
-        let data_clone = data.clone();
-        let path = TODO_FILE.to_string();
-        let watch_path = path.clone();
+        let data = TODO_DATA.clone();
+        let watch_path = TODO_FILE.to_string();
         let watcher = watch_json(&watch_path, {
             let watch_path = watch_path.clone();
+            let data_clone = data.clone();
             move || {
                 if let Ok(list) = load_todos(&watch_path) {
                     if let Ok(mut lock) = data_clone.lock() {

--- a/src/plugins/todo.rs
+++ b/src/plugins/todo.rs
@@ -1,3 +1,10 @@
+//! Todo plugin and helpers.
+//!
+//! `TODO_DATA` is a process-wide cache of todos loaded from `todo.json`.
+//! Any operation that writes to disk updates this cache, and a `JsonWatcher`
+//! refreshes it when the file changes externally. This keeps plugin state and
+//! tests synchronized with the latest on-disk data.
+
 use crate::actions::Action;
 use crate::common::json_watch::{watch_json, JsonWatcher};
 use crate::plugin::Plugin;
@@ -19,6 +26,9 @@ pub struct TodoEntry {
     pub tags: Vec<String>,
 }
 
+/// Shared in-memory todo cache kept in sync with `todo.json`.
+/// Disk writes and the [`JsonWatcher`] ensure updates are visible immediately
+/// to all plugin instances and tests.
 pub static TODO_DATA: Lazy<Arc<Mutex<Vec<TodoEntry>>>> =
     Lazy::new(|| Arc::new(Mutex::new(load_todos(TODO_FILE).unwrap_or_default())));
 

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -104,6 +104,24 @@ fn mark_done_toggles_status() {
 }
 
 #[test]
+fn search_reflects_done_state_immediately() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    append_todo(TODO_FILE, "task", 0, &[]).unwrap();
+    let plugin = TodoPlugin::default();
+
+    mark_done(TODO_FILE, 0).unwrap();
+    let results = plugin.search("todo list");
+    assert!(results[0].label.starts_with("[x]"));
+
+    mark_done(TODO_FILE, 0).unwrap();
+    let results = plugin.search("todo list");
+    assert!(results[0].label.starts_with("[ ]"));
+}
+
+#[test]
 fn set_priority_and_tags_update_entry() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- keep a shared todo cache to reflect file edits immediately
- refresh todo list results after toggling items
- test that the list shows the updated done state instantly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e8bda88848332b68cf38c6314bdfa