### PR TITLE
feat(rss): add feed poller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02a15dbb4ba5223a427ec7c678c47e295ec9ecd48cd15ab015a205d15388a43"
+dependencies = [
+ "chrono",
+ "mime",
+ "quick-xml 0.31.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.1",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "figlet-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3230,7 @@ dependencies = [
  "egui_commonmark",
  "embed-resource",
  "exmex",
+ "feed-rs",
  "figlet-rs",
  "fst",
  "fuzzy-matcher",
@@ -4115,6 +4133,16 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -5507,6 +5535,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
 slab = "0.4.11"
 scraper = "0.18"
 tempfile = "3"
+feed-rs = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2" }

--- a/src/plugins/rss/mod.rs
+++ b/src/plugins/rss/mod.rs
@@ -1,6 +1,7 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
 
+pub mod poller;
 pub mod source;
 pub mod storage;
 

--- a/src/plugins/rss/poller.rs
+++ b/src/plugins/rss/poller.rs
@@ -1,0 +1,185 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, ETAG, IF_MODIFIED_SINCE, IF_NONE_MATCH, LAST_MODIFIED};
+use std::time::Duration;
+
+use super::storage::{CachedItem, FeedCache, FeedConfig, FeedState, StateFile};
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct MediaMetadata {
+    pub url: Option<String>,
+    pub content_type: Option<String>,
+    pub length: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Item {
+    pub id: String,
+    pub title: Option<String>,
+    pub link: Option<String>,
+    pub published: Option<u64>,
+    pub author: Option<String>,
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub media: Vec<MediaMetadata>,
+}
+
+pub struct Poller {
+    client: Client,
+}
+
+impl Poller {
+    pub fn new() -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent("multi-launcher rss poller")
+            .build()?;
+        Ok(Self { client })
+    }
+
+    /// Poll a single feed returning newly discovered items.
+    ///
+    /// Updates state and optional cache on success.
+    pub fn poll_feed(
+        &self,
+        feed: &FeedConfig,
+        state: &mut StateFile,
+        cache_items: bool,
+    ) -> Result<Vec<Item>> {
+        let now = Utc::now().timestamp() as u64;
+        let entry = state.feeds.entry(feed.id.clone()).or_default();
+
+        // Respect backoff if a previous error requested it.
+        if let Some(until) = entry.backoff_until {
+            if until > now {
+                return Ok(Vec::new());
+            }
+        }
+
+        // Conditional request using stored ETag / Last-Modified headers.
+        let mut req = self.client.get(&feed.url);
+        if let Some(etag) = &entry.etag {
+            req = req.header(IF_NONE_MATCH, etag.as_str());
+        }
+        if let Some(lm) = &entry.last_modified {
+            req = req.header(IF_MODIFIED_SINCE, lm.as_str());
+        }
+
+        let resp = match req.send() {
+            Ok(r) => r,
+            Err(err) => {
+                record_error(entry, now, err.to_string());
+                state.save()?;
+                return Err(err.into());
+            }
+        };
+
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+            // Nothing new; update fetch timestamp and reset errors.
+            entry.last_fetch = Some(now);
+            entry.error = None;
+            entry.error_count = 0;
+            entry.backoff_until = None;
+            state.save()?;
+            return Ok(Vec::new());
+        }
+
+        if !resp.status().is_success() {
+            let msg = format!("http status {}", resp.status());
+            record_error(entry, now, msg.clone());
+            state.save()?;
+            anyhow::bail!(msg);
+        }
+
+        let headers = resp.headers().clone();
+        let bytes = resp.bytes().context("read feed body")?;
+        let feed_model = feed_rs::parser::parse(&bytes[..]).context("parse feed")?;
+
+        // Collect new items until the last known GUID is encountered.
+        let mut new_items = Vec::new();
+        for entry_model in &feed_model.entries {
+            let id = entry_model.id.clone();
+            if entry.last_guid.as_deref() == Some(&id) {
+                break;
+            }
+            new_items.push(convert_entry(entry_model));
+        }
+        if !new_items.is_empty() {
+            // Preserve chronological order from oldest to newest.
+            new_items.reverse();
+            entry.last_guid = Some(feed_model.entries[0].id.clone());
+            entry.unread = entry.unread.saturating_add(new_items.len() as u32);
+            if cache_items {
+                let mut cache = FeedCache::load(&feed.id);
+                for it in &new_items {
+                    cache.items.push(CachedItem {
+                        guid: it.id.clone(),
+                        title: it.title.clone().unwrap_or_default(),
+                        link: it.link.clone(),
+                        timestamp: it.published,
+                    });
+                }
+                cache.save(&feed.id)?;
+            }
+        }
+
+        update_success(entry, now, &headers);
+        state.save()?;
+        Ok(new_items)
+    }
+}
+
+fn record_error(state: &mut FeedState, now: u64, msg: String) {
+    state.error = Some(msg);
+    state.error_count += 1;
+    let delay = 2u64.pow(state.error_count.min(5)) * 60; // seconds
+    state.backoff_until = Some(now + delay);
+}
+
+fn update_success(state: &mut FeedState, now: u64, headers: &HeaderMap) {
+    state.last_fetch = Some(now);
+    state.etag = headers
+        .get(ETAG)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+    state.last_modified = headers
+        .get(LAST_MODIFIED)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+    state.error = None;
+    state.error_count = 0;
+    state.backoff_until = None;
+}
+
+fn convert_entry(entry: &feed_rs::model::Entry) -> Item {
+    let link = entry.links.first().map(|l| l.href.clone());
+    let title = entry.title.as_ref().map(|t| t.content.clone());
+    let published = entry
+        .published
+        .or(entry.updated)
+        .map(|dt| dt.timestamp() as u64);
+    let author = entry.authors.first().map(|p| p.name.clone());
+    let summary = entry.summary.as_ref().map(|s| s.content.clone());
+
+    let mut media = Vec::new();
+    for m in &entry.media {
+        for c in &m.content {
+            media.push(MediaMetadata {
+                url: c.url.as_ref().map(|u| u.to_string()),
+                content_type: c.content_type.as_ref().map(|m| m.to_string()),
+                length: c.size,
+            });
+        }
+    }
+
+    Item {
+        id: entry.id.clone(),
+        title,
+        link,
+        published,
+        author,
+        summary,
+        media,
+    }
+}

--- a/src/plugins/rss/storage.rs
+++ b/src/plugins/rss/storage.rs
@@ -146,6 +146,18 @@ pub struct FeedState {
     pub last_guid: Option<String>,
     #[serde(default)]
     pub last_fetch: Option<u64>,
+    #[serde(default)]
+    pub etag: Option<String>,
+    #[serde(default)]
+    pub last_modified: Option<String>,
+    #[serde(default)]
+    pub unread: u32,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub error_count: u32,
+    #[serde(default)]
+    pub backoff_until: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -156,7 +168,7 @@ pub struct StateFile {
 }
 
 impl StateFile {
-    pub const VERSION: u32 = 1;
+    pub const VERSION: u32 = 2;
 
     pub fn load() -> Self {
         load_json(&state_path()).unwrap_or_default()


### PR DESCRIPTION
## Summary
- add feed poller with conditional HTTP requests and item parsing
- extend RSS state tracking for unread counts and error recovery
- integrate poller module and dependency

## Testing
- `cargo test` *(fails: test logging)*

------
https://chatgpt.com/codex/tasks/task_e_68a22e68aa148332aa988d861879549a