### PR TITLE
Add per-process audio mute control

### DIFF
--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -67,6 +67,12 @@ pub fn set_process_volume(pid: u32, level: u32) {
     super::super::launcher::set_process_volume(pid, level);
 }
 
+#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+pub fn toggle_process_mute(pid: u32) {
+    #[cfg(target_os = "windows")]
+    super::super::launcher::toggle_process_mute(pid);
+}
+
 pub fn recycle_clean() {
     #[cfg(target_os = "windows")]
     {

--- a/src/gui/volume_dialog.rs
+++ b/src/gui/volume_dialog.rs
@@ -29,6 +29,21 @@ struct ProcessVolume {
     pid: u32,
     name: String,
     value: u8,
+    muted: bool,
+}
+
+impl ProcessVolume {
+    /// Returns an action string to toggle mute if the process is currently muted.
+    /// The caller is responsible for dispatching the action if returned.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    fn slider_changed(&mut self) -> Option<String> {
+        if self.muted {
+            self.muted = false;
+            Some(format!("volume:pid_toggle_mute:{}", self.pid))
+        } else {
+            None
+        }
+    }
 }
 
 impl VolumeDialog {
@@ -70,7 +85,17 @@ impl VolumeDialog {
                     for proc in &mut self.processes {
                         ui.horizontal(|ui| {
                             ui.label(format!("{} (PID {})", proc.name, proc.pid));
-                            ui.add(egui::Slider::new(&mut proc.value, 0..=100).text("Level"));
+                            let resp = ui.add(egui::Slider::new(&mut proc.value, 0..=100).text("Level"));
+                            if resp.changed() {
+                                if let Some(action) = proc.slider_changed() {
+                                    let _ = launch_action(&Action {
+                                        label: String::new(),
+                                        desc: "Volume".into(),
+                                        action,
+                                        args: None,
+                                    });
+                                }
+                            }
                             if ui.button("Set").clicked() {
                                 let _ = launch_action(&Action {
                                     label: String::new(),
@@ -78,6 +103,18 @@ impl VolumeDialog {
                                     action: format!("volume:pid:{}:{}", proc.pid, proc.value),
                                     args: None,
                                 });
+                            }
+                            if ui.button("Mute").clicked() {
+                                let _ = launch_action(&Action {
+                                    label: String::new(),
+                                    desc: "Volume".into(),
+                                    action: format!("volume:pid_toggle_mute:{}", proc.pid),
+                                    args: None,
+                                });
+                                proc.muted = !proc.muted;
+                            }
+                            if proc.muted {
+                                ui.colored_label(egui::Color32::RED, "muted");
                             }
                         });
                     }
@@ -156,10 +193,15 @@ fn get_process_volumes() -> Vec<ProcessVolume> {
                                                     .process(sysinfo::Pid::from_u32(pid))
                                                     .map(|p| p.name().to_string_lossy().to_string())
                                                     .unwrap_or_else(|| format!("PID {pid}"));
+                                                let muted = vol
+                                                    .GetMute()
+                                                    .map(|m| m.as_bool())
+                                                    .unwrap_or(false);
                                                 entries.push(ProcessVolume {
                                                     pid,
                                                     name,
                                                     value: (val * 100.0).round() as u8,
+                                                    muted,
                                                 });
                                             }
                                         }
@@ -180,4 +222,25 @@ fn get_process_volumes() -> Vec<ProcessVolume> {
 #[cfg(not(target_os = "windows"))]
 fn get_process_volumes() -> Vec<ProcessVolume> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slider_change_unmutes() {
+        let mut proc = ProcessVolume {
+            pid: 1,
+            name: "test".into(),
+            value: 50,
+            muted: true,
+        };
+        let action = proc.slider_changed();
+        assert_eq!(
+            action,
+            Some("volume:pid_toggle_mute:1".to_string())
+        );
+        assert!(!proc.muted);
+    }
 }


### PR DESCRIPTION
## Summary
- track per-process mute state in volume dialog
- add UI and action handling for toggling process mute
- expose system call to toggle process audio mute

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fda1dba88332a04510c4d9431349