### PR TITLE
Fix recycle bin cleanup return type

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -168,7 +168,6 @@ pub(crate) fn clean_recycle_bin() -> windows::core::Result<()> {
             None,
             SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI | SHERB_NOSOUND,
         )
-        .ok()
     }
 }
 


### PR DESCRIPTION
## Summary
- return `Result` from recycle bin cleanup instead of `Option`

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68926dd1f86c83329323b4f57f5c1eac