### PR TITLE
Enable immediate RSS refresh and add coverage

### DIFF
--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -96,17 +96,9 @@ fn refresh(args: &str) -> Result<()> {
     let mut feeds = storage::FeedsFile::load();
     let mut state = storage::StateFile::load();
     let poller = Poller::new()?;
-    let now = chrono::Utc::now().timestamp() as u64;
     let mut changed = false;
     let targets = resolve_targets_mut(&mut feeds, target);
     for feed in targets {
-        if !force {
-            if let Some(next) = feed.next_poll {
-                if next > now {
-                    continue;
-                }
-            }
-        }
         let _ = poller.poll_feed(feed, &mut state, true, force);
         changed = true;
     }

--- a/tests/rss_refresh.rs
+++ b/tests/rss_refresh.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+use httpmock::prelude::*;
+use multi_launcher::actions::rss;
+use multi_launcher::plugins::rss::storage::{FeedConfig, FeedsFile, StateFile};
+
+#[test]
+fn refresh_polls_even_when_not_due() {
+    // Ensure a clean config directory
+    let _ = fs::remove_dir_all("config/rss");
+
+    let server = MockServer::start();
+    let feed_body = r#"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<feed xmlns=\"http://www.w3.org/2005/Atom\">
+  <id>test</id>
+  <title>Test</title>
+  <updated>2023-01-02T00:00:00Z</updated>
+  <entry>
+    <id>1</id>
+    <title>First</title>
+    <updated>2023-01-01T00:00:00Z</updated>
+  </entry>
+</feed>"#;
+
+    let m = server.mock(|when, then| {
+        when.method(GET).path("/feed");
+        then.status(200)
+            .header("content-type", "application/atom+xml")
+            .body(feed_body);
+    });
+
+    let mut feeds = FeedsFile::default();
+    feeds.feeds.push(FeedConfig {
+        id: "f".into(),
+        url: format!("{}/feed", server.base_url()),
+        title: None,
+        group: None,
+        last_poll: None,
+        next_poll: Some(9_999_999_999),
+        cadence: None,
+    });
+    feeds.save().unwrap();
+    StateFile::default().save().unwrap();
+
+    rss::run("refresh f").unwrap();
+
+    m.assert();
+}


### PR DESCRIPTION
## Summary
- allow `rss:refresh` to poll feeds immediately regardless of schedule
- add test verifying refresh polls even when next poll time is in the future

## Testing
- `cargo test` *(fails: macros_file_change_reload – passes when run individually)*
- `cargo test --test macros_plugin macros_file_change_reload -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68a2663a6d5c83329f305b4936550ed5