### PR TITLE
Implement versioned RSS storage helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ lipsum = "0.9"
 egui_commonmark = "0.15.0"
 rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
 slab = "0.4.11"
+tempfile = "3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2" }
@@ -73,7 +74,6 @@ unstable_grab = []
 notify = ["notify-rust"]
 
 [dev-dependencies]
-tempfile = "3"
 criterion = "0.5"
 serial_test = "2"
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,62 +1,62 @@
 use crate::actions::Action;
 use crate::plugins::asciiart::AsciiArtPlugin;
-use crate::plugins::emoji::EmojiPlugin;
-use crate::plugins::screenshot::ScreenshotPlugin;
-use crate::plugins::text_case::TextCasePlugin;
+use crate::plugins::base_convert::BaseConvertPlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
+#[cfg(target_os = "windows")]
+use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::clipboard::ClipboardPlugin;
+use crate::plugins::convert_panel::ConvertPanelPlugin;
 use crate::plugins::dropcalc::DropCalcPlugin;
+use crate::plugins::emoji::EmojiPlugin;
+use crate::plugins::fav::FavPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::history::HistoryPlugin;
+use crate::plugins::ip::IpPlugin;
+use crate::plugins::lorem::LoremPlugin;
+use crate::plugins::macros::MacrosPlugin;
 use crate::plugins::media::MediaPlugin;
+use crate::plugins::missing::MissingPlugin;
 use crate::plugins::network::NetworkPlugin;
 use crate::plugins::note::NotePlugin;
+use crate::plugins::omni_search::OmniSearchPlugin;
 use crate::plugins::processes::ProcessesPlugin;
+use crate::plugins::random::RandomPlugin;
 use crate::plugins::recycle::RecyclePlugin;
 use crate::plugins::reddit::RedditPlugin;
+use crate::plugins::rss::RssPlugin;
 use crate::plugins::runescape::RunescapeSearchPlugin;
+use crate::plugins::screenshot::ScreenshotPlugin;
+use crate::plugins::settings::SettingsPlugin;
 use crate::plugins::shell::ShellPlugin;
 use crate::plugins::snippets::SnippetsPlugin;
-use crate::plugins::fav::FavPlugin;
-use crate::plugins::macros::MacrosPlugin;
-use crate::plugins::omni_search::OmniSearchPlugin;
+use crate::plugins::stopwatch::StopwatchPlugin;
 use crate::plugins::sysinfo::SysInfoPlugin;
 use crate::plugins::system::SystemPlugin;
-use crate::plugins::settings::SettingsPlugin;
-use crate::plugins::missing::MissingPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::task_manager::TaskManagerPlugin;
 use crate::plugins::tempfile::TempfilePlugin;
+use crate::plugins::text_case::TextCasePlugin;
 use crate::plugins::timer::TimerPlugin;
-use crate::plugins::stopwatch::StopwatchPlugin;
+use crate::plugins::timestamp::TimestampPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::unit_convert::UnitConvertPlugin;
-use crate::plugins::base_convert::BaseConvertPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::wikipedia::WikipediaPlugin;
 #[cfg(target_os = "windows")]
 use crate::plugins::windows::WindowsPlugin;
-#[cfg(target_os = "windows")]
-use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
-use crate::plugins::ip::IpPlugin;
-use crate::plugins::timestamp::TimestampPlugin;
-use crate::plugins::random::RandomPlugin;
-use crate::plugins::lorem::LoremPlugin;
-use crate::plugins::convert_panel::ConvertPanelPlugin;
-use crate::plugins::rss::RssPlugin;
 use crate::plugins_builtin::{CalculatorPlugin, WebSearchPlugin};
 use crate::settings::NetUnit;
-use std::collections::HashSet;
-use std::sync::Arc;
+use eframe::egui;
 use libloading::Library;
 use serde_json::Value;
-use eframe::egui;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 pub trait Plugin: Send + Sync {
     /// Return actions based on the query string
@@ -161,7 +161,7 @@ impl PluginManager {
         self.register_with_settings(RandomPlugin::default(), plugin_settings);
         self.register_with_settings(LoremPlugin, plugin_settings);
         self.register_with_settings(ConvertPanelPlugin, plugin_settings);
-        self.register_with_settings(RssPlugin, plugin_settings);
+        self.register_with_settings(RssPlugin::default(), plugin_settings);
         #[cfg(target_os = "windows")]
         {
             self.register_with_settings(VolumePlugin, plugin_settings);

--- a/src/plugins/rss/mod.rs
+++ b/src/plugins/rss/mod.rs
@@ -1,6 +1,8 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 
+pub mod storage;
+
 /// RSS plugin registering the `rss` prefix.
 ///
 /// Commands are routed to the handlers in `crate::actions::rss` via
@@ -10,6 +12,22 @@ use crate::plugin::Plugin;
 ///   rss refresh all
 ///   rss open feed-name
 pub struct RssPlugin;
+
+impl RssPlugin {
+    /// Create a new instance of the RSS plugin.
+    ///
+    /// Ensures the configuration directory exists on initialization.
+    pub fn new() -> Self {
+        storage::ensure_config_dir();
+        Self
+    }
+}
+
+impl Default for RssPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Plugin for RssPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
@@ -67,4 +85,3 @@ impl Plugin for RssPlugin {
         }]
     }
 }
-

--- a/src/plugins/rss/storage.rs
+++ b/src/plugins/rss/storage.rs
@@ -1,0 +1,233 @@
+use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+/// Return the configuration directory for the RSS plugin.
+///
+/// The directory and the `cache` sub-directory are created on first use so
+/// subsequent operations can assume they exist.
+pub fn ensure_config_dir() -> PathBuf {
+    static DIR: Lazy<PathBuf> = Lazy::new(|| {
+        let base = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("rss");
+        let _ = fs::create_dir_all(&base);
+        let _ = fs::create_dir_all(base.join("cache"));
+        base
+    });
+    DIR.clone()
+}
+
+fn feeds_path() -> PathBuf {
+    ensure_config_dir().join("feeds.json")
+}
+
+fn state_path() -> PathBuf {
+    ensure_config_dir().join("state.json")
+}
+
+/// Path to the cache file for a specific feed identified by `feed_id`.
+pub fn cache_path(feed_id: &str) -> PathBuf {
+    ensure_config_dir()
+        .join("cache")
+        .join(format!("{feed_id}.json"))
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir)?;
+    let mut tmp = NamedTempFile::new_in(dir)?;
+    tmp.write_all(data)?;
+    tmp.flush()?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path)?;
+    Ok(())
+}
+
+/// Trait implemented by versioned files stored by the RSS plugin.
+pub trait HasVersion {
+    const VERSION: u32;
+    fn version(&self) -> u32;
+}
+
+fn load_json<T>(path: &Path) -> Option<T>
+where
+    T: for<'de> Deserialize<'de> + Default + HasVersion,
+{
+    match fs::read_to_string(path) {
+        Ok(content) => match serde_json::from_str::<T>(&content) {
+            Ok(data) if data.version() == T::VERSION => Some(data),
+            _ => {
+                let _ = fs::rename(path, path.with_extension("corrupt"));
+                None
+            }
+        },
+        Err(err) => {
+            if err.kind() != io::ErrorKind::NotFound {
+                let _ = fs::rename(path, path.with_extension("corrupt"));
+            }
+            None
+        }
+    }
+}
+
+fn save_json<T>(path: &Path, value: &T) -> Result<()>
+where
+    T: Serialize,
+{
+    let json = serde_json::to_vec_pretty(value)?;
+    atomic_write(path, &json).context("atomic write")?;
+    Ok(())
+}
+
+// ----------------------------------------------------------------------------
+// feeds.json
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FeedConfig {
+    pub id: String,
+    pub url: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub group: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FeedsFile {
+    pub version: u32,
+    #[serde(default)]
+    pub feeds: Vec<FeedConfig>,
+}
+
+impl FeedsFile {
+    pub const VERSION: u32 = 1;
+
+    pub fn load() -> Self {
+        load_json(&feeds_path()).unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<()> {
+        save_json(&feeds_path(), self)
+    }
+}
+
+impl Default for FeedsFile {
+    fn default() -> Self {
+        Self {
+            version: Self::VERSION,
+            feeds: Vec::new(),
+        }
+    }
+}
+
+impl HasVersion for FeedsFile {
+    const VERSION: u32 = FeedsFile::VERSION;
+    fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+// ----------------------------------------------------------------------------
+// state.json
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct FeedState {
+    #[serde(default)]
+    pub last_guid: Option<String>,
+    #[serde(default)]
+    pub last_fetch: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StateFile {
+    pub version: u32,
+    #[serde(default)]
+    pub feeds: HashMap<String, FeedState>,
+}
+
+impl StateFile {
+    pub const VERSION: u32 = 1;
+
+    pub fn load() -> Self {
+        load_json(&state_path()).unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<()> {
+        save_json(&state_path(), self)
+    }
+}
+
+impl Default for StateFile {
+    fn default() -> Self {
+        Self {
+            version: Self::VERSION,
+            feeds: HashMap::new(),
+        }
+    }
+}
+
+impl HasVersion for StateFile {
+    const VERSION: u32 = StateFile::VERSION;
+    fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+// ----------------------------------------------------------------------------
+// per-feed caches
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct CachedItem {
+    pub guid: String,
+    pub title: String,
+    #[serde(default)]
+    pub link: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FeedCache {
+    pub version: u32,
+    #[serde(default)]
+    pub items: Vec<CachedItem>,
+}
+
+impl FeedCache {
+    pub const VERSION: u32 = 1;
+
+    pub fn load(feed_id: &str) -> Self {
+        load_json(&cache_path(feed_id)).unwrap_or_default()
+    }
+
+    pub fn save(&self, feed_id: &str) -> Result<()> {
+        save_json(&cache_path(feed_id), self)
+    }
+}
+
+impl Default for FeedCache {
+    fn default() -> Self {
+        Self {
+            version: Self::VERSION,
+            items: Vec::new(),
+        }
+    }
+}
+
+impl HasVersion for FeedCache {
+    const VERSION: u32 = FeedCache::VERSION;
+    fn version(&self) -> u32 {
+        self.version
+    }
+}


### PR DESCRIPTION
## Summary
- add persistent storage structs for RSS feeds, state, and per-feed caches
- ensure config directory exists on plugin init
- use atomic JSON read/write with version checks

## Testing
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message)*

------
https://chatgpt.com/codex/tasks/task_e_68a22414e5bc8332b336be0cfb6710c2