### PR TITLE
Add external-open setting for note plugin

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -60,6 +60,7 @@ use crate::launcher::launch_action;
 use crate::plugin::PluginManager;
 use crate::plugin_editor::PluginEditor;
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
+use crate::plugins::note::{NotePluginSettings, NoteExternalOpen};
 use crate::settings::Settings;
 use crate::settings_editor::SettingsEditor;
 use crate::toast_log::{append_toast_log, TOAST_LOG_FILE};
@@ -361,6 +362,7 @@ pub struct LauncherApp {
     pub note_always_overwrite: bool,
     pub note_images_as_links: bool,
     pub note_external_editor: Option<String>,
+    pub note_external_open: NoteExternalOpen,
     pub note_font_size: f32,
     pub follow_mouse: bool,
     pub static_location_enabled: bool,
@@ -699,6 +701,13 @@ impl LauncherApp {
         let follow_mouse = settings.follow_mouse;
         let static_enabled = settings.static_location_enabled;
 
+        let note_external_open = settings
+            .plugin_settings
+            .get("note")
+            .and_then(|v| serde_json::from_value::<NotePluginSettings>(v.clone()).ok())
+            .map(|s| s.external_open)
+            .unwrap_or(NoteExternalOpen::Neither);
+
         let settings_editor = SettingsEditor::new_with_plugins(&settings);
         let plugin_editor = PluginEditor::new(&settings);
         let mut app = Self {
@@ -787,6 +796,7 @@ impl LauncherApp {
             note_always_overwrite: settings.note_always_overwrite,
             note_images_as_links: settings.note_images_as_links,
             note_external_editor: settings.note_external_editor.clone(),
+            note_external_open,
             note_font_size: 16.0,
             follow_mouse,
             static_location_enabled: static_enabled,

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -1,6 +1,7 @@
 use crate::gui::LauncherApp;
 use crate::hotkey::parse_hotkey;
 use crate::settings::Settings;
+use crate::plugins::note::NotePluginSettings;
 use eframe::egui;
 use egui_toast::{Toast, ToastKind, ToastOptions};
 #[cfg(target_os = "windows")]
@@ -646,6 +647,16 @@ impl SettingsEditor {
                                                 &new_settings.plugin_settings,
                                                 actions_arc,
                                             );
+                                            if let Some(val) =
+                                                new_settings.plugin_settings.get("note")
+                                            {
+                                                if let Ok(cfg) = serde_json::from_value::<
+                                                    NotePluginSettings,
+                                                >(val.clone())
+                                                {
+                                                    app.note_external_open = cfg.external_open;
+                                                }
+                                            }
                                             crate::request_hotkey_restart(new_settings);
                                             if app.enable_toasts {
                                                 app.add_toast(Toast {


### PR DESCRIPTION
## Summary
- add `NoteExternalOpen` setting and default storage for notes plugin
- persist note plugin external-open choice in `LauncherApp`
- allow settings editor to save and reload note plugin external-open value

## Testing
- `cargo test` *(fails: cargo not found)*
- `apt-get install -y cargo` *(fails: Package 'cargo' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a67cc93b5883328b8c0d1cc35617c1