### PR TITLE
Serialize RSS tests for stable results

### DIFF
--- a/tests/rss_group.rs
+++ b/tests/rss_group.rs
@@ -2,8 +2,10 @@ use std::fs;
 
 use multi_launcher::actions::rss;
 use multi_launcher::plugins::rss::storage::{FeedConfig, FeedsFile};
+use serial_test::serial;
 
 #[test]
+#[serial]
 fn group_add_mv_rm_updates_feeds() {
     let _ = fs::remove_dir_all("config/rss");
     let mut feeds = FeedsFile::default();

--- a/tests/rss_mark.rs
+++ b/tests/rss_mark.rs
@@ -1,7 +1,10 @@
 use std::fs;
 
 use multi_launcher::actions::rss;
-use multi_launcher::plugins::rss::storage::{self, FeedCache, FeedConfig, FeedsFile, StateFile, CachedItem};
+use multi_launcher::plugins::rss::storage::{
+    self, CachedItem, FeedCache, FeedConfig, FeedsFile, StateFile,
+};
+use serial_test::serial;
 
 fn setup_feed_with_cache(items: Vec<CachedItem>) {
     let _ = fs::remove_dir_all("config/rss");
@@ -22,6 +25,7 @@ fn setup_feed_with_cache(items: Vec<CachedItem>) {
 }
 
 #[test]
+#[serial]
 fn open_marks_items_read() {
     setup_feed_with_cache(vec![CachedItem {
         guid: "a".into(),
@@ -30,7 +34,13 @@ fn open_marks_items_read() {
         timestamp: Some(1),
     }]);
     let mut state = StateFile::default();
-    state.feeds.insert("f".into(), storage::FeedState { unread: 1, ..Default::default() });
+    state.feeds.insert(
+        "f".into(),
+        storage::FeedState {
+            unread: 1,
+            ..Default::default()
+        },
+    );
     state.save().unwrap();
 
     rss::run("open f --n 1").unwrap();
@@ -42,6 +52,7 @@ fn open_marks_items_read() {
 }
 
 #[test]
+#[serial]
 fn open_copy_marks_items_read() {
     setup_feed_with_cache(vec![CachedItem {
         guid: "a".into(),
@@ -50,7 +61,13 @@ fn open_copy_marks_items_read() {
         timestamp: Some(1),
     }]);
     let mut state = StateFile::default();
-    state.feeds.insert("f".into(), storage::FeedState { unread: 1, ..Default::default() });
+    state.feeds.insert(
+        "f".into(),
+        storage::FeedState {
+            unread: 1,
+            ..Default::default()
+        },
+    );
     state.save().unwrap();
 
     rss::run("open f --n 1 --copy").unwrap();
@@ -62,14 +79,34 @@ fn open_copy_marks_items_read() {
 }
 
 #[test]
+#[serial]
 fn mark_read_and_unread_updates_state() {
     setup_feed_with_cache(vec![
-        CachedItem { guid: "a".into(), title: "A".into(), link: None, timestamp: Some(1) },
-        CachedItem { guid: "b".into(), title: "B".into(), link: None, timestamp: Some(2) },
-        CachedItem { guid: "c".into(), title: "C".into(), link: None, timestamp: Some(3) },
+        CachedItem {
+            guid: "a".into(),
+            title: "A".into(),
+            link: None,
+            timestamp: Some(1),
+        },
+        CachedItem {
+            guid: "b".into(),
+            title: "B".into(),
+            link: None,
+            timestamp: Some(2),
+        },
+        CachedItem {
+            guid: "c".into(),
+            title: "C".into(),
+            link: None,
+            timestamp: Some(3),
+        },
     ]);
     let mut state = StateFile::default();
-    let mut entry = storage::FeedState { last_read_published: Some(1), unread: 1, ..Default::default() };
+    let mut entry = storage::FeedState {
+        last_read_published: Some(1),
+        unread: 1,
+        ..Default::default()
+    };
     entry.read.insert("a".into());
     entry.read.insert("c".into());
     state.feeds.insert("f".into(), entry);

--- a/tests/rss_opml.rs
+++ b/tests/rss_opml.rs
@@ -2,17 +2,14 @@ use std::fs;
 
 use multi_launcher::actions::rss;
 use multi_launcher::plugins::rss::storage;
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 #[test]
+#[serial]
 fn import_export_opml() {
     // clean RSS config directory
-    let base = std::env::current_exe()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("rss");
-    let _ = fs::remove_dir_all(&base);
+    let _ = fs::remove_dir_all("config/rss");
 
     let opml = r#"<?xml version="1.0"?>
 <opml version="1.0">
@@ -47,4 +44,3 @@ fn import_export_opml() {
     assert!(exported.contains("https://example.com/1"));
     assert!(exported.contains("Group1"));
 }
-


### PR DESCRIPTION
## Summary
- mark RSS-related tests as `#[serial]` to avoid config directory races
- fix OPML test cleanup to use the correct config path

## Testing
- `cargo test --test rss_group`
- `cargo test --test rss_mark`
- `cargo test --test rss_opml`
- `cargo test --test rss_plugin`
- `cargo test --test window_manager`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1aed9088332803676e14ce8a09f