### PR TITLE
Move xcb dependency under Unix targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ lipsum = "0.9"
 egui_commonmark = "0.15.0"
 rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
 slab = "0.4.11"
+
+[target.'cfg(unix)'.dependencies]
 xcb = "1.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -78,6 +80,8 @@ notify = ["notify-rust"]
 tempfile = "3"
 criterion = "0.5"
 serial_test = "2"
+
+[target.'cfg(unix)'.dev-dependencies]
 xcb = "1.6.0"
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- restrict `xcb` to Unix builds by moving it to `cfg(unix)` sections
- align dev dependency so tests only depend on `xcb` on Unix

## Testing
- `cargo test --quiet` *(hangs; interrupted after warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab27f7847083329b7716b3cb2ee990