### PR TITLE
Parse markdown links with labels

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -36,7 +36,11 @@ pub use fav_dialog::FavDialog;
 pub use image_panel::ImagePanel;
 pub use macro_dialog::MacroDialog;
 pub use note_panel::{
-    build_nvim_command, build_wezterm_command, extract_links, show_wiki_link, spawn_external,
+    build_nvim_command,
+    build_wezterm_command,
+    extract_links,
+    show_wiki_link,
+    spawn_external,
     NotePanel,
 };
 pub use notes_dialog::NotesDialog;

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -292,13 +292,21 @@ fn missing_link_colored_red() {
 
 #[test]
 fn link_validation_rejects_invalid_urls() {
-    let content = "visit http://example.com and http://exa%mple.com also https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com";
+    let content = "visit http://example.com and http://exa%mple.com also [Rust](https://rust-lang.org) and https://rust-lang.org and https://rust-lang.org and www.example.com and www.example.com and www.exa%mple.com and [Google](www.google.com)";
     let links = extract_links(content);
     assert_eq!(
         links,
         vec![
-            "https://rust-lang.org".to_string(),
-            "www.example.com".to_string(),
+            ("Google".to_string(), "https://www.google.com".to_string()),
+            ("Rust".to_string(), "https://rust-lang.org".to_string()),
+            (
+                "https://rust-lang.org".to_string(),
+                "https://rust-lang.org".to_string(),
+            ),
+            (
+                "www.example.com".to_string(),
+                "https://www.example.com".to_string(),
+            ),
         ]
     );
 }


### PR DESCRIPTION
## Summary
- canonicalize `www.` links to `https://` so markdown links launch externally
- treat non-web markdown targets as internal wiki links
- update link extraction tests for canonical URLs

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b7e94cd8833283595abf7285a693