### PR TITLE
Add filter UI to Snippets dialog and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mouse_gestures.json
 todo.json
 dashboard.json
 /notes
+snippets.json

--- a/src/gui/snippet_dialog.rs
+++ b/src/gui/snippet_dialog.rs
@@ -10,6 +10,18 @@ pub struct SnippetDialog {
     edit_idx: Option<usize>,
     alias: String,
     text: String,
+    filter: String,
+}
+
+fn matches_snippet_filter(entry: &SnippetEntry, filter: &str) -> bool {
+    let filter = filter.trim();
+    if filter.is_empty() {
+        return true;
+    }
+
+    let lowered_filter = filter.to_lowercase();
+    entry.alias.to_lowercase().contains(&lowered_filter)
+        || entry.text.to_lowercase().contains(&lowered_filter)
 }
 
 impl SnippetDialog {
@@ -19,10 +31,12 @@ impl SnippetDialog {
         self.edit_idx = None;
         self.alias.clear();
         self.text.clear();
+        self.filter.clear();
     }
 
     pub fn open_edit(&mut self, alias: &str) {
         self.entries = load_snippets(SNIPPETS_FILE).unwrap_or_default();
+        self.filter.clear();
         if let Some(pos) = self.entries.iter().position(|e| e.alias == alias) {
             self.edit_idx = Some(pos);
             self.alias = alias.to_string();
@@ -97,11 +111,20 @@ impl SnippetDialog {
                     });
                 } else {
                     let mut remove: Option<usize> = None;
+                    ui.horizontal(|ui| {
+                        ui.label("Filter");
+                        ui.add(egui::TextEdit::singleline(&mut self.filter));
+                    });
+                    let mut shown_count = 0usize;
                     egui::ScrollArea::vertical()
                         .max_height(200.0)
                         .show(ui, |ui| {
                             for idx in 0..self.entries.len() {
                                 let entry = self.entries[idx].clone();
+                                if !matches_snippet_filter(&entry, &self.filter) {
+                                    continue;
+                                }
+                                shown_count += 1;
                                 ui.horizontal(|ui| {
                                     ui.label(format!(
                                         "{}: {}",
@@ -119,6 +142,9 @@ impl SnippetDialog {
                                 });
                             }
                         });
+                    if shown_count == 0 {
+                        ui.label("No snippets match filter");
+                    }
                     if let Some(idx) = remove {
                         self.entries.remove(idx);
                         save_now = true;
@@ -139,5 +165,50 @@ impl SnippetDialog {
         if close {
             self.open = false;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_snippet_filter;
+    use crate::plugins::snippets::SnippetEntry;
+
+    fn snippet(alias: &str, text: &str) -> SnippetEntry {
+        SnippetEntry {
+            alias: alias.to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_filter_matches_all() {
+        let entry = snippet("greet", "hello world");
+        assert!(matches_snippet_filter(&entry, ""));
+        assert!(matches_snippet_filter(&entry, "   "));
+    }
+
+    #[test]
+    fn alias_only_match() {
+        let entry = snippet("git-status", "show status");
+        assert!(matches_snippet_filter(&entry, "status"));
+    }
+
+    #[test]
+    fn text_only_match() {
+        let entry = snippet("gs", "Git Status Output");
+        assert!(matches_snippet_filter(&entry, "output"));
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        let entry = snippet("DockerUp", "Start Containers");
+        assert!(matches_snippet_filter(&entry, "docker"));
+        assert!(matches_snippet_filter(&entry, "CONTAINERS"));
+    }
+
+    #[test]
+    fn non_match_behavior() {
+        let entry = snippet("deploy", "release production");
+        assert!(!matches_snippet_filter(&entry, "staging"));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a quick, case-insensitive way to filter snippets by alias or text in the Snippets dialog to improve discoverability and UX.
- Keep edit/remove actions working correctly when the list is filtered by preserving original indices.

### Description
- Add `filter: String` to `SnippetDialog` state and clear it in both `open()` and `open_edit()` for consistent behavior.
- Introduce a pure helper `matches_snippet_filter(entry, filter)` that performs case-insensitive `to_lowercase().contains()` matching against alias and text with empty/whitespace filters matching all.
- Add a non-edit UI row containing `Filter` + `egui::TextEdit::singleline` above the scroll list and apply the filter in the render loop by skipping non-matching rows while keeping original `idx` so `Edit`/`Remove` mutate the correct entry.
- Show a lightweight message `No snippets match filter` when nothing is visible, and keep the `Add Snippet` button available regardless of filter results.
- Add unit tests next to the dialog for `matches_snippet_filter` covering empty-filter, alias-only, text-only, case-insensitive, and non-match behavior.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test snippet_dialog -- --nocapture`, but the build failed in this environment due to a missing system dependency required by a transitive crate (`alsa.pc` not found; `alsa-sys` pkg-config failure), so the Rust test binary could not be produced here.
- Unit tests were added and are pure Rust logic; they should run successfully in an environment where the project builds (i.e., with system deps installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b35a7108288332b29ab2110625e7e7)