### PR TITLE
Add keep_open flag for shell commands

### DIFF
--- a/src/actions/shell.rs
+++ b/src/actions/shell.rs
@@ -1,25 +1,18 @@
-pub fn run(cmd: &str) -> anyhow::Result<()> {
+pub fn run(cmd: &str, keep_open: bool) -> anyhow::Result<()> {
     let mut command = {
         let mut c = std::process::Command::new("cmd");
-        c.arg("/C").arg(cmd);
+        c.arg(if keep_open { "/K" } else { "/C" }).arg(cmd);
         c
     };
     command.spawn().map(|_| ()).map_err(|e| e.into())
 }
 
 pub fn add(name: &str, args: &str) -> anyhow::Result<()> {
-    crate::plugins::shell::append_shell_cmd(
-        crate::plugins::shell::SHELL_CMDS_FILE,
-        name,
-        args,
-    )?;
+    crate::plugins::shell::append_shell_cmd(crate::plugins::shell::SHELL_CMDS_FILE, name, args)?;
     Ok(())
 }
 
 pub fn remove(name: &str) -> anyhow::Result<()> {
-    crate::plugins::shell::remove_shell_cmd(
-        crate::plugins::shell::SHELL_CMDS_FILE,
-        name,
-    )?;
+    crate::plugins::shell::remove_shell_cmd(crate::plugins::shell::SHELL_CMDS_FILE, name)?;
     Ok(())
 }

--- a/src/gui/shell_cmd_dialog.rs
+++ b/src/gui/shell_cmd_dialog.rs
@@ -64,6 +64,7 @@ impl ShellCmdDialog {
                                         name: self.name.clone(),
                                         args: self.args.clone(),
                                         autocomplete: true,
+                                        keep_open: false,
                                     });
                                 } else if let Some(e) = self.entries.get_mut(idx) {
                                     e.name = self.name.clone();

--- a/tests/shell_plugin.rs
+++ b/tests/shell_plugin.rs
@@ -19,6 +19,7 @@ fn load_shell_cmds_roundtrip() {
         name: "test".into(),
         args: "echo hi".into(),
         autocomplete: true,
+        keep_open: false,
     }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
     let loaded = load_shell_cmds(SHELL_CMDS_FILE).unwrap();
@@ -26,6 +27,7 @@ fn load_shell_cmds_roundtrip() {
     assert_eq!(loaded[0].name, "test");
     assert_eq!(loaded[0].args, "echo hi");
     assert!(loaded[0].autocomplete);
+    assert!(!loaded[0].keep_open);
 }
 
 #[test]
@@ -38,6 +40,7 @@ fn search_named_command_returns_action() {
         name: "demo".into(),
         args: "dir".into(),
         autocomplete: true,
+        keep_open: false,
     }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
 
@@ -57,6 +60,7 @@ fn search_respects_autocomplete_flag() {
         name: "demo".into(),
         args: "dir".into(),
         autocomplete: false,
+        keep_open: false,
     }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
 
@@ -64,6 +68,26 @@ fn search_respects_autocomplete_flag() {
     let results = plugin.search("sh demo");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].action, "shell:demo");
+}
+
+#[test]
+fn search_keep_open_uses_shell_keep_prefix() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(dir.path()).unwrap();
+
+    let entries = vec![ShellCmdEntry {
+        name: "demo".into(),
+        args: "dir".into(),
+        autocomplete: true,
+        keep_open: true,
+    }];
+    save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
+
+    let plugin = ShellPlugin;
+    let results = plugin.search("sh demo");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].action, "shell_keep:dir");
 }
 
 #[test]
@@ -98,11 +122,13 @@ fn rm_lists_matching_commands() {
             name: "a".into(),
             args: "cmd_a".into(),
             autocomplete: true,
+            keep_open: false,
         },
         ShellCmdEntry {
             name: "b".into(),
             args: "cmd_b".into(),
             autocomplete: true,
+            keep_open: false,
         },
     ];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
@@ -123,6 +149,7 @@ fn list_returns_saved_commands() {
         name: "x".into(),
         args: "dir".into(),
         autocomplete: true,
+        keep_open: false,
     }];
     save_shell_cmds(SHELL_CMDS_FILE, &entries).unwrap();
 


### PR DESCRIPTION
## Summary
- support `keep_open` flag on saved shell commands
- encode keep-open shell actions as `shell_keep:` and parse the new prefix
- allow shell actions to use `/K` to leave the command window open

## Testing
- `cargo test` *(fails: Need to activate either wayland or x11 feature on linux, no `Keyboard` in `linux`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae556514a483329ca4ee654990e1cc