### PR TITLE
Add LRU caching for plugin searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "exmex",
  "figlet-rs",
  "fuzzy-matcher",
+ "hashbrown 0.14.5",
  "hex",
  "image 0.24.9",
  "ipconfig",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ winit = "0.29"
 once_cell = "1"
 regex = "1"
 slug = "0.1"
+hashbrown = "0.14"
 urlencoding = "2"
 url = "2"
 windows = { version = "0.58", features = [

--- a/src/common/lru.rs
+++ b/src/common/lru.rs
@@ -1,0 +1,62 @@
+use hashbrown::HashMap;
+use std::collections::VecDeque;
+use std::hash::Hash;
+
+/// A simple LRU cache backed by `hashbrown::HashMap`.
+#[derive(Default)]
+pub struct LruCache<K, V> {
+    map: HashMap<K, V>,
+    order: VecDeque<K>,
+    capacity: usize,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> LruCache<K, V> {
+    /// Create a new cache limited to `capacity` entries.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    /// Retrieve a value from the cache, updating its recency.
+    pub fn get(&mut self, key: &K) -> Option<V> {
+        if let Some(value) = self.map.get(key).cloned() {
+            if let Some(pos) = self.order.iter().position(|k| k == key) {
+                self.order.remove(pos);
+            }
+            self.order.push_back(key.clone());
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Insert a value into the cache.
+    pub fn put(&mut self, key: K, value: V) {
+        if self.map.contains_key(&key) {
+            self.map.insert(key.clone(), value);
+            if let Some(pos) = self.order.iter().position(|k| k == &key) {
+                self.order.remove(pos);
+            }
+            self.order.push_back(key);
+            return;
+        }
+
+        if self.map.len() == self.capacity {
+            if let Some(old) = self.order.pop_front() {
+                self.map.remove(&old);
+            }
+        }
+        self.map.insert(key.clone(), value);
+        self.order.push_back(key);
+    }
+
+    /// Clear all cached entries.
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.order.clear();
+    }
+}
+

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,3 +8,4 @@ pub fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
 
 pub mod json_watch;
 pub mod slug;
+pub mod lru;

--- a/src/plugins/bookmarks.rs
+++ b/src/plugins/bookmarks.rs
@@ -1,12 +1,23 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+use crate::common::lru::LruCache;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
+use once_cell::sync::Lazy;
 
 pub const BOOKMARKS_FILE: &str = "bookmarks.json";
+
+static BOOKMARK_CACHE: Lazy<Arc<Mutex<LruCache<String, Vec<Action>>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(LruCache::new(64))));
+
+fn invalidate_bookmark_cache() {
+    if let Ok(mut cache) = BOOKMARK_CACHE.lock() {
+        cache.clear();
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BookmarkEntry {
@@ -18,6 +29,7 @@ pub struct BookmarkEntry {
 pub struct BookmarksPlugin {
     matcher: SkimMatcherV2,
     data: Arc<Mutex<Vec<BookmarkEntry>>>,
+    cache: Arc<Mutex<LruCache<String, Vec<Action>>>>,
     #[allow(dead_code)]
     watcher: Option<RecommendedWatcher>,
 }
@@ -28,11 +40,13 @@ impl BookmarksPlugin {
         let data = Arc::new(Mutex::new(
             load_bookmarks(BOOKMARKS_FILE).unwrap_or_default(),
         ));
+        let cache = BOOKMARK_CACHE.clone();
         let data_clone = data.clone();
         let path = BOOKMARKS_FILE.to_string();
         let mut watcher = RecommendedWatcher::new(
             {
                 let path = path.clone();
+                let cache_clone = cache.clone();
                 move |res: notify::Result<notify::Event>| {
                     if let Ok(event) = res {
                         if matches!(
@@ -42,6 +56,9 @@ impl BookmarksPlugin {
                             if let Ok(list) = load_bookmarks(&path) {
                                 if let Ok(mut lock) = data_clone.lock() {
                                     *lock = list;
+                                }
+                                if let Ok(mut c) = cache_clone.lock() {
+                                    c.clear();
                                 }
                             }
                         }
@@ -61,114 +78,12 @@ impl BookmarksPlugin {
         Self {
             matcher: SkimMatcherV2::default(),
             data,
+            cache,
             watcher,
         }
     }
-}
 
-fn normalize_url(url: &str) -> String {
-    let mut out = url.trim().to_string();
-    if out.starts_with("http://") {
-        out = out.replacen("http://", "https://", 1);
-    } else if !out.starts_with("https://") {
-        out = format!("https://{out}");
-    }
-    if let Some(rest) = out.strip_prefix("https://") {
-        let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
-        if !host.starts_with("www.") && !host.contains('.') {
-            let host = format!("www.{host}");
-            out = if path.is_empty() {
-                format!("https://{host}")
-            } else {
-                format!("https://{host}/{path}")
-            };
-        }
-    }
-    out
-}
-
-/// Load bookmarks from `path`.
-///
-/// Returns an empty list if the file does not exist or is empty.
-pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<BookmarkEntry>> {
-    let content = std::fs::read_to_string(path).unwrap_or_default();
-    if content.trim().is_empty() {
-        return Ok(Vec::new());
-    }
-    // Try new format first, fall back to plain string list for backward compatibility
-    let list: Result<Vec<BookmarkEntry>, _> = serde_json::from_str(&content);
-    match list {
-        Ok(items) => Ok(items),
-        Err(_) => {
-            let list: Vec<String> = serde_json::from_str(&content)?;
-            Ok(list
-                .into_iter()
-                .map(|url| BookmarkEntry { url, alias: None })
-                .collect())
-        }
-    }
-}
-
-/// Save the provided `bookmarks` to `path` in JSON format.
-pub fn save_bookmarks(path: &str, bookmarks: &[BookmarkEntry]) -> anyhow::Result<()> {
-    let json = serde_json::to_string_pretty(bookmarks)?;
-    std::fs::write(path, json)?;
-    Ok(())
-}
-
-/// Append a new bookmark `url` to the file at `path`.
-///
-/// The URL is normalized and duplicates are ignored.
-pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
-    let mut list = load_bookmarks(path).unwrap_or_default();
-    let fixed = normalize_url(url);
-    if !list.iter().any(|b| b.url == fixed) {
-        list.push(BookmarkEntry {
-            url: fixed,
-            alias: None,
-        });
-        save_bookmarks(path, &list)?;
-    }
-    Ok(())
-}
-
-/// Remove the bookmark matching `url` from the file at `path`.
-pub fn remove_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
-    let mut list = load_bookmarks(path).unwrap_or_default();
-    let fixed = normalize_url(url);
-    if let Some(pos) = list.iter().position(|b| b.url == fixed) {
-        list.remove(pos);
-        save_bookmarks(path, &list)?;
-    }
-    Ok(())
-}
-
-/// Set or clear the alias of a bookmark.
-///
-/// Passing an empty `alias` removes the existing alias.
-pub fn set_alias(path: &str, url: &str, alias: &str) -> anyhow::Result<()> {
-    let mut list = load_bookmarks(path).unwrap_or_default();
-    let fixed = normalize_url(url);
-    if let Some(item) = list.iter_mut().find(|b| b.url == fixed) {
-        item.alias = if alias.is_empty() {
-            None
-        } else {
-            Some(alias.to_string())
-        };
-        save_bookmarks(path, &list)?;
-    }
-    Ok(())
-}
-
-impl Default for BookmarksPlugin {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Plugin for BookmarksPlugin {
-    fn search(&self, query: &str) -> Vec<Action> {
-        let trimmed = query.trim();
+    fn search_internal(&self, trimmed: &str) -> Vec<Action> {
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "bm") {
             if rest.trim().is_empty() || rest.trim().eq_ignore_ascii_case("add") {
                 return vec![Action {
@@ -273,6 +188,129 @@ impl Plugin for BookmarksPlugin {
                 }
             })
             .collect()
+    }
+}
+
+fn normalize_url(url: &str) -> String {
+    let mut out = url.trim().to_string();
+    if out.starts_with("http://") {
+        out = out.replacen("http://", "https://", 1);
+    } else if !out.starts_with("https://") {
+        out = format!("https://{out}");
+    }
+    if let Some(rest) = out.strip_prefix("https://") {
+        let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+        if !host.starts_with("www.") && !host.contains('.') {
+            let host = format!("www.{host}");
+            out = if path.is_empty() {
+                format!("https://{host}")
+            } else {
+                format!("https://{host}/{path}")
+            };
+        }
+    }
+    out
+}
+
+/// Load bookmarks from `path`.
+///
+/// Returns an empty list if the file does not exist or is empty.
+pub fn load_bookmarks(path: &str) -> anyhow::Result<Vec<BookmarkEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    // Try new format first, fall back to plain string list for backward compatibility
+    let list: Result<Vec<BookmarkEntry>, _> = serde_json::from_str(&content);
+    match list {
+        Ok(items) => Ok(items),
+        Err(_) => {
+            let list: Vec<String> = serde_json::from_str(&content)?;
+            Ok(list
+                .into_iter()
+                .map(|url| BookmarkEntry { url, alias: None })
+                .collect())
+        }
+    }
+}
+
+/// Save the provided `bookmarks` to `path` in JSON format.
+pub fn save_bookmarks(path: &str, bookmarks: &[BookmarkEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(bookmarks)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Append a new bookmark `url` to the file at `path`.
+///
+/// The URL is normalized and duplicates are ignored.
+pub fn append_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
+    let mut list = load_bookmarks(path).unwrap_or_default();
+    let fixed = normalize_url(url);
+    if !list.iter().any(|b| b.url == fixed) {
+        list.push(BookmarkEntry {
+            url: fixed,
+            alias: None,
+        });
+        save_bookmarks(path, &list)?;
+        invalidate_bookmark_cache();
+    }
+    Ok(())
+}
+
+/// Remove the bookmark matching `url` from the file at `path`.
+pub fn remove_bookmark(path: &str, url: &str) -> anyhow::Result<()> {
+    let mut list = load_bookmarks(path).unwrap_or_default();
+    let fixed = normalize_url(url);
+    if let Some(pos) = list.iter().position(|b| b.url == fixed) {
+        list.remove(pos);
+        save_bookmarks(path, &list)?;
+        invalidate_bookmark_cache();
+    }
+    Ok(())
+}
+
+/// Set or clear the alias of a bookmark.
+///
+/// Passing an empty `alias` removes the existing alias.
+pub fn set_alias(path: &str, url: &str, alias: &str) -> anyhow::Result<()> {
+    let mut list = load_bookmarks(path).unwrap_or_default();
+    let fixed = normalize_url(url);
+    if let Some(item) = list.iter_mut().find(|b| b.url == fixed) {
+        item.alias = if alias.is_empty() {
+            None
+        } else {
+            Some(alias.to_string())
+        };
+        save_bookmarks(path, &list)?;
+        invalidate_bookmark_cache();
+    }
+    Ok(())
+}
+
+impl Default for BookmarksPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for BookmarksPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        let key = trimmed.to_string();
+        if let Ok(mut cache) = self.cache.lock() {
+            if let Some(res) = cache.get(&key) {
+                return res;
+            }
+        }
+
+        let result = self.search_internal(trimmed);
+
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.put(key, result.clone());
+        }
+
+        result
     }
 
     fn name(&self) -> &str {


### PR DESCRIPTION
## Summary
- add reusable LRU cache helper backed by hashbrown
- cache todo and bookmark search results and invalidate on data changes

## Testing
- `cargo test` *(fails: macros_file_change_reload)*

------
https://chatgpt.com/codex/tasks/task_e_689d268bea4c8332aff663a037340990