### PR TITLE
Add WezTerm support for shell plugin

### DIFF
--- a/src/actions/shell.rs
+++ b/src/actions/shell.rs
@@ -1,9 +1,22 @@
-pub fn run(cmd: &str, keep_open: bool) -> anyhow::Result<()> {
-    let mut command = {
+use crate::plugins::shell::use_wezterm;
+
+pub fn build_shell_command(cmd: &str, keep_open: bool) -> (std::process::Command, String) {
+    let arg = if keep_open { "/K" } else { "/C" };
+    if use_wezterm() {
+        let mut c = std::process::Command::new("wezterm");
+        c.arg("start").arg("--").arg("cmd").arg(arg).arg(cmd);
+        let desc = format!("wezterm start -- cmd {arg} {cmd}");
+        (c, desc)
+    } else {
         let mut c = std::process::Command::new("cmd");
-        c.arg(if keep_open { "/K" } else { "/C" }).arg(cmd);
-        c
-    };
+        c.arg(arg).arg(cmd);
+        let desc = format!("cmd {arg} {cmd}");
+        (c, desc)
+    }
+}
+
+pub fn run(cmd: &str, keep_open: bool) -> anyhow::Result<()> {
+    let (mut command, _) = build_shell_command(cmd, keep_open);
     command.spawn().map(|_| ()).map_err(|e| e.into())
 }
 


### PR DESCRIPTION
## Summary
- add plugin settings for launching commands in WezTerm
- expose settings UI and apply chosen WezTerm flag at runtime
- refactor shell action to build command for either cmd or WezTerm

## Testing
- `cargo test` *(fails: unresolved import `crate::linux::Keyboard` in rdev crate)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ebfdcc0883328307b421c24d58a9