### PR TITLE
feat(rss): track read state and cursor

### DIFF
--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -1,18 +1,22 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use chrono::DateTime;
+use shlex;
+
+use crate::plugins::rss::storage;
 
 /// Execute an RSS command routed from the launcher.
 ///
-/// Commands use a colon separated format: `<verb>:<target>`.
+/// Commands are space separated: `<verb> [args...]`.
 /// The `target` may be a feed id, name, group or `all` depending on the
-/// verb. All handlers are currently placeholders.
+/// verb.
 pub fn run(command: &str) -> Result<()> {
-    let mut parts = command.splitn(2, ':');
+    let mut parts = command.splitn(2, ' ');
     let verb = parts.next().unwrap_or("");
-    let target = parts.next().unwrap_or("");
+    let rest = parts.next().unwrap_or("");
     match verb {
-        "refresh" => refresh(target),
-        "open" => open(target),
-        "mark" => mark(target),
+        "refresh" => refresh(rest),
+        "open" => open(rest),
+        "mark" => mark(rest),
         // `dialog` opens the UI; nothing to do in CLI.
         "dialog" => Ok(()),
         _ => Ok(()),
@@ -24,12 +28,137 @@ fn refresh(_target: &str) -> Result<()> {
     Ok(())
 }
 
-fn open(_target: &str) -> Result<()> {
-    // Open the given feed or group in the default browser.
-    Ok(())
+fn open(target: &str) -> Result<()> {
+    let feed_id = target.trim();
+    if feed_id.is_empty() {
+        return Ok(());
+    }
+    let mut state = storage::StateFile::load();
+    let feeds = storage::FeedsFile::load();
+    let feed = feeds
+        .feeds
+        .iter()
+        .find(|f| f.id == feed_id || f.title.as_deref() == Some(feed_id))
+        .ok_or_else(|| anyhow!("feed not found"))?;
+
+    let cache = storage::FeedCache::load(&feed.id);
+    let entry = state.feeds.entry(feed.id.clone()).or_default();
+    let cursor = entry.catchup.unwrap_or(0);
+    for item in &cache.items {
+        let ts = item.timestamp.unwrap_or(0);
+        if ts <= cursor || entry.read.contains(&item.guid) {
+            continue;
+        }
+        if let Some(link) = &item.link {
+            let _ = open::that(link);
+        }
+        entry.read.insert(item.guid.clone());
+    }
+    recompute_unread(&feed.id, entry);
+    state.save()
 }
 
-fn mark(_target: &str) -> Result<()> {
-    // Mark items as read/unread for a feed or group.
-    Ok(())
+fn mark(command: &str) -> Result<()> {
+    let mut parts = command.splitn(2, ' ');
+    let subverb = parts.next().unwrap_or("");
+    let rest = parts.next().unwrap_or("");
+    match subverb {
+        "read" => mark_read(rest),
+        "unread" => mark_unread(rest),
+        _ => Ok(()),
+    }
+}
+
+fn mark_read(args: &str) -> Result<()> {
+    let parts = shlex::split(args).unwrap_or_default();
+    if parts.is_empty() {
+        return Ok(());
+    }
+    let target = &parts[0];
+    // parse --through
+    let mut through: Option<String> = None;
+    let mut i = 1;
+    while i < parts.len() {
+        if parts[i] == "--through" && i + 1 < parts.len() {
+            through = Some(parts[i + 1].clone());
+            break;
+        }
+        i += 1;
+    }
+    let through = through.ok_or_else(|| anyhow!("--through required"))?;
+    let mut state = storage::StateFile::load();
+    let feeds = storage::FeedsFile::load();
+    let targets: Vec<String> = if target == "all" {
+        feeds.feeds.iter().map(|f| f.id.clone()).collect()
+    } else {
+        feeds
+            .feeds
+            .iter()
+            .filter(|f| f.id == *target || f.title.as_deref() == Some(target))
+            .map(|f| f.id.clone())
+            .collect()
+    };
+    for fid in targets {
+        let cache = storage::FeedCache::load(&fid);
+        let entry = state.feeds.entry(fid.clone()).or_default();
+        let mut new_ts = if through == "newest" {
+            cache
+                .items
+                .iter()
+                .filter_map(|i| i.timestamp)
+                .max()
+                .unwrap_or(0)
+        } else {
+            DateTime::parse_from_rfc3339(&through)?.timestamp() as u64
+        };
+        if let Some(cur) = entry.catchup {
+            if new_ts < cur {
+                new_ts = cur;
+            }
+        }
+        entry.catchup = Some(new_ts);
+        // Build map of guid -> timestamp for pruning
+        let ts_map: std::collections::HashMap<_, _> = cache
+            .items
+            .iter()
+            .filter_map(|i| i.timestamp.map(|ts| (i.guid.clone(), ts)))
+            .collect();
+        let cutoff = new_ts;
+        entry
+            .read
+            .retain(|id| ts_map.get(id).map(|t| *t > cutoff).unwrap_or(true));
+        recompute_unread(&fid, entry);
+    }
+    state.save()
+}
+
+fn mark_unread(args: &str) -> Result<()> {
+    let ids = shlex::split(args).unwrap_or_default();
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let mut state = storage::StateFile::load();
+    for spec in ids {
+        if let Some((fid, guid)) = spec.split_once('/') {
+            if let Some(entry) = state.feeds.get_mut(fid) {
+                entry.read.remove(guid);
+                recompute_unread(fid, entry);
+            }
+        }
+    }
+    state.save()
+}
+
+fn recompute_unread(feed_id: &str, entry: &mut storage::FeedState) {
+    let cache = storage::FeedCache::load(feed_id);
+    let cursor = entry.catchup.unwrap_or(0);
+    let count = cache
+        .items
+        .iter()
+        .filter(|i| {
+            let ts = i.timestamp.unwrap_or(0);
+            ts > cursor && !entry.read.contains(&i.guid)
+        })
+        .count();
+    entry.unread = count as u32;
 }

--- a/src/plugins/rss/storage.rs
+++ b/src/plugins/rss/storage.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -158,6 +158,12 @@ pub struct FeedState {
     pub error_count: u32,
     #[serde(default)]
     pub backoff_until: Option<u64>,
+    /// Timestamp cursor up to which all items are considered read.
+    #[serde(default)]
+    pub catchup: Option<u64>,
+    /// Explicit set of read item IDs beyond the catch-up cursor.
+    #[serde(default)]
+    pub read: HashSet<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -168,7 +174,7 @@ pub struct StateFile {
 }
 
 impl StateFile {
-    pub const VERSION: u32 = 2;
+    pub const VERSION: u32 = 3;
 
     pub fn load() -> Self {
         load_json(&state_path()).unwrap_or_default()


### PR DESCRIPTION
## Summary
- track per-feed read ids and catch-up cursor in `state.json`
- auto-mark items read when opened via `rss open`
- add `rss mark read` and `rss mark unread` commands for cursor control

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2326066fc8332b7a20db34bf8e437