### PR TITLE
Fix RSS feed display to show feed URLs

### DIFF
--- a/src/actions/rss.rs
+++ b/src/actions/rss.rs
@@ -86,10 +86,14 @@ fn add(args: &str) -> Result<()> {
         id = format!("{id_base}-{idx}");
         idx += 1;
     }
+    // Store the canonical feed URL both in the `url` field and as the initial
+    // title so it can be rendered meaningfully in the UI before a poll populates
+    // a feed-provided title. Without this the UI falls back to using the slugged
+    // identifier which produced labels such as `http(0)`.
     feeds.feeds.push(storage::FeedConfig {
         id: id.clone(),
-        url: resolved,
-        title: None,
+        url: resolved.clone(),
+        title: Some(resolved),
         group: None,
         last_poll: None,
         next_poll: None,

--- a/src/gui/rss_dialog.rs
+++ b/src/gui/rss_dialog.rs
@@ -56,7 +56,9 @@ impl RssDialog {
                     });
                     for f in feed_iter {
                         let unread = state.feeds.get(&f.id).map(|s| s.unread).unwrap_or(0);
-                        let title = f.title.clone().unwrap_or_else(|| f.id.clone());
+                        // Prefer the stored title but fall back to the feed URL instead of
+                        // the internal slug identifier to avoid labels like `http(0)`.
+                        let title = f.title.clone().unwrap_or_else(|| f.url.clone());
                         if cols[1]
                             .selectable_label(self.selected_feed.as_deref() == Some(&f.id), format!("{title} ({unread})"))
                             .clicked()

--- a/src/plugins/rss/actions.rs
+++ b/src/plugins/rss/actions.rs
@@ -82,7 +82,10 @@ pub fn rm(args: &str) -> Vec<Action> {
             .feeds
             .iter()
             .map(|f| {
-                let title = f.title.clone().unwrap_or_else(|| f.id.clone());
+                // Display the stored feed title when available, otherwise fall back to
+                // the feed URL instead of the internal slugged identifier. Using the
+                // slug resulted in truncated labels like `http(0)`.
+                let title = f.title.clone().unwrap_or_else(|| f.url.clone());
                 Action {
                     label: format!("Remove {title}"),
                     desc: "RSS".into(),
@@ -121,7 +124,9 @@ pub fn refresh(args: &str) -> Vec<Action> {
             });
         }
         for f in &feeds.feeds {
-            let title = f.title.clone().unwrap_or_else(|| f.id.clone());
+            // Use the feed URL as a fallback to avoid showing the slugged id such
+            // as `http(0)` when no explicit title has been stored yet.
+            let title = f.title.clone().unwrap_or_else(|| f.url.clone());
             acts.push(Action {
                 label: format!("Refresh {title}"),
                 desc: "RSS".into(),
@@ -203,7 +208,9 @@ pub fn items(args: &str) -> Vec<Action> {
         // Individual feeds
         for f in &feeds.feeds {
             let unread = state.feeds.get(&f.id).map(|s| s.unread).unwrap_or(0);
-            let title = f.title.clone().unwrap_or_else(|| f.id.clone());
+            // When no title is present use the feed URL instead of the slugged id
+            // to ensure the UI reflects the actual feed source.
+            let title = f.title.clone().unwrap_or_else(|| f.url.clone());
             acts.push(Action {
                 label: format!("Items for {title} ({unread})"),
                 desc: "RSS".into(),


### PR DESCRIPTION
## Summary
- Preserve feed URL as initial title when adding RSS feeds
- Prefer stored title or URL instead of slugged IDs in RSS actions
- Show full feed URL in RSS dialog when no title is available

## Testing
- `cargo test --quiet` *(fails: open_marks_items_read, open_copy_marks_items_read, mark_read_and_unread_updates_state)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b6a1237883328627bc85f0a21dd0