### PR TITLE
test: add key combo validity tests

### DIFF
--- a/tests/is_valid_key_combo.rs
+++ b/tests/is_valid_key_combo.rs
@@ -1,0 +1,14 @@
+#![cfg(windows)]
+use multi_launcher::workspace::is_valid_key_combo;
+
+#[test]
+fn valid_key_combos() {
+    assert!(is_valid_key_combo("Ctrl+Alt+F5"));
+    assert!(is_valid_key_combo("F24"));
+}
+
+#[test]
+fn invalid_key_combos() {
+    assert!(!is_valid_key_combo("Ctrl+Shift"));
+    assert!(!is_valid_key_combo("Foo"));
+}


### PR DESCRIPTION
## Summary
- add tests for `is_valid_key_combo`

## Testing
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message)*


------
https://chatgpt.com/codex/tasks/task_e_68a1fc9e11bc8332aca0e336df88ddf1