### PR TITLE
Refresh notes after removal

### DIFF
--- a/src/gui/note_delete_dialog.rs
+++ b/src/gui/note_delete_dialog.rs
@@ -52,12 +52,10 @@ impl NoteDeleteDialog {
                                             },
                                         );
                                     }
-                                    if app.notes_dialog.open {
-                                        app.notes_dialog.open();
-                                    }
+                                    app.notes_dialog.open();
+                                    app.search();
+                                    app.focus_input();
                                 }
-                                app.search();
-                                app.focus_input();
                             }
                         }
                         self.open = false;


### PR DESCRIPTION
## Summary
- Always reopen notes dialog after deleting a note and rerun search to refresh lists

## Testing
- `cargo test`
- Manually reran `note rm` query to confirm cache updated after removal


------
https://chatgpt.com/codex/tasks/task_e_6892a47418088332b0a3dc8ede02eabc