### PR TITLE
Validate note links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "walkdir",
  "windows 0.58.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1"
 regex = "1"
 slug = "0.1"
 urlencoding = "2"
+url = "2"
 windows = { version = "0.58", features = [
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",


### PR DESCRIPTION
## Summary
- filter URLs in notes to include only valid http/https links
- guard note link opening with URL parsing and error toasts
- add tests for note link extraction and opening

## Testing
- `cargo test --lib open_note_link_valid_and_invalid --quiet`
- `cargo test --lib extract_links_filters_invalid --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6891eca14fc48332bc5433b966a7b159