### PR TITLE
Drop non-Windows code paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,6 @@ dependencies = [
  "walkdir",
  "windows 0.58.0",
  "winit",
- "xcb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,6 @@ lipsum = "0.9"
 egui_commonmark = "0.15.0"
 rfd = { version = "0.15.3", features = ["xdg-portal", "common-controls-v6"] }
 slab = "0.4.11"
-
-[target.'cfg(unix)'.dependencies]
-xcb = "1.6.0"
-
-[target.'cfg(target_os = "windows")'.dependencies]
 rdev = { git = "https://github.com/Narsil/rdev", rev = "c14f2dc5c8100a96c5d7e3013de59d6aa0b9eae2" }
 rodio = { version = "0.17", default-features = false, features = ["wav"] }
 
@@ -80,9 +75,6 @@ notify = ["notify-rust"]
 tempfile = "3"
 criterion = "0.5"
 serial_test = "2"
-
-[target.'cfg(unix)'.dev-dependencies]
-xcb = "1.6.0"
 
 [build-dependencies]
 embed-resource = "2"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,4 @@
-#[cfg(target_os = "windows")]
 fn main() {
     // no custom macros are passed to the resource compiler
     embed_resource::compile("Resources/windows.rc", embed_resource::NONE);
 }
-
-#[cfg(not(target_os = "windows"))]
-fn main() {}

--- a/src/actions/screenshot.rs
+++ b/src/actions/screenshot.rs
@@ -1,16 +1,10 @@
-#[cfg(target_os = "windows")]
 use chrono::Local;
-#[cfg(target_os = "windows")]
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-#[cfg(target_os = "windows")]
 use crate::plugins::screenshot::screenshot_dir;
-#[cfg(target_os = "windows")]
 use screenshots::Screen;
-#[cfg(target_os = "windows")]
 use windows::Win32::Foundation::RECT;
-#[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowRect};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20,7 +14,6 @@ pub enum Mode {
     Desktop,
 }
 
-#[cfg(target_os = "windows")]
 pub fn capture_raw(mode: Mode) -> anyhow::Result<image::RgbaImage> {
     match mode {
         Mode::Desktop => {
@@ -85,7 +78,6 @@ pub fn capture_raw(mode: Mode) -> anyhow::Result<image::RgbaImage> {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
     let dir = screenshot_dir();
     std::fs::create_dir_all(&dir)?;
@@ -110,7 +102,3 @@ pub fn capture(mode: Mode, clipboard: bool) -> anyhow::Result<PathBuf> {
     Ok(path)
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn capture(_mode: Mode, _clipboard: bool) -> anyhow::Result<PathBuf> {
-    anyhow::bail!("screenshot not supported on this platform")
-}

--- a/src/actions/shell.rs
+++ b/src/actions/shell.rs
@@ -1,18 +1,10 @@
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    #[cfg(target_os = "windows")]
-    {
-        let mut command = {
-            let mut c = std::process::Command::new("cmd");
-            c.arg("/C").arg(cmd);
-            c
-        };
-        command.spawn().map(|_| ()).map_err(|e| e.into())
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = cmd;
-        Ok(())
-    }
+    let mut command = {
+        let mut c = std::process::Command::new("cmd");
+        c.arg("/C").arg(cmd);
+        c
+    };
+    command.spawn().map(|_| ()).map_err(|e| e.into())
 }
 
 pub fn add(name: &str, args: &str) -> anyhow::Result<()> {

--- a/src/actions/system.rs
+++ b/src/actions/system.rs
@@ -15,88 +15,61 @@ pub fn process_kill(pid: u32) {
     }
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn process_switch(pid: u32) {
-    #[cfg(target_os = "windows")]
-    {
-        super::super::window_manager::activate_process(pid);
-    }
+    super::super::window_manager::activate_process(pid);
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn window_switch(hwnd: isize) {
-    #[cfg(target_os = "windows")]
-    {
-        use windows::Win32::Foundation::HWND;
-        super::super::window_manager::force_restore_and_foreground(HWND(hwnd as _));
-    }
+    use windows::Win32::Foundation::HWND;
+    super::super::window_manager::force_restore_and_foreground(HWND(hwnd as _));
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn window_close(hwnd: isize) {
-    #[cfg(target_os = "windows")]
-    {
-        use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
-        use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-        unsafe {
-            let _ = PostMessageW(HWND(hwnd as _), WM_CLOSE, WPARAM(0), LPARAM(0));
-        }
+    use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+    unsafe {
+        let _ = PostMessageW(HWND(hwnd as _), WM_CLOSE, WPARAM(0), LPARAM(0));
     }
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn set_brightness(v: u32) {
-    #[cfg(target_os = "windows")]
     super::super::launcher::set_display_brightness(v);
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn set_volume(v: u32) {
-    #[cfg(target_os = "windows")]
     super::super::launcher::set_system_volume(v);
 }
 
 pub fn mute_active_window() {
-    #[cfg(target_os = "windows")]
     super::super::launcher::mute_active_window();
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn set_process_volume(pid: u32, level: u32) {
-    #[cfg(target_os = "windows")]
     super::super::launcher::set_process_volume(pid, level);
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn toggle_process_mute(pid: u32) {
-    #[cfg(target_os = "windows")]
     super::super::launcher::toggle_process_mute(pid);
 }
 
 pub fn recycle_clean() {
-    #[cfg(target_os = "windows")]
-    {
-        // Emptying the recycle bin can take a noticeable amount of time on
-        // Windows. Running it on the current thread would block the UI and
-        // cause `launch_action` to return slowly, which in turn makes the
-        // `recycle_plugin` test fail. Spawn a background thread instead so the
-        // command returns immediately while the cleanup happens asynchronously.
-        //
-        // To keep callers responsive, dispatch a success event right away and
-        // perform the actual cleanup in the background. Any errors from the
-        // cleanup are ignored since we have already notified listeners.
-        std::thread::spawn(|| {
-            let _ = super::super::launcher::clean_recycle_bin();
-        });
-        crate::gui::send_event(crate::gui::WatchEvent::Recycle(Ok(())));
-    }
+    // Emptying the recycle bin can take a noticeable amount of time on
+    // Windows. Running it on the current thread would block the UI and
+    // cause `launch_action` to return slowly, which in turn makes the
+    // `recycle_plugin` test fail. Spawn a background thread instead so the
+    // command returns immediately while the cleanup happens asynchronously.
+    //
+    // To keep callers responsive, dispatch a success event right away and
+    // perform the actual cleanup in the background. Any errors from the
+    // cleanup are ignored since we have already notified listeners.
+    std::thread::spawn(|| {
+        let _ = super::super::launcher::clean_recycle_bin();
+    });
+    crate::gui::send_event(crate::gui::WatchEvent::Recycle(Ok(())));
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
 pub fn browser_tab_switch(runtime_id: &[i32]) {
-    #[cfg(target_os = "windows")]
-    {
-        use windows::core::VARIANT;
+    use windows::core::VARIANT;
         use windows::Win32::System::Com::{
             CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
             COINIT_APARTMENTTHREADED,
@@ -298,5 +271,4 @@ pub fn browser_tab_switch(runtime_id: &[i32]) {
             }
             CoUninitialize();
         }
-    }
 }

--- a/src/global_hotkey.rs
+++ b/src/global_hotkey.rs
@@ -1,10 +1,7 @@
-#[cfg(target_os = "windows")]
 use crate::workspace::is_valid_key_combo;
-#[cfg(target_os = "windows")]
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-#[cfg(target_os = "windows")]
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     RegisterHotKey, HOT_KEY_MODIFIERS, MOD_CONTROL, MOD_ALT, MOD_SHIFT, MOD_WIN,
 };
@@ -12,7 +9,6 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Hotkey {
     pub key_sequence: String,
-    #[cfg(target_os = "windows")]
     #[serde(skip)]
     pub id: Option<i32>,
 }
@@ -24,7 +20,6 @@ impl fmt::Display for Hotkey {
 }
 
 impl Hotkey {
-    #[cfg(target_os = "windows")]
     pub fn new(key_sequence: &str) -> Result<Self, String> {
         if is_valid_key_combo(key_sequence) {
             Ok(Self {
@@ -36,7 +31,6 @@ impl Hotkey {
         }
     }
 
-    #[cfg(target_os = "windows")]
     pub fn register(&mut self, app: &crate::gui::LauncherApp, id: i32) -> bool {
         let mut modifiers: u32 = 0;
         let mut vk_code: Option<u32> = None;

--- a/src/gui/add_action_dialog.rs
+++ b/src/gui/add_action_dialog.rs
@@ -2,7 +2,6 @@ use crate::actions::{save_actions, Action};
 use crate::gui::LauncherApp;
 use eframe::egui;
 use std::sync::Arc;
-#[cfg(target_os = "windows")]
 use rfd::FileDialog;
 
 /// Dialog state used when adding a new user defined command.
@@ -111,7 +110,6 @@ impl AddActionDialog {
                         ui.label("Path");
                         ui.text_edit_singleline(&mut self.path);
                         if ui.button("Browse").clicked() {
-                            #[cfg(target_os = "windows")]
                             if let Some(file) = FileDialog::new().pick_file() {
                                 if let Some(p) = file.to_str() {
                                     self.path = p.to_owned();

--- a/src/gui/brightness_dialog.rs
+++ b/src/gui/brightness_dialog.rs
@@ -51,7 +51,6 @@ impl BrightnessDialog {
     }
 }
 
-#[cfg(target_os = "windows")]
 fn get_main_display_brightness() -> Option<u8> {
     use windows::Win32::Foundation::{BOOL, LPARAM, RECT};
     use windows::Win32::Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR};
@@ -102,8 +101,3 @@ fn get_main_display_brightness() -> Option<u8> {
     Some(percent as u8)
 }
 
-#[cfg(not(target_os = "windows"))]
-fn get_main_display_brightness() -> Option<u8> {
-    BRIGHTNESS_QUERIES.fetch_add(1, Ordering::Relaxed);
-    None
-}

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -17,7 +17,6 @@ use regex::Regex;
 use rfd::FileDialog;
 use std::collections::HashMap;
 use std::process::Command;
-#[cfg(target_os = "windows")]
 use std::{
     env,
     path::{Path, PathBuf},
@@ -957,26 +956,10 @@ impl NotePanel {
         let path = self.note.path.clone();
         let result = match choice {
             NoteExternalOpen::Powershell => {
-                #[cfg(target_os = "windows")]
-                {
-                    let (mut cmd, _cmd_str) = build_nvim_command(&path);
-                    cmd.spawn()
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    Command::new("nvim").arg(&path).spawn()
-                }
+                let (mut cmd, _cmd_str) = build_nvim_command(&path);
+                cmd.spawn()
             }
-            NoteExternalOpen::Notepad => {
-                #[cfg(target_os = "windows")]
-                {
-                    Command::new("notepad.exe").arg(&path).spawn()
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    Command::new("notepad").arg(&path).spawn()
-                }
-            }
+            NoteExternalOpen::Notepad => Command::new("notepad.exe").arg(&path).spawn(),
             NoteExternalOpen::Neither => return,
         };
         if let Err(e) = result {
@@ -1050,7 +1033,6 @@ fn insert_tag_menu(
         });
 }
 
-#[cfg(target_os = "windows")]
 fn detect_shell() -> PathBuf {
     let ps7_path = env::var("ML_PWSH7_PATH")
         .map(PathBuf::from)
@@ -1068,7 +1050,6 @@ fn detect_shell() -> PathBuf {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn build_nvim_command(note_path: &Path) -> (Command, String) {
     let shell = detect_shell();
     let mut cmd = Command::new(&shell);

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -1,93 +1,4 @@
-#[cfg(target_os = "windows")]
 pub use rdev::Key;
-
-#[cfg(not(target_os = "windows"))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Key {
-    Space,
-    Tab,
-    Return,
-    Escape,
-    Delete,
-    Backspace,
-    CapsLock,
-    Home,
-    End,
-    PageUp,
-    PageDown,
-    LeftArrow,
-    RightArrow,
-    UpArrow,
-    DownArrow,
-    F1,
-    F2,
-    F3,
-    F4,
-    F5,
-    F6,
-    F7,
-    F8,
-    F9,
-    F10,
-    F11,
-    F12,
-    F13,
-    F14,
-    F15,
-    F16,
-    F17,
-    F18,
-    F19,
-    F20,
-    F21,
-    F22,
-    F23,
-    F24,
-    Num0,
-    Num1,
-    Num2,
-    Num3,
-    Num4,
-    Num5,
-    Num6,
-    Num7,
-    Num8,
-    Num9,
-    KeyA,
-    KeyB,
-    KeyC,
-    KeyD,
-    KeyE,
-    KeyF,
-    KeyG,
-    KeyH,
-    KeyI,
-    KeyJ,
-    KeyK,
-    KeyL,
-    KeyM,
-    KeyN,
-    KeyO,
-    KeyP,
-    KeyQ,
-    KeyR,
-    KeyS,
-    KeyT,
-    KeyU,
-    KeyV,
-    KeyW,
-    KeyX,
-    KeyY,
-    KeyZ,
-    ControlLeft,
-    ControlRight,
-    ShiftLeft,
-    ShiftRight,
-    MetaLeft,
-    MetaRight,
-    Alt,
-    AltGr,
-}
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,9 +11,7 @@ use std::sync::{
     mpsc::Sender,
     Arc, Mutex,
 };
-#[cfg(target_os = "windows")]
 use std::thread;
-#[cfg(target_os = "windows")]
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
@@ -287,7 +196,6 @@ impl HotkeyTrigger {
         }
     }
 
-    #[cfg(target_os = "windows")]
     pub fn start_listener(
         triggers: Vec<Arc<HotkeyTrigger>>,
         _label: &'static str,
@@ -434,17 +342,6 @@ impl HotkeyTrigger {
         });
 
         HotkeyListener { stop: stop_flag }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    pub fn start_listener(
-        _triggers: Vec<Arc<HotkeyTrigger>>,
-        _label: &'static str,
-        _event_tx: Sender<()>,
-    ) -> HotkeyListener {
-        HotkeyListener {
-            stop: Arc::new(AtomicBool::new(false)),
-        }
     }
 
     pub fn take(&self) -> bool {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,7 +1,6 @@
 use crate::actions::Action;
 use crate::plugins::calc_history::{self, CalcHistoryEntry, CALC_HISTORY_FILE, MAX_ENTRIES};
 
-#[cfg(target_os = "windows")]
 pub(crate) fn set_system_volume(percent: u32) {
     use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
     use windows::Win32::Media::Audio::{
@@ -46,7 +45,6 @@ mod tests {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub(crate) fn mute_active_window() {
     use windows::core::Interface;
     use windows::Win32::Media::Audio::{
@@ -92,7 +90,6 @@ pub(crate) fn mute_active_window() {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub(crate) fn set_process_volume(pid: u32, level: u32) {
     use windows::core::Interface;
     use windows::Win32::Media::Audio::{
@@ -138,7 +135,6 @@ pub(crate) fn set_process_volume(pid: u32, level: u32) {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub(crate) fn toggle_process_mute(pid: u32) {
     use windows::core::Interface;
     use windows::Win32::Media::Audio::{
@@ -182,7 +178,6 @@ pub(crate) fn toggle_process_mute(pid: u32) {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub(crate) fn set_display_brightness(percent: u32) {
     use windows::Win32::Devices::Display::{
         DestroyPhysicalMonitors, GetNumberOfPhysicalMonitorsFromHMONITOR,
@@ -221,7 +216,6 @@ pub(crate) fn set_display_brightness(percent: u32) {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub(crate) fn clean_recycle_bin() -> windows::core::Result<()> {
     use windows::Win32::UI::Shell::{
         SHEmptyRecycleBinW, SHERB_NOCONFIRMATION, SHERB_NOPROGRESSUI, SHERB_NOSOUND,
@@ -236,37 +230,29 @@ pub(crate) fn clean_recycle_bin() -> windows::core::Result<()> {
 }
 
 pub(crate) fn system_command(action: &str) -> Option<std::process::Command> {
-    #[cfg(target_os = "windows")]
-    {
-        use std::process::Command;
-        return match action {
-            "shutdown" => {
-                let mut c = Command::new("shutdown");
-                c.args(["/s", "/t", "0"]);
-                Some(c)
-            }
-            "reboot" => {
-                let mut c = Command::new("shutdown");
-                c.args(["/r", "/t", "0"]);
-                Some(c)
-            }
-            "lock" => {
-                let mut c = Command::new("rundll32.exe");
-                c.args(["user32.dll,LockWorkStation"]);
-                Some(c)
-            }
-            "logoff" => {
-                let mut c = Command::new("shutdown");
-                c.arg("/l");
-                Some(c)
-            }
-            _ => None,
-        };
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = action;
-        None
+    use std::process::Command;
+    match action {
+        "shutdown" => {
+            let mut c = Command::new("shutdown");
+            c.args(["/s", "/t", "0"]);
+            Some(c)
+        }
+        "reboot" => {
+            let mut c = Command::new("shutdown");
+            c.args(["/r", "/t", "0"]);
+            Some(c)
+        }
+        "lock" => {
+            let mut c = Command::new("rundll32.exe");
+            c.args(["user32.dll,LockWorkStation"]);
+            Some(c)
+        }
+        "logoff" => {
+            let mut c = Command::new("shutdown");
+            c.arg("/l");
+            Some(c)
+        }
+        _ => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+#![windows_subsystem = "windows"]
 
 use multi_launcher::actions::{load_actions, Action};
 use multi_launcher::gui::LauncherApp;
@@ -103,11 +103,8 @@ fn spawn_gui(
         let native_options = eframe::NativeOptions {
             viewport,
             event_loop_builder: Some(Box::new(|_builder| {
-                #[cfg(target_os = "windows")]
-                {
-                    use winit::platform::windows::EventLoopBuilderExtWindows;
-                    _builder.with_any_thread(true);
-                }
+                use winit::platform::windows::EventLoopBuilderExtWindows;
+                _builder.with_any_thread(true);
             })),
             ..Default::default()
         };

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,6 @@ use crate::plugins::emoji::EmojiPlugin;
 use crate::plugins::screenshot::ScreenshotPlugin;
 use crate::plugins::text_case::TextCasePlugin;
 use crate::plugins::bookmarks::BookmarksPlugin;
-#[cfg(target_os = "windows")]
 use crate::plugins::brightness::BrightnessPlugin;
 use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::dropcalc::DropCalcPlugin;
@@ -27,7 +26,6 @@ use crate::plugins::sysinfo::SysInfoPlugin;
 use crate::plugins::system::SystemPlugin;
 use crate::plugins::settings::SettingsPlugin;
 use crate::plugins::missing::MissingPlugin;
-#[cfg(target_os = "windows")]
 use crate::plugins::task_manager::TaskManagerPlugin;
 use crate::plugins::tempfile::TempfilePlugin;
 use crate::plugins::timer::TimerPlugin;
@@ -35,13 +33,10 @@ use crate::plugins::stopwatch::StopwatchPlugin;
 use crate::plugins::todo::TodoPlugin;
 use crate::plugins::unit_convert::UnitConvertPlugin;
 use crate::plugins::base_convert::BaseConvertPlugin;
-#[cfg(target_os = "windows")]
 use crate::plugins::volume::VolumePlugin;
 use crate::plugins::weather::WeatherPlugin;
 use crate::plugins::wikipedia::WikipediaPlugin;
-#[cfg(target_os = "windows")]
 use crate::plugins::windows::WindowsPlugin;
-#[cfg(target_os = "windows")]
 use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::youtube::YoutubePlugin;
 use crate::plugins::ip::IpPlugin;
@@ -162,14 +157,11 @@ impl PluginManager {
         self.register_with_settings(LoremPlugin, plugin_settings);
         self.register_with_settings(ConvertPanelPlugin, plugin_settings);
         self.register_with_settings(ColorPickerPlugin::default(), plugin_settings);
-        #[cfg(target_os = "windows")]
-        {
-            self.register_with_settings(VolumePlugin, plugin_settings);
-            self.register_with_settings(BrightnessPlugin, plugin_settings);
-            self.register_with_settings(TaskManagerPlugin, plugin_settings);
-            self.register_with_settings(WindowsPlugin, plugin_settings);
-            self.register_with_settings(BrowserTabsPlugin::default(), plugin_settings);
-        }
+        self.register_with_settings(VolumePlugin, plugin_settings);
+        self.register_with_settings(BrightnessPlugin, plugin_settings);
+        self.register_with_settings(TaskManagerPlugin, plugin_settings);
+        self.register_with_settings(WindowsPlugin, plugin_settings);
+        self.register_with_settings(BrowserTabsPlugin::default(), plugin_settings);
         self.register_with_settings(SettingsPlugin, plugin_settings);
         self.register_with_settings(HelpPlugin, plugin_settings);
         self.register_with_settings(TimerPlugin, plugin_settings);

--- a/src/plugins/brightness.rs
+++ b/src/plugins/brightness.rs
@@ -4,7 +4,6 @@ use crate::plugin::Plugin;
 pub struct BrightnessPlugin;
 
 impl Plugin for BrightnessPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim();
         if let Some(rest) = crate::common::strip_prefix_ci(trimmed, "bright") {
@@ -28,11 +27,6 @@ impl Plugin for BrightnessPlugin {
                 }
             }
         }
-        Vec::new()
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/src/plugins/browser_tabs.rs
+++ b/src/plugins/browser_tabs.rs
@@ -33,7 +33,6 @@ impl Default for BrowserTabsPlugin {
     }
 }
 
-#[cfg(target_os = "windows")]
 mod imp {
     use super::*;
     use once_cell::sync::Lazy;
@@ -398,7 +397,6 @@ mod imp {
 }
 
 impl Plugin for BrowserTabsPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "tab";
         let trimmed = query.trim();
@@ -427,11 +425,6 @@ impl Plugin for BrowserTabsPlugin {
         let filter = rest.to_lowercase();
 
         imp::cached_actions(&filter, self.recalc_each_query)
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
-        Vec::new()
     }
 
     fn name(&self) -> &str {
@@ -501,17 +494,6 @@ impl Plugin for BrowserTabsPlugin {
     }
 }
 
-#[cfg(all(test, not(target_os = "windows")))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn search_is_empty_on_non_windows() {
-        let plugin = BrowserTabsPlugin::default();
-        assert!(plugin.search("tab ").is_empty());
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BrowserTabsPluginSettings {
     #[serde(default)]
@@ -526,25 +508,14 @@ impl Default for BrowserTabsPluginSettings {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn take_cache_messages() -> Vec<String> {
     imp::take_messages()
 }
-#[cfg(not(target_os = "windows"))]
-pub fn take_cache_messages() -> Vec<String> {
-    Vec::new()
-}
 
-#[cfg(target_os = "windows")]
 pub fn rebuild_cache() {
     imp::force_refresh();
 }
-#[cfg(not(target_os = "windows"))]
-pub fn rebuild_cache() {}
 
-#[cfg(target_os = "windows")]
 pub fn clear_cache() {
     imp::clear_cache();
 }
-#[cfg(not(target_os = "windows"))]
-pub fn clear_cache() {}

--- a/src/plugins/ip.rs
+++ b/src/plugins/ip.rs
@@ -4,7 +4,6 @@ use crate::plugin::Plugin;
 pub struct IpPlugin;
 
 impl Plugin for IpPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         if crate::common::strip_prefix_ci(query.trim(), "ip").is_none() {
             return Vec::new();
@@ -37,11 +36,6 @@ impl Plugin for IpPlugin {
             }
         }
         out
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
-        Vec::new()
     }
 
     fn name(&self) -> &str {

--- a/src/plugins/recycle.rs
+++ b/src/plugins/recycle.rs
@@ -4,7 +4,6 @@ use crate::plugin::Plugin;
 pub struct RecyclePlugin;
 
 impl Plugin for RecyclePlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "rec";
         let trimmed = query.trim_start();
@@ -16,11 +15,6 @@ impl Plugin for RecyclePlugin {
                 args: None,
             }];
         }
-        Vec::new()
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/src/plugins/screenshot.rs
+++ b/src/plugins/screenshot.rs
@@ -4,7 +4,6 @@ use crate::settings::Settings;
 use eframe::egui;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-#[cfg(target_os = "windows")]
 use rfd::FileDialog;
 
 /// Return the directory used to store screenshots.
@@ -42,7 +41,6 @@ impl Default for ScreenshotPluginSettings {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn launch_editor(
     app: &mut crate::gui::LauncherApp,
     mode: crate::actions::screenshot::Mode,
@@ -87,19 +85,10 @@ pub fn launch_editor(
     Ok(())
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn launch_editor(
-    _app: &mut crate::gui::LauncherApp,
-    _mode: crate::actions::screenshot::Mode,
-    _clip: bool,
-) -> anyhow::Result<()> {
-    anyhow::bail!("screenshot not supported on this platform")
-}
 
 pub struct ScreenshotPlugin;
 
 impl Plugin for ScreenshotPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         if crate::common::strip_prefix_ci(query.trim(), "ss").is_none() {
             return Vec::new();
@@ -144,11 +133,6 @@ impl Plugin for ScreenshotPlugin {
         ]
     }
 
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
-        Vec::new()
-    }
-
     fn name(&self) -> &str {
         "screenshot"
     }
@@ -188,7 +172,6 @@ impl Plugin for ScreenshotPlugin {
         ui.horizontal(|ui| {
             ui.label("Screenshot directory");
             ui.text_edit_singleline(&mut cfg.screenshot_dir);
-            #[cfg(target_os = "windows")]
             if ui.button("Browse").clicked() {
                 if let Some(dir) = FileDialog::new().pick_folder() {
                     cfg.screenshot_dir = dir.display().to_string();

--- a/src/plugins/task_manager.rs
+++ b/src/plugins/task_manager.rs
@@ -4,7 +4,6 @@ use crate::plugin::Plugin;
 pub struct TaskManagerPlugin;
 
 impl Plugin for TaskManagerPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         let trimmed = query.trim_start();
         if crate::common::strip_prefix_ci(trimmed, "tm").is_some() {
@@ -15,11 +14,6 @@ impl Plugin for TaskManagerPlugin {
                 args: None,
             }];
         }
-        Vec::new()
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/src/plugins/volume.rs
+++ b/src/plugins/volume.rs
@@ -1,18 +1,13 @@
 use crate::actions::Action;
 use crate::plugin::Plugin;
-#[cfg(target_os = "windows")]
 use once_cell::sync::Lazy;
-#[cfg(target_os = "windows")]
 use std::sync::Mutex;
-#[cfg(target_os = "windows")]
 use std::time::{Duration, Instant};
-#[cfg(target_os = "windows")]
 use sysinfo::{ProcessesToUpdate, System};
 
 pub struct VolumePlugin;
 
 impl Plugin for VolumePlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         static SYSTEM_CACHE: Lazy<Mutex<(System, Instant)>> =
             Lazy::new(|| Mutex::new((System::new_all(), Instant::now())));
@@ -94,11 +89,6 @@ impl Plugin for VolumePlugin {
                 _ => {}
             }
         }
-        Vec::new()
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
         Vec::new()
     }
 

--- a/src/plugins/windows.rs
+++ b/src/plugins/windows.rs
@@ -4,7 +4,6 @@ use crate::plugin::Plugin;
 pub struct WindowsPlugin;
 
 impl Plugin for WindowsPlugin {
-    #[cfg(target_os = "windows")]
     fn search(&self, query: &str) -> Vec<Action> {
         const PREFIX: &str = "win";
         let trimmed = query.trim();
@@ -56,11 +55,6 @@ impl Plugin for WindowsPlugin {
             let _ = EnumWindows(Some(enum_cb), LPARAM(ctx_ptr as isize));
         }
         ctx.out
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn search(&self, _query: &str) -> Vec<Action> {
-        Vec::new()
     }
 
     fn name(&self) -> &str {

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -5,7 +5,6 @@ use crate::plugins::screenshot::ScreenshotPluginSettings;
 use crate::settings::Settings;
 use eframe::egui;
 use egui_toast::{Toast, ToastKind, ToastOptions};
-#[cfg(target_os = "windows")]
 use rfd::FileDialog;
 use std::sync::Arc;
 
@@ -537,7 +536,6 @@ impl SettingsEditor {
                                 ui.horizontal(|ui| {
                                     ui.label("External editor");
                                     ui.text_edit_singleline(&mut self.note_external_editor);
-                                    #[cfg(target_os = "windows")]
                                     if ui.button("Browse").clicked() {
                                         if let Some(file) = FileDialog::new().pick_file() {
                                             self.note_external_editor = file.display().to_string();

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,6 +1,4 @@
-#[cfg(target_os = "windows")]
 use once_cell::sync::Lazy;
-#[cfg(target_os = "windows")]
 use std::io::Cursor;
 
 pub static SOUND_NAMES: &[&str] = &[
@@ -21,7 +19,6 @@ pub static SOUND_NAMES: &[&str] = &[
     "StartUp.wav",
 ];
 
-#[cfg(target_os = "windows")]
 static SOUNDS: Lazy<Vec<(&'static str, &'static [u8])>> = Lazy::new(|| {
     vec![
         ("Alarm.wav", include_bytes!("../Resources/sounds/Alarm.wav")),
@@ -80,7 +77,6 @@ static SOUNDS: Lazy<Vec<(&'static str, &'static [u8])>> = Lazy::new(|| {
     ]
 });
 
-#[cfg(target_os = "windows")]
 pub fn play_sound(name: &str) {
     if name == "None" {
         return;
@@ -101,5 +97,3 @@ pub fn play_sound(name: &str) {
     });
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn play_sound(_name: &str) {}

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -166,25 +166,15 @@ pub fn current_mouse_position() -> Option<(f32, f32)> {
         tracing::error!("failed to lock MOCK_MOUSE_POSITION");
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        use windows::Win32::Foundation::POINT;
-        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
-        let mut pt = POINT::default();
-        if unsafe { GetCursorPos(&mut pt).is_ok() } {
-            Some((pt.x as f32, pt.y as f32))
-        } else {
-            None
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        Some((0.0, 0.0))
+    use windows::Win32::Foundation::POINT;
+    use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
+    let mut pt = POINT::default();
+    if unsafe { GetCursorPos(&mut pt).is_ok() } {
+        Some((pt.x as f32, pt.y as f32))
+    } else {
+        None
     }
 }
-
-#[cfg(target_os = "windows")]
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 /// Ensure the given window resides on the active virtual desktop.
@@ -192,7 +182,6 @@ use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 /// This uses the `IVirtualDesktopManager` COM interface to check if `hwnd`
 /// already belongs to the current desktop. If not, it is moved to the desktop
 /// of the foreground window.
-#[cfg(target_os = "windows")]
 pub fn move_to_current_desktop(hwnd: windows::Win32::Foundation::HWND) {
     use windows::Win32::System::Com::{
         CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
@@ -218,7 +207,6 @@ pub fn move_to_current_desktop(hwnd: windows::Win32::Foundation::HWND) {
 }
 
 /// On Windows, restore the window and bring it to the foreground.
-#[cfg(target_os = "windows")]
 pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
     use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
     use windows::Win32::UI::WindowsAndMessaging::{
@@ -243,7 +231,6 @@ pub fn force_restore_and_foreground(hwnd: windows::Win32::Foundation::HWND) {
 }
 
 /// Extract the HWND from an eframe [`Frame`].
-#[cfg(target_os = "windows")]
 pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWND> {
     if let Ok(handle) = frame.window_handle() {
         match handle.as_raw() {
@@ -257,7 +244,6 @@ pub fn get_hwnd(frame: &eframe::Frame) -> Option<windows::Win32::Foundation::HWN
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn activate_process(pid: u32) {
     use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
     use windows::Win32::UI::WindowsAndMessaging::{
@@ -282,13 +268,11 @@ pub fn activate_process(pid: u32) {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn activate_window(hwnd: usize) {
     use windows::Win32::Foundation::HWND;
     crate::window_manager::force_restore_and_foreground(HWND(hwnd as *mut _));
 }
 
-#[cfg(target_os = "windows")]
 pub fn close_window(hwnd: usize) {
     use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
     use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
@@ -297,7 +281,6 @@ pub fn close_window(hwnd: usize) {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn send_end_key() {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,15 +1,11 @@
-#[cfg(any(test, target_os = "windows"))]
 use once_cell::sync::Lazy;
-#[cfg(any(test, target_os = "windows"))]
 use regex::Regex;
 
-#[cfg(any(test, target_os = "windows"))]
 static HOTKEY_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:(?:Ctrl|Alt|Shift|Win)\+)?(?:F(?:[1-9]|1[0-2]|1[3-9]|2[0-4])|[A-Z]|[0-9]|NUMPAD[0-9]|NUMPAD(?:MULTIPLY|ADD|SEPARATOR|SUBTRACT|DOT|DIVIDE)|UP|DOWN|LEFT|RIGHT|BACKSPACE|TAB|ENTER|PAUSE|CAPSLOCK|ESCAPE|SPACE|PAGEUP|PAGEDOWN|END|HOME|INSERT|DELETE|OEM_(?:PLUS|COMMA|MINUS|PERIOD|[1-7])|PRINTSCREEN|SCROLLLOCK|NUMLOCK|LEFT(?:SHIFT|CTRL|ALT)|RIGHT(?:SHIFT|CTRL|ALT))$")
         .expect("invalid hotkey regex")
 });
 
-#[cfg(any(test, target_os = "windows"))]
 pub fn is_valid_key_combo(input: &str) -> bool {
     HOTKEY_REGEX.is_match(input)
 }

--- a/tests/brightness_plugin.rs
+++ b/tests/brightness_plugin.rs
@@ -7,24 +7,16 @@ use std::sync::atomic::Ordering;
 fn search_set_numeric() {
     let plugin = BrightnessPlugin;
     let results = plugin.search("bright 50");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "brightness:set:50");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "brightness:set:50");
 }
 
 #[test]
 fn search_plain_bright() {
     let plugin = BrightnessPlugin;
     let results = plugin.search("bright");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "brightness:dialog");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "brightness:dialog");
 }
 
 #[test]

--- a/tests/ip_plugin.rs
+++ b/tests/ip_plugin.rs
@@ -5,9 +5,5 @@ use multi_launcher::plugins::ip::IpPlugin;
 fn search_returns_addresses() {
     let plugin = IpPlugin;
     let results = plugin.search("ip");
-    if cfg!(target_os = "windows") {
-        assert!(!results.is_empty());
-    } else {
-        assert!(results.is_empty());
-    }
+    assert!(!results.is_empty());
 }

--- a/tests/screenshot_plugin.rs
+++ b/tests/screenshot_plugin.rs
@@ -5,20 +5,16 @@ use multi_launcher::plugins::screenshot::ScreenshotPlugin;
 fn search_lists_screenshot_actions() {
     let plugin = ScreenshotPlugin;
     let results = plugin.search("ss");
-    if cfg!(target_os = "windows") {
-        assert!(!results.is_empty());
-        let prefixes = [
-            "screenshot:window",
-            "screenshot:region",
-            "screenshot:desktop",
-            "screenshot:window_clip",
-            "screenshot:region_clip",
-            "screenshot:desktop_clip",
-        ];
-        for prefix in prefixes.iter() {
-            assert!(results.iter().any(|a| a.action == *prefix), "missing action {}", prefix);
-        }
-    } else {
-        assert!(results.is_empty());
+    assert!(!results.is_empty());
+    let prefixes = [
+        "screenshot:window",
+        "screenshot:region",
+        "screenshot:desktop",
+        "screenshot:window_clip",
+        "screenshot:region_clip",
+        "screenshot:desktop_clip",
+    ];
+    for prefix in prefixes.iter() {
+        assert!(results.iter().any(|a| a.action == *prefix), "missing action {}", prefix);
     }
 }

--- a/tests/sound.rs
+++ b/tests/sound.rs
@@ -6,7 +6,6 @@ fn sound_names_contains_expected() {
     assert!(SOUND_NAMES.contains(&"Alarm.wav"));
 }
 
-#[cfg(not(target_os = "windows"))]
 #[test]
 fn play_sound_returns_quickly_and_no_panic() {
     use std::time::{Duration, Instant};

--- a/tests/task_manager_plugin.rs
+++ b/tests/task_manager_plugin.rs
@@ -5,10 +5,6 @@ use multi_launcher::plugins::task_manager::TaskManagerPlugin;
 fn search_returns_action() {
     let plugin = TaskManagerPlugin;
     let results = plugin.search("tm");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "shell:taskmgr");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "shell:taskmgr");
 }

--- a/tests/volume_plugin.rs
+++ b/tests/volume_plugin.rs
@@ -5,60 +5,40 @@ use multi_launcher::plugins::volume::VolumePlugin;
 fn search_set_zero() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol 0");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "volume:set:0");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "volume:set:0");
 }
 
 #[test]
 fn search_set_fifty() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol 50");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "volume:set:50");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "volume:set:50");
 }
 
 #[test]
 fn search_mute_active() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol ma");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "volume:mute_active");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "volume:mute_active");
 }
 
 #[test]
 fn search_plain_vol() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "volume:dialog");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "volume:dialog");
 }
 
 #[test]
 fn search_pid_level() {
     let plugin = VolumePlugin;
     let results = plugin.search("vol pid 42 30");
-    if cfg!(target_os = "windows") {
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].action, "volume:pid:42:30");
-    } else {
-        assert!(results.is_empty());
-    }
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "volume:pid:42:30");
 }
 
 #[test]

--- a/tests/windows_plugin.rs
+++ b/tests/windows_plugin.rs
@@ -5,10 +5,6 @@ use multi_launcher::plugins::windows::WindowsPlugin;
 fn search_lists_windows() {
     let plugin = WindowsPlugin;
     let results = plugin.search("win");
-    if cfg!(target_os = "windows") {
-        assert!(results.iter().any(|a| a.action.starts_with("window:switch:")));
-        assert!(results.iter().any(|a| a.action.starts_with("window:close:")));
-    } else {
-        assert!(results.is_empty());
-    }
+    assert!(results.iter().any(|a| a.action.starts_with("window:switch:")));
+    assert!(results.iter().any(|a| a.action.starts_with("window:close:")));
 }


### PR DESCRIPTION
## Summary
- remove all non-Windows cfg blocks and make Windows code unconditional
- simplify tests and build script for Windows-only build
- move Windows crates to main dependencies

## Testing
- `cargo check --target x86_64-pc-windows-gnu` *(fails: failed to run custom build command for `ring v0.17.14` - missing x86_64-w64-mingw32-gcc)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b245090833299b8db6effa7b37d