### PR TITLE
Manage note assets and screenshot insertion

### DIFF
--- a/src/gui/image_panel.rs
+++ b/src/gui/image_panel.rs
@@ -53,7 +53,12 @@ impl ImagePanel {
             .open(&mut open)
             .resizable(true)
             .show(ctx, |ui| {
-                ui.add(egui::Slider::new(&mut self.zoom, 0.1..=5.0).text("Zoom"));
+                ui.horizontal(|ui| {
+                    ui.add(egui::Slider::new(&mut self.zoom, 0.1..=5.0).text("Zoom"));
+                    if ui.button("Open in Default Viewer").clicked() {
+                        let _ = open::that(&self.path);
+                    }
+                });
                 if let Some(tex) = &self.texture {
                     let size = tex.size_vec2() * self.zoom;
                     egui::ScrollArea::both().show(ui, |ui| {

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -169,6 +169,9 @@ impl NotesDialog {
                         self.edit_idx = Some(self.entries.len());
                         self.text.clear();
                     }
+                    if ui.button("Unused Assets").clicked() {
+                        app.unused_assets_dialog.open();
+                    }
                     if ui.button("Close").clicked() {
                         close = true;
                     }

--- a/src/gui/unused_assets_dialog.rs
+++ b/src/gui/unused_assets_dialog.rs
@@ -1,0 +1,65 @@
+use crate::gui::LauncherApp;
+use crate::plugins::note::{assets_dir, unused_assets};
+use eframe::egui;
+
+#[derive(Default)]
+pub struct UnusedAssetsDialog {
+    pub open: bool,
+    assets: Vec<String>,
+    selected: Vec<bool>,
+}
+
+impl UnusedAssetsDialog {
+    pub fn open(&mut self) {
+        self.assets = unused_assets();
+        self.selected = vec![false; self.assets.len()];
+        self.open = true;
+    }
+
+    pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
+        if !self.open {
+            return;
+        }
+        let mut open_flag = self.open;
+        let mut close = false;
+        egui::Window::new("Unused Note Assets")
+            .open(&mut open_flag)
+            .resizable(true)
+            .default_size((300.0, 200.0))
+            .show(ctx, |ui| {
+                egui::ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
+                    if self.assets.is_empty() {
+                        ui.label("No unused assets found");
+                    } else {
+                        for (idx, asset) in self.assets.iter().enumerate() {
+                            ui.horizontal(|ui| {
+                                ui.checkbox(&mut self.selected[idx], "");
+                                ui.label(asset);
+                            });
+                        }
+                    }
+                });
+                ui.separator();
+                if ui.button("Delete Selected").clicked() {
+                    for i in (0..self.assets.len()).rev() {
+                        if self.selected[i] {
+                            let path = assets_dir().join(&self.assets[i]);
+                            if let Err(e) = std::fs::remove_file(&path) {
+                                app.set_error(format!("Failed to delete {}: {e}", self.assets[i]));
+                            } else {
+                                self.assets.remove(i);
+                                self.selected.remove(i);
+                            }
+                        }
+                    }
+                }
+                if ui.button("Close").clicked() {
+                    close = true;
+                }
+            });
+        if close {
+            open_flag = false;
+        }
+        self.open = open_flag;
+    }
+}


### PR DESCRIPTION
## Summary
- add unused asset detection and maintenance dialog
- allow screenshots to be inserted directly into notes
- open image panel files in system viewer

## Testing
- `cargo test` *(fails: gui::tests::delete_note_uses_alias_and_logs_message)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad8eef608332a6a204447785795d