### PR TITLE
Keep note panel size fixed with internal scrolling

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -33,38 +33,50 @@ impl NotePanel {
         }
         let mut open = self.open;
         let mut save_now = false;
+        let screen_rect = ctx.available_rect();
+        let max_width = screen_rect.width().min(800.0);
+        let max_height = screen_rect.height().min(600.0);
         egui::Window::new(self.note.title.clone())
             .open(&mut open)
             .resizable(true)
             .default_size(app.note_panel_default_size)
             .min_width(200.0)
             .min_height(150.0)
+            .max_width(max_width)
+            .max_height(max_height)
             .movable(true)
             .show(ctx, |ui| {
                 let content_id = egui::Id::new("note_content");
-                let resp = egui::ScrollArea::vertical()
-                    .show(ui, |ui| {
+                let total_available = ui.available_size();
+                let footer_reserved_height = 90.0; // space for buttons/tags
+                let scrollable_height = total_available.y - footer_reserved_height;
+
+                let mut text_resp: Option<egui::Response> = None;
+                egui::ScrollArea::vertical()
+                    .id_source(content_id)
+                    .show_viewport(ui, |ui, _viewport| {
+                        ui.set_min_height(scrollable_height);
                         if self.preview_mode {
                             CommonMarkViewer::new("note_content").show(
                                 ui,
                                 &mut self.markdown_cache,
                                 &self.note.content,
                             );
-                            None
                         } else {
-                            Some(
-                                ui.add(
-                                    egui::TextEdit::multiline(&mut self.note.content)
-                                        .desired_width(f32::INFINITY)
-                                        .desired_rows(15)
-                                        .id_source(content_id),
-                                ),
-                            )
+                            let resp = ui.add(
+                                egui::TextEdit::multiline(&mut self.note.content)
+                                    .id_source(content_id)
+                                    .desired_width(f32::INFINITY)
+                                    .frame(true)
+                                    .lock_focus(true)
+                                    .desired_rows(10),
+                            );
+                            text_resp = Some(resp);
                         }
-                    })
-                    .inner;
+                    });
+
                 if !self.preview_mode {
-                    if let Some(resp) = resp {
+                    if let Some(resp) = text_resp {
                         resp.context_menu(|ui| {
                             ui.set_min_width(200.0);
                             ui.label("Insert link:");
@@ -106,6 +118,8 @@ impl NotePanel {
                         }
                     }
                 }
+
+                ui.separator();
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
                         save_now = true;
@@ -119,7 +133,7 @@ impl NotePanel {
                         self.preview_mode = true;
                     }
                 });
-                ui.separator();
+
                 let tags = extract_tags(&self.note.content);
                 if !tags.is_empty() {
                     ui.horizontal_wrapped(|ui| {
@@ -129,6 +143,7 @@ impl NotePanel {
                         }
                     });
                 }
+
                 let wiki = extract_wiki_links(&self.note.content);
                 let links = extract_links(&self.note.content);
                 if !wiki.is_empty() || !links.is_empty() {


### PR DESCRIPTION
## Summary
- bound the scrollable text area to the note window's available space so the panel stays at the user's chosen size
- moved buttons and tags to a footer below the scroll area so controls remain visible

## Testing
- `timeout -v 30 cargo test` (timed out during test run)
- `cargo test --test quit_hotkey --quiet` (warning then interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68934e2c3a008332b262b452ce23935d