### PR TITLE
Normalize note tags to lowercase

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -212,7 +212,7 @@ fn extract_tags(content: &str) -> Vec<String> {
     static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"#([A-Za-z0-9_]+)").unwrap());
     let mut tags: Vec<String> = TAG_RE
         .captures_iter(content)
-        .map(|c| c[1].to_string())
+        .map(|c| c[1].to_lowercase())
         .collect();
     tags.sort();
     tags.dedup();

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -76,7 +76,7 @@ static WIKI_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[\[([^\]]+)\]\]").unwra
 fn extract_tags(content: &str) -> Vec<String> {
     let mut tags: Vec<String> = TAG_RE
         .captures_iter(content)
-        .map(|c| c[1].to_string())
+        .map(|c| c[1].to_lowercase())
         .collect();
     tags.sort();
     tags.dedup();

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -116,12 +116,14 @@ fn note_search_finds_content() {
 fn note_tags_parses_edge_cases() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let _tmp = setup();
-    append_note("alpha", "#foo #bar-baz #baz_1 #dup #dup").unwrap();
+    append_note("alpha", "#Foo #foo #bar-baz #baz_1 #dup #dup").unwrap();
     let plugin = NotePlugin::default();
     let results = plugin.search("note tags");
     assert_eq!(results.len(), 4);
     let labels: Vec<String> = results.iter().map(|a| a.label.clone()).collect();
+    assert_eq!(labels.iter().filter(|l| l.as_str() == "#foo").count(), 1);
     assert!(labels.contains(&"#foo".to_string()));
+    assert!(!labels.iter().any(|l| l.as_str() == "#Foo"));
     assert!(labels.contains(&"#bar".to_string()));
     assert!(labels.contains(&"#baz_1".to_string()));
     assert!(labels.contains(&"#dup".to_string()));


### PR DESCRIPTION
## Summary
- lowercase tags when extracting note metadata
- do the same in note panel GUI
- test dedupes mixed-case tags to a single lowercase value

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6897a9ceac188332974704385f8dbcba