### PR TITLE
feat(notes): index tags and backlinks

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -67,7 +67,10 @@ impl NotePanel {
             });
         if save_now {
             self.note.tags = extract_tags(&self.note.content);
-            self.note.links = extract_links(&self.note.content);
+            self.note.links = extract_wiki_links(&self.note.content)
+                .into_iter()
+                .map(|l| slugify(&l))
+                .collect();
             if let Some(first) = self.note.content.lines().next() {
                 if let Some(t) = first.strip_prefix("# ") {
                     self.note.title = t.to_string();


### PR DESCRIPTION
## Summary
- cache note tags and backlinks on load
- list unique tags via `note tags`
- support backlinks with `note link`
- refresh note cache after creating, saving, or deleting notes to keep results current

## Testing
- `cargo test --test note_plugin`


------
https://chatgpt.com/codex/tasks/task_e_6891c89aaa748332a5b972208502a8c4