### PR TITLE
Use FST index for OmniSearch and add benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,6 +3009,7 @@ dependencies = [
  "embed-resource",
  "exmex",
  "figlet-rs",
+ "fst",
  "fuzzy-matcher",
  "hashbrown 0.14.5",
  "hex",
@@ -5065,6 +5075,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ eframe = "0.27"               # egui-based GUI
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 fuzzy-matcher = "0.3"
+fst = { version = "0.4", features = ["levenshtein"] }
 open = "5.0"                   # Open files/folders/apps cross-platform
 anyhow = "1.0"
 walkdir = "2.4"
@@ -79,4 +80,8 @@ embed-resource = "2"
 
 [[bench]]
 name = "search"
+harness = false
+
+[[bench]]
+name = "omni_search"
 harness = false

--- a/benches/omni_search.rs
+++ b/benches/omni_search.rs
@@ -1,0 +1,64 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use fst::{automaton::Subsequence, IntoStreamer, Map, MapBuilder, Streamer};
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use multi_launcher::actions::Action;
+use std::collections::HashSet;
+
+fn build_index(actions: &[Action]) -> Map<Vec<u8>> {
+    let mut entries: Vec<(String, u64)> = Vec::new();
+    for (i, a) in actions.iter().enumerate() {
+        entries.push((a.label.to_lowercase(), i as u64));
+        if !a.desc.is_empty() {
+            entries.push((a.desc.to_lowercase(), i as u64));
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut builder = MapBuilder::memory();
+    for (k, v) in entries {
+        builder.insert(k, v).unwrap();
+    }
+    Map::new(builder.into_inner().unwrap()).unwrap()
+}
+
+fn bench_omni_search(c: &mut Criterion) {
+    let actions: Vec<Action> = (0..10_000)
+        .map(|i| Action {
+            label: format!("Item {i}"),
+            desc: format!("Description {i}"),
+            action: i.to_string(),
+            args: None,
+        })
+        .collect();
+    let index = build_index(&actions);
+    let matcher = SkimMatcherV2::default();
+
+    c.bench_function("search_linear", |b| {
+        b.iter(|| {
+            let q = "Item 9999";
+            actions
+                .iter()
+                .filter(|a| {
+                    matcher.fuzzy_match(&a.label, q).is_some()
+                        || matcher.fuzzy_match(&a.desc, q).is_some()
+                })
+                .count()
+        })
+    });
+
+    c.bench_function("search_indexed", |b| {
+        b.iter(|| {
+            let q = "Item 9999".to_lowercase();
+            let automaton = Subsequence::new(&q);
+            let mut stream = index.search(automaton).into_stream();
+            let mut seen = HashSet::new();
+            while let Some((_, idx)) = stream.next() {
+                seen.insert(idx);
+            }
+            seen.len()
+        })
+    });
+}
+
+criterion_group!(benches, bench_omni_search);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- build an fst index for launcher actions
- query the index in omni-search instead of linear scan
- benchmark indexed vs linear action search

## Testing
- `cargo test`
- `cargo bench --bench omni_search`


 