### PR TITLE
Add tests for logging initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,12 +1902,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1902,6 +1931,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1966,6 +2006,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3088,6 +3129,7 @@ dependencies = [
  "screenshots",
  "serde",
  "serde_json",
+ "serial_test",
  "shlex",
  "slug",
  "sysinfo",
@@ -4457,6 +4499,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ notify = ["notify-rust"]
 [dev-dependencies]
 tempfile = "3"
 criterion = "0.5"
+serial_test = "2"
 
 [build-dependencies]
 embed-resource = "2"

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -1,0 +1,34 @@
+use std::{fs, thread::sleep, time::Duration};
+
+use serial_test::serial;
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn writes_log_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("log.txt");
+
+    multi_launcher::logging::init(true, Some(path.clone()));
+    tracing::info!("test");
+
+    sleep(Duration::from_millis(100));
+
+    assert!(path.exists(), "log file was not created");
+    let contents = fs::read_to_string(path).unwrap();
+    assert!(contents.contains("test"));
+}
+
+#[test]
+#[serial]
+fn init_without_file_creates_no_log() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("log.txt");
+
+    multi_launcher::logging::init(false, None);
+    tracing::info!("test");
+
+    sleep(Duration::from_millis(100));
+
+    assert!(!path.exists(), "log file should not be created");
+}


### PR DESCRIPTION
## Summary
- add tests to verify logging initialization and log file behavior
- introduce `serial_test` dev dependency

## Testing
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message, gui::todo_dialog::tests::enter_adds_todo_with_tags)*

------
https://chatgpt.com/codex/tasks/task_e_68a2065be04083329bd3cdb721f631a7