### PR TITLE
Parse markdown links with labels

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -36,7 +36,11 @@ pub use fav_dialog::FavDialog;
 pub use image_panel::ImagePanel;
 pub use macro_dialog::MacroDialog;
 pub use note_panel::{
-    build_nvim_command, build_wezterm_command, extract_links, show_wiki_link, spawn_external,
+    build_nvim_command,
+    build_wezterm_command,
+    extract_links,
+    show_wiki_link,
+    spawn_external,
     NotePanel,
 };
 pub use notes_dialog::NotesDialog;

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1175,7 +1175,7 @@ pub fn extract_links(content: &str) -> Vec<(String, String)> {
             .filter(|u| u.scheme() == "https")
             .is_some()
         {
-            links.push((label, raw));
+            links.push((label, url));
         }
     }
 
@@ -1190,7 +1190,7 @@ pub fn extract_links(content: &str) -> Vec<(String, String)> {
         Url::parse(&url)
             .ok()
             .filter(|u| u.scheme() == "https")
-            .map(|_| (raw.to_string(), raw.to_string()))
+            .map(|_| (raw.to_string(), url))
     }));
 
     links.sort();
@@ -1445,7 +1445,10 @@ mod tests {
                     "https://rust-lang.org".to_string(),
                     "https://rust-lang.org".to_string(),
                 ),
-                ("www.example.com".to_string(), "www.example.com".to_string()),
+                (
+                    "www.example.com".to_string(),
+                    "https://www.example.com".to_string(),
+                ),
             ]
         );
     }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1469,7 +1469,11 @@ mod tests {
             });
         });
         assert_eq!(
-            output.open_url.unwrap().url,
+            output
+                .platform_output
+                .open_url
+                .unwrap()
+                .url,
             "https://www.example.com"
         );
     }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -237,11 +237,15 @@ impl NotePanel {
                 let links = extract_links(&self.note.content);
                 enum LinkKind {
                     Wiki(String),
-                    Url(String),
+                    Url(String, String),
                 }
                 let mut all_links: Vec<LinkKind> = Vec::new();
                 all_links.extend(wiki.into_iter().map(LinkKind::Wiki));
-                all_links.extend(links.into_iter().map(LinkKind::Url));
+                all_links.extend(
+                    links
+                        .into_iter()
+                        .map(|(label, url)| LinkKind::Url(label, url)),
+                );
                 if !all_links.is_empty() {
                     let was_focused = ui.ctx().memory(|m| m.has_focus(content_id));
                     ui.horizontal_wrapped(|ui| {
@@ -255,8 +259,8 @@ impl NotePanel {
                                 LinkKind::Wiki(s) => {
                                     let _ = show_wiki_link(ui, app, s);
                                 }
-                                LinkKind::Url(s) => {
-                                    let _ = ui.hyperlink(s);
+                                LinkKind::Url(label, url) => {
+                                    let _ = ui.hyperlink_to(label, url);
                                 }
                             }
                         }
@@ -1151,24 +1155,44 @@ fn extract_tags(content: &str) -> Vec<String> {
     tags
 }
 
-pub fn extract_links(content: &str) -> Vec<String> {
+pub fn extract_links(content: &str) -> Vec<(String, String)> {
+    static MARKDOWN_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
     static LINK_RE: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"([a-zA-Z][a-zA-Z0-9+.-]*://\S+|www\.\S+)").unwrap());
-    let mut links: Vec<String> = LINK_RE
-        .find_iter(content)
-        .filter_map(|m| {
-            let raw = m.as_str();
-            let url = if raw.starts_with("www.") {
-                format!("https://{raw}")
-            } else {
-                raw.to_string()
-            };
-            Url::parse(&url)
-                .ok()
-                .filter(|u| u.scheme() == "https")
-                .map(|_| raw.to_string())
-        })
-        .collect();
+
+    let mut links: Vec<(String, String)> = Vec::new();
+
+    for cap in MARKDOWN_RE.captures_iter(content) {
+        let label = cap[1].to_string();
+        let raw = cap[2].to_string();
+        let url = if raw.starts_with("www.") {
+            format!("https://{raw}")
+        } else {
+            raw.clone()
+        };
+        if Url::parse(&url)
+            .ok()
+            .filter(|u| u.scheme() == "https")
+            .is_some()
+        {
+            links.push((label, raw));
+        }
+    }
+
+    let stripped = MARKDOWN_RE.replace_all(content, "");
+    links.extend(LINK_RE.find_iter(&stripped).filter_map(|m| {
+        let raw = m.as_str();
+        let url = if raw.starts_with("www.") {
+            format!("https://{raw}")
+        } else {
+            raw.to_string()
+        };
+        Url::parse(&url)
+            .ok()
+            .filter(|u| u.scheme() == "https")
+            .map(|_| (raw.to_string(), raw.to_string()))
+    }));
+
     links.sort();
     links.dedup();
     links
@@ -1411,13 +1435,17 @@ mod tests {
 
     #[test]
     fn extract_links_filters_invalid() {
-        let content = "visit http://example.com and http://exa%mple.com also https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
+        let content = "visit http://example.com and http://exa%mple.com also [Rust](https://rust-lang.org) and https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
         let links = extract_links(content);
         assert_eq!(
             links,
             vec![
-                "https://rust-lang.org".to_string(),
-                "www.example.com".to_string(),
+                ("Rust".to_string(), "https://rust-lang.org".to_string()),
+                (
+                    "https://rust-lang.org".to_string(),
+                    "https://rust-lang.org".to_string(),
+                ),
+                ("www.example.com".to_string(), "www.example.com".to_string()),
             ]
         );
     }

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -302,7 +302,10 @@ fn link_validation_rejects_invalid_urls() {
                 "https://rust-lang.org".to_string(),
                 "https://rust-lang.org".to_string(),
             ),
-            ("www.example.com".to_string(), "www.example.com".to_string()),
+            (
+                "www.example.com".to_string(),
+                "https://www.example.com".to_string(),
+            ),
         ]
     );
 }

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -292,13 +292,17 @@ fn missing_link_colored_red() {
 
 #[test]
 fn link_validation_rejects_invalid_urls() {
-    let content = "visit http://example.com and http://exa%mple.com also https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
+    let content = "visit http://example.com and http://exa%mple.com also [Rust](https://rust-lang.org) and https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
     let links = extract_links(content);
     assert_eq!(
         links,
         vec![
-            "https://rust-lang.org".to_string(),
-            "www.example.com".to_string(),
+            ("Rust".to_string(), "https://rust-lang.org".to_string()),
+            (
+                "https://rust-lang.org".to_string(),
+                "https://rust-lang.org".to_string(),
+            ),
+            ("www.example.com".to_string(), "www.example.com".to_string()),
         ]
     );
 }


### PR DESCRIPTION
## Summary
- parse markdown `[label](url)` links and return label+URL pairs
- render links with labels in notes panel
- update link extraction tests for `(label, url)` output

## Testing
- `cargo test` *(fails: Need to activate either wayland or x11 feature on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b7e94cd8833283595abf7285a693