### PR TITLE
Add basic RSS plugin skeleton and routing

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -37,3 +37,4 @@ pub mod exec;
 pub mod fav;
 pub mod screenshot;
 pub mod calc;
+pub mod rss;

--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+
+/// Execute an RSS command routed from the launcher.
+///
+/// Commands use a colon separated format: `<verb>:<target>`.
+/// The `target` may be a feed id, name, group or `all` depending on the
+/// verb. All handlers are currently placeholders.
+pub fn run(command: &str) -> Result<()> {
+    let mut parts = command.splitn(2, ':');
+    let verb = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+    match verb {
+        "refresh" => refresh(target),
+        "open" => open(target),
+        "mark" => mark(target),
+        // `dialog` opens the UI; nothing to do in CLI.
+        "dialog" => Ok(()),
+        _ => Ok(()),
+    }
+}
+
+fn refresh(_target: &str) -> Result<()> {
+    // Refresh feed(s); accepts id, name, group or `all`.
+    Ok(())
+}
+
+fn open(_target: &str) -> Result<()> {
+    // Open the given feed or group in the default browser.
+    Ok(())
+}
+
+fn mark(_target: &str) -> Result<()> {
+    // Mark items as read/unread for a feed or group.
+    Ok(())
+}

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -377,6 +377,7 @@ enum ActionKind<'a> {
         args: Option<&'a str>,
     },
     Macro(&'a str),
+    Rss(&'a str),
 }
 
 fn parse_action_kind(action: &Action) -> ActionKind<'_> {
@@ -697,6 +698,9 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
             return ActionKind::TempfileAlias { path, alias };
         }
     }
+    if let Some(cmd) = s.strip_prefix("rss:") {
+        return ActionKind::Rss(cmd);
+    }
     if let Some(name) = s.strip_prefix("macro:") {
         return ActionKind::Macro(name);
     }
@@ -883,6 +887,7 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         ActionKind::TempfileClear => tempfiles::clear(),
         ActionKind::TempfileRemove(path) => tempfiles::remove(path),
         ActionKind::TempfileAlias { path, alias } => tempfiles::set_alias(path, alias),
+        ActionKind::Rss(cmd) => rss::run(cmd),
         ActionKind::Macro(name) => {
             crate::plugins::macros::run_macro(name)?;
             Ok(())

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -49,6 +49,7 @@ use crate::plugins::timestamp::TimestampPlugin;
 use crate::plugins::random::RandomPlugin;
 use crate::plugins::lorem::LoremPlugin;
 use crate::plugins::convert_panel::ConvertPanelPlugin;
+use crate::plugins::rss::RssPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
 use std::collections::HashSet;
@@ -160,6 +161,7 @@ impl PluginManager {
         self.register_with_settings(RandomPlugin::default(), plugin_settings);
         self.register_with_settings(LoremPlugin, plugin_settings);
         self.register_with_settings(ConvertPanelPlugin, plugin_settings);
+        self.register_with_settings(RssPlugin, plugin_settings);
         #[cfg(target_os = "windows")]
         {
             self.register_with_settings(VolumePlugin, plugin_settings);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -44,3 +44,4 @@ pub mod lorem;
 pub mod convert_panel;
 pub mod missing;
 pub mod calc_history;
+pub mod rss;

--- a/src/plugins/rss/mod.rs
+++ b/src/plugins/rss/mod.rs
@@ -1,0 +1,70 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+
+/// RSS plugin registering the `rss` prefix.
+///
+/// Commands are routed to the handlers in `crate::actions::rss` via
+/// colon-separated action strings such as `rss:refresh:all`.
+///
+/// Example daily usage:
+///   rss refresh all
+///   rss open feed-name
+pub struct RssPlugin;
+
+impl Plugin for RssPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        const PREFIX: &str = "rss";
+        let trimmed = query.trim();
+
+        // Bare `rss` opens the feed management UI.
+        if trimmed.eq_ignore_ascii_case(PREFIX) {
+            return vec![Action {
+                label: "rss: manage feeds".into(),
+                desc: "RSS".into(),
+                action: "rss:dialog".into(),
+                args: None,
+            }];
+        }
+
+        if let Some(rest) = crate::common::strip_prefix_ci(query, "rss ") {
+            let cmd = rest.trim();
+            if cmd.is_empty() {
+                return vec![Action {
+                    label: "rss: manage feeds".into(),
+                    desc: "RSS".into(),
+                    action: "rss:dialog".into(),
+                    args: None,
+                }];
+            }
+            return vec![Action {
+                label: format!("rss {cmd}"),
+                desc: "RSS".into(),
+                action: format!("rss:{cmd}"),
+                args: None,
+            }];
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "rss"
+    }
+
+    fn description(&self) -> &str {
+        "Manage RSS feeds (prefix: `rss`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "rss".into(),
+            desc: "RSS feeds".into(),
+            action: "query:rss ".into(),
+            args: None,
+        }]
+    }
+}
+

--- a/src/plugins_builtin.rs
+++ b/src/plugins_builtin.rs
@@ -1,5 +1,6 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
+pub use crate::plugins::rss::RssPlugin;
 use urlencoding::encode;
 use crate::plugins::calc_history::{self, CalcHistoryEntry, CALC_HISTORY_FILE, MAX_ENTRIES};
 use eframe::egui;


### PR DESCRIPTION
## Summary
- introduce `rss` plugin module exposing `rss` prefix
- wire plugin into manager and action dispatch
- scaffold RSS CLI handlers

## Testing
- `cargo test` *(fails: terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a21fb096348332a8f5b08b5230cbc0