### PR TITLE
Cache plugin manager for macros and add benchmark

### DIFF
--- a/benches/macros_search.rs
+++ b/benches/macros_search.rs
@@ -1,0 +1,16 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use multi_launcher::plugins::macros::search_first_action;
+
+/// Benchmark the cached `PluginManager` lookup used by `search_first_action`.
+fn bench_macros_search(c: &mut Criterion) {
+    // Warm-up to ensure the `PluginManager` is initialised.
+    let _ = search_first_action("help");
+    c.bench_function("search_first_action_cached", |b| {
+        b.iter(|| {
+            let _ = search_first_action("help");
+        })
+    });
+}
+
+criterion_group!(benches, bench_macros_search);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- lazy-init a global PluginManager for macros via OnceCell and refresh on settings changes
- document thread safety and caching behavior
- add Criterion benchmark for search_first_action

## Testing
- `cargo test` *(fails: hung after compile)*

------
https://chatgpt.com/codex/tasks/task_e_6899166eb53c8332b47130da556fa1e9