### PR TITLE
feat: add rss groups and dialog

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,6 +4,7 @@ mod alias_dialog;
 mod bookmark_alias_dialog;
 mod brightness_dialog;
 mod clipboard_dialog;
+mod rss_dialog;
 mod convert_panel;
 mod cpu_list_dialog;
 mod fav_dialog;
@@ -28,6 +29,7 @@ pub use bookmark_alias_dialog::BookmarkAliasDialog;
 pub use brightness_dialog::BrightnessDialog;
 pub use brightness_dialog::BRIGHTNESS_QUERIES;
 pub use clipboard_dialog::ClipboardDialog;
+pub use rss_dialog::RssDialog;
 pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;
 pub use fav_dialog::FavDialog;
@@ -326,6 +328,7 @@ pub struct LauncherApp {
     image_panels: Vec<ImagePanel>,
     todo_dialog: TodoDialog,
     todo_view_dialog: TodoViewDialog,
+    rss_dialog: RssDialog,
     clipboard_dialog: ClipboardDialog,
     convert_panel: ConvertPanel,
     volume_dialog: VolumeDialog,
@@ -740,6 +743,7 @@ impl LauncherApp {
             image_panels: Vec::new(),
             todo_dialog: TodoDialog::default(),
             todo_view_dialog: TodoViewDialog::default(),
+            rss_dialog: RssDialog::default(),
             clipboard_dialog: ClipboardDialog::default(),
             convert_panel: ConvertPanel::default(),
             volume_dialog: VolumeDialog::default(),
@@ -2039,6 +2043,8 @@ impl eframe::App for LauncherApp {
                             }
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
+                        } else if a.action == "rss:dialog" {
+                            self.rss_dialog.open();
                         } else if a.action == "todo:view" {
                             self.todo_view_dialog.open();
                         } else if let Some(idx) = a.action.strip_prefix("todo:edit:") {
@@ -2779,6 +2785,8 @@ impl eframe::App for LauncherApp {
                             }
                         } else if a.action == "todo:dialog" {
                             self.todo_dialog.open();
+                        } else if a.action == "rss:dialog" {
+                            self.rss_dialog.open();
                         } else if a.action == "todo:view" {
                             self.todo_view_dialog.open();
                         } else if let Some(idx) = a.action.strip_prefix("todo:edit:") {
@@ -3114,6 +3122,9 @@ impl eframe::App for LauncherApp {
         let mut todo_dlg = std::mem::take(&mut self.todo_dialog);
         todo_dlg.ui(ctx, self);
         self.todo_dialog = todo_dlg;
+        let mut rss_dlg = std::mem::take(&mut self.rss_dialog);
+        rss_dlg.ui(ctx, self);
+        self.rss_dialog = rss_dlg;
         let mut todo_view = std::mem::take(&mut self.todo_view_dialog);
         todo_view.ui(ctx, self);
         self.todo_view_dialog = todo_view;

--- a/src/gui/rss_dialog.rs
+++ b/src/gui/rss_dialog.rs
@@ -1,0 +1,104 @@
+use eframe::egui;
+use crate::plugins::rss::storage;
+use super::{LauncherApp, open_link};
+
+#[derive(Default)]
+pub struct RssDialog {
+    pub open: bool,
+    selected_group: Option<String>,
+    selected_feed: Option<String>,
+}
+
+impl RssDialog {
+    pub fn open(&mut self) {
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, _app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut open = self.open;
+        egui::Window::new("RSS")
+            .open(&mut open)
+            .resizable(true)
+            .show(ctx, |ui| {
+                let feeds_file = storage::FeedsFile::load();
+                let mut state = storage::StateFile::load();
+                ui.columns(3, |cols| {
+                    // Column 0: groups
+                    for g in &feeds_file.groups {
+                        let unread: u32 = feeds_file
+                            .feeds
+                            .iter()
+                            .filter(|f| f.group.as_deref() == Some(g))
+                            .map(|f| state.feeds.get(&f.id).map(|s| s.unread).unwrap_or(0))
+                            .sum();
+                        if cols[0]
+                            .selectable_label(self.selected_group.as_deref() == Some(g), format!("{g} ({unread})"))
+                            .clicked()
+                        {
+                            self.selected_group = Some(g.clone());
+                            self.selected_feed = None;
+                        }
+                    }
+
+                    // Column 1: feeds in selected group
+                    let feed_iter = feeds_file.feeds.iter().filter(|f| {
+                        if let Some(g) = &self.selected_group {
+                            f.group.as_deref() == Some(g)
+                        } else {
+                            true
+                        }
+                    });
+                    for f in feed_iter {
+                        let unread = state.feeds.get(&f.id).map(|s| s.unread).unwrap_or(0);
+                        let title = f.title.clone().unwrap_or_else(|| f.id.clone());
+                        if cols[1]
+                            .selectable_label(self.selected_feed.as_deref() == Some(&f.id), format!("{title} ({unread})"))
+                            .clicked()
+                        {
+                            self.selected_feed = Some(f.id.clone());
+                        }
+                    }
+
+                    // Column 2: items for selected feed
+                    if let Some(fid) = &self.selected_feed {
+                        let cache = storage::FeedCache::load(fid);
+                        let entry = state.feeds.entry(fid.clone()).or_default();
+                        let cursor = entry.catchup.unwrap_or(0);
+                        let mut changed = false;
+                        for item in cache.items.iter().rev() {
+                            let ts = item.timestamp.unwrap_or(0);
+                            let unread = ts > cursor && !entry.read.contains(&item.guid);
+                            let label = if unread {
+                                format!("* {}", item.title)
+                            } else {
+                                item.title.clone()
+                            };
+                            if cols[2].button(label).clicked() {
+                                if let Some(link) = &item.link {
+                                    let _ = open_link(link);
+                                }
+                                entry.read.insert(item.guid.clone());
+                                let count = cache
+                                    .items
+                                    .iter()
+                                    .filter(|i| {
+                                        let ts = i.timestamp.unwrap_or(0);
+                                        ts > cursor && !entry.read.contains(&i.guid)
+                                    })
+                                    .count();
+                                entry.unread = count as u32;
+                                changed = true;
+                            }
+                        }
+                        if changed {
+                            let _ = state.save();
+                        }
+                    }
+                });
+            });
+        self.open = open;
+    }
+}

--- a/src/plugins/rss/storage.rs
+++ b/src/plugins/rss/storage.rs
@@ -106,10 +106,12 @@ pub struct FeedsFile {
     pub version: u32,
     #[serde(default)]
     pub feeds: Vec<FeedConfig>,
+    #[serde(default)]
+    pub groups: Vec<String>,
 }
 
 impl FeedsFile {
-    pub const VERSION: u32 = 1;
+    pub const VERSION: u32 = 2;
 
     pub fn load() -> Self {
         load_json(&feeds_path()).unwrap_or_default()
@@ -125,6 +127,7 @@ impl Default for FeedsFile {
         Self {
             version: Self::VERSION,
             feeds: Vec::new(),
+            groups: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- track RSS groups in feeds.json and provide group add/rm/mv commands
- extend RSS CLI with ls, items and open filters
- add basic RSS reader dialog with groups, feeds and items

## Testing
- `cargo test` *(failed: no output / hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a2361945d083329a88b54bf8259504