### PR TITLE
Open notes in preview mode by default

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -22,7 +22,7 @@ impl NotePanel {
             open: true,
             note,
             link_search: String::new(),
-            preview_mode: false,
+            preview_mode: true,
             markdown_cache: CommonMarkCache::default(),
         }
     }
@@ -365,7 +365,9 @@ mod tests {
             links: Vec::new(),
             slug: String::new(),
         };
-        app.note_panels.push(NotePanel::from_note(note));
+        let mut panel = NotePanel::from_note(note);
+        panel.preview_mode = false;
+        app.note_panels.push(panel);
 
         let _ = ctx.run(Default::default(), |ctx| {
             egui::CentralPanel::default().show(ctx, |_ui| {


### PR DESCRIPTION
## Summary
- default `NotePanel` to render content before editing
- ensure tests that simulate note editing explicitly disable preview mode

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689750b5d4688332bd49aea7da378a38