### PR TITLE
Sort plugin list in favorites dialog

### DIFF
--- a/src/gui/fav_dialog.rs
+++ b/src/gui/fav_dialog.rs
@@ -79,6 +79,9 @@ impl FavDialog {
                     ui.separator();
                     ui.horizontal(|ui| {
                         ui.label("Category");
+                        let mut plugin_names: Vec<_> =
+                            app.plugins.iter().map(|p| p.name().to_string()).collect();
+                        plugin_names.sort_unstable();
                         egui::ComboBox::from_id_source("fav_cat")
                             .selected_text(if self.add_plugin.is_empty() {
                                 "Select".to_string()
@@ -86,8 +89,7 @@ impl FavDialog {
                                 self.add_plugin.clone()
                             })
                             .show_ui(ui, |ui| {
-                                for p in app.plugins.iter() {
-                                    let name = p.name();
+                                for name in plugin_names.iter() {
                                     ui.selectable_value(
                                         &mut self.add_plugin,
                                         name.to_string(),


### PR DESCRIPTION
## Summary
- Display plugin categories alphabetically in the Favorites dialog

## Testing
- `cargo test` *(fails: macros_file_change_reload)*

------
https://chatgpt.com/codex/tasks/task_e_689bb34625a083329f19f7ac7c2ed69b