### PR TITLE
Prefer PowerShell when launching Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ RUST_LOG=info cargo run
 - Press the help hotkey (F1 by default) to display a quick list of available commands.
 - Right click a folder result to set a custom alias for easier access.
 - Right click a note entry to edit, remove, or open it in Neovim.
+- On Windows, Neovim launches via PowerShell 7 when available, then `powershell.exe`, falling back to `cmd.exe`.
 - Use the *Snapshot* button in Settings when adjusting static window placement.
 - Searches are case-insensitive and also match on command aliases.
 - Tweak `fuzzy_weight` and `usage_weight` if you want results to favour name matches or past usage differently.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -34,6 +34,9 @@ pub use cpu_list_dialog::CpuListDialog;
 pub use fav_dialog::FavDialog;
 pub use image_panel::ImagePanel;
 pub use macro_dialog::MacroDialog;
+#[cfg(target_os = "windows")]
+pub use note_panel::{build_nvim_command, extract_links, show_wiki_link, NotePanel};
+#[cfg(not(target_os = "windows"))]
 pub use note_panel::{extract_links, show_wiki_link, NotePanel};
 pub use notes_dialog::NotesDialog;
 pub use shell_cmd_dialog::ShellCmdDialog;

--- a/tests/note_panel_shell.rs
+++ b/tests/note_panel_shell.rs
@@ -1,0 +1,58 @@
+#![cfg(windows)]
+use multi_launcher::gui::build_nvim_command;
+use once_cell::sync::Lazy;
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+use tempfile::tempdir;
+
+static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test]
+fn prefers_powershell7_then_powershell_then_cmd() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let note = Path::new("note.txt");
+
+    // PowerShell 7 available
+    let dir = tempdir().unwrap();
+    let ps7 = dir.path().join("pwsh.exe");
+    fs::write(&ps7, "").unwrap();
+    env::set_var("ML_PWSH7_PATH", &ps7);
+    env::set_var("PATH", "");
+    let (cmd, _) = build_nvim_command(note);
+    assert!(cmd
+        .get_program()
+        .to_string_lossy()
+        .ends_with("pwsh.exe"));
+    let args: Vec<_> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(args, ["-NoLogo", "-NoExit", "-Command", "nvim note.txt"]);
+
+    // PowerShell in PATH
+    let dir = tempdir().unwrap();
+    let ps = dir.path().join("powershell.exe");
+    fs::write(&ps, "").unwrap();
+    env::remove_var("ML_PWSH7_PATH");
+    env::set_var("PATH", dir.path());
+    let (cmd, _) = build_nvim_command(note);
+    assert!(cmd
+        .get_program()
+        .to_string_lossy()
+        .ends_with("powershell.exe"));
+
+    // Fallback to cmd.exe
+    env::set_var("PATH", "");
+    let (cmd, _) = build_nvim_command(note);
+    assert!(cmd
+        .get_program()
+        .to_string_lossy()
+        .ends_with("cmd.exe"));
+    let args: Vec<_> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(args, ["/C", "nvim", "note.txt"]);
+}

--- a/tests/note_panel_shell.rs
+++ b/tests/note_panel_shell.rs
@@ -13,13 +13,17 @@ static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 fn prefers_powershell7_then_powershell_then_cmd() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let note = Path::new("note.txt");
+    let orig_ps7 = env::var_os("ML_PWSH7_PATH");
+    let orig_path = env::var_os("PATH");
 
     // PowerShell 7 available
     let dir = tempdir().unwrap();
     let ps7 = dir.path().join("pwsh.exe");
     fs::write(&ps7, "").unwrap();
-    env::set_var("ML_PWSH7_PATH", &ps7);
-    env::set_var("PATH", "");
+    unsafe {
+        env::set_var("ML_PWSH7_PATH", &ps7);
+        env::set_var("PATH", "");
+    }
     let (cmd, _) = build_nvim_command(note);
     assert!(cmd
         .get_program()
@@ -35,8 +39,11 @@ fn prefers_powershell7_then_powershell_then_cmd() {
     let dir = tempdir().unwrap();
     let ps = dir.path().join("powershell.exe");
     fs::write(&ps, "").unwrap();
-    env::remove_var("ML_PWSH7_PATH");
-    env::set_var("PATH", dir.path());
+    let missing = dir.path().join("missing_pwsh.exe");
+    unsafe {
+        env::set_var("ML_PWSH7_PATH", &missing);
+        env::set_var("PATH", dir.path());
+    }
     let (cmd, _) = build_nvim_command(note);
     assert!(cmd
         .get_program()
@@ -44,7 +51,7 @@ fn prefers_powershell7_then_powershell_then_cmd() {
         .ends_with("powershell.exe"));
 
     // Fallback to cmd.exe
-    env::set_var("PATH", "");
+    unsafe { env::set_var("PATH", ""); }
     let (cmd, _) = build_nvim_command(note);
     assert!(cmd
         .get_program()
@@ -55,4 +62,15 @@ fn prefers_powershell7_then_powershell_then_cmd() {
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
     assert_eq!(args, ["/C", "nvim", "note.txt"]);
+
+    unsafe {
+        match orig_ps7 {
+            Some(v) => env::set_var("ML_PWSH7_PATH", v),
+            None => env::remove_var("ML_PWSH7_PATH"),
+        }
+        match orig_path {
+            Some(v) => env::set_var("PATH", v),
+            None => env::remove_var("PATH"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Detect PowerShell 7 and `powershell.exe` before falling back to `cmd.exe` when opening Neovim on Windows
- Expose helper for building the Neovim command and add Windows-only tests for shell selection order
- Document Windows shell preference in README

## Testing
- `cargo test` *(failed: build ran but full test suite did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68a6639d3b848332a5843e2db61270a6