### PR TITLE
Add note auto-save on close option

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -17,6 +17,7 @@
     420.0,
     320.0
   ],
+  "note_save_on_close": false,
   "enable_toasts": true,
   "toast_duration": 3.0,
   "show_examples": false,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -8,9 +8,9 @@ mod convert_panel;
 mod cpu_list_dialog;
 mod fav_dialog;
 mod macro_dialog;
+mod note_delete_dialog;
 mod note_panel;
 mod notes_dialog;
-mod note_delete_dialog;
 mod shell_cmd_dialog;
 mod snippet_dialog;
 mod tempfile_alias_dialog;
@@ -31,9 +31,9 @@ pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;
 pub use fav_dialog::FavDialog;
 pub use macro_dialog::MacroDialog;
-pub use note_panel::{NotePanel, show_wiki_link, extract_links};
-pub use notes_dialog::NotesDialog;
 pub use note_delete_dialog::NoteDeleteDialog;
+pub use note_panel::{extract_links, show_wiki_link, NotePanel};
+pub use notes_dialog::NotesDialog;
 pub use shell_cmd_dialog::ShellCmdDialog;
 pub use snippet_dialog::SnippetDialog;
 pub use tempfile_alias_dialog::TempfileAliasDialog;
@@ -64,20 +64,20 @@ use egui_toast::{Toast, ToastKind, ToastOptions, Toasts};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use url::Url;
-use serde::{Serialize, Deserialize};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Mutex;
-use once_cell::sync::Lazy;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-#[cfg(test)]
-use std::sync::atomic::AtomicUsize;
 use std::time::Instant;
+use url::Url;
 
 const SUBCOMMANDS: &[&str] = &[
     "add", "rm", "list", "clear", "open", "new", "alias", "set", "pause", "resume", "cancel",
@@ -162,8 +162,7 @@ fn push_toast(toasts: &mut Toasts, toast: Toast) {
     toasts.add(toast);
 }
 
-static APP_EVENT_TXS: Lazy<Mutex<Vec<Sender<WatchEvent>>>> =
-    Lazy::new(|| Mutex::new(Vec::new()));
+static APP_EVENT_TXS: Lazy<Mutex<Vec<Sender<WatchEvent>>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 pub fn register_event_sender(tx: Sender<WatchEvent>) {
     if let Ok(mut guard) = APP_EVENT_TXS.lock() {
@@ -349,6 +348,7 @@ pub struct LauncherApp {
     pub usage_weight: f32,
     pub page_jump: usize,
     pub note_panel_default_size: (f32, f32),
+    pub note_save_on_close: bool,
     pub follow_mouse: bool,
     pub static_location_enabled: bool,
     pub static_pos: Option<(i32, i32)>,
@@ -435,6 +435,7 @@ impl LauncherApp {
         always_on_top: Option<bool>,
         page_jump: Option<usize>,
         note_panel_default_size: Option<(f32, f32)>,
+        note_save_on_close: Option<bool>,
     ) {
         self.plugin_dirs = plugin_dirs;
         self.index_paths = index_paths;
@@ -502,6 +503,9 @@ impl LauncherApp {
         }
         if let Some(v) = note_panel_default_size {
             self.note_panel_default_size = v;
+        }
+        if let Some(v) = note_save_on_close {
+            self.note_save_on_close = v;
         }
     }
 
@@ -692,6 +696,7 @@ impl LauncherApp {
             usage_weight: settings.usage_weight,
             page_jump: settings.page_jump,
             note_panel_default_size: settings.note_panel_default_size,
+            note_save_on_close: settings.note_save_on_close,
             follow_mouse,
             static_location_enabled: static_enabled,
             static_pos,
@@ -1239,7 +1244,11 @@ impl LauncherApp {
                 self.panel_states.note_delete_dialog = false;
             }
             Panel::NotePanel => {
-                let _ = self.note_panels.pop();
+                if let Some(mut panel) = self.note_panels.pop() {
+                    if self.note_save_on_close {
+                        panel.save(self);
+                    }
+                }
                 self.panel_states.note_panel = false;
             }
             Panel::TodoDialog => {
@@ -1421,7 +1430,7 @@ impl LauncherApp {
             Panel::FavDialog => self.fav_dialog.open = true,
             Panel::NotesDialog => self.notes_dialog.open = true,
             Panel::NoteDeleteDialog => self.note_delete_dialog.open = true,
-            Panel::NotePanel => {},
+            Panel::NotePanel => {}
             Panel::TodoDialog => self.todo_dialog.open = true,
             Panel::TodoViewDialog => self.todo_view_dialog.open = true,
             Panel::ClipboardDialog => self.clipboard_dialog.open = true,
@@ -1774,32 +1783,36 @@ impl eframe::App for LauncherApp {
                     .map(|b| (b.url, b.alias))
                     .collect();
                 }
-                WatchEvent::Recycle(res) => {
-                    match res {
-                        Ok(()) => {
-                            if self.enable_toasts {
-                                push_toast(&mut self.toasts, Toast {
+                WatchEvent::Recycle(res) => match res {
+                    Ok(()) => {
+                        if self.enable_toasts {
+                            push_toast(
+                                &mut self.toasts,
+                                Toast {
                                     text: "Emptied Recycle Bin".into(),
                                     kind: ToastKind::Success,
                                     options: ToastOptions::default()
                                         .duration_in_seconds(self.toast_duration as f64),
-                                });
-                            }
+                                },
+                            );
                         }
-                        Err(e) => {
-                            let msg = format!("Failed to empty recycle bin: {e}");
-                            self.set_error(msg.clone());
-                            if self.enable_toasts {
-                                push_toast(&mut self.toasts, Toast {
+                    }
+                    Err(e) => {
+                        let msg = format!("Failed to empty recycle bin: {e}");
+                        self.set_error(msg.clone());
+                        if self.enable_toasts {
+                            push_toast(
+                                &mut self.toasts,
+                                Toast {
                                     text: msg.into(),
                                     kind: ToastKind::Error,
                                     options: ToastOptions::default()
                                         .duration_in_seconds(self.toast_duration as f64),
-                                });
-                            }
+                                },
+                            );
                         }
                     }
-                }
+                },
             }
         }
 
@@ -3050,9 +3063,7 @@ impl LauncherApp {
                 let title = slug.replace('-', " ");
                 let content = if let Some(tpl_name) = template {
                     if let Some(tpl) = get_template(tpl_name) {
-                        let filled = tpl
-                            .replace("{{title}}", &title)
-                            .replace("{{date}}", slug);
+                        let filled = tpl.replace("{{title}}", &title).replace("{{date}}", slug);
                         if filled.starts_with("# ") {
                             filled
                         } else {
@@ -3221,7 +3232,10 @@ mod tests {
     use super::*;
     use crate::{plugin::PluginManager, settings::Settings};
     use eframe::egui;
-    use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
     use tempfile::tempdir;
 
     fn new_app(ctx: &egui::Context) -> LauncherApp {

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3,6 +3,7 @@ use crate::gui::LauncherApp;
 use crate::plugin::Plugin;
 use crate::plugins::note::{load_notes, save_note, Note, NotePlugin};
 use eframe::egui::{self, Color32};
+use egui_toast::{Toast, ToastKind, ToastOptions};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -33,6 +34,9 @@ impl NotePanel {
         }
         let mut open = self.open;
         let mut save_now = false;
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            open = false;
+        }
         let screen_rect = ctx.available_rect();
         let max_width = screen_rect.width().min(800.0);
         let max_height = screen_rect.height().min(600.0);
@@ -163,25 +167,37 @@ impl NotePanel {
                     });
                 }
             });
-        if save_now {
-            self.note.tags = extract_tags(&self.note.content);
-            self.note.links = extract_wiki_links(&self.note.content)
-                .into_iter()
-                .map(|l| slugify(&l))
-                .collect();
-            if let Some(first) = self.note.content.lines().next() {
-                if let Some(t) = first.strip_prefix("# ") {
-                    self.note.title = t.to_string();
-                }
-            }
-            if let Err(e) = save_note(&mut self.note) {
-                app.set_error(format!("Failed to save note: {e}"));
-            } else {
-                app.search();
-                app.focus_input();
-            }
+        if save_now || (!open && app.note_save_on_close) {
+            self.save(app);
         }
         self.open = open;
+    }
+
+    pub fn save(&mut self, app: &mut LauncherApp) {
+        self.note.tags = extract_tags(&self.note.content);
+        self.note.links = extract_wiki_links(&self.note.content)
+            .into_iter()
+            .map(|l| slugify(&l))
+            .collect();
+        if let Some(first) = self.note.content.lines().next() {
+            if let Some(t) = first.strip_prefix("# ") {
+                self.note.title = t.to_string();
+            }
+        }
+        if let Err(e) = save_note(&mut self.note) {
+            app.set_error(format!("Failed to save note: {e}"));
+        } else {
+            app.search();
+            app.focus_input();
+            if app.enable_toasts {
+                app.add_toast(Toast {
+                    text: format!("Saved note {}", self.note.title).into(),
+                    kind: ToastKind::Success,
+                    options: ToastOptions::default()
+                        .duration_in_seconds(app.toast_duration as f64),
+                });
+            }
+        }
     }
 }
 

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -126,6 +126,7 @@ impl PluginEditor {
                         None,
                         None,
                         None,
+                        None,
                     );
                     let dirs = s.plugin_dirs.clone().unwrap_or_default();
                     let actions_arc = Arc::clone(&app.actions);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::hotkey::Key;
 
-use crate::hotkey::{parse_hotkey, Hotkey};
 use crate::gui::Panel;
+use crate::hotkey::{parse_hotkey, Hotkey};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -71,6 +71,10 @@ pub struct Settings {
     /// Default size for note editor panels.
     #[serde(default = "default_note_panel_size")]
     pub note_panel_default_size: (f32, f32),
+    /// When enabled, the note panel saves its contents before closing (e.g. via `Esc`).
+    /// Defaults to `false` when the field is missing in the settings file.
+    #[serde(default = "default_note_save_on_close")]
+    pub note_save_on_close: bool,
     /// Enable toast notifications in the UI.
     #[serde(default = "default_toasts")]
     pub enable_toasts: bool,
@@ -197,6 +201,10 @@ fn default_note_panel_size() -> (f32, f32) {
     (420.0, 320.0)
 }
 
+fn default_note_save_on_close() -> bool {
+    false
+}
+
 fn default_log_path() -> PathBuf {
     std::env::current_exe()
         .ok()
@@ -227,6 +235,7 @@ impl Default for Settings {
             offscreen_pos: Some((2000, 2000)),
             window_size: Some((400, 220)),
             note_panel_default_size: default_note_panel_size(),
+            note_save_on_close: default_note_save_on_close(),
             enable_toasts: true,
             toast_duration: default_toast_duration(),
             query_scale: Some(1.0),

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -29,6 +29,7 @@ pub struct SettingsEditor {
     window_h: i32,
     note_panel_w: f32,
     note_panel_h: f32,
+    note_save_on_close: bool,
     query_scale: f32,
     list_scale: f32,
     history_limit: usize,
@@ -111,6 +112,7 @@ impl SettingsEditor {
             window_h: settings.window_size.unwrap_or((400, 220)).1,
             note_panel_w: settings.note_panel_default_size.0,
             note_panel_h: settings.note_panel_default_size.1,
+            note_save_on_close: settings.note_save_on_close,
             query_scale: settings.query_scale.unwrap_or(1.0),
             list_scale: settings.list_scale.unwrap_or(1.0),
             history_limit: settings.history_limit,
@@ -199,6 +201,7 @@ impl SettingsEditor {
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
             note_panel_default_size: (self.note_panel_w, self.note_panel_h),
+            note_save_on_close: self.note_save_on_close,
             query_scale: Some(self.query_scale),
             list_scale: Some(self.list_scale),
             history_limit: self.history_limit,
@@ -413,7 +416,6 @@ impl SettingsEditor {
                             &mut self.screenshot_save_file,
                             "Save file when copying screenshot",
                         );
-
                         ui.separator();
                         if ui
                             .button(if self.plugins_expanded {
@@ -465,7 +467,28 @@ impl SettingsEditor {
                                     plugin.settings_ui(ui, entry);
                                 });
                         }
+                        let id = ui.make_persistent_id("plugin_notes");
+                        let mut state = egui::collapsing_header::CollapsingState::load_with_default_open(
+                            ui.ctx(),
+                            id,
+                            false,
+                        );
+                        if let Some(open) = self.expand_request {
+                            state.set_open(open);
+                        }
+                        state
+                            .show_header(ui, |ui| {
+                                ui.label("Note settings");
+                            })
+                            .body(|ui| {
+                                ui.checkbox(
+                                    &mut self.note_save_on_close,
+                                    "Save note on close (Esc)",
+                                );
+                            });
+
                         self.expand_request = None;
+                        ui.separator();
 
                         if ui.button("Save").clicked() {
                             if parse_hotkey(&self.hotkey).is_none() {
@@ -547,6 +570,7 @@ impl SettingsEditor {
                                                 Some(new_settings.always_on_top),
                                                 Some(new_settings.page_jump),
                                                 Some(new_settings.note_panel_default_size),
+                                                Some(new_settings.note_save_on_close),
                                             );
                                             ctx.send_viewport_cmd(
                                                 egui::ViewportCommand::WindowLevel(

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -71,6 +71,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/note_panel_auto_save.rs
+++ b/tests/note_panel_auto_save.rs
@@ -1,0 +1,80 @@
+use eframe::egui;
+use multi_launcher::gui::{LauncherApp, NotePanel};
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::plugins::note::{append_note, load_notes, save_notes};
+use multi_launcher::settings::Settings;
+use once_cell::sync::Lazy;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn setup() -> tempfile::TempDir {
+    let dir = tempdir().unwrap();
+    let notes_dir = dir.path().join("notes");
+    std::fs::create_dir_all(&notes_dir).unwrap();
+    std::env::set_var("ML_NOTES_DIR", &notes_dir);
+    std::env::set_var("HOME", dir.path());
+    save_notes(&[]).unwrap();
+    dir
+}
+
+fn new_app(ctx: &egui::Context) -> LauncherApp {
+    let mut settings = Settings::default();
+    settings.note_save_on_close = true;
+    LauncherApp::new(
+        ctx,
+        Arc::new(Vec::new()),
+        0,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn note_panel_auto_saves_on_close() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let _tmp = setup();
+    append_note("alpha", "original").unwrap();
+    let ctx = egui::Context::default();
+    let mut app = new_app(&ctx);
+    let mut note = load_notes()
+        .unwrap()
+        .into_iter()
+        .find(|n| n.slug == "alpha")
+        .unwrap();
+    note.content.push_str(" updated");
+    let mut panel = NotePanel::from_note(note);
+
+    ctx.begin_frame(egui::RawInput {
+        events: vec![egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::default(),
+        }],
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(800.0, 600.0),
+        )),
+        ..Default::default()
+    });
+    panel.ui(&ctx, &mut app);
+    let _ = ctx.end_frame();
+
+    let notes = load_notes().unwrap();
+    let note = notes.into_iter().find(|n| n.slug == "alpha").unwrap();
+    assert!(note.content.contains("updated"));
+}
+


### PR DESCRIPTION
## Summary
- encapsulate note saving logic into `NotePanel::save`
- invoke note saving when panels are closed via Escape

## Testing
- `cargo test --test note_panel_auto_save -- --nocapture`
- `cargo test`

 