### PR TITLE
Defer brightness hardware queries

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -25,6 +25,7 @@ pub use add_bookmark_dialog::AddBookmarkDialog;
 pub use alias_dialog::AliasDialog;
 pub use bookmark_alias_dialog::BookmarkAliasDialog;
 pub use brightness_dialog::BrightnessDialog;
+pub use brightness_dialog::BRIGHTNESS_QUERIES;
 pub use clipboard_dialog::ClipboardDialog;
 pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;

--- a/tests/brightness_plugin.rs
+++ b/tests/brightness_plugin.rs
@@ -1,5 +1,7 @@
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::brightness::BrightnessPlugin;
+use multi_launcher::gui::BRIGHTNESS_QUERIES;
+use std::sync::atomic::Ordering;
 
 #[test]
 fn search_set_numeric() {
@@ -23,4 +25,12 @@ fn search_plain_bright() {
     } else {
         assert!(results.is_empty());
     }
+}
+
+#[test]
+fn search_bright_no_hardware_calls() {
+    BRIGHTNESS_QUERIES.store(0, Ordering::SeqCst);
+    let plugin = BrightnessPlugin;
+    let _ = plugin.search("bright");
+    assert_eq!(BRIGHTNESS_QUERIES.load(Ordering::SeqCst), 0);
 }


### PR DESCRIPTION
## Summary
- avoid querying monitor brightness on each search by caching and deferring the hardware call until the brightness dialog UI renders
- expose a brightness query counter for tests
- add regression test ensuring typing `bright` does not trigger hardware access

## Testing
- `cargo test --test brightness_plugin`
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message)*

 