### PR TITLE
Document WezTerm as default note editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Display local network interface addresses with the `ip` prefix. Append `public` 
 Type `color` to open an interactive picker or specify a hex value such as `color #ff0000`. The plugin outputs the selected color in multiple formats: `#RRGGBB`, `rgb(r, g, b)` and `hsl(h, s%, l%)`. Use the arrow keys to highlight a format and press <kbd>Enter</kbd> to copy it to the clipboard.
 
 ### Notes Plugin
-Manage quick Markdown notes with the `note` prefix. The editor window includes an **Open externally** button to open the current note in another program. A setting under the Note plugin labelled *Open externally* chooses the default opener: **Powershell**, **Notepad** or **Neither** to be asked each time. The **Powershell** option uses PowerShell 7 when available (listed as "Powershell" in the menu) and falls back to `powershell.exe`.
+Manage quick Markdown notes with the `note` prefix. The editor window includes an **Open externally** button to open the current note in another program. A setting under the Note plugin labelled *Open externally* chooses the default opener: **WezTerm**, **Powershell**, **Notepad** or **Neither** to be asked each time. **WezTerm** is supported and is the default external editor. The **Powershell** option uses PowerShell 7 when available (listed as "Powershell" in the menu) and falls back to `powershell.exe`.
 
 When the search box is empty the launcher shows these shortcuts along with `app <alias>` entries for saved actions.
 

--- a/settings.json
+++ b/settings.json
@@ -20,7 +20,7 @@
   "note_save_on_close": false,
   "note_always_overwrite": false,
   "note_images_as_links": false,
-  "note_external_editor": null,
+    "note_external_editor": "wezterm",
   "note_more_limit": 5,
   "enable_toasts": true,
   "toast_duration": 3.0,

--- a/tests/wezterm_command.rs
+++ b/tests/wezterm_command.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 #[test]
 fn builds_wezterm_command() {
     let note = Path::new("note.txt");
-    let (cmd, _cmd_str) = build_wezterm_command(note, "nvim");
+    let (cmd, _cmd_str) = build_wezterm_command(note, "wezterm");
     assert_eq!(cmd.get_program().to_string_lossy(), "wezterm");
     let args: Vec<_> = cmd
         .get_args()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
-    assert_eq!(args, ["start", "--", "nvim", "note.txt"]);
+    assert_eq!(args, ["start", "--", "wezterm", "note.txt"]);
 }


### PR DESCRIPTION
## Summary
- Mention WezTerm support and default in Notes Plugin documentation
- Default `note_external_editor` to `wezterm`
- Test WezTerm command builder uses editor parameter

## Testing
- `cargo test` *(fails: Need to activate either wayland or x11 feature on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e53c16588332aec225024d79ba66