### PR TITLE
Add note reload action

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2131,7 +2131,21 @@ impl eframe::App for LauncherApp {
                                 let count = self.usage.entry(a.action.clone()).or_insert(0);
                                 *count += 1;
                             }
-                            if a.action.starts_with("bookmark:add:") {
+                            if a.action == "note:reload" {
+                                refresh = true;
+                                set_focus = true;
+                                if self.enable_toasts {
+                                    push_toast(
+                                        &mut self.toasts,
+                                        Toast {
+                                            text: "Reloaded notes".into(),
+                                            kind: ToastKind::Success,
+                                            options: ToastOptions::default()
+                                                .duration_in_seconds(self.toast_duration as f64),
+                                        },
+                                    );
+                                }
+                            } else if a.action.starts_with("bookmark:add:") {
                                 if self.preserve_command {
                                     self.query = "bm add ".into();
                                 } else {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -303,6 +303,7 @@ enum ActionKind<'a> {
         path: &'a str,
         alias: &'a str,
     },
+    NoteReload,
     ExecPath {
         path: &'a str,
         args: Option<&'a str>,
@@ -592,6 +593,9 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
     if s == "recycle:clean" {
         return ActionKind::RecycleClean;
     }
+    if s == "note:reload" {
+        return ActionKind::NoteReload;
+    }
     if let Some(alias) = s.strip_prefix("tempfile:new:") {
         return ActionKind::TempfileNew(Some(alias));
     }
@@ -772,6 +776,11 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         }
         ActionKind::RecycleClean => {
             system::recycle_clean();
+            Ok(())
+        }
+        ActionKind::NoteReload => {
+            crate::plugins::note::load_notes()?;
+            crate::plugins::note::refresh_cache()?;
             Ok(())
         }
         ActionKind::TempfileNew(alias) => tempfiles::new(alias),

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -184,7 +184,7 @@ pub fn load_notes() -> anyhow::Result<Vec<Note>> {
     Ok(notes)
 }
 
-fn refresh_cache() -> anyhow::Result<()> {
+pub fn refresh_cache() -> anyhow::Result<()> {
     let notes = load_notes()?;
     let cache = NoteCache::from_notes(notes);
     if let Ok(mut guard) = CACHE.lock() {
@@ -362,6 +362,12 @@ impl Plugin for NotePlugin {
                         action: "query:note rm ".into(),
                         args: None,
                     },
+                    Action {
+                        label: "note reload".into(),
+                        desc: "Note".into(),
+                        action: "note:reload".into(),
+                        args: None,
+                    },
                 ]);
                 return actions;
             }
@@ -376,6 +382,16 @@ impl Plugin for NotePlugin {
             };
 
             match cmd.as_str() {
+                "reload" => {
+                    if args.is_empty() {
+                        return vec![Action {
+                            label: "Reload notes".into(),
+                            desc: "Note".into(),
+                            action: "note:reload".into(),
+                            args: None,
+                        }];
+                    }
+                }
                 "new" => {
                     if !args.is_empty() {
                         let mut title = args;
@@ -643,6 +659,12 @@ impl Plugin for NotePlugin {
                 label: "note rm".into(),
                 desc: "Note".into(),
                 action: "query:note rm ".into(),
+                args: None,
+            },
+            Action {
+                label: "note reload".into(),
+                desc: "Note".into(),
+                action: "note:reload".into(),
                 args: None,
             },
         ]

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -61,6 +61,7 @@ fn note_root_query_returns_actions_in_order() {
             "query:note today",
             "query:note link ",
             "query:note rm ",
+            "note:reload",
         ]
     );
 }
@@ -73,6 +74,16 @@ fn note_new_generates_action() {
     let results = plugin.search("note new Hello World");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "note:new:hello-world");
+}
+
+#[test]
+fn note_reload_action_generated() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let _tmp = setup();
+    let plugin = NotePlugin::default();
+    let results = plugin.search("note reload");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "note:reload");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `note reload` command to note plugin and expose refresh cache
- wire `note:reload` action through launcher and GUI with a success toast
- test note reload handling

## Testing
- `cargo test --test notes_plugin --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689a8ea425188332b694310b08ca8820