### PR TITLE
chore: bump xcb to 1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
  "walkdir",
  "windows 0.58.0",
  "winit",
+ "xcb",
 ]
 
 [[package]]
@@ -6507,9 +6508,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcb"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e2f212bb1a92cd8caac8051b829a6582ede155ccb60b5d5908b81b100952be"
+checksum = "f07c123b796139bfe0603e654eaf08e132e52387ba95b252c78bad3640ba37ea"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ lipsum = "0.9"
 egui_commonmark = "0.15.0"
 rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
 slab = "0.4.11"
+xcb = "1.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2" }
@@ -77,6 +78,7 @@ notify = ["notify-rust"]
 tempfile = "3"
 criterion = "0.5"
 serial_test = "2"
+xcb = "1.6.0"
 
 [build-dependencies]
 embed-resource = "2"


### PR DESCRIPTION
## Summary
- update xcb dependency to 1.6.0 in Cargo.toml and dev-dependencies
- refresh Cargo.lock to pull xcb 1.6.0

## Testing
- `cargo test` *(fails: tests hang after build, likely due to GUI requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68ab09fa2b10833286a744072543d873