### PR TITLE
Add note add/create aliases for new notes

### DIFF
--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -157,6 +157,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
             "note",
             "note add buy milk",
             "note new buy milk",
+            "note create buy milk",
             "note list",
             "note rm groceries",
         ]),

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -444,7 +444,7 @@ impl Plugin for NotePlugin {
                         }];
                     }
                 }
-              "new" | "add" => {
+              "new" | "add" | "create" => {
                     if !args.is_empty() {
                         let mut title = args;
                         let mut template = None;
@@ -707,6 +707,12 @@ impl Plugin for NotePlugin {
                 label: "note add".into(),
                 desc: "Note".into(),
                 action: "query:note add ".into(),
+                args: None,
+            },
+            Action {
+                label: "note create".into(),
+                desc: "Note".into(),
+                action: "query:note create ".into(),
                 args: None,
             },
             Action {

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -78,6 +78,16 @@ fn note_new_generates_action() {
 }
 
 #[test]
+fn note_create_generates_action() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let _tmp = setup();
+    let plugin = NotePlugin::default();
+    let results = plugin.search("note create Hello World");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "note:new:hello-world");
+}
+
+#[test]
 fn note_reload_action_generated() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let _tmp = setup();


### PR DESCRIPTION
## Summary
- allow `note add` and `note create` to reuse existing `note new` logic
- document `note add`/`note create` in command list and help window
- test `note create` command

## Testing
- `cargo test`


 