### PR TITLE
Clamp note panel body with scroll area

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -172,11 +172,11 @@ impl NotePanel {
                     });
                 }
                 ui.separator();
-                let scroll_height = ui.available_height();
+                let remaining = ui.available_height();
                 let resp = egui::ScrollArea::vertical()
                     .id_source(content_id)
+                    .max_height(remaining)
                     .show(ui, |ui| {
-                        ui.set_min_height(scroll_height);
                         if self.preview_mode {
                             let mut last = 0usize;
                             let content_clone = self.note.content.clone();

--- a/tests/note_panel_scroll.rs
+++ b/tests/note_panel_scroll.rs
@@ -1,0 +1,77 @@
+use eframe::egui;
+use multi_launcher::gui::{LauncherApp, NotePanel};
+use multi_launcher::plugin::PluginManager;
+use multi_launcher::plugins::note::{save_notes, Note};
+use multi_launcher::settings::Settings;
+use once_cell::sync::Lazy;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+fn setup() -> tempfile::TempDir {
+    let dir = tempdir().unwrap();
+    let notes_dir = dir.path().join("notes");
+    std::fs::create_dir_all(&notes_dir).unwrap();
+    std::env::set_var("ML_NOTES_DIR", &notes_dir);
+    std::env::set_var("HOME", dir.path());
+    save_notes(&[]).unwrap();
+    dir
+}
+
+fn new_app(ctx: &egui::Context) -> LauncherApp {
+    let settings = Settings::default();
+    LauncherApp::new(
+        ctx,
+        Arc::new(Vec::new()),
+        0,
+        PluginManager::new(),
+        "actions.json".into(),
+        "settings.json".into(),
+        settings,
+        None,
+        None,
+        None,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+#[test]
+fn long_note_panel_respects_max_height() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let _tmp = setup();
+    let ctx = egui::Context::default();
+    let mut app = new_app(&ctx);
+
+    let long_content = (0..5000).map(|i| format!("line {i}\n")).collect::<String>();
+    let note = Note {
+        title: "Long note".into(),
+        path: std::path::PathBuf::new(),
+        content: long_content,
+        tags: Vec::new(),
+        links: Vec::new(),
+        slug: String::new(),
+        alias: None,
+    };
+    let mut panel = NotePanel::from_note(note);
+
+    ctx.begin_frame(egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(1000.0, 1000.0),
+        )),
+        ..Default::default()
+    });
+    panel.ui(&ctx, &mut app);
+    let _ = ctx.end_frame();
+
+    let rect = ctx
+        .memory(|m| m.area_rect(egui::Id::new("Long note")))
+        .expect("window rect");
+    assert!(rect.height() <= 600.0);
+}
+


### PR DESCRIPTION
## Summary
- keep note panel within screen bounds by clamping body to remaining height and using a scroll area
- regression test: long note respects max window height

## Testing
- `cargo test --test note_panel_scroll -- --nocapture`
- `cargo test` *(fails: aborted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68a6460af8b88332a28159455476b313