### PR TITLE
Use event-driven main loop

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -97,6 +97,7 @@ pub enum EventType {
 }
 use std::sync::{
     atomic::{AtomicBool, Ordering},
+    mpsc::Sender,
     Arc, Mutex,
 };
 #[cfg(target_os = "windows")]
@@ -290,6 +291,7 @@ impl HotkeyTrigger {
     pub fn start_listener(
         triggers: Vec<Arc<HotkeyTrigger>>,
         _label: &'static str,
+        event_tx: Sender<()>,
     ) -> HotkeyListener {
         use windows::Win32::System::Threading::{
             GetCurrentThread, SetThreadPriority, THREAD_PRIORITY_HIGHEST,
@@ -420,6 +422,7 @@ impl HotkeyTrigger {
                                 if let Ok(mut flag) = open_listeners[i].lock() {
                                     *flag = true;
                                 }
+                                let _ = event_tx.send(());
                             }
                         } else {
                             triggered[i] = false;
@@ -437,6 +440,7 @@ impl HotkeyTrigger {
     pub fn start_listener(
         _triggers: Vec<Arc<HotkeyTrigger>>,
         _label: &'static str,
+        _event_tx: Sender<()>,
     ) -> HotkeyListener {
         HotkeyListener {
             stop: Arc::new(AtomicBool::new(false)),

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -34,12 +34,14 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
     static_pos: Option<(f32, f32)>,
     static_size: Option<(f32, f32)>,
     window_size: (f32, f32),
-) {
+) -> bool {
+    let mut changed = false;
     if trigger.take() {
         let old = visibility.load(Ordering::SeqCst);
         let next = !old;
         tracing::debug!(from=?old, to=?next, "visibility updated");
         visibility.store(next, Ordering::SeqCst);
+        changed = old != next;
         if let Ok(guard) = ctx_handle.lock() {
             if let Some(c) = &*guard {
                 apply_visibility(
@@ -75,6 +77,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
             if let Some(c) = &*guard {
                 let old = visibility.load(Ordering::SeqCst);
                 visibility.store(next, Ordering::SeqCst);
+                changed = old != next;
                 tracing::debug!(from=?old, to=?next, "visibility updated");
                 apply_visibility(
                     next,
@@ -94,6 +97,7 @@ pub fn handle_visibility_trigger<C: ViewportCtx>(
             }
         }
     }
+    changed
 }
 
 /// Apply the current visibility state to the viewport.

--- a/tests/focus_visibility.rs
+++ b/tests/focus_visibility.rs
@@ -19,7 +19,7 @@ fn focus_when_becoming_visible() {
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -32,6 +32,7 @@ fn focus_when_becoming_visible() {
         None,
         (400.0, 220.0),
     );
+    assert!(changed);
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert!(queued_visibility.is_none());

--- a/tests/gui_visibility.rs
+++ b/tests/gui_visibility.rs
@@ -17,7 +17,7 @@ fn queued_visibility_applies_when_context_available() {
 
     // simulate hotkey press while no context is available
     *trigger.open.lock().unwrap() = true;
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -30,6 +30,7 @@ fn queued_visibility_applies_when_context_available() {
         None,
         (400.0, 220.0),
     );
+    assert!(changed);
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert_eq!(queued_visibility, Some(true));
@@ -41,7 +42,7 @@ fn queued_visibility_applies_when_context_available() {
         *guard = Some(ctx.clone());
     }
 
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -54,6 +55,7 @@ fn queued_visibility_applies_when_context_available() {
         None,
         (400.0, 220.0),
     );
+    assert!(!changed);
 
     assert!(queued_visibility.is_none());
     let cmds = ctx.commands.lock().unwrap();

--- a/tests/hotkey_events.rs
+++ b/tests/hotkey_events.rs
@@ -50,7 +50,7 @@ fn zero_key_events_toggle_visibility() {
     let restore = Arc::new(AtomicBool::new(false));
     let mut queued_visibility: Option<bool> = None;
 
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -63,10 +63,11 @@ fn zero_key_events_toggle_visibility() {
         None,
         (400.0, 220.0),
     );
+    assert!(changed);
     assert_eq!(visibility.load(Ordering::SeqCst), true);
 
     process_test_events(&triggers, &events);
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -79,6 +80,7 @@ fn zero_key_events_toggle_visibility() {
         None,
         (400.0, 220.0),
     );
+    assert!(changed);
     assert_eq!(visibility.load(Ordering::SeqCst), false);
 }
 

--- a/tests/trigger_visibility.rs
+++ b/tests/trigger_visibility.rs
@@ -19,7 +19,7 @@ fn visibility_toggle_immediate_when_context_present() {
     // simulate hotkey press
     *trigger.open.lock().unwrap() = true;
 
-    handle_visibility_trigger(
+    let changed = handle_visibility_trigger(
         &trigger,
         &visibility,
         &restore,
@@ -32,6 +32,7 @@ fn visibility_toggle_immediate_when_context_present() {
         None,
         (400.0, 220.0),
     );
+    assert!(changed);
 
     assert_eq!(visibility.load(Ordering::SeqCst), true);
     assert!(queued_visibility.is_none());


### PR DESCRIPTION
## Summary
- Replace polling loop with event-driven receiver
- Notify main thread when hotkeys or visibility change
- Remove fixed 50ms sleep delay

## Testing
- `cargo test` *(fails: process hung; likely requires a display environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ebce9eb083328b45e48565c59dd7