### PR TITLE
Fix Enter handling in note panels

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1636,6 +1636,7 @@ impl eframe::App for LauncherApp {
                     && !self.notes_dialog.open
                     && !self.todo_dialog.open
                     && !self.todo_view_dialog.open
+                    && self.note_panels.is_empty()
                 {
                     launch_idx = self.handle_key(egui::Key::Enter);
                 }


### PR DESCRIPTION
## Summary
- avoid triggering global Enter handler while note panels are open
- focus note text fields and consume Enter so newlines don't launch queries
- add regression test for Enter behavior inside note panel

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_6892053650608332965c6b976aceb14a