### PR TITLE
Handle partial 'check missing' queries

### DIFF
--- a/src/plugins/missing.rs
+++ b/src/plugins/missing.rs
@@ -9,7 +9,11 @@ pub struct MissingPlugin;
 
 impl Plugin for MissingPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
-        if !query.trim().eq_ignore_ascii_case("check missing") {
+        let trimmed = query.trim();
+        let prefix = "check missing";
+        if crate::common::strip_prefix_ci(trimmed, prefix).is_none()
+            && !prefix.starts_with(&trimmed.to_ascii_lowercase())
+        {
             return Vec::new();
         }
         let mut out = Vec::new();
@@ -91,9 +95,9 @@ impl Plugin for MissingPlugin {
 
     fn commands(&self) -> Vec<Action> {
         vec![Action {
-            label: "check missing".into(),
+            label: "check miss".into(),
             desc: "Maintenance".into(),
-            action: "query:check missing".into(),
+            action: "query:check miss".into(),
             args: None,
         }]
     }

--- a/tests/missing_plugin.rs
+++ b/tests/missing_plugin.rs
@@ -1,0 +1,30 @@
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::missing::MissingPlugin;
+use multi_launcher::plugins::bookmarks::BOOKMARKS_FILE;
+use multi_launcher::plugins::fav::FAV_FILE;
+use multi_launcher::plugins::folders::FOLDERS_FILE;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn prefix_triggers_actions() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    std::fs::write(BOOKMARKS_FILE, "[]").unwrap();
+    std::fs::write(FAV_FILE, "[]").unwrap();
+    std::fs::write(FOLDERS_FILE, "[]").unwrap();
+
+    let plugin = MissingPlugin;
+    let partial = plugin.search("check miss");
+    assert_eq!(partial.len(), 1);
+    assert_eq!(partial[0].action, "noop:");
+
+    let full = plugin.search("check missing");
+    assert_eq!(full.len(), 1);
+    assert_eq!(full[0].action, "noop:");
+}


### PR DESCRIPTION
## Summary
- allow the Missing plugin to trigger on partial `check missing` queries
- advertise the shorter `check miss` command
- test that both `check miss` and `check missing` produce maintenance actions

## Testing
- `cargo test --test missing_plugin -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_689f894e13948332b7f9b7d113661d53