### PR TITLE
Add calculator history

### DIFF
--- a/src/actions/calc.rs
+++ b/src/actions/calc.rs
@@ -1,0 +1,15 @@
+use arboard::Clipboard;
+
+pub fn copy_history_result(index: usize) -> anyhow::Result<()> {
+    if let Some(entry) = crate::plugins::calc_history::load_history(
+        crate::plugins::calc_history::CALC_HISTORY_FILE,
+    )
+    .unwrap_or_default()
+    .get(index)
+    .cloned()
+    {
+        let mut cb = Clipboard::new()?;
+        cb.set_text(entry.result)?;
+    }
+    Ok(())
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -36,3 +36,4 @@ pub mod system;
 pub mod exec;
 pub mod fav;
 pub mod screenshot;
+pub mod calc;

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -114,7 +114,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "runescape_search" => Some(&["rs dragon scimitar", "osrs agility guide"]),
         "youtube" => Some(&["yt rust"]),
         "reddit" => Some(&["red cats"]),
-        "calculator" => Some(&["= 1+2"]),
+        "calculator" => Some(&["= 1+2", "= history"]),
         "unit_convert" => Some(&[
             "conv 10 km to mi",
             "conv 1 kwh to j",

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -218,6 +218,7 @@ enum ActionKind<'a> {
     ClipboardCopy(usize),
     ClipboardText(&'a str),
     Calc(&'a str),
+    CalcHistory(usize),
     BookmarkAdd(&'a str),
     BookmarkRemove(&'a str),
     FolderAdd(&'a str),
@@ -334,6 +335,11 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
             }
         }
         return ActionKind::ClipboardText(rest);
+    }
+    if let Some(idx) = s.strip_prefix("calc:history:") {
+        if let Ok(i) = idx.parse::<usize>() {
+            return ActionKind::CalcHistory(i);
+        }
     }
     if let Some(val) = s.strip_prefix("calc:") {
         return ActionKind::Calc(val);
@@ -643,6 +649,7 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         ActionKind::ClipboardCopy(i) => clipboard::copy_entry(i),
         ActionKind::ClipboardText(text) => clipboard::set_text(text),
         ActionKind::Calc(val) => clipboard::calc_to_clipboard(val),
+        ActionKind::CalcHistory(i) => crate::actions::calc::copy_history_result(i),
         ActionKind::BookmarkAdd(url) => bookmarks::add(url),
         ActionKind::BookmarkRemove(url) => bookmarks::remove(url),
         ActionKind::FolderAdd(path) => folders::add(path),

--- a/src/plugins/calc_history.rs
+++ b/src/plugins/calc_history.rs
@@ -1,0 +1,58 @@
+use serde::{Serialize, Deserialize};
+use std::collections::VecDeque;
+
+pub const CALC_HISTORY_FILE: &str = "calc_history.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CalcHistoryEntry {
+    pub expr: String,
+    pub result: String,
+}
+
+/// Load calc history from `path`.
+/// Returns empty queue when file missing or empty.
+pub fn load_history(path: &str) -> anyhow::Result<VecDeque<CalcHistoryEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(VecDeque::new());
+    }
+    let list: Vec<CalcHistoryEntry> = serde_json::from_str(&content)?;
+    Ok(list.into())
+}
+
+/// Save calc `history` to `path`.
+pub fn save_history(path: &str, history: &VecDeque<CalcHistoryEntry>) -> anyhow::Result<()> {
+    let list: Vec<CalcHistoryEntry> = history.iter().cloned().collect();
+    let json = serde_json::to_string_pretty(&list)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Remove history entry at `index` from file at `path`.
+pub fn remove_entry(path: &str, index: usize) -> anyhow::Result<()> {
+    let mut history = load_history(path).unwrap_or_default();
+    if index < history.len() {
+        history.remove(index);
+        save_history(path, &history)?;
+    }
+    Ok(())
+}
+
+/// Clear the calc history file at `path`.
+pub fn clear_history_file(path: &str) -> anyhow::Result<()> {
+    save_history(path, &VecDeque::new())
+}
+
+/// Append an entry to calc history at `path` keeping up to `max` items.
+pub fn append_entry(path: &str, entry: CalcHistoryEntry, max: usize) -> anyhow::Result<()> {
+    let mut history = load_history(path).unwrap_or_default();
+    if let Some(pos) = history.iter().position(|e| e.expr == entry.expr && e.result == entry.result) {
+        history.remove(pos);
+    }
+    history.push_front(entry);
+    while history.len() > max {
+        history.pop_back();
+    }
+    save_history(path, &history)
+}
+

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -43,3 +43,4 @@ pub mod random;
 pub mod lorem;
 pub mod convert_panel;
 pub mod missing;
+pub mod calc_history;

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -1,6 +1,7 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 use urlencoding::encode;
+use crate::plugins::calc_history::{self, CalcHistoryEntry, CALC_HISTORY_FILE};
 
 pub struct WebSearchPlugin;
 
@@ -40,15 +41,49 @@ pub struct CalculatorPlugin;
 
 impl Plugin for CalculatorPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if query.starts_with("=") {
-            let expr = &query[1..];
-            match exmex::eval_str::<f64>(expr) {
-                Ok(v) => vec![Action {
-                    label: format!("{} = {}", expr, v),
+        const MAX_ENTRIES: usize = 20;
+        let trimmed = query.trim();
+        if trimmed.eq_ignore_ascii_case("calc list")
+            || trimmed.eq_ignore_ascii_case("= history")
+            || trimmed.eq_ignore_ascii_case("= list")
+        {
+            return calc_history::load_history(CALC_HISTORY_FILE)
+                .unwrap_or_default()
+                .iter()
+                .enumerate()
+                .map(|(idx, entry)| Action {
+                    label: format!("{} = {}", entry.expr, entry.result),
                     desc: "Calculator".into(),
-                    action: format!("calc:{}", v),
+                    action: format!("calc:history:{idx}"),
                     args: None,
-                }],
+                })
+                .collect();
+        }
+
+        if let Some(rest) = trimmed.strip_prefix('=') {
+            let expr = rest.trim();
+            if expr.is_empty() {
+                return Vec::new();
+            }
+            match exmex::eval_str::<f64>(expr) {
+                Ok(v) => {
+                    let result = v.to_string();
+                    let entry = CalcHistoryEntry {
+                        expr: expr.to_string(),
+                        result: result.clone(),
+                    };
+                    let _ = calc_history::append_entry(
+                        CALC_HISTORY_FILE,
+                        entry,
+                        MAX_ENTRIES,
+                    );
+                    vec![Action {
+                        label: format!("{} = {}", expr, result),
+                        desc: "Calculator".into(),
+                        action: format!("calc:{}", result),
+                        args: None,
+                    }]
+                }
                 Err(_) => Vec::new(),
             }
         } else {
@@ -61,7 +96,7 @@ impl Plugin for CalculatorPlugin {
     }
 
     fn description(&self) -> &str {
-        "Evaluate mathematical expressions (prefix: `=`)"
+        "Evaluate mathematical expressions (prefix: `=`; `= history` to list)"
     }
 
     fn capabilities(&self) -> &[&str] {
@@ -69,6 +104,25 @@ impl Plugin for CalculatorPlugin {
     }
 
     fn commands(&self) -> Vec<Action> {
-        vec![Action { label: "=".into(), desc: "Calculator".into(), action: "query:= ".into(), args: None }]
+        vec![
+            Action {
+                label: "=".into(),
+                desc: "Calculator".into(),
+                action: "query:= ".into(),
+                args: None,
+            },
+            Action {
+                label: "= history".into(),
+                desc: "Calculator".into(),
+                action: "query:= history".into(),
+                args: None,
+            },
+            Action {
+                label: "calc list".into(),
+                desc: "Calculator".into(),
+                action: "query:calc list".into(),
+                args: None,
+            },
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- track calculator evaluations in `calc_history.json`
- expose `= history`/`calc list` query and copyable history actions
- document calculator history usage

## Testing
- `cargo test` *(fails: hangs)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e57886c833283481eb97d9c045e