### PR TITLE
Add RSS plugin with subcommand discovery and help docs

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -37,3 +37,4 @@ pub mod exec;
 pub mod fav;
 pub mod screenshot;
 pub mod calc;
+pub mod rss;

--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -1,0 +1,9 @@
+pub fn add(url: &str) -> anyhow::Result<()> {
+    crate::plugins::rss::append_feed(crate::plugins::rss::RSS_FILE, url)?;
+    Ok(())
+}
+
+pub fn remove(url: &str) -> anyhow::Result<()> {
+    crate::plugins::rss::remove_feed(crate::plugins::rss::RSS_FILE, url)?;
+    Ok(())
+}

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -134,6 +134,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         "folders" => Some(&["f add C:/path", "f rm docs"]),
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),
+        "rss" => Some(&["rss add <url>", "rss list"]),
         "sysinfo" => Some(&["info", "info cpu", "info cpu list 5"]),
         "network" => Some(&["net"]),
         "weather" => Some(&["weather Berlin"]),

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -285,6 +285,8 @@ enum ActionKind<'a> {
     CalcHistory(usize),
     BookmarkAdd(&'a str),
     BookmarkRemove(&'a str),
+    RssAdd(&'a str),
+    RssRemove(&'a str),
     FolderAdd(&'a str),
     FolderRemove(&'a str),
     HistoryClear,
@@ -419,6 +421,12 @@ fn parse_action_kind(action: &Action) -> ActionKind<'_> {
     }
     if let Some(url) = s.strip_prefix("bookmark:remove:") {
         return ActionKind::BookmarkRemove(url);
+    }
+    if let Some(url) = s.strip_prefix("rss:add:") {
+        return ActionKind::RssAdd(url);
+    }
+    if let Some(url) = s.strip_prefix("rss:remove:") {
+        return ActionKind::RssRemove(url);
     }
     if let Some(path) = s.strip_prefix("folder:add:") {
         return ActionKind::FolderAdd(path);
@@ -736,6 +744,8 @@ pub fn launch_action(action: &Action) -> anyhow::Result<()> {
         ActionKind::CalcHistory(i) => crate::actions::calc::copy_history_result(i),
         ActionKind::BookmarkAdd(url) => bookmarks::add(url),
         ActionKind::BookmarkRemove(url) => bookmarks::remove(url),
+        ActionKind::RssAdd(url) => rss::add(url),
+        ActionKind::RssRemove(url) => rss::remove(url),
         ActionKind::FolderAdd(path) => folders::add(path),
         ActionKind::FolderRemove(path) => folders::remove(path),
         ActionKind::HistoryClear => history::clear(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,6 +23,7 @@ use crate::plugins::snippets::SnippetsPlugin;
 use crate::plugins::fav::FavPlugin;
 use crate::plugins::macros::MacrosPlugin;
 use crate::plugins::omni_search::OmniSearchPlugin;
+use crate::plugins::rss::RssPlugin;
 use crate::plugins::sysinfo::SysInfoPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::settings::SettingsPlugin;
@@ -134,6 +135,7 @@ impl PluginManager {
         self.register_with_settings(WikipediaPlugin, plugin_settings);
         self.register_with_settings(ClipboardPlugin::new(clipboard_limit), plugin_settings);
         self.register_with_settings(BookmarksPlugin::default(), plugin_settings);
+        self.register_with_settings(RssPlugin::default(), plugin_settings);
         self.register_with_settings(FoldersPlugin::default(), plugin_settings);
         self.register_with_settings(OmniSearchPlugin::new(actions.clone()), plugin_settings);
         self.register_with_settings(SystemPlugin, plugin_settings);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -15,6 +15,7 @@ pub mod sysinfo;
 pub mod network;
 pub mod weather;
 pub mod note;
+pub mod rss;
 pub mod todo;
 pub mod timer;
 pub mod stopwatch;

--- a/src/plugins/rss.rs
+++ b/src/plugins/rss.rs
@@ -1,0 +1,214 @@
+use crate::actions::Action;
+use crate::plugin::Plugin;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+pub const RSS_FILE: &str = "rss.json";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RssEntry {
+    pub url: String,
+}
+
+static RSS_DATA: Lazy<Arc<Mutex<Vec<RssEntry>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(load_rss(RSS_FILE).unwrap_or_default())));
+
+fn load_rss(path: &str) -> anyhow::Result<Vec<RssEntry>> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let list: Vec<RssEntry> = serde_json::from_str(&content)?;
+    Ok(list)
+}
+
+fn save_rss(path: &str, feeds: &[RssEntry]) -> anyhow::Result<()> {
+    let json = serde_json::to_string_pretty(feeds)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn append_feed(path: &str, url: &str) -> anyhow::Result<()> {
+    let mut list = load_rss(path).unwrap_or_default();
+    if !list.iter().any(|f| f.url == url) {
+        list.push(RssEntry {
+            url: url.to_string(),
+        });
+        save_rss(path, &list)?;
+        if let Ok(mut data) = RSS_DATA.lock() {
+            *data = list;
+        }
+    }
+    Ok(())
+}
+
+pub fn remove_feed(path: &str, url: &str) -> anyhow::Result<()> {
+    let mut list = load_rss(path).unwrap_or_default();
+    if let Some(pos) = list.iter().position(|f| f.url == url) {
+        list.remove(pos);
+        save_rss(path, &list)?;
+        if let Ok(mut data) = RSS_DATA.lock() {
+            *data = list;
+        }
+    }
+    Ok(())
+}
+
+pub struct RssPlugin {
+    matcher: SkimMatcherV2,
+    data: Arc<Mutex<Vec<RssEntry>>>,
+}
+
+impl Default for RssPlugin {
+    fn default() -> Self {
+        Self {
+            matcher: SkimMatcherV2::default(),
+            data: RSS_DATA.clone(),
+        }
+    }
+}
+
+impl Plugin for RssPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let trimmed = query.trim();
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "rss") {
+            if rest.trim().is_empty() {
+                return vec![
+                    Action {
+                        label: "rss add".into(),
+                        desc: "RSS".into(),
+                        action: "query:rss add ".into(),
+                        args: None,
+                    },
+                    Action {
+                        label: "rss list".into(),
+                        desc: "RSS".into(),
+                        action: "query:rss list".into(),
+                        args: None,
+                    },
+                    Action {
+                        label: "rss rm".into(),
+                        desc: "RSS".into(),
+                        action: "query:rss rm ".into(),
+                        args: None,
+                    },
+                ];
+            }
+        }
+        const ADD_PREFIX: &str = "rss add ";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, ADD_PREFIX) {
+            let url = rest.trim();
+            if !url.is_empty() {
+                return vec![Action {
+                    label: format!("Add RSS feed {url}"),
+                    desc: "RSS".into(),
+                    action: format!("rss:add:{url}"),
+                    args: None,
+                }];
+            }
+        }
+        const RM_PREFIX: &str = "rss rm";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, RM_PREFIX) {
+            let filter = rest.trim();
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
+                .filter(|f| self.matcher.fuzzy_match(&f.url, filter).is_some())
+                .map(|f| Action {
+                    label: format!("Remove RSS feed {}", f.url),
+                    desc: "RSS".into(),
+                    action: format!("rss:remove:{}", f.url),
+                    args: None,
+                })
+                .collect();
+        }
+        const LIST_PREFIX: &str = "rss list";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, LIST_PREFIX) {
+            let filter = rest.trim();
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
+                .filter(|f| self.matcher.fuzzy_match(&f.url, filter).is_some())
+                .map(|f| Action {
+                    label: f.url.clone(),
+                    desc: "RSS".into(),
+                    action: f.url.clone(),
+                    args: None,
+                })
+                .collect();
+        }
+        const PREFIX: &str = "rss";
+        if let Some(rest) = crate::common::strip_prefix_ci(trimmed, PREFIX) {
+            let filter = rest.trim();
+            if filter.is_empty() {
+                return Vec::new();
+            }
+            let guard = match self.data.lock() {
+                Ok(g) => g,
+                Err(_) => return Vec::new(),
+            };
+            return guard
+                .iter()
+                .filter(|f| self.matcher.fuzzy_match(&f.url, filter).is_some())
+                .map(|f| Action {
+                    label: f.url.clone(),
+                    desc: "RSS".into(),
+                    action: f.url.clone(),
+                    args: None,
+                })
+                .collect();
+        }
+        Vec::new()
+    }
+
+    fn name(&self) -> &str {
+        "rss"
+    }
+
+    fn description(&self) -> &str {
+        "Manage RSS feed URLs (prefix: `rss`)"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            Action {
+                label: "rss".into(),
+                desc: "RSS".into(),
+                action: "query:rss ".into(),
+                args: None,
+            },
+            Action {
+                label: "rss add".into(),
+                desc: "RSS".into(),
+                action: "query:rss add ".into(),
+                args: None,
+            },
+            Action {
+                label: "rss list".into(),
+                desc: "RSS".into(),
+                action: "query:rss list".into(),
+                args: None,
+            },
+            Action {
+                label: "rss rm".into(),
+                desc: "RSS".into(),
+                action: "query:rss rm ".into(),
+                args: None,
+            },
+        ]
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement RSS plugin with add/list/remove and command suggestions
- expose `rss` commands in global command listing and help examples
- wire RSS actions into launcher and plugin registry

## Testing
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message)*
 