### PR TITLE
chore: upgrade slab to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,6 +3131,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shlex",
+ "slab",
  "slug",
  "sysinfo",
  "tempfile",
@@ -4575,9 +4576,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slotmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rand = "0.8"
 lipsum = "0.9"
 egui_commonmark = "0.15.0"
 rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
+slab = "0.4.11"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2" }


### PR DESCRIPTION
## Summary
- use `slab` crate 0.4.11
- update lockfile

## Testing
- `cargo build`
- `cargo test` *(fails: hung/incomplete - test run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a210605598833296b2aa92ac438e0e