### PR TITLE
Spawn recycle clean in background

### DIFF
--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -69,7 +69,13 @@ pub fn set_process_volume(pid: u32, level: u32) {
 
 pub fn recycle_clean() {
     #[cfg(target_os = "windows")]
-    super::super::launcher::clean_recycle_bin();
+    {
+        std::thread::spawn(|| {
+            let res = super::super::launcher::clean_recycle_bin()
+                .map_err(|e| format!("{e:?}"));
+            crate::gui::send_event(crate::gui::WatchEvent::Recycle(res));
+        });
+    }
 }
 
 #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -158,16 +158,17 @@ pub(crate) fn set_display_brightness(percent: u32) {
 }
 
 #[cfg(target_os = "windows")]
-pub(crate) fn clean_recycle_bin() {
+pub(crate) fn clean_recycle_bin() -> windows::core::Result<()> {
     use windows::Win32::UI::Shell::{
         SHEmptyRecycleBinW, SHERB_NOCONFIRMATION, SHERB_NOPROGRESSUI, SHERB_NOSOUND,
     };
     unsafe {
-        let _ = SHEmptyRecycleBinW(
+        SHEmptyRecycleBinW(
             None,
             None,
             SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND,
-        );
+        )
+        .ok()
     }
 }
 

--- a/tests/recycle_plugin.rs
+++ b/tests/recycle_plugin.rs
@@ -1,5 +1,45 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::recycle::RecyclePlugin;
+use multi_launcher::{
+    actions::Action,
+    gui::{LauncherApp, WatchEvent},
+    launcher::launch_action,
+    plugin::PluginManager,
+    settings::Settings,
+};
+use eframe::egui;
+use std::sync::{atomic::AtomicBool, Arc};
+
+fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
+    let custom_len = actions.len();
+    let mut plugins = PluginManager::new();
+    let dirs: Vec<String> = Vec::new();
+    let actions_arc = Arc::new(actions.clone());
+    plugins.reload_from_dirs(
+        &dirs,
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        actions_arc,
+    );
+    LauncherApp::new(
+        ctx,
+        actions,
+        custom_len,
+        plugins,
+        "actions.json".into(),
+        "settings.json".into(),
+        Settings::default(),
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
 
 #[test]
 fn search_returns_action() {
@@ -11,5 +51,29 @@ fn search_returns_action() {
         assert_eq!(results[0].action, "recycle:clean");
     } else {
         assert!(results.is_empty());
+    }
+}
+
+#[test]
+fn command_returns_immediately_and_cleans() {
+    if !cfg!(target_os = "windows") {
+        return;
+    }
+    let ctx = egui::Context::default();
+    let actions: Vec<Action> = Vec::new();
+    let mut app = new_app(&ctx, actions);
+    app.query = "rec".into();
+    app.search();
+    if cfg!(target_os = "windows") {
+        assert_eq!(app.results.len(), 1);
+        let a = app.results[0].clone();
+        let rx = app.watch_receiver();
+        let start = std::time::Instant::now();
+        launch_action(&a).unwrap();
+        assert!(start.elapsed() < std::time::Duration::from_millis(100));
+        match rx.recv_timeout(std::time::Duration::from_secs(3)) {
+            Ok(WatchEvent::Recycle(res)) => assert!(res.is_ok()),
+            _ => panic!("unexpected event"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- clean recycle bin on a background thread and notify the UI when done
- report recycle bin results through the launcher toast system
- add regression test for recycle plugin to ensure non-blocking behaviour

## Testing
- `cargo test --lib`
- `cargo test --test recycle_plugin`

------
https://chatgpt.com/codex/tasks/task_e_689253a15fc083328fa301aafcf02180