### PR TITLE
feat: improve RSS command discovery and list support

### DIFF
--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -23,7 +23,7 @@ pub fn run(command: &str) -> Result<()> {
         "add" => add(rest),
         "rm" => rm(rest),
         "refresh" => refresh(rest),
-        "ls" => ls(rest),
+        "list" => list(rest),
         "items" => items(rest),
         "open" => open(rest),
         "group" => group(rest),
@@ -181,7 +181,7 @@ fn open(args: &str) -> Result<()> {
     state.save()
 }
 
-fn ls(args: &str) -> Result<()> {
+fn list(args: &str) -> Result<()> {
     let parts = shlex::split(args).unwrap_or_default();
     let target = parts.get(0).map(|s| s.as_str()).unwrap_or("groups");
     let mut unread_only = false;

--- a/src/help_window.rs
+++ b/src/help_window.rs
@@ -131,6 +131,7 @@ fn example_queries(name: &str) -> Option<&'static [&'static str]> {
         ]),
         "clipboard" => Some(&["cb"]),
         "bookmarks" => Some(&["bm add https://example.com", "bm rm", "bm list"]),
+        "rss" => Some(&["rss add <url>", "rss list"]),
         "folders" => Some(&["f add C:/path", "f rm docs"]),
         "shell" => Some(&["sh", "sh echo hello"]),
         "system" => Some(&["sys shutdown"]),

--- a/src/plugins/rss/actions.rs
+++ b/src/plugins/rss/actions.rs
@@ -8,7 +8,7 @@ pub fn root() -> Vec<Action> {
         ("add", "Add feed"),
         ("rm", "Remove feed"),
         ("refresh", "Refresh feeds"),
-        ("ls", "List feeds/groups"),
+        ("list", "List feeds/groups"),
         ("items", "Show feed items"),
         ("open", "Open feed items"),
         ("group", "Manage groups"),
@@ -139,21 +139,21 @@ pub fn refresh(args: &str) -> Vec<Action> {
     }]
 }
 
-/// Handle `rss ls` subcommand.
-pub fn ls(args: &str) -> Vec<Action> {
+/// Handle `rss list` subcommand.
+pub fn list(args: &str) -> Vec<Action> {
     let trimmed = args.trim();
     if trimmed.is_empty() {
         return vec![
             Action {
-                label: "rss ls groups".into(),
+                label: "rss list groups".into(),
                 desc: "RSS".into(),
-                action: "rss:ls groups".into(),
+                action: "rss:list groups".into(),
                 args: None,
             },
             Action {
-                label: "rss ls feeds".into(),
+                label: "rss list feeds".into(),
                 desc: "RSS".into(),
-                action: "rss:ls feeds".into(),
+                action: "rss:list feeds".into(),
                 args: None,
             },
         ];
@@ -161,7 +161,7 @@ pub fn ls(args: &str) -> Vec<Action> {
     vec![Action {
         label: format!("List {trimmed}"),
         desc: "RSS".into(),
-        action: format!("rss:ls {trimmed}"),
+        action: format!("rss:list {trimmed}"),
         args: None,
     }]
 }

--- a/src/plugins/rss/mod.rs
+++ b/src/plugins/rss/mod.rs
@@ -37,14 +37,19 @@ impl Plugin for RssPlugin {
         const PREFIX: &str = "rss";
         let trimmed = query.trim();
 
-        // Bare `rss` opens the feed management UI.
+        // Bare `rss` discovers available subcommands and offers to manage feeds.
         if trimmed.eq_ignore_ascii_case(PREFIX) {
-            return vec![Action {
-                label: "rss: manage feeds".into(),
-                desc: "RSS".into(),
-                action: "rss:dialog".into(),
-                args: None,
-            }];
+            let mut acts = actions::root();
+            acts.insert(
+                0,
+                Action {
+                    label: "rss: manage feeds".into(),
+                    desc: "RSS".into(),
+                    action: "rss:dialog".into(),
+                    args: None,
+                },
+            );
+            return acts;
         }
 
         // `rss ` (with space) should list subcommands handled below.
@@ -62,7 +67,7 @@ impl Plugin for RssPlugin {
                 "add" => actions::add(args),
                 "rm" => actions::rm(args),
                 "refresh" => actions::refresh(args),
-                "ls" => actions::ls(args),
+                "list" => actions::list(args),
                 "items" => actions::items(args),
                 "open" => actions::open(args),
                 "group" => actions::group(args),
@@ -88,11 +93,31 @@ impl Plugin for RssPlugin {
     }
 
     fn commands(&self) -> Vec<Action> {
-        vec![Action {
-            label: "rss".into(),
-            desc: "RSS feeds".into(),
-            action: "query:rss ".into(),
-            args: None,
-        }]
+        vec![
+            Action {
+                label: "rss".into(),
+                desc: "RSS feeds".into(),
+                action: "query:rss ".into(),
+                args: None,
+            },
+            Action {
+                label: "rss add".into(),
+                desc: "RSS feeds".into(),
+                action: "query:rss add ".into(),
+                args: None,
+            },
+            Action {
+                label: "rss list".into(),
+                desc: "RSS feeds".into(),
+                action: "query:rss list".into(),
+                args: None,
+            },
+            Action {
+                label: "rss rm".into(),
+                desc: "RSS feeds".into(),
+                action: "query:rss rm ".into(),
+                args: None,
+            },
+        ]
     }
 }

--- a/tests/rss_plugin_search.rs
+++ b/tests/rss_plugin_search.rs
@@ -1,0 +1,20 @@
+use multi_launcher::plugins::rss::RssPlugin;
+use multi_launcher::plugin::Plugin;
+
+#[test]
+fn rss_command_discovery() {
+    let plugin = RssPlugin::default();
+    let acts = plugin.search("rss");
+    let labels: Vec<_> = acts.iter().map(|a| a.label.as_str()).collect();
+    assert!(labels.contains(&"rss add"));
+    assert!(labels.contains(&"rss list"));
+}
+
+#[test]
+fn rss_list_subcommand() {
+    let plugin = RssPlugin::default();
+    let acts = plugin.search("rss list");
+    let labels: Vec<_> = acts.iter().map(|a| a.label.as_str()).collect();
+    assert!(labels.contains(&"rss list groups"));
+    assert!(labels.contains(&"rss list feeds"));
+}


### PR DESCRIPTION
## Summary
- show RSS sub-commands when typing `rss`
- rename `rss ls` to `rss list`
- expose `rss add`, `rss list`, and `rss rm` as global commands
- document RSS usage examples

## Testing
- `cargo test` *(fails: macros_file_change_reload)*
 