### PR TITLE
Prevent tempfile alias collisions

### DIFF
--- a/src/actions/tempfiles.rs
+++ b/src/actions/tempfiles.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::path::Path;
 
 pub fn new(alias: Option<&str>) -> anyhow::Result<()> {
@@ -28,6 +29,7 @@ pub fn remove(path: &str) -> anyhow::Result<()> {
 }
 
 pub fn set_alias(path: &str, alias: &str) -> anyhow::Result<()> {
-    crate::plugins::tempfile::set_alias(Path::new(path), alias)?;
+    crate::plugins::tempfile::set_alias(Path::new(path), alias)
+        .context("failed to rename tempfile")?;
     Ok(())
 }

--- a/src/plugins/tempfile.rs
+++ b/src/plugins/tempfile.rs
@@ -85,7 +85,12 @@ pub fn set_alias(path: &Path, alias: &str) -> anyhow::Result<PathBuf> {
     let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("txt");
     let new_name = format!("temp_{}.{}", alias, ext);
     let new_path = dir.join(new_name);
-    fs::rename(path, &new_path)?;
+    if new_path.exists() && new_path != path {
+        anyhow::bail!("file already exists");
+    }
+    if path != new_path {
+        fs::rename(path, &new_path)?;
+    }
     Ok(new_path)
 }
 

--- a/tests/tempfile_plugin.rs
+++ b/tests/tempfile_plugin.rs
@@ -154,6 +154,22 @@ fn set_alias_renames_file() {
 }
 
 #[test]
+fn set_alias_errors_if_target_exists() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    clear_files().unwrap();
+    let file1 = create_file().unwrap();
+    let file2 = create_file().unwrap();
+    let new_path = set_alias(&file1, "alias").unwrap();
+    let res = set_alias(&file2, "alias");
+    assert!(res.is_err());
+    remove_file(&new_path).unwrap();
+    remove_file(&file2).unwrap();
+}
+
+#[test]
 fn create_named_file_rejects_invalid_alias() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- fail `tempfile::set_alias` when target name already exists
- surface alias rename errors and cover with tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68990a080b408332b1426695fa7df40c