### PR TITLE
Add PageUp/PageDown navigation to launcher results

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -960,6 +960,25 @@ impl LauncherApp {
                 }
                 None
             }
+            egui::Key::PageDown => {
+                if !self.results.is_empty() {
+                    let max = self.results.len() - 1;
+                    self.selected = match self.selected {
+                        Some(i) => Some((i + 5).min(max)),
+                        None => Some(0),
+                    };
+                }
+                None
+            }
+            egui::Key::PageUp => {
+                if !self.results.is_empty() {
+                    self.selected = match self.selected {
+                        Some(i) => Some(i.saturating_sub(5)),
+                        None => Some(0),
+                    };
+                }
+                None
+            }
             egui::Key::Enter => {
                 if let Some(i) = self.selected {
                     Some(i)
@@ -1538,6 +1557,14 @@ impl eframe::App for LauncherApp {
 
                 if ctx.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
                     self.handle_key(egui::Key::ArrowUp);
+                }
+
+                if ctx.input(|i| i.key_pressed(egui::Key::PageDown)) {
+                    self.handle_key(egui::Key::PageDown);
+                }
+
+                if ctx.input(|i| i.key_pressed(egui::Key::PageUp)) {
+                    self.handle_key(egui::Key::PageUp);
                 }
 
                 let mut launch_idx: Option<usize> = None;

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -58,3 +58,32 @@ fn enter_returns_selected_index() {
     let idx = app.handle_key(egui::Key::Enter);
     assert_eq!(idx, Some(0));
 }
+
+#[test]
+fn page_keys_update_selection() {
+    let ctx = egui::Context::default();
+    let acts: Vec<Action> = (0..10)
+        .map(|i| Action {
+            label: format!("act{i}"),
+            desc: "".into(),
+            action: format!("act{i}"),
+            args: None,
+        })
+        .collect();
+    let mut app = new_app(&ctx, acts);
+    app.query = APP_PREFIX.into();
+    app.search();
+    assert_eq!(app.selected, None);
+    app.handle_key(egui::Key::PageDown);
+    assert_eq!(app.selected, Some(0));
+    app.handle_key(egui::Key::PageDown);
+    assert_eq!(app.selected, Some(5));
+    app.handle_key(egui::Key::PageDown);
+    assert_eq!(app.selected, Some(9));
+    app.handle_key(egui::Key::PageUp);
+    assert_eq!(app.selected, Some(4));
+    app.handle_key(egui::Key::PageUp);
+    assert_eq!(app.selected, Some(0));
+    app.handle_key(egui::Key::PageUp);
+    assert_eq!(app.selected, Some(0));
+}


### PR DESCRIPTION
## Summary
- handle PageUp and PageDown in `LauncherApp` to jump selection by five entries
- listen for PageUp/PageDown keys in update loop
- test PageUp/PageDown navigation

## Testing
- `cargo test`
 