### PR TITLE
feat: preserve selection for formatting and link insertion

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -70,6 +70,10 @@ pub struct NotePanel {
     show_open_with_menu: bool,
     tags_expanded: bool,
     links_expanded: bool,
+    pending_selection: Option<(usize, usize)>,
+    link_dialog_open: bool,
+    link_text: String,
+    link_url: String,
 }
 
 impl NotePanel {
@@ -87,6 +91,10 @@ impl NotePanel {
             show_open_with_menu: false,
             tags_expanded: false,
             links_expanded: false,
+            pending_selection: None,
+            link_dialog_open: false,
+            link_text: String::new(),
+            link_url: String::new(),
         }
     }
 
@@ -99,6 +107,7 @@ impl NotePanel {
         let screen_rect = ctx.available_rect();
         let max_width = screen_rect.width().min(800.0);
         let max_height = screen_rect.height().min(600.0);
+        let content_id = egui::Id::new("note_content");
         egui::Window::new(self.note.title.clone())
             .open(&mut open)
             .resizable(true)
@@ -109,7 +118,6 @@ impl NotePanel {
             .max_height(max_height)
             .movable(true)
             .show(ctx, |ui| {
-                let content_id = egui::Id::new("note_content");
                 if ui
                     .ctx()
                     .input(|i| i.modifiers.ctrl && i.key_pressed(Key::Equals))
@@ -259,11 +267,15 @@ impl NotePanel {
                 }
                 ui.separator();
                 let remaining = ui.available_height();
+                let pre_state =
+                    egui::widgets::text_edit::TextEditState::load(ctx, content_id)
+                        .unwrap_or_default();
                 let resp = egui::ScrollArea::vertical()
                     .id_source(content_id)
                     .max_height(remaining)
                     .show(ui, |ui| {
                         if self.preview_mode {
+                            ui.spacing_mut().item_spacing.y = 0.0;
                             let mut last = 0usize;
                             let content_clone = self.note.content.clone();
                             let mut modified = false;
@@ -400,6 +412,14 @@ impl NotePanel {
                     });
                 if !self.preview_mode {
                     if let Some(resp) = resp.inner {
+                        if resp.secondary_clicked() {
+                            if let Some(range) = pre_state.cursor.char_range() {
+                                let [min, max] = range.sorted();
+                                self.pending_selection = Some((min.index, max.index));
+                            } else {
+                                self.pending_selection = None;
+                            }
+                        }
                         resp.context_menu(|ui| self.build_textedit_menu(ui, &resp, app));
                         if resp.has_focus()
                             && ctx.input(|i| i.modifiers.ctrl && i.key_pressed(Key::Period))
@@ -487,6 +507,34 @@ impl NotePanel {
                     }
                 }
             });
+        if self.link_dialog_open {
+            let mut open_link = self.link_dialog_open;
+            let mut cancel = false;
+            egui::Window::new("Insert Link")
+                .collapsible(false)
+                .resizable(false)
+                .open(&mut open_link)
+                .show(ctx, |ui| {
+                    ui.label("Text:");
+                    ui.text_edit_singleline(&mut self.link_text);
+                    ui.label("URL:");
+                    ui.text_edit_singleline(&mut self.link_url);
+                    ui.horizontal(|ui| {
+                        if ui.button("Insert").clicked() {
+                            self.insert_link(ctx, content_id);
+                        }
+                        if ui.button("Cancel").clicked() {
+                            cancel = true;
+                            self.link_text.clear();
+                            self.link_url.clear();
+                        }
+                    });
+                });
+            if cancel {
+                open_link = false;
+            }
+            self.link_dialog_open = open_link;
+        }
         if save_now || (!open && app.note_save_on_close) {
             self.save(app);
             if self.overwrite_prompt {
@@ -644,45 +692,20 @@ impl NotePanel {
                 ui.close_menu();
             }
             if ui.button("Bold Selection").clicked() {
-                let mut state = egui::widgets::text_edit::TextEditState::load(ui.ctx(), resp.id)
-                    .unwrap_or_default();
-                if let Some(range) = state.cursor.char_range() {
-                    let [min, max] = range.sorted();
-                    let mut start = min.index;
-                    let mut end = max.index;
-                    self.note.content.insert_str(end, "**");
-                    self.note.content.insert_str(start, "**");
-                    start += 2;
-                    end += 2;
-                    state
-                        .cursor
-                        .set_char_range(Some(egui::text::CCursorRange::two(
-                            egui::text::CCursor::new(start),
-                            egui::text::CCursor::new(end),
-                        )));
-                    state.store(ui.ctx(), resp.id);
-                }
+                self.wrap_selection(ui.ctx(), resp.id, "**", "**");
                 ui.close_menu();
             }
-            if ui.button("Underline Selection").clicked() {
-                let mut state = egui::widgets::text_edit::TextEditState::load(ui.ctx(), resp.id)
-                    .unwrap_or_default();
-                if let Some(range) = state.cursor.char_range() {
-                    let [min, max] = range.sorted();
-                    let mut start = min.index;
-                    let mut end = max.index;
-                    self.note.content.insert_str(end, "__");
-                    self.note.content.insert_str(start, "__");
-                    start += 2;
-                    end += 2;
-                    state
-                        .cursor
-                        .set_char_range(Some(egui::text::CCursorRange::two(
-                            egui::text::CCursor::new(start),
-                            egui::text::CCursor::new(end),
-                        )));
-                    state.store(ui.ctx(), resp.id);
+            if ui.button("Italic Selection").clicked() {
+                self.wrap_selection(ui.ctx(), resp.id, "*", "*");
+                ui.close_menu();
+            }
+            if ui.button("Insert Link...").clicked() {
+                if let Some((start, end)) = self.pending_selection {
+                    self.link_text = self.note.content[start..end].to_string();
+                } else {
+                    self.link_text.clear();
                 }
+                self.link_dialog_open = true;
                 ui.close_menu();
             }
         });
@@ -836,6 +859,74 @@ impl NotePanel {
         ui.menu_button("Insert tag", |ui| {
             insert_tag_menu(ui, resp, &mut self.note.content, &mut self.tag_search);
         });
+    }
+
+    pub fn wrap_selection(
+        &mut self,
+        ctx: &egui::Context,
+        id: egui::Id,
+        start_marker: &str,
+        end_marker: &str,
+    ) {
+        if let Some((start, end)) = self.pending_selection.take() {
+            self.note.content.insert_str(end, end_marker);
+            self.note.content.insert_str(start, start_marker);
+            let mut state =
+                egui::widgets::text_edit::TextEditState::load(ctx, id).unwrap_or_default();
+            let new_start = start + start_marker.chars().count();
+            let new_end = end + start_marker.chars().count();
+            state
+                .cursor
+                .set_char_range(Some(egui::text::CCursorRange::two(
+                    egui::text::CCursor::new(new_start),
+                    egui::text::CCursor::new(new_end),
+                )));
+            state.store(ctx, id);
+        }
+    }
+
+    pub fn insert_link(&mut self, ctx: &egui::Context, id: egui::Id) {
+        let text = if self.link_text.is_empty() {
+            if let Some((start, end)) = self.pending_selection {
+                self.note.content[start..end].to_string()
+            } else {
+                String::new()
+            }
+        } else {
+            self.link_text.clone()
+        };
+        let insert = format!("[{text}]({})", self.link_url);
+        if let Some((start, end)) = self.pending_selection.take() {
+            self.note.content.replace_range(start..end, &insert);
+            let mut state =
+                egui::widgets::text_edit::TextEditState::load(ctx, id).unwrap_or_default();
+            let cursor = start + insert.chars().count();
+            state
+                .cursor
+                .set_char_range(Some(egui::text::CCursorRange::one(
+                    egui::text::CCursor::new(cursor),
+                )));
+            state.store(ctx, id);
+        } else {
+            let mut state =
+                egui::widgets::text_edit::TextEditState::load(ctx, id).unwrap_or_default();
+            let idx = state
+                .cursor
+                .char_range()
+                .map(|r| r.primary.index)
+                .unwrap_or_else(|| self.note.content.chars().count());
+            self.note.content.insert_str(idx, &insert);
+            let cursor = idx + insert.chars().count();
+            state
+                .cursor
+                .set_char_range(Some(egui::text::CCursorRange::one(
+                    egui::text::CCursor::new(cursor),
+                )));
+            state.store(ctx, id);
+        }
+        self.link_dialog_open = false;
+        self.link_text.clear();
+        self.link_url.clear();
     }
 
     fn open_external(&self, app: &mut LauncherApp, choice: NoteExternalOpen) {
@@ -1054,6 +1145,45 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
         )
+    }
+
+    fn empty_note(content: &str) -> Note {
+        Note {
+            title: String::new(),
+            path: std::path::PathBuf::new(),
+            content: content.to_string(),
+            tags: Vec::new(),
+            links: Vec::new(),
+            slug: String::new(),
+            alias: None,
+        }
+    }
+
+    #[test]
+    fn wrap_selection_preserves_range() {
+        let ctx = egui::Context::default();
+        let mut panel = NotePanel::from_note(empty_note("hello world"));
+        let id = egui::Id::new("note_content");
+        panel.pending_selection = Some((0, 5));
+        panel.wrap_selection(&ctx, id, "**", "**");
+        assert_eq!(panel.note.content, "**hello** world");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let range = state.cursor.char_range().unwrap();
+        let [min, max] = range.sorted();
+        assert_eq!((min.index, max.index), (2, 7));
+        assert!(panel.pending_selection.is_none());
+    }
+
+    #[test]
+    fn insert_link_replaces_selection() {
+        let ctx = egui::Context::default();
+        let mut panel = NotePanel::from_note(empty_note("hello world"));
+        let id = egui::Id::new("note_content");
+        panel.pending_selection = Some((6, 11));
+        panel.link_url = "http://example.com".to_string();
+        panel.insert_link(&ctx, id);
+        assert_eq!(panel.note.content, "hello [world](http://example.com)");
+        assert!(panel.pending_selection.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track right-click selections in note editor
- format or insert links using stored selection
- add dialog for inserting generic markdown links
- fix link dialog cancel action and tighten rendered spacing

## Testing
- `cargo test --no-run wrap_selection_preserves_range`
- (attempted) `cargo test wrap_selection_preserves_range -- --test-threads=1 --nocapture` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad27cccc8332842d33e5e8b14012