### PR TITLE
feat(gui): add open in neovim option

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ RUST_LOG=info cargo run
 
 - Press the help hotkey (F1 by default) to display a quick list of available commands.
 - Right click a folder result to set a custom alias for easier access.
+- Right click a note entry to edit, remove, or open it in Neovim.
 - Use the *Snapshot* button in Settings when adjusting static window placement.
 - Searches are case-insensitive and also match on command aliases.
 - Tweak `fuzzy_weight` and `usage_weight` if you want results to favour name matches or past usage differently.


### PR DESCRIPTION
## Summary
- allow opening notes directly in Neovim from the context menu
- test Neovim launch: note resolution, spawn, error handling, and closing the menu
- clarify helper semantics and document menu option in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896a07fc04883328992532880093f69