### PR TITLE
Add Windows browser tabs plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ windows = { version = "0.58", features = [
     "Win32_UI_Shell",
     "Win32_System_Com",
     "Win32_System_Variant",
+    "Win32_System_Ole",
     "Win32_UI_Accessibility",
     "Win32_Media_Audio",
     "Win32_Media_Audio_Endpoints",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ windows = { version = "0.58", features = [
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_System_Com",
+    "Win32_System_Variant",
+    "Win32_UI_Accessibility",
     "Win32_Media_Audio",
     "Win32_Media_Audio_Endpoints",
     "Win32_Graphics_Gdi",

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -93,7 +93,7 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                 CoCreateInstance::<_, IUIAutomation>(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
             {
                 // Build SAFEARRAY from runtime ID pieces
-                let psa = SafeArrayCreateVector(VT_I4.0 as u16, 0, runtime_id.len() as u32);
+                let psa = SafeArrayCreateVector(VT_I4, 0, runtime_id.len() as u32);
                 if !psa.is_null() {
                     for (i, v) in runtime_id.iter().enumerate() {
                         let mut idx = i as i32;

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -183,28 +183,32 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
 
                                                                     let mut hwnd = elem
                                                                         .CurrentNativeWindowHandle()
-                                                                        .unwrap_or(HWND(0));
-                                                                    if hwnd.0 == 0 {
-                                                                        let mut cur = elem.clone();
-                                                                        loop {
-                                                                            if let Ok(h) = cur
-                                                                                .CurrentNativeWindowHandle()
-                                                                            {
-                                                                                if h.0 != 0 {
-                                                                                    hwnd = h;
+                                                                        .unwrap_or(HWND(std::ptr::null_mut()));
+                                                                    if hwnd.0.is_null() {
+                                                                        if let Ok(walker) =
+                                                                            automation.RawViewWalker()
+                                                                        {
+                                                                            let mut cur = elem.clone();
+                                                                            loop {
+                                                                                if let Ok(h) = cur
+                                                                                    .CurrentNativeWindowHandle()
+                                                                                {
+                                                                                    if !h.0.is_null() {
+                                                                                        hwnd = h;
+                                                                                        break;
+                                                                                    }
+                                                                                }
+                                                                                if let Ok(p) = walker
+                                                                                    .GetParentElement(&cur)
+                                                                                {
+                                                                                    cur = p;
+                                                                                } else {
                                                                                     break;
                                                                                 }
                                                                             }
-                                                                            if let Ok(p) =
-                                                                                cur.GetCurrentParent()
-                                                                            {
-                                                                                cur = p;
-                                                                            } else {
-                                                                                break;
-                                                                            }
                                                                         }
                                                                     }
-                                                                    if hwnd.0 != 0 {
+                                                                    if !hwnd.0.is_null() {
                                                                         super::super::window_manager::force_restore_and_foreground(hwnd);
                                                                     }
 

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -100,6 +100,19 @@ pub fn browser_tab_switch(title: &str) {
                                         if let Ok(name) = elem.CurrentName() {
                                             if name.to_string() == title {
                                                 let _ = elem.SetFocus();
+                                                if let Ok(sel) = elem
+                                                    .GetCurrentPatternAs::<
+                                                        IUIAutomationSelectionItemPattern,
+                                                    >(UIA_SelectionItemPatternId)
+                                                {
+                                                    let _ = sel.Select();
+                                                } else if let Ok(inv) = elem
+                                                    .GetCurrentPatternAs::<
+                                                        IUIAutomationInvokePattern,
+                                                    >(UIA_InvokePatternId)
+                                                {
+                                                    let _ = inv.Invoke();
+                                                }
                                                 break;
                                             }
                                         }

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -76,11 +76,11 @@ pub fn recycle_clean() {
 pub fn browser_tab_switch(runtime_id: &[i32]) {
     #[cfg(target_os = "windows")]
     {
+        use windows::core::VARIANT;
         use windows::Win32::System::Com::{
             CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
             COINIT_APARTMENTTHREADED,
         };
-        use windows::core::VARIANT;
         use windows::Win32::System::Ole::{
             SafeArrayCreateVector, SafeArrayDestroy, SafeArrayPutElement,
         };
@@ -117,9 +117,10 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                                         if let Ok(elem) = tabs.GetElement(i) {
                                             if let Ok(elem_id) = elem.GetRuntimeId() {
                                                 if !elem_id.is_null() {
-                                                    if let Ok(same) =
-                                                        automation.CompareRuntimeIds(elem_id, psa)
-                                                    {
+                                                    if let Ok(same) = automation.CompareRuntimeIds(
+                                                        elem_id as *const _,
+                                                        psa as *const _,
+                                                    ) {
                                                         if same.as_bool() {
                                                             let _ = elem.SetFocus();
                                                             if let Ok(sel) = elem
@@ -141,11 +142,13 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                                                             {
                                                                 let _ = acc.DoDefaultAction();
                                                             }
-                                                            let _ = SafeArrayDestroy(elem_id);
+                                                            let _ = SafeArrayDestroy(
+                                                                elem_id as *const _,
+                                                            );
                                                             break 'outer;
                                                         }
                                                     }
-                                                    let _ = SafeArrayDestroy(elem_id);
+                                                    let _ = SafeArrayDestroy(elem_id as *const _);
                                                 }
                                             }
                                         }
@@ -154,7 +157,7 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                             }
                         }
                     }
-                    let _ = SafeArrayDestroy(psa);
+                    let _ = SafeArrayDestroy(psa as *const _);
                 }
             }
             CoUninitialize();

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -122,7 +122,6 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                                                         psa as *const _,
                                                     ) {
                                                         if same.as_bool() {
-                                                            let _ = elem.SetFocus();
                                                             if let Ok(sel) = elem
                                                                 .GetCurrentPatternAs::<
                                                                     IUIAutomationSelectionItemPattern,
@@ -142,6 +141,7 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                                                             {
                                                                 let _ = acc.DoDefaultAction();
                                                             }
+                                                            let _ = elem.SetFocus();
                                                             let _ = SafeArrayDestroy(
                                                                 elem_id as *const _,
                                                             );

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -71,3 +71,46 @@ pub fn recycle_clean() {
     #[cfg(target_os = "windows")]
     super::super::launcher::clean_recycle_bin();
 }
+
+#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+pub fn browser_tab_switch(title: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+            COINIT_APARTMENTTHREADED,
+        };
+        use windows::Win32::UI::Accessibility::*;
+
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            if let Ok(automation) =
+                CoCreateInstance::<_, IUIAutomation>(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
+            {
+                if let Ok(root) = automation.GetRootElement() {
+                    use windows::core::VARIANT;
+                    if let Ok(cond) = automation.CreatePropertyCondition(
+                        UIA_ControlTypePropertyId,
+                        &VARIANT::from(UIA_TabItemControlTypeId.0),
+                    ) {
+                        if let Ok(tabs) = root.FindAll(TreeScope_Subtree, &cond) {
+                            if let Ok(count) = tabs.Length() {
+                                for i in 0..count {
+                                    if let Ok(elem) = tabs.GetElement(i) {
+                                        if let Ok(name) = elem.CurrentName() {
+                                            if name.to_string() == title {
+                                                let _ = elem.SetFocus();
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            CoUninitialize();
+        }
+    }
+}

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -80,9 +80,11 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
             CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
             COINIT_APARTMENTTHREADED,
         };
+        use windows::core::VARIANT;
         use windows::Win32::System::Ole::{
-            SafeArrayCreateVector, SafeArrayDestroy, SafeArrayPutElement, VT_I4,
+            SafeArrayCreateVector, SafeArrayDestroy, SafeArrayPutElement,
         };
+        use windows::Win32::System::Variant::VT_I4;
         use windows::Win32::UI::Accessibility::*;
 
         unsafe {
@@ -90,7 +92,8 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
             if let Ok(automation) =
                 CoCreateInstance::<_, IUIAutomation>(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
             {
-                let psa = SafeArrayCreateVector(VT_I4, 0, runtime_id.len() as u32);
+                // Build SAFEARRAY from runtime ID pieces
+                let psa = SafeArrayCreateVector(VT_I4.0 as u16, 0, runtime_id.len() as u32);
                 if !psa.is_null() {
                     for (i, v) in runtime_id.iter().enumerate() {
                         let mut idx = i as i32;
@@ -101,26 +104,54 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
                             &val as *const _ as *const core::ffi::c_void,
                         );
                     }
-                    if let Ok(elem) = automation.ElementFromRuntimeId(psa) {
-                        let _ = elem.SetFocus();
-                        if let Ok(sel) = elem
-                            .GetCurrentPatternAs::<IUIAutomationSelectionItemPattern>(
-                                UIA_SelectionItemPatternId,
-                            )
-                        {
-                            let _ = sel.Select();
-                        } else if let Ok(inv) = elem
-                            .GetCurrentPatternAs::<IUIAutomationInvokePattern>(
-                                UIA_InvokePatternId,
-                            )
-                        {
-                            let _ = inv.Invoke();
-                        } else if let Ok(acc) = elem
-                            .GetCurrentPatternAs::<IUIAutomationLegacyIAccessiblePattern>(
-                                UIA_LegacyIAccessiblePatternId,
-                            )
-                        {
-                            let _ = acc.DoDefaultAction();
+
+                    // Enumerate tab elements and find matching runtime ID
+                    if let Ok(cond) = automation.CreatePropertyCondition(
+                        UIA_ControlTypePropertyId,
+                        &VARIANT::from(UIA_TabItemControlTypeId.0),
+                    ) {
+                        if let Ok(root) = automation.GetRootElement() {
+                            if let Ok(tabs) = root.FindAll(TreeScope_Subtree, &cond) {
+                                if let Ok(count) = tabs.Length() {
+                                    'outer: for i in 0..count {
+                                        if let Ok(elem) = tabs.GetElement(i) {
+                                            if let Ok(elem_id) = elem.GetRuntimeId() {
+                                                if !elem_id.is_null() {
+                                                    if let Ok(same) =
+                                                        automation.CompareRuntimeIds(elem_id, psa)
+                                                    {
+                                                        if same.as_bool() {
+                                                            let _ = elem.SetFocus();
+                                                            if let Ok(sel) = elem
+                                                                .GetCurrentPatternAs::<
+                                                                    IUIAutomationSelectionItemPattern,
+                                                                >(UIA_SelectionItemPatternId)
+                                                            {
+                                                                let _ = sel.Select();
+                                                            } else if let Ok(inv) = elem
+                                                                .GetCurrentPatternAs::<
+                                                                    IUIAutomationInvokePattern,
+                                                                >(UIA_InvokePatternId)
+                                                            {
+                                                                let _ = inv.Invoke();
+                                                            } else if let Ok(acc) = elem
+                                                                .GetCurrentPatternAs::<
+                                                                    IUIAutomationLegacyIAccessiblePattern,
+                                                                >(UIA_LegacyIAccessiblePatternId)
+                                                            {
+                                                                let _ = acc.DoDefaultAction();
+                                                            }
+                                                            let _ = SafeArrayDestroy(elem_id);
+                                                            break 'outer;
+                                                        }
+                                                    }
+                                                    let _ = SafeArrayDestroy(elem_id);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                     let _ = SafeArrayDestroy(psa);

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1312,6 +1312,19 @@ impl eframe::App for LauncherApp {
                 );
             }
         }
+        for msg in crate::plugins::browser_tabs::take_cache_messages() {
+            if self.enable_toasts {
+                push_toast(
+                    &mut self.toasts,
+                    Toast {
+                        text: msg.into(),
+                        kind: ToastKind::Info,
+                        options: ToastOptions::default()
+                            .duration_in_seconds(self.toast_duration as f64),
+                    },
+                );
+            }
+        }
         for err in crate::plugins::macros::take_error_messages() {
             self.macro_dialog.push_debug(err);
         }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1600,6 +1600,36 @@ impl eframe::App for LauncherApp {
                             if let Ok(count) = n.parse::<usize>() {
                                 self.cpu_list_dialog.open(count);
                             }
+                        } else if a.action.starts_with("tab:switch:") {
+                            if self.enable_toasts {
+                                push_toast(
+                                    &mut self.toasts,
+                                    Toast {
+                                        text: format!("Switching to {}", a.label).into(),
+                                        kind: ToastKind::Info,
+                                        options: ToastOptions::default()
+                                            .duration_in_seconds(self.toast_duration as f64),
+                                    },
+                                );
+                            }
+                            let act = a.clone();
+                            std::thread::spawn(move || {
+                                if let Err(e) = launch_action(&act) {
+                                    tracing::error!(?e, "failed to switch tab");
+                                }
+                            });
+                            if a.action != "help:show" {
+                                let _ = history::append_history(
+                                    HistoryEntry {
+                                        query: current.clone(),
+                                        query_lc: String::new(),
+                                        action: a.clone(),
+                                    },
+                                    self.history_limit,
+                                );
+                                let count = self.usage.entry(a.action.clone()).or_insert(0);
+                                *count += 1;
+                            }
                         } else if let Err(e) = launch_action(&a) {
                             if a.desc == "Fav" && !a.action.starts_with("fav:") {
                                 tracing::error!(?e, fav=%a.label, "failed to run favorite");

--- a/src/gui/volume_dialog.rs
+++ b/src/gui/volume_dialog.rs
@@ -3,7 +3,7 @@ use crate::gui::LauncherApp;
 use crate::launcher::launch_action;
 use eframe::egui;
 #[cfg(target_os = "windows")]
-use sysinfo::{Pid, System};
+use sysinfo::System;
 
 pub struct VolumeDialog {
     pub open: bool,

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -293,6 +293,8 @@ enum ActionKind<'a> {
     WindowSwitch(isize),
     WindowClose(isize),
     BrowserTabSwitch(Vec<i32>),
+    BrowserTabCache,
+    BrowserTabClear,
     TempfileNew(Option<&'a str>),
     TempfileOpen,
     TempfileClear,
@@ -386,6 +388,12 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
         if !parts.is_empty() {
             return ActionKind::BrowserTabSwitch(parts);
         }
+    }
+    if s == "tab:cache" {
+        return ActionKind::BrowserTabCache;
+    }
+    if s == "tab:clear" {
+        return ActionKind::BrowserTabClear;
     }
     if let Some(id) = s.strip_prefix("timer:cancel:") {
         if let Ok(i) = id.parse::<u64>() {
@@ -662,6 +670,14 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         }
         ActionKind::BrowserTabSwitch(ids) => {
             system::browser_tab_switch(&ids);
+            Ok(())
+        }
+        ActionKind::BrowserTabCache => {
+            crate::plugins::browser_tabs::rebuild_cache();
+            Ok(())
+        }
+        ActionKind::BrowserTabClear => {
+            crate::plugins::browser_tabs::clear_cache();
             Ok(())
         }
         ActionKind::TimerCancel(id) => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -158,7 +158,7 @@ impl PluginManager {
             self.register_with_settings(BrightnessPlugin, plugin_settings);
             self.register_with_settings(TaskManagerPlugin, plugin_settings);
             self.register_with_settings(WindowsPlugin, plugin_settings);
-            self.register_with_settings(BrowserTabsPlugin, plugin_settings);
+            self.register_with_settings(BrowserTabsPlugin::default(), plugin_settings);
         }
         self.register_with_settings(SettingsPlugin, plugin_settings);
         self.register_with_settings(HelpPlugin, plugin_settings);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -40,6 +40,8 @@ use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::wikipedia::WikipediaPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::windows::WindowsPlugin;
+#[cfg(target_os = "windows")]
+use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::ip::IpPlugin;
 use crate::plugins::timestamp::TimestampPlugin;
@@ -156,6 +158,7 @@ impl PluginManager {
             self.register_with_settings(BrightnessPlugin, plugin_settings);
             self.register_with_settings(TaskManagerPlugin, plugin_settings);
             self.register_with_settings(WindowsPlugin, plugin_settings);
+            self.register_with_settings(BrowserTabsPlugin, plugin_settings);
         }
         self.register_with_settings(SettingsPlugin, plugin_settings);
         self.register_with_settings(HelpPlugin, plugin_settings);

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -126,16 +126,16 @@ mod imp {
                         SafeArrayDestroy, SafeArrayLock, SafeArrayUnlock,
                     };
                     if !sa_ptr.is_null() {
-                        let psa = *sa_ptr;
-                        if SafeArrayLock(psa).is_ok() {
-                            let len = (*psa).rgsabound[0].cElements as usize;
-                            let data = (*psa).pvData as *const i32;
+                        if SafeArrayLock(sa_ptr).is_ok() {
+                            let len = (*sa_ptr).rgsabound[0].cElements as usize;
+                            let data = (*sa_ptr).pvData as *const i32;
                             if !data.is_null() {
-                                runtime_id = std::slice::from_raw_parts(data, len).to_vec();
+                                runtime_id =
+                                    std::slice::from_raw_parts(data, len).to_vec();
                             }
-                            let _ = SafeArrayUnlock(psa);
+                            let _ = SafeArrayUnlock(sa_ptr);
                         }
-                        let _ = SafeArrayDestroy(psa);
+                        let _ = SafeArrayDestroy(sa_ptr);
                     }
                 }
                 if runtime_id.is_empty() {

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -44,8 +44,7 @@ mod imp {
 
         let mut out = Vec::new();
         unsafe {
-            let init = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
-            if let Err(e) = init {
+            if let Err(e) = CoInitializeEx(None, COINIT_APARTMENTTHREADED).ok() {
                 log_enum_error("CoInitializeEx failed", e);
                 return out;
             }

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -9,7 +9,9 @@ pub struct BrowserTabsPlugin {
 
 impl Default for BrowserTabsPlugin {
     fn default() -> Self {
-        Self { recalc_each_query: false }
+        Self {
+            recalc_each_query: false,
+        }
     }
 }
 
@@ -37,7 +39,7 @@ mod imp {
         Lazy::new(|| Mutex::new(Instant::now() - Duration::from_secs(60)));
     static MESSAGES: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
-    pub(crate) fn take_messages() -> Vec<String> {
+    pub(super) fn take_messages() -> Vec<String> {
         if let Ok(mut list) = MESSAGES.lock() {
             let out = list.clone();
             list.clear();
@@ -401,7 +403,10 @@ impl Plugin for BrowserTabsPlugin {
     fn settings_ui(&mut self, ui: &mut egui::Ui, value: &mut serde_json::Value) {
         let mut cfg: BrowserTabsPluginSettings =
             serde_json::from_value(value.clone()).unwrap_or_default();
-        ui.checkbox(&mut cfg.recalc_each_query, "Recalculate cache on each query");
+        ui.checkbox(
+            &mut cfg.recalc_each_query,
+            "Recalculate cache on each query",
+        );
         self.recalc_each_query = cfg.recalc_each_query;
         if let Ok(v) = serde_json::to_value(&cfg) {
             *value = v;
@@ -437,7 +442,9 @@ impl Default for BrowserTabsPluginSettings {
 }
 
 #[cfg(target_os = "windows")]
-pub(crate) use imp::take_messages as take_cache_messages;
+pub fn take_cache_messages() -> Vec<String> {
+    imp::take_messages()
+}
 #[cfg(not(target_os = "windows"))]
 pub fn take_cache_messages() -> Vec<String> {
     Vec::new()

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -8,9 +8,12 @@
 //!
 //! Only top-level windows on the active desktop session are scanned. Tabs in
 //! minimized or non‑UIA compliant windows might be missed, and changes in a
-//! browser's accessibility implementation could break enumeration. When UIA
-//! patterns fail to activate a tab, the plugin falls back to simulating a mouse
-//! click on the tab's bounding rectangle.
+//! browser's accessibility implementation could break enumeration.
+//!
+//! When activation patterns like `SelectionItem` or `Invoke` are missing or
+//! fail, the plugin falls back to simulating a mouse click on the tab's center.
+//! This requires the window to be visible and may briefly move the cursor before
+//! restoring its position.
 //!
 //! The plugin is Windows-only; on other platforms it returns no results.
 use crate::actions::Action;
@@ -372,7 +375,7 @@ impl Plugin for BrowserTabsPlugin {
     }
 
     fn description(&self) -> &str {
-        "Switch between browser tabs (prefix: `tab`)"
+        "Switch between browser tabs (prefix: `tab`). Uses UI Automation and may simulate a mouse click when activation patterns are unsupported"
     }
 
     fn capabilities(&self) -> &[&str] {
@@ -421,6 +424,9 @@ impl Plugin for BrowserTabsPlugin {
         ui.checkbox(
             &mut cfg.recalc_each_query,
             "Recalculate cache on each query",
+        );
+        ui.label(
+            "If UI Automation can't activate a tab, a mouse click is simulated and the cursor may briefly move",
         );
         self.recalc_each_query = cfg.recalc_each_query;
         if let Ok(v) = serde_json::to_value(&cfg) {

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -1,3 +1,18 @@
+//! Browser tab search and switching on Windows using UI Automation.
+//!
+//! The plugin enumerates `TabItem` elements exposed by browsers via the
+//! Windows UI Automation (UIA) tree. This currently works reliably with
+//! Chromium-based browsers such as Microsoft Edge and Google Chrome; other
+//! browsers may not expose their tabs as `TabItem` controls and will therefore
+//! not appear in search results.
+//!
+//! Only top-level windows on the active desktop session are scanned. Tabs in
+//! minimized or non‑UIA compliant windows might be missed, and changes in a
+//! browser's accessibility implementation could break enumeration. When UIA
+//! patterns fail to activate a tab, the plugin falls back to simulating a mouse
+//! click on the tab's bounding rectangle.
+//!
+//! The plugin is Windows-only; on other platforms it returns no results.
 use crate::actions::Action;
 use crate::plugin::Plugin;
 use eframe::egui;

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -1,0 +1,282 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+pub struct BrowserTabsPlugin;
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Mutex, RwLock};
+    use std::time::{Duration, Instant};
+    use tracing::{error, warn};
+
+    #[derive(Clone)]
+    pub(super) struct TabInfo {
+        title: String,
+        url: String,
+    }
+
+    static CACHE: Lazy<RwLock<Vec<TabInfo>>> = Lazy::new(|| RwLock::new(Vec::new()));
+    static LAST_REFRESH: Lazy<Mutex<Instant>> =
+        Lazy::new(|| Mutex::new(Instant::now() - Duration::from_secs(60)));
+    static REFRESHING: AtomicBool = AtomicBool::new(false);
+    static LAST_ENUM_ERR: Lazy<Mutex<Instant>> = Lazy::new(|| {
+        Mutex::new(Instant::now() - Duration::from_secs(60))
+    });
+
+    fn log_enum_error(msg: &str, err: windows::core::Error) {
+        let mut last = LAST_ENUM_ERR.lock().unwrap();
+        if last.elapsed() > Duration::from_secs(30) {
+            error!(?err, "BrowserTabsPlugin: {msg}");
+            *last = Instant::now();
+        }
+    }
+
+    fn enumerate_tabs() -> Vec<TabInfo> {
+        use windows::core::{BSTR, VARIANT};
+        use windows::Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+            COINIT_APARTMENTTHREADED,
+        };
+        use windows::Win32::UI::Accessibility::*;
+
+        let mut out = Vec::new();
+        unsafe {
+            let init = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            if let Err(e) = init {
+                log_enum_error("CoInitializeEx failed", e);
+                return out;
+            }
+
+            let automation = match CoCreateInstance::<_, IUIAutomation>(
+                &CUIAutomation,
+                None,
+                CLSCTX_INPROC_SERVER,
+            ) {
+                Ok(a) => a,
+                Err(e) => {
+                    log_enum_error("CoCreateInstance(IUIAutomation) failed", e);
+                    CoUninitialize();
+                    return out;
+                }
+            };
+
+            let root = match automation.GetRootElement() {
+                Ok(r) => r,
+                Err(e) => {
+                    log_enum_error("GetRootElement failed", e);
+                    CoUninitialize();
+                    return out;
+                }
+            };
+
+            let cond = match automation.CreatePropertyCondition(
+                UIA_ControlTypePropertyId,
+                &VARIANT::from(UIA_TabItemControlTypeId.0),
+            ) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(?e, "BrowserTabsPlugin: CreatePropertyCondition failed");
+                    CoUninitialize();
+                    return out;
+                }
+            };
+
+            let tabs = match root.FindAll(TreeScope_Subtree, &cond) {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(?e, "BrowserTabsPlugin: FindAll failed");
+                    CoUninitialize();
+                    return out;
+                }
+            };
+
+            let count = match tabs.Length() {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(?e, "BrowserTabsPlugin: tabs.Length failed");
+                    CoUninitialize();
+                    return out;
+                }
+            };
+
+            for i in 0..count {
+                let elem = match tabs.GetElement(i) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        warn!(?e, "BrowserTabsPlugin: GetElement failed");
+                        continue;
+                    }
+                };
+                let title = elem.CurrentName().unwrap_or_default().to_string();
+                let mut url = String::new();
+                match elem.GetCurrentPropertyValue(UIA_LegacyIAccessibleValuePropertyId) {
+                    Ok(var) => {
+                        if let Ok(bstr) = BSTR::try_from(&var) {
+                            url = bstr.to_string();
+                        }
+                    }
+                    Err(e) => warn!(?e, "BrowserTabsPlugin: GetCurrentPropertyValue failed"),
+                }
+                out.push(TabInfo { title, url });
+            }
+
+            CoUninitialize();
+        }
+        out
+    }
+
+    fn refresh_cache() {
+        let tabs = enumerate_tabs();
+        if let Ok(mut cache) = CACHE.write() {
+            *cache = tabs;
+        } else {
+            warn!("BrowserTabsPlugin: failed to lock cache for writing");
+        }
+        if let Ok(mut last) = LAST_REFRESH.lock() {
+            *last = Instant::now();
+        } else {
+            warn!("BrowserTabsPlugin: failed to lock last refresh time");
+        }
+        REFRESHING.store(false, Ordering::Release);
+    }
+
+    fn trigger_refresh() {
+        let refresh_needed = {
+            if let Ok(last) = LAST_REFRESH.lock() {
+                last.elapsed() > Duration::from_secs(2)
+            } else {
+                false
+            }
+        };
+        if refresh_needed
+            && REFRESHING
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            std::thread::spawn(refresh_cache);
+        }
+    }
+
+    pub(super) fn cached_actions(filter: &str) -> Vec<Action> {
+        trigger_refresh();
+
+        let mut out = Vec::new();
+        if let Ok(cache) = CACHE.read() {
+            for tab in cache.iter() {
+                if filter.is_empty()
+                    || tab.title.to_lowercase().contains(filter)
+                    || tab.url.to_lowercase().contains(filter)
+                {
+                    let encoded = urlencoding::encode(&tab.title);
+                    out.push(Action {
+                        label: format!("Switch to {}", tab.title),
+                        desc: if tab.url.is_empty() {
+                            "Browser Tab".into()
+                        } else {
+                            tab.url.clone()
+                        },
+                        action: format!("tab:switch:{encoded}"),
+                        args: None,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::thread::sleep;
+        use std::time::{Duration, Instant};
+        use super::super::BrowserTabsPlugin;
+
+        #[test]
+        fn search_refreshes_cache() {
+            {
+                let mut cache = CACHE.write().unwrap();
+                cache.clear();
+                cache.push(TabInfo {
+                    title: "Dummy".into(),
+                    url: "about:blank".into(),
+                });
+            }
+
+            {
+                let mut last = LAST_REFRESH.lock().unwrap();
+                *last = Instant::now();
+            }
+
+            let plugin = BrowserTabsPlugin;
+            let first = plugin.search("tab ");
+            assert_eq!(first.len(), 1);
+            assert!(first[0].label.contains("Dummy"));
+
+            {
+                let mut last = LAST_REFRESH.lock().unwrap();
+                *last = Instant::now() - Duration::from_secs(60);
+            }
+
+            let _ = plugin.search("tab ");
+            sleep(Duration::from_millis(500));
+            let refreshed = plugin.search("tab ");
+            assert!(refreshed.iter().all(|a| !a.label.contains("Dummy")));
+        }
+    }
+}
+
+impl Plugin for BrowserTabsPlugin {
+    #[cfg(target_os = "windows")]
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "tab";
+        let trimmed = query.trim();
+        let rest = match crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            Some(r) => r.trim(),
+            None => return Vec::new(),
+        };
+        let filter = rest.to_lowercase();
+
+        imp::cached_actions(&filter)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn search(&self, _query: &str) -> Vec<Action> {
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "browser_tabs"
+    }
+
+    fn description(&self) -> &str {
+        "Switch between browser tabs (prefix: `tab`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "tab".into(),
+            desc: "Browser tabs".into(),
+            action: "query:tab ".into(),
+            args: None,
+        }]
+    }
+}
+
+#[cfg(all(test, not(target_os = "windows")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_is_empty_on_non_windows() {
+        let plugin = BrowserTabsPlugin;
+        assert!(plugin.search("tab ").is_empty());
+    }
+}
+

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -37,7 +37,7 @@ mod imp {
         Lazy::new(|| Mutex::new(Instant::now() - Duration::from_secs(60)));
     static MESSAGES: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
-    pub(super) fn take_messages() -> Vec<String> {
+    pub(crate) fn take_messages() -> Vec<String> {
         if let Ok(mut list) = MESSAGES.lock() {
             let out = list.clone();
             list.clear();
@@ -437,7 +437,7 @@ impl Default for BrowserTabsPluginSettings {
 }
 
 #[cfg(target_os = "windows")]
-pub use imp::take_messages as take_cache_messages;
+pub(crate) use imp::take_messages as take_cache_messages;
 #[cfg(not(target_os = "windows"))]
 pub fn take_cache_messages() -> Vec<String> {
     Vec::new()

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -31,6 +31,7 @@ pub mod asciiart;
 pub mod emoji;
 pub mod task_manager;
 pub mod windows;
+pub mod browser_tabs;
 pub mod screenshot;
 pub mod ip;
 pub mod omni_search;


### PR DESCRIPTION
## Summary
- enumerate Windows browser tabs via UI Automation
- wire up `tab` search command to switch to matching tabs
- cache tab enumeration and refresh asynchronously to keep the UI responsive
- exercise browser tab search in unit tests and verify non-Windows stubs
- log UIA and COM failures while throttling repeated errors

## Testing
- `cargo test --lib --quiet`
- `cargo test plugins::browser_tabs::tests::search_is_empty_on_non_windows -- --exact --nocapture`

 