### PR TITLE
Ensure unique note slugs and confirm deletions

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,3 +7,4 @@ pub fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
 }
 
 pub mod json_watch;
+pub mod slug;

--- a/src/common/slug.rs
+++ b/src/common/slug.rs
@@ -1,0 +1,51 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Global lookup of slug base -> next suffix index.
+static SLUGS: Lazy<Mutex<HashMap<String, usize>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Reset the slug lookup. Should be called before scanning existing notes.
+pub fn reset_slug_lookup() {
+    if let Ok(mut m) = SLUGS.lock() {
+        m.clear();
+    }
+}
+
+/// Register an already existing slug so future generations avoid collisions.
+pub fn register_slug(slug: &str) {
+    let (base, next) = parse_slug(slug);
+    if let Ok(mut m) = SLUGS.lock() {
+        let entry = m.entry(base.to_string()).or_insert(0);
+        *entry = (*entry).max(next + 1);
+    }
+}
+
+fn parse_slug(s: &str) -> (&str, usize) {
+    if let Some((base, num)) = s.rsplit_once('-') {
+        if let Ok(n) = num.parse::<usize>() {
+            return (base, n);
+        }
+    }
+    (s, 0)
+}
+
+/// Convert a title to a filesystem safe slug.
+pub fn slugify(title: &str) -> String {
+    slug::slugify(title)
+}
+
+/// Generate a unique slug for a title, appending numeric suffixes when needed.
+pub fn unique_slug(title: &str) -> String {
+    let base = slugify(title);
+    let mut m = SLUGS.lock().unwrap();
+    let count = m.entry(base.clone()).or_insert(0);
+    let slug = if *count == 0 {
+        base.clone()
+    } else {
+        format!("{}-{}", base, *count)
+    };
+    *count += 1;
+    slug
+}

--- a/src/gui/note_delete_dialog.rs
+++ b/src/gui/note_delete_dialog.rs
@@ -1,0 +1,69 @@
+use super::{push_toast, LauncherApp};
+use crate::plugins::note::{load_notes, remove_note};
+use eframe::egui::{self, Context};
+use egui_toast::{Toast, ToastKind, ToastOptions};
+
+#[derive(Default)]
+pub struct NoteDeleteDialog {
+    pub open: bool,
+    slug: String,
+}
+
+impl NoteDeleteDialog {
+    pub fn open(&mut self, slug: String) {
+        self.open = true;
+        self.slug = slug;
+    }
+
+    pub fn ui(&mut self, ctx: &Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut keep_open = true;
+        let slug = self.slug.clone();
+        egui::Window::new("Delete note?")
+            .open(&mut keep_open)
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label(format!("Delete note '{slug}'?"));
+                ui.horizontal(|ui| {
+                    if ui.button("Delete").clicked() {
+                        if let Ok(notes) = load_notes() {
+                            if let Some((idx, note)) =
+                                notes.into_iter().enumerate().find(|(_, n)| n.slug == slug)
+                            {
+                                let word_count = note.content.split_whitespace().count();
+                                if let Err(e) = remove_note(idx) {
+                                    app.set_error(format!("Failed to remove note: {e}"));
+                                } else if app.enable_toasts {
+                                    push_toast(
+                                        &mut app.toasts,
+                                        Toast {
+                                            text: format!(
+                                                "Removed note {} ({} words)",
+                                                note.title, word_count
+                                            )
+                                            .into(),
+                                            kind: ToastKind::Success,
+                                            options: ToastOptions::default()
+                                                .duration_in_seconds(app.toast_duration as f64),
+                                        },
+                                    );
+                                }
+                                app.search();
+                                app.focus_input();
+                            }
+                        }
+                        self.open = false;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        self.open = false;
+                    }
+                });
+            });
+        if !keep_open {
+            self.open = false;
+        }
+    }
+}

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3,7 +3,7 @@ use crate::plugins::note::{save_note, Note};
 use eframe::egui;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use slug::slugify;
+use crate::common::slug::slugify;
 
 #[derive(Clone)]
 pub struct NotePanel {
@@ -184,7 +184,7 @@ mod tests {
         });
 
         assert_eq!(app.note_panels.len(), 1);
-        assert_eq!(slug::slugify(&app.note_panels[0].note.title), "second-note");
+        assert_eq!(slugify(&app.note_panels[0].note.title), "second-note");
     }
 
     #[test]

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -75,6 +75,7 @@ impl NotesDialog {
                                         content: self.text.clone(),
                                         tags: Vec::new(),
                                         links: Vec::new(),
+                                        slug: String::new(),
                                     });
                                 } else if let Some(e) = self.entries.get_mut(idx) {
                                     e.content = self.text.clone();


### PR DESCRIPTION
## Summary
- add central slug utilities that generate unique, filesystem-safe note slugs
- store and reuse note slugs when saving or searching notes
- present a confirmation dialog before deleting a note

## Testing
- `cargo test --test note_plugin -- --nocapture`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6891d0e3543c8332b52c1496f1f6ba0a