### PR TITLE
Add command to detect and remove missing entries

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,6 +26,7 @@ use crate::plugins::omni_search::OmniSearchPlugin;
 use crate::plugins::sysinfo::SysInfoPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::settings::SettingsPlugin;
+use crate::plugins::missing::MissingPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::task_manager::TaskManagerPlugin;
 use crate::plugins::tempfile::TempfilePlugin;
@@ -146,6 +147,7 @@ impl PluginManager {
         self.register_with_settings(SnippetsPlugin::default(), plugin_settings);
         self.register_with_settings(MacrosPlugin::default(), plugin_settings);
         self.register_with_settings(FavPlugin::default(), plugin_settings);
+        self.register_with_settings(MissingPlugin, plugin_settings);
         self.register_with_settings(RecyclePlugin, plugin_settings);
         self.register_with_settings(TempfilePlugin, plugin_settings);
         self.register_with_settings(MediaPlugin, plugin_settings);

--- a/src/plugins/missing.rs
+++ b/src/plugins/missing.rs
@@ -1,0 +1,100 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use crate::plugins::bookmarks::{load_bookmarks, BOOKMARKS_FILE};
+use crate::plugins::fav::{load_favs, FAV_FILE};
+use crate::plugins::folders::{load_folders, FOLDERS_FILE};
+use url::Url;
+
+pub struct MissingPlugin;
+
+impl Plugin for MissingPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        if !query.trim().eq_ignore_ascii_case("check missing") {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+
+        if let Ok(folders) = load_folders(FOLDERS_FILE) {
+            for f in folders {
+                if !std::path::Path::new(&f.path).exists() {
+                    out.push(Action {
+                        label: format!("Remove missing folder {}", f.path),
+                        desc: "Maintenance".into(),
+                        action: format!("folder:remove:{}", f.path),
+                        args: None,
+                    });
+                }
+            }
+        }
+
+        if let Ok(bookmarks) = load_bookmarks(BOOKMARKS_FILE) {
+            for b in bookmarks {
+                if Url::parse(&b.url).is_err() {
+                    out.push(Action {
+                        label: format!("Remove invalid bookmark {}", b.url),
+                        desc: "Maintenance".into(),
+                        action: format!("bookmark:remove:{}", b.url),
+                        args: None,
+                    });
+                }
+            }
+        }
+
+        if let Ok(favs) = load_favs(FAV_FILE) {
+            for f in favs {
+                let mut missing = false;
+                if let Some(arg) = f.args.as_ref() {
+                    let path = std::path::Path::new(arg);
+                    if path.is_absolute() && !path.exists() {
+                        missing = true;
+                    }
+                } else {
+                    let path = std::path::Path::new(&f.action);
+                    if path.is_absolute() && !path.exists() {
+                        missing = true;
+                    }
+                }
+                if missing {
+                    out.push(Action {
+                        label: format!("Remove missing fav {}", f.label),
+                        desc: "Maintenance".into(),
+                        action: format!("fav:remove:{}", f.label),
+                        args: None,
+                    });
+                }
+            }
+        }
+
+        if out.is_empty() {
+            out.push(Action {
+                label: "No missing entries".into(),
+                desc: "Maintenance".into(),
+                action: "noop:".into(),
+                args: None,
+            });
+        }
+
+        out
+    }
+
+    fn name(&self) -> &str {
+        "missing"
+    }
+
+    fn description(&self) -> &str {
+        "Check and remove entries with missing paths"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "check missing".into(),
+            desc: "Maintenance".into(),
+            action: "query:check missing".into(),
+            args: None,
+        }]
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -42,3 +42,4 @@ pub mod timestamp;
 pub mod random;
 pub mod lorem;
 pub mod convert_panel;
+pub mod missing;


### PR DESCRIPTION
## Summary
- add `MissingPlugin` providing a `check missing` command
- surface actions to remove invalid folder, bookmark or fav entries
- register the plugin with the launcher

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689a8eb2576c8332b7ec38113b476ecd