### PR TITLE
Add window manager tests

### DIFF
--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -22,7 +22,7 @@ pub fn clear_mock_mouse_position() {
     }
 }
 
-#[cfg(any(test, target_os = "windows"))]
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn virtual_key_from_string(key: &str) -> Option<u32> {
     match key.to_uppercase().as_str() {
         "F1" => Some(0x70),

--- a/tests/window_manager.rs
+++ b/tests/window_manager.rs
@@ -1,0 +1,32 @@
+use multi_launcher::window_manager::{
+    set_mock_mouse_position,
+    clear_mock_mouse_position,
+    current_mouse_position,
+    virtual_key_from_string,
+};
+
+#[test]
+fn mock_mouse_position_override_and_clear() {
+    // Set a custom mouse position and confirm it is returned
+    set_mock_mouse_position(Some((10.0, 20.0)));
+    assert_eq!(current_mouse_position(), Some((10.0, 20.0)));
+
+    // Clear the mock and ensure the default is returned
+    clear_mock_mouse_position();
+    assert_eq!(current_mouse_position(), Some((0.0, 0.0)));
+}
+
+#[test]
+fn virtual_key_from_string_cases() {
+    let cases = [
+        ("A", Some(0x41)),
+        ("F1", Some(0x70)),
+        ("LEFTALT", Some(0xA4)),
+        ("INVALID", None),
+    ];
+
+    for (input, expected) in cases {
+        assert_eq!(virtual_key_from_string(input), expected, "input: {input}");
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure `virtual_key_from_string` builds on all platforms
- test mock mouse position overrides and clearing behavior
- validate a few key codes through `virtual_key_from_string`

## Testing
- `cargo test --test window_manager`


------
https://chatgpt.com/codex/tasks/task_e_68a20235047c833295fdb646f63bf1a6