### PR TITLE
Use `note rm` command for removing notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Built-in commands:
 | `ip` | `ip` | Show IP addresses |
 | `sh` | `sh echo hi` | Shell commands |
 | `hi` | `hi` | Search history |
-| `note` | `note add <text>` | Quick notes |
+| `note` | `note add <text>` or `note rm <slug>` | Quick notes |
 | `todo` | `todo add <task>` | Todo items |
 | `todo edit` | `todo edit` | Edit todos |
 | `todo export` | `todo export` | Export todos |

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1753,7 +1753,7 @@ impl eframe::App for LauncherApp {
                             set_focus = true;
                         } else if let Some(link) = a.action.strip_prefix("note:link:") {
                             self.open_note_link(link);
-                        } else if let Some(slug) = a.action.strip_prefix("note:delete:") {
+                        } else if let Some(slug) = a.action.strip_prefix("note:remove:") {
                             self.delete_note(slug);
                         } else if a.action == "convert:panel" {
                             self.convert_panel.open();
@@ -2434,7 +2434,7 @@ impl eframe::App for LauncherApp {
                             set_focus = true;
                         } else if let Some(link) = a.action.strip_prefix("note:link:") {
                             self.open_note_link(link);
-                        } else if let Some(slug) = a.action.strip_prefix("note:delete:") {
+                        } else if let Some(slug) = a.action.strip_prefix("note:remove:") {
                             self.delete_note(slug);
                         } else if a.action == "convert:panel" {
                             self.convert_panel.open();

--- a/src/gui/note_delete_dialog.rs
+++ b/src/gui/note_delete_dialog.rs
@@ -36,20 +36,25 @@ impl NoteDeleteDialog {
                                 let word_count = note.content.split_whitespace().count();
                                 if let Err(e) = remove_note(idx) {
                                     app.set_error(format!("Failed to remove note: {e}"));
-                                } else if app.enable_toasts {
-                                    push_toast(
-                                        &mut app.toasts,
-                                        Toast {
-                                            text: format!(
-                                                "Removed note {} ({} words)",
-                                                note.title, word_count
-                                            )
-                                            .into(),
-                                            kind: ToastKind::Success,
-                                            options: ToastOptions::default()
-                                                .duration_in_seconds(app.toast_duration as f64),
-                                        },
-                                    );
+                                } else {
+                                    if app.enable_toasts {
+                                        push_toast(
+                                            &mut app.toasts,
+                                            Toast {
+                                                text: format!(
+                                                    "Removed note {} ({} words)",
+                                                    note.title, word_count
+                                                )
+                                                .into(),
+                                                kind: ToastKind::Success,
+                                                options: ToastOptions::default()
+                                                    .duration_in_seconds(app.toast_duration as f64),
+                                            },
+                                        );
+                                    }
+                                    if app.notes_dialog.open {
+                                        app.notes_dialog.open();
+                                    }
                                 }
                                 app.search();
                                 app.focus_input();

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -30,25 +30,25 @@ impl HelpWindow {
                         ui.label(format!("Help overlay: {hk}"));
                     }
                     ui.separator();
-                ui.label(egui::RichText::new("Commands").strong());
-                ui.text_edit_singleline(&mut self.filter);
-                let mut infos = app.plugins.plugin_infos();
-                infos.sort_by(|a, b| a.0.cmp(&b.0));
-                let area_height = ui.available_height();
-                egui::ScrollArea::vertical()
-                    .max_height(area_height)
-                    .show(ui, |ui| {
-                        let filt = self.filter.to_lowercase();
-                        for (name, desc, _) in &infos {
-                            if !filt.is_empty()
-                                && !name.to_lowercase().contains(&filt)
-                                && !desc.to_lowercase().contains(&filt)
-                            {
-                                continue;
+                    ui.label(egui::RichText::new("Commands").strong());
+                    ui.text_edit_singleline(&mut self.filter);
+                    let mut infos = app.plugins.plugin_infos();
+                    infos.sort_by(|a, b| a.0.cmp(&b.0));
+                    let area_height = ui.available_height();
+                    egui::ScrollArea::vertical()
+                        .max_height(area_height)
+                        .show(ui, |ui| {
+                            let filt = self.filter.to_lowercase();
+                            for (name, desc, _) in &infos {
+                                if !filt.is_empty()
+                                    && !name.to_lowercase().contains(&filt)
+                                    && !desc.to_lowercase().contains(&filt)
+                                {
+                                    continue;
+                                }
+                                ui.label(format!("{name}: {desc}"));
                             }
-                            ui.label(format!("{name}: {desc}"));
-                        }
-                    });
+                        });
                 });
             self.overlay_open = open;
         }
@@ -63,7 +63,10 @@ impl HelpWindow {
             .show(ctx, |ui| {
                 ui.vertical_centered(|ui| ui.heading("Available commands"));
                 ui.separator();
-                if ui.checkbox(&mut self.show_examples, "Show examples").changed() {
+                if ui
+                    .checkbox(&mut self.show_examples, "Show examples")
+                    .changed()
+                {
                     if let Ok(mut s) = crate::settings::Settings::load(&app.settings_path) {
                         s.show_examples = self.show_examples;
                         let _ = s.save(&app.settings_path);
@@ -150,7 +153,12 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
             "timer cancel  # cancel timers/alarms",
             "timer rm  # remove timers",
         ]),
-        "notes" => Some(&["note", "note add buy milk", "note list", "note rm milk"]),
+        "notes" => Some(&[
+            "note",
+            "note add buy milk",
+            "note list",
+            "note rm groceries",
+        ]),
         "volume" => Some(&["vol 50"]),
         "brightness" => Some(&["bright 50"]),
         "asciiart" => Some(&["ascii hello"]),

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -353,9 +353,9 @@ impl Plugin for NotePlugin {
                         args: None,
                     },
                     Action {
-                        label: "note delete".into(),
+                        label: "note rm".into(),
                         desc: "Note".into(),
-                        action: "query:note delete ".into(),
+                        action: "query:note rm ".into(),
                         args: None,
                     },
                 ]);
@@ -525,16 +525,16 @@ impl Plugin for NotePlugin {
                     }
                     return Vec::new();
                 }
-                "delete" => {
+                "rm" => {
                     let filter = args;
                     return guard
                         .notes
                         .iter()
                         .filter(|n| self.matcher.fuzzy_match(&n.title, filter).is_some())
                         .map(|n| Action {
-                            label: format!("Delete {}", n.title),
+                            label: format!("Remove {}", n.title),
                             desc: "Note".into(),
-                            action: format!("note:delete:{}", n.slug),
+                            action: format!("note:remove:{}", n.slug),
                             args: None,
                         })
                         .collect();
@@ -636,9 +636,9 @@ impl Plugin for NotePlugin {
                 args: None,
             },
             Action {
-                label: "note delete".into(),
+                label: "note rm".into(),
                 desc: "Note".into(),
-                action: "query:note delete ".into(),
+                action: "query:note rm ".into(),
                 args: None,
             },
         ]

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -1,13 +1,13 @@
 use chrono::Local;
-use multi_launcher::plugin::Plugin;
-use multi_launcher::plugins::note::{append_note, save_notes, NotePlugin};
-use multi_launcher::gui::{LauncherApp, show_wiki_link, extract_links};
-use multi_launcher::plugin::PluginManager;
-use multi_launcher::settings::Settings;
 use eframe::egui;
-use std::sync::{Arc, atomic::AtomicBool};
+use multi_launcher::gui::{extract_links, show_wiki_link, LauncherApp};
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::plugins::note::{append_note, save_notes, NotePlugin};
+use multi_launcher::settings::Settings;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
+use std::sync::{atomic::AtomicBool, Arc};
 use tempfile::tempdir;
 
 static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
@@ -60,7 +60,7 @@ fn note_root_query_returns_actions_in_order() {
             "query:note open ",
             "query:note today",
             "query:note link ",
-            "query:note delete ",
+            "query:note rm ",
         ]
     );
 }


### PR DESCRIPTION
## Summary
- rename `note delete` commands to `note rm` and update action prefix to `note:remove`
- refresh NotesDialog after removing a note so the list updates
- document the new `note rm` command and adjust tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689272c3e36c8332bf402baa6d28eef8