### PR TITLE
Add option to clear query after running actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ value as shown below:
   "history_limit": 100,
   "clipboard_limit": 20,
   "preserve_command": false,
+  "clear_query_after_run": false,
   "follow_mouse": true,
   "static_location_enabled": false,
   "static_pos": [0, 0],
@@ -158,6 +159,7 @@ Example: typing `test` will only list entries containing `test`. If an alias mat
 `history_limit` defines how many entries the history plugin keeps.
 `clipboard_limit` sets how many clipboard entries are persisted for the clipboard plugin.
 `preserve_command` keeps the typed command prefix (like `bm add` or `f add`) in the search field after running an action.
+`clear_query_after_run` removes the search text after a successful action whenever you prefer starting with a blank box.
 `enabled_capabilities` maps plugin names to capability identifiers so features can be toggled individually. The folders plugin, for example, exposes `show_full_path`.
 `screenshot_dir` sets the directory used when saving screenshots. If omitted, screenshots are stored in a `MultiLauncher_Screenshots` folder in the current working directory.
 `screenshot_save_file` determines whether screenshots copied to the clipboard are also written to disk. The default is `true`.

--- a/settings.json
+++ b/settings.json
@@ -8,7 +8,10 @@
   "enabled_capabilities": null,
   "debug_logging": false,
   "log_file": null,
-  "offscreen_pos": null,
+  "offscreen_pos": [
+    2000,
+    2000
+  ],
   "window_size": [
     718,
     777
@@ -34,20 +37,64 @@
   "clipboard_limit": 20,
   "follow_mouse": true,
   "static_location_enabled": false,
-  "static_pos": null,
-  "static_size": null,
-  "hide_after_run": false,
+  "static_pos": [
+    0,
+    0
+  ],
+  "static_size": [
+    400,
+    220
+  ],
+  "hide_after_run": true,
   "always_on_top": true,
   "timer_refresh": 1.0,
   "disable_timer_updates": false,
   "preserve_command": false,
-  "clear_query_after_run": false,
+  "clear_query_after_run": true,
   "net_refresh": 1.0,
   "net_unit": "auto",
   "screenshot_dir": null,
   "screenshot_save_file": false,
   "screenshot_auto_save": true,
   "screenshot_use_editor": true,
-  "plugin_settings": {},
+  "plugin_settings": {
+    "network": {
+      "refresh_rate": 1.0,
+      "unit": "auto"
+    },
+    "history": {
+      "max_entries": 100
+    },
+    "color_picker": {
+      "color": [
+        255,
+        0,
+        0,
+        255
+      ]
+    },
+    "browser_tabs": {
+      "recalc_each_query": false
+    },
+    "stopwatch": {
+      "precision": 2,
+      "refresh_rate": 1.0
+    },
+    "screenshot": {
+      "screenshot_auto_save": true,
+      "screenshot_dir": "",
+      "screenshot_save_file": false,
+      "screenshot_use_editor": true
+    },
+    "shell": {
+      "open_in_wezterm": false
+    },
+    "calculator": {
+      "save_on_enter": false
+    },
+    "clipboard": {
+      "max_entries": 20
+    }
+  },
   "pinned_panels": []
 }

--- a/settings.json
+++ b/settings.json
@@ -41,6 +41,7 @@
   "timer_refresh": 1.0,
   "disable_timer_updates": false,
   "preserve_command": false,
+  "clear_query_after_run": false,
   "net_refresh": 1.0,
   "net_unit": "auto",
   "screenshot_dir": null,

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -116,6 +116,7 @@ impl PluginEditor {
                         s.static_pos,
                         s.static_size,
                         Some(s.hide_after_run),
+                        Some(s.clear_query_after_run),
                         Some(s.timer_refresh),
                         Some(s.disable_timer_updates),
                         Some(s.preserve_command),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -149,6 +149,9 @@ pub struct Settings {
     /// Keep the command prefix in the query after running an action.
     #[serde(default)]
     pub preserve_command: bool,
+    /// Clear the search query after successfully running an action.
+    #[serde(default)]
+    pub clear_query_after_run: bool,
     #[serde(default = "default_net_refresh")]
     pub net_refresh: f32,
     #[serde(default)]
@@ -294,6 +297,7 @@ impl Default for Settings {
             net_unit: NetUnit::Auto,
             disable_timer_updates: false,
             preserve_command: false,
+            clear_query_after_run: false,
             show_examples: false,
             screenshot_dir: Some(
                 std::env::current_dir()

--- a/src/settings_editor.rs
+++ b/src/settings_editor.rs
@@ -51,6 +51,7 @@ pub struct SettingsEditor {
     timer_refresh: f32,
     disable_timer_updates: bool,
     preserve_command: bool,
+    clear_query_after_run: bool,
     query_autocomplete: bool,
     net_refresh: f32,
     net_unit: crate::settings::NetUnit,
@@ -140,6 +141,7 @@ impl SettingsEditor {
             timer_refresh: settings.timer_refresh,
             disable_timer_updates: settings.disable_timer_updates,
             preserve_command: settings.preserve_command,
+            clear_query_after_run: settings.clear_query_after_run,
             query_autocomplete: settings.query_autocomplete,
             net_refresh: settings.net_refresh,
             net_unit: settings.net_unit,
@@ -252,6 +254,7 @@ impl SettingsEditor {
             timer_refresh: self.timer_refresh,
             disable_timer_updates: self.disable_timer_updates,
             preserve_command: self.preserve_command,
+            clear_query_after_run: self.clear_query_after_run,
             query_autocomplete: self.query_autocomplete,
             net_refresh: self.net_refresh,
             net_unit: self.net_unit,
@@ -357,9 +360,15 @@ impl SettingsEditor {
                                 );
                             });
                         }
-                        ui.checkbox(&mut self.hide_after_run, "Hide window after running action");
+                        ui.horizontal_wrapped(|ui| {
+                            ui.checkbox(
+                                &mut self.hide_after_run,
+                                "Hide window after running action",
+                            );
+                            ui.checkbox(&mut self.preserve_command, "Preserve command after run");
+                            ui.checkbox(&mut self.clear_query_after_run, "Clear query after run");
+                        });
                         ui.checkbox(&mut self.always_on_top, "Always on top");
-                        ui.checkbox(&mut self.preserve_command, "Preserve command after run");
                         ui.checkbox(&mut self.query_autocomplete, "Enable query autocomplete");
                         ui.checkbox(
                             &mut self.disable_timer_updates,
@@ -642,6 +651,7 @@ impl SettingsEditor {
                                                 new_settings.static_pos,
                                                 new_settings.static_size,
                                                 Some(new_settings.hide_after_run),
+                                                Some(new_settings.clear_query_after_run),
                                                 Some(new_settings.timer_refresh),
                                                 Some(new_settings.disable_timer_updates),
                                                 Some(new_settings.preserve_command),
@@ -680,6 +690,8 @@ impl SettingsEditor {
                                             app.clipboard_limit = new_settings.clipboard_limit;
                                             app.page_jump = new_settings.page_jump;
                                             app.preserve_command = new_settings.preserve_command;
+                                            app.clear_query_after_run =
+                                                new_settings.clear_query_after_run;
                                             app.query_autocomplete =
                                                 new_settings.query_autocomplete;
                                             app.net_refresh = new_settings.net_refresh;

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -78,6 +78,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();


### PR DESCRIPTION
## Summary
- add a `clear_query_after_run` setting with documentation, defaults, and sample config updates
- expose the new toggle in the settings UI, propagate it through plugin/settings saves, and store it on the app
- clear the query after running actions when the option is enabled while keeping command-specific overrides intact

## Testing
- `cargo fmt`
- `cargo test` *(fails: missing system library `alsa` for `alsa-sys` build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d73b5c208c83329f4129d25b7474f5