### PR TITLE
Implement note panel size setting and UI tweaks

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -333,6 +333,7 @@ pub struct LauncherApp {
     pub fuzzy_weight: f32,
     pub usage_weight: f32,
     pub page_jump: usize,
+    pub note_panel_default_size: (f32, f32),
     pub follow_mouse: bool,
     pub static_location_enabled: bool,
     pub static_pos: Option<(i32, i32)>,
@@ -418,6 +419,7 @@ impl LauncherApp {
         screenshot_save_file: Option<bool>,
         always_on_top: Option<bool>,
         page_jump: Option<usize>,
+        note_panel_default_size: Option<(f32, f32)>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -482,6 +484,9 @@ impl LauncherApp {
         }
         if let Some(v) = page_jump {
             self.page_jump = v;
+        }
+        if let Some(v) = note_panel_default_size {
+            self.note_panel_default_size = v;
         }
     }
 
@@ -670,6 +675,7 @@ impl LauncherApp {
             fuzzy_weight: settings.fuzzy_weight,
             usage_weight: settings.usage_weight,
             page_jump: settings.page_jump,
+            note_panel_default_size: settings.note_panel_default_size,
             follow_mouse,
             static_location_enabled: static_enabled,
             static_pos,

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -125,6 +125,7 @@ impl PluginEditor {
                         Some(s.screenshot_save_file),
                         None,
                         None,
+                        None,
                     );
                     let dirs = s.plugin_dirs.clone().unwrap_or_default();
                     let actions_arc = Arc::new(app.actions.clone());

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -67,6 +67,9 @@ pub struct Settings {
     /// Last known window size. If absent, a default size is used.
     #[serde(default)]
     pub window_size: Option<(i32, i32)>,
+    /// Default size for note editor panels.
+    #[serde(default = "default_note_panel_size")]
+    pub note_panel_default_size: (f32, f32),
     /// Enable toast notifications in the UI.
     #[serde(default = "default_toasts")]
     pub enable_toasts: bool,
@@ -187,6 +190,10 @@ fn default_net_refresh() -> f32 {
     1.0
 }
 
+fn default_note_panel_size() -> (f32, f32) {
+    (420.0, 320.0)
+}
+
 fn default_log_path() -> PathBuf {
     std::env::current_exe()
         .ok()
@@ -216,6 +223,7 @@ impl Default for Settings {
             log_file: None,
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),
+            note_panel_default_size: default_note_panel_size(),
             enable_toasts: true,
             toast_duration: default_toast_duration(),
             query_scale: Some(1.0),

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -27,6 +27,8 @@ pub struct SettingsEditor {
     offscreen_y: i32,
     window_w: i32,
     window_h: i32,
+    note_panel_w: f32,
+    note_panel_h: f32,
     query_scale: f32,
     list_scale: f32,
     history_limit: usize,
@@ -107,6 +109,8 @@ impl SettingsEditor {
             offscreen_y: settings.offscreen_pos.unwrap_or((2000, 2000)).1,
             window_w: settings.window_size.unwrap_or((400, 220)).0,
             window_h: settings.window_size.unwrap_or((400, 220)).1,
+            note_panel_w: settings.note_panel_default_size.0,
+            note_panel_h: settings.note_panel_default_size.1,
             query_scale: settings.query_scale.unwrap_or(1.0),
             list_scale: settings.list_scale.unwrap_or(1.0),
             history_limit: settings.history_limit,
@@ -194,6 +198,7 @@ impl SettingsEditor {
             toast_duration: self.toast_duration,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
+            note_panel_default_size: (self.note_panel_w, self.note_panel_h),
             query_scale: Some(self.query_scale),
             list_scale: Some(self.list_scale),
             history_limit: self.history_limit,
@@ -360,6 +365,13 @@ impl SettingsEditor {
                             ui.add(egui::DragValue::new(&mut self.offscreen_x));
                             ui.label("Y");
                             ui.add(egui::DragValue::new(&mut self.offscreen_y));
+                        });
+
+                        ui.horizontal(|ui| {
+                            ui.label("Note panel W");
+                            ui.add(egui::DragValue::new(&mut self.note_panel_w));
+                            ui.label("H");
+                            ui.add(egui::DragValue::new(&mut self.note_panel_h));
                         });
 
                         ui.checkbox(&mut self.follow_mouse, "Follow mouse");
@@ -533,6 +545,7 @@ impl SettingsEditor {
                                                 Some(new_settings.screenshot_save_file),
                                                 Some(new_settings.always_on_top),
                                                 Some(new_settings.page_jump),
+                                                Some(new_settings.note_panel_default_size),
                                             );
                                             ctx.send_viewport_cmd(
                                                 egui::ViewportCommand::WindowLevel(

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -69,6 +69,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();


### PR DESCRIPTION
## Summary
- avoid stealing focus unless user clicks inside note panel
- allow scrolling note content and wrapping tags
- add configurable default note panel size in settings and editor

## Testing
- `cargo test --lib`

 