### PR TITLE
Refactor action sharing with Arc

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use eframe::egui;
-use multi_launcher::{gui::LauncherApp, plugin::PluginManager, actions::Action, settings::Settings};
+use multi_launcher::{actions::Action, gui::LauncherApp, plugin::PluginManager, settings::Settings};
+use std::sync::Arc;
 
 fn bench_search(c: &mut Criterion) {
     let ctx = egui::Context::default();
@@ -12,10 +13,11 @@ fn bench_search(c: &mut Criterion) {
             args: None,
         })
         .collect();
+    let actions_arc = Arc::new(actions);
     let settings = Settings::default();
     let mut app = LauncherApp::new(
         &ctx,
-        actions,
+        actions_arc,
         10_000,
         PluginManager::new(),
         "actions.json".into(),
@@ -25,9 +27,9 @@ fn bench_search(c: &mut Criterion) {
         None,
         None,
         None,
-        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
     );
     app.query = "app Item 9999".to_string();
     c.bench_function("search_10k", |b| b.iter(|| app.search()));

--- a/src/actions_editor.rs
+++ b/src/actions_editor.rs
@@ -2,6 +2,7 @@ use crate::actions::save_actions;
 use crate::gui::AddActionDialog;
 use crate::gui::LauncherApp;
 use eframe::egui;
+use std::sync::Arc;
 
 /// State container for the app editor window.
 ///
@@ -86,10 +87,12 @@ impl ActionsEditor {
             });
 
             if let Some(i) = remove {
-                app.actions.remove(i);
+                let mut new_actions = (*app.actions).clone();
+                new_actions.remove(i);
                 if i < app.custom_len {
                     app.custom_len -= 1;
                 }
+                app.actions = Arc::new(new_actions);
                 app.search();
                 if let Err(e) = save_actions(&app.actions_path, &app.actions[..app.custom_len]) {
                     app.set_error(format!("Failed to save: {e}"));

--- a/src/gui/add_action_dialog.rs
+++ b/src/gui/add_action_dialog.rs
@@ -1,6 +1,7 @@
-use crate::actions::{Action, save_actions};
+use crate::actions::{save_actions, Action};
 use crate::gui::LauncherApp;
 use eframe::egui;
+use std::sync::Arc;
 #[cfg(target_os = "windows")]
 use rfd::FileDialog;
 
@@ -138,7 +139,8 @@ impl AddActionDialog {
                             } else {
                                 match self.mode {
                                     DialogMode::Add => {
-                                        app.actions.push(Action {
+                                        let mut new_actions = (*app.actions).clone();
+                                        new_actions.push(Action {
                                             label: self.label.clone(),
                                             desc: self.desc.clone(),
                                             action: self.path.clone(),
@@ -149,10 +151,12 @@ impl AddActionDialog {
                                             },
                                         });
                                         app.custom_len += 1;
+                                        app.actions = Arc::new(new_actions);
                                         app.update_action_cache();
                                     }
                                     DialogMode::Edit(idx) => {
-                                        if let Some(act) = app.actions.get_mut(idx) {
+                                        let mut new_actions = (*app.actions).clone();
+                                        if let Some(act) = new_actions.get_mut(idx) {
                                             act.label = self.label.clone();
                                             act.desc = self.desc.clone();
                                             act.action = self.path.clone();
@@ -161,6 +165,7 @@ impl AddActionDialog {
                                             } else {
                                                 None
                                             };
+                                            app.actions = Arc::new(new_actions);
                                             app.update_action_cache();
                                         }
                                     }

--- a/src/gui/macro_dialog.rs
+++ b/src/gui/macro_dialog.rs
@@ -297,7 +297,7 @@ impl MacroDialog {
                         .id_source("macro_app_list")
                         .max_height(100.0)
                         .show(ui, |ui| {
-                            for act in &app.actions {
+                            for act in app.actions.iter() {
                                 if !filter.is_empty()
                                     && !act.label.to_lowercase().contains(&filter)
                                     && !act.desc.to_lowercase().contains(&filter)

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -248,7 +248,7 @@ mod tests {
     fn new_app(ctx: &egui::Context) -> LauncherApp {
         LauncherApp::new(
             ctx,
-            Vec::new(),
+            Arc::new(Vec::new()),
             0,
             PluginManager::new(),
             "actions.json".into(),

--- a/src/gui/shell_cmd_dialog.rs
+++ b/src/gui/shell_cmd_dialog.rs
@@ -125,7 +125,7 @@ mod tests {
     fn new_app(ctx: &egui::Context) -> LauncherApp {
         LauncherApp::new(
             ctx,
-            Vec::new(),
+            Arc::new(Vec::new()),
             0,
             PluginManager::new(),
             "actions.json".into(),

--- a/src/gui/todo_dialog.rs
+++ b/src/gui/todo_dialog.rs
@@ -272,7 +272,7 @@ mod tests {
     fn new_app(ctx: &egui::Context) -> LauncherApp {
         LauncherApp::new(
             ctx,
-            Vec::new(),
+            Arc::new(Vec::new()),
             0,
             PluginManager::new(),
             "actions.json".into(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -103,6 +103,12 @@ impl PluginManager {
     }
 
     /// Rebuild the plugin list, keeping previously loaded libraries alive.
+    ///
+    /// `actions` is the shared list of launcher actions. An [`Arc`] is used so
+    /// plugins such as [`OmniSearchPlugin`](crate::plugins::omni_search::OmniSearchPlugin)
+    /// can cheaply clone the pointer for read-only access without duplicating
+    /// the underlying `Vec`. This keeps the action data consistent across the
+    /// application while allowing plugins to inspect it from their own threads.
     pub fn reload_from_dirs(
         &mut self,
         dirs: &[String],

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -128,7 +128,7 @@ impl PluginEditor {
                         None,
                     );
                     let dirs = s.plugin_dirs.clone().unwrap_or_default();
-                    let actions_arc = Arc::new(app.actions.clone());
+                    let actions_arc = Arc::clone(&app.actions);
                     app.plugins.reload_from_dirs(
                         &dirs,
                         app.clipboard_limit,

--- a/src/plugins/omni_search.rs
+++ b/src/plugins/omni_search.rs
@@ -6,14 +6,28 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use std::sync::Arc;
 
+/// Combined search across folders, bookmarks, and launcher actions.
+///
+/// The action list is provided as an [`Arc<Vec<Action>>`] so the plugin can
+/// participate in searches without holding its own copy. Cloning the `Arc`
+/// replicates only the pointer, keeping the underlying `Vec` shared and
+/// thread-safe.
 pub struct OmniSearchPlugin {
     folders: FoldersPlugin,
     bookmarks: BookmarksPlugin,
+    /// Shared list of launcher actions searched alongside folders and
+    /// bookmarks. Cloning the `Arc` only clones the pointer so the underlying
+    /// `Vec` remains shared.
     actions: Arc<Vec<Action>>,
     matcher: SkimMatcherV2,
 }
 
 impl OmniSearchPlugin {
+    /// Create a new `OmniSearchPlugin`.
+    ///
+    /// `actions` is an [`Arc`] over the application's action list. Cloning the
+    /// `Arc` does not clone the `Vec` itself, so the plugin can read the shared
+    /// action data without duplicating it.
     pub fn new(actions: Arc<Vec<Action>>) -> Self {
         Self {
             folders: FoldersPlugin::default(),

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -579,7 +579,7 @@ impl SettingsEditor {
                                                 .plugin_dirs
                                                 .clone()
                                                 .unwrap_or_default();
-                                            let actions_arc = Arc::new(app.actions.clone());
+                                            let actions_arc = Arc::clone(&app.actions);
                                             app.plugins.reload_from_dirs(
                                                 &dirs,
                                                 app.clipboard_limit,

--- a/tests/file_drop.rs
+++ b/tests/file_drop.rs
@@ -7,7 +7,7 @@ fn new_app(ctx: &egui::Context) -> LauncherApp {
     let custom_len = actions.len();
     LauncherApp::new(
         ctx,
-        actions,
+        Arc::new(actions),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -15,10 +15,11 @@ fn new_app_with_settings(
 ) -> (LauncherApp, Arc<AtomicBool>) {
     let custom_len = actions.len();
     let visible = Arc::new(AtomicBool::new(true));
+    let actions_arc = Arc::new(actions);
     (
         LauncherApp::new(
             ctx,
-            actions,
+            actions_arc,
             custom_len,
             PluginManager::new(),
             "actions.json".into(),

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -25,7 +25,7 @@ fn setup() -> tempfile::TempDir {
 fn new_app(ctx: &egui::Context) -> LauncherApp {
     LauncherApp::new(
         ctx,
-        Vec::new(),
+        Arc::new(Vec::new()),
         0,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -9,18 +9,18 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),
@@ -45,19 +45,19 @@ fn new_app_with_settings(
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
     let plugin_settings = settings.plugin_settings.clone();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &dirs,
         settings.clipboard_limit,
         settings.net_unit,
         false,
         &plugin_settings,
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     let enabled_plugins = settings.enabled_plugins.clone();
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/plugin_exact_match.rs
+++ b/tests/plugin_exact_match.rs
@@ -22,11 +22,11 @@ fn new_app(ctx: &egui::Context, settings: Settings) -> LauncherApp {
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        Vec::new(),
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/preserve_command.rs
+++ b/tests/preserve_command.rs
@@ -11,7 +11,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>, preserve: bool) -> Launche
     settings.preserve_command = preserve;
     LauncherApp::new(
         ctx,
-        actions,
+        Arc::new(actions),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/ranking.rs
+++ b/tests/ranking.rs
@@ -9,7 +9,7 @@ fn new_app_with_settings(ctx: &egui::Context, actions: Vec<Action>, settings: Se
     let custom_len = actions.len();
     LauncherApp::new(
         ctx,
-        actions,
+        Arc::new(actions),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/recycle_plugin.rs
+++ b/tests/recycle_plugin.rs
@@ -14,18 +14,18 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/selection.rs
+++ b/tests/selection.rs
@@ -9,7 +9,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     LauncherApp::new(
         ctx,
-        actions,
+        Arc::new(actions),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),
@@ -124,7 +124,7 @@ fn page_keys_respect_setting() {
     let custom_len = acts.len();
     let mut app = LauncherApp::new(
         &ctx,
-        acts,
+        Arc::new(acts),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/settings_plugin.rs
+++ b/tests/settings_plugin.rs
@@ -7,18 +7,18 @@ use eframe::egui;
 fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/stopwatch_refresh.rs
+++ b/tests/stopwatch_refresh.rs
@@ -10,18 +10,18 @@ fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
     let actions: Vec<Action> = Vec::new();
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/timer_refresh.rs
+++ b/tests/timer_refresh.rs
@@ -9,18 +9,18 @@ fn new_app(ctx: &eframe::egui::Context) -> LauncherApp {
     let actions: Vec<Action> = Vec::new();
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &[],
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/tmp_rm_refresh.rs
+++ b/tests/tmp_rm_refresh.rs
@@ -13,18 +13,18 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),

--- a/tests/todo_plugin.rs
+++ b/tests/todo_plugin.rs
@@ -16,7 +16,7 @@ static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 fn new_app(ctx: &egui::Context) -> LauncherApp {
     LauncherApp::new(
         ctx,
-        Vec::new(),
+        Arc::new(Vec::new()),
         0,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/watcher_failures.rs
+++ b/tests/watcher_failures.rs
@@ -14,7 +14,7 @@ static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 fn new_app(actions_path: &str, ctx: &egui::Context) -> LauncherApp {
     LauncherApp::new(
         ctx,
-        Vec::new(),
+        Arc::new(Vec::new()),
         0,
         PluginManager::new(),
         actions_path.into(),

--- a/tests/watchers.rs
+++ b/tests/watchers.rs
@@ -17,7 +17,7 @@ fn new_app(ctx: &egui::Context, actions: Vec<Action>) -> LauncherApp {
     let custom_len = actions.len();
     LauncherApp::new(
         ctx,
-        actions,
+        Arc::new(actions),
         custom_len,
         PluginManager::new(),
         "actions.json".into(),

--- a/tests/web_search_prefix.rs
+++ b/tests/web_search_prefix.rs
@@ -9,18 +9,18 @@ fn new_app_with_plugins(ctx: &egui::Context, actions: Vec<Action>) -> LauncherAp
     let custom_len = actions.len();
     let mut plugins = PluginManager::new();
     let dirs: Vec<String> = Vec::new();
-    let actions_arc = Arc::new(actions.clone());
+    let actions_arc = Arc::new(actions);
     plugins.reload_from_dirs(
         &dirs,
         Settings::default().clipboard_limit,
         Settings::default().net_unit,
         false,
         &std::collections::HashMap::new(),
-        actions_arc,
+        Arc::clone(&actions_arc),
     );
     LauncherApp::new(
         ctx,
-        actions,
+        actions_arc,
         custom_len,
         plugins,
         "actions.json".into(),


### PR DESCRIPTION
## Summary
- pass an `Arc<Vec<Action>>` into `LauncherApp::new` and use it directly
- update editors and dialogs to mutate actions by rebuilding the shared `Arc`
- document `LauncherApp::actions`, `spawn_gui`, plugin manager, and omni-search plugin for `Arc<Vec<Action>>` sharing
- clarify `Arc`-based action sharing semantics across threads and modules

## Testing
- `cargo test --no-run` *(interrupted after extended compile time)*

------
https://chatgpt.com/codex/tasks/task_e_6893f7e2aae083329f6a30846d7cc9ca