### PR TITLE
Use wrapped layout for note links

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -152,7 +152,7 @@ impl NotePanel {
                 let wiki = extract_wiki_links(&self.note.content);
                 let links = extract_links(&self.note.content);
                 if !wiki.is_empty() || !links.is_empty() {
-                    ui.horizontal(|ui| {
+                    ui.horizontal_wrapped(|ui| {
                         ui.label("Links:");
                         for l in wiki {
                             show_wiki_link(ui, app, &l);


### PR DESCRIPTION
## Summary
- wrap note link list in `horizontal_wrapped` so multiple links wrap to new lines

## Testing
- `cargo test` *(fails: hangs during test run)*
- `cargo run --no-default-features` *(fails: interrupted due to long build or missing display)*

------
https://chatgpt.com/codex/tasks/task_e_6897949219c48332b51df2dc059f1c5e