### PR TITLE
Use platform-aware Neovim spawning

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2845,10 +2845,18 @@ impl eframe::App for LauncherApp {
                                             &slug,
                                             crate::plugins::note::load_notes,
                                             |path| {
-                                                std::process::Command::new("nvim")
-                                                    .arg(path)
-                                                    .spawn()
-                                                    .map(|_| ())
+                                                #[cfg(target_os = "windows")]
+                                                {
+                                                    let (mut cmd, _cmd_str) = build_nvim_command(path);
+                                                    cmd.spawn().map(|_| ())
+                                                }
+                                                #[cfg(not(target_os = "windows"))]
+                                                {
+                                                    std::process::Command::new("nvim")
+                                                        .arg(path)
+                                                        .spawn()
+                                                        .map(|_| ())
+                                                }
                                             },
                                         ) {
                                             ui.close_menu();


### PR DESCRIPTION
## Summary
- make "Open in Neovim" branch spawn platform-specific command

## Testing
- `cargo test` *(failed: gui::tests::delete_note_uses_alias_and_logs_message, gui::tests::tab_cycles_through_suggestions, gui::todo_dialog::tests::enter_adds_todo_with_filter_focus)*
 