### PR TITLE
Deduplicate link extraction in notes

### DIFF
--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -201,7 +201,7 @@ fn missing_link_colored_red() {
 
 #[test]
 fn link_validation_rejects_invalid_urls() {
-    let content = "visit http://example.com and http://exa%mple.com also https://rust-lang.org and www.example.com and www.exa%mple.com";
+    let content = "visit http://example.com and http://exa%mple.com also https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
     let links = extract_links(content);
     assert_eq!(
         links,


### PR DESCRIPTION
## Summary
- dedupe extracted web links and wiki links before storing
- test that repeated links and wiki links are unique

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689799a37b648332942bd8c46f6164a4