### PR TITLE
Add Windows browser tabs plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ windows = { version = "0.58", features = [
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_System_Com",
+    "Win32_System_Variant",
+    "Win32_UI_Accessibility",
     "Win32_Media_Audio",
     "Win32_Media_Audio_Endpoints",
     "Win32_Graphics_Gdi",

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -71,3 +71,46 @@ pub fn recycle_clean() {
     #[cfg(target_os = "windows")]
     super::super::launcher::clean_recycle_bin();
 }
+
+#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+pub fn browser_tab_switch(title: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+            COINIT_APARTMENTTHREADED,
+        };
+        use windows::Win32::UI::Accessibility::*;
+
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            if let Ok(automation) =
+                CoCreateInstance::<_, IUIAutomation>(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
+            {
+                if let Ok(root) = automation.GetRootElement() {
+                    use windows::core::VARIANT;
+                    if let Ok(cond) = automation.CreatePropertyCondition(
+                        UIA_ControlTypePropertyId,
+                        &VARIANT::from(UIA_TabItemControlTypeId.0),
+                    ) {
+                        if let Ok(tabs) = root.FindAll(TreeScope_Subtree, &cond) {
+                            if let Ok(count) = tabs.Length() {
+                                for i in 0..count {
+                                    if let Ok(elem) = tabs.GetElement(i) {
+                                        if let Ok(name) = elem.CurrentName() {
+                                            if name.to_string() == title {
+                                                let _ = elem.SetFocus();
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            CoUninitialize();
+        }
+    }
+}

--- a/src/gui/volume_dialog.rs
+++ b/src/gui/volume_dialog.rs
@@ -3,7 +3,7 @@ use crate::gui::LauncherApp;
 use crate::launcher::launch_action;
 use eframe::egui;
 #[cfg(target_os = "windows")]
-use sysinfo::{Pid, System};
+use sysinfo::System;
 
 pub struct VolumeDialog {
     pub open: bool,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -40,6 +40,8 @@ use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::wikipedia::WikipediaPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::windows::WindowsPlugin;
+#[cfg(target_os = "windows")]
+use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::ip::IpPlugin;
 use crate::plugins::timestamp::TimestampPlugin;
@@ -156,6 +158,7 @@ impl PluginManager {
             self.register_with_settings(BrightnessPlugin, plugin_settings);
             self.register_with_settings(TaskManagerPlugin, plugin_settings);
             self.register_with_settings(WindowsPlugin, plugin_settings);
+            self.register_with_settings(BrowserTabsPlugin, plugin_settings);
         }
         self.register_with_settings(SettingsPlugin, plugin_settings);
         self.register_with_settings(HelpPlugin, plugin_settings);

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -1,0 +1,168 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct BrowserTabsPlugin;
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Mutex, RwLock};
+    use std::time::{Duration, Instant};
+
+    #[derive(Clone)]
+    struct TabInfo {
+        title: String,
+        url: String,
+    }
+
+    static CACHE: Lazy<RwLock<Vec<TabInfo>>> = Lazy::new(|| RwLock::new(Vec::new()));
+    static LAST_REFRESH: Lazy<Mutex<Instant>> =
+        Lazy::new(|| Mutex::new(Instant::now() - Duration::from_secs(60)));
+    static REFRESHING: AtomicBool = AtomicBool::new(false);
+
+    fn enumerate_tabs() -> Vec<TabInfo> {
+        use windows::core::{BSTR, VARIANT};
+        use windows::Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+            COINIT_APARTMENTTHREADED,
+        };
+        use windows::Win32::UI::Accessibility::*;
+
+        let mut out = Vec::new();
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            if let Ok(automation) =
+                CoCreateInstance::<_, IUIAutomation>(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
+            {
+                if let Ok(root) = automation.GetRootElement() {
+                    if let Ok(cond) = automation.CreatePropertyCondition(
+                        UIA_ControlTypePropertyId,
+                        &VARIANT::from(UIA_TabItemControlTypeId.0),
+                    ) {
+                        if let Ok(tabs) = root.FindAll(TreeScope_Subtree, &cond) {
+                            if let Ok(count) = tabs.Length() {
+                                for i in 0..count {
+                                    if let Ok(elem) = tabs.GetElement(i) {
+                                        let title = elem.CurrentName().unwrap_or_default().to_string();
+                                        let mut url = String::new();
+                                        if let Ok(var) = elem
+                                            .GetCurrentPropertyValue(
+                                                UIA_LegacyIAccessibleValuePropertyId,
+                                            )
+                                        {
+                                            if let Ok(bstr) = BSTR::try_from(&var) {
+                                                url = bstr.to_string();
+                                            }
+                                        }
+                                        out.push(TabInfo { title, url });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            CoUninitialize();
+        }
+        out
+    }
+
+    fn refresh_cache() {
+        let tabs = enumerate_tabs();
+        if let Ok(mut cache) = CACHE.write() {
+            *cache = tabs;
+        }
+        if let Ok(mut last) = LAST_REFRESH.lock() {
+            *last = Instant::now();
+        }
+        REFRESHING.store(false, Ordering::Release);
+    }
+
+    fn trigger_refresh() {
+        let refresh_needed = {
+            if let Ok(last) = LAST_REFRESH.lock() {
+                last.elapsed() > Duration::from_secs(2)
+            } else {
+                false
+            }
+        };
+        if refresh_needed
+            && REFRESHING
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            std::thread::spawn(refresh_cache);
+        }
+    }
+
+    pub(super) fn cached_actions(filter: &str) -> Vec<Action> {
+        trigger_refresh();
+
+        let mut out = Vec::new();
+        if let Ok(cache) = CACHE.read() {
+            for tab in cache.iter() {
+                if filter.is_empty()
+                    || tab.title.to_lowercase().contains(filter)
+                    || tab.url.to_lowercase().contains(filter)
+                {
+                    let encoded = urlencoding::encode(&tab.title);
+                    out.push(Action {
+                        label: format!("Switch to {}", tab.title),
+                        desc: if tab.url.is_empty() {
+                            "Browser Tab".into()
+                        } else {
+                            tab.url.clone()
+                        },
+                        action: format!("tab:switch:{encoded}"),
+                        args: None,
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+impl Plugin for BrowserTabsPlugin {
+    #[cfg(target_os = "windows")]
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "tab";
+        let trimmed = query.trim();
+        let rest = match crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            Some(r) => r.trim(),
+            None => return Vec::new(),
+        };
+        let filter = rest.to_lowercase();
+
+        imp::cached_actions(&filter)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "browser_tabs"
+    }
+
+    fn description(&self) -> &str {
+        "Switch between browser tabs (prefix: `tab`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "tab".into(),
+            desc: "Browser tabs".into(),
+            action: "query:tab ".into(),
+            args: None,
+        }]
+    }
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -31,6 +31,7 @@ pub mod asciiart;
 pub mod emoji;
 pub mod task_manager;
 pub mod windows;
+pub mod browser_tabs;
 pub mod screenshot;
 pub mod ip;
 pub mod omni_search;


### PR DESCRIPTION
## Summary
- enumerate Windows browser tabs via UI Automation
- wire up `tab` search command to switch to matching tabs
- cache tab enumeration and refresh asynchronously to keep the UI responsive

## Testing
- `cargo test --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688f5acf81fc8332adb96858e29e7527