### PR TITLE
Add launcher-owned MultiManager state

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -92,6 +92,8 @@ use crate::indexer;
 use crate::launcher::launch_action;
 use crate::mouse_gestures::db::{load_gestures, save_gestures, GESTURES_FILE};
 use crate::mouse_gestures::selection::{GestureFocusArgs, GestureToggleArgs};
+use crate::multi_manager::state::MultiManagerState;
+use crate::multi_manager::ui::{MultiManagerDialog, MultiManagerSettingsDialog};
 use crate::plugin::{PluginManager, CAP_FORCE_LIST_RESULTS, CAP_GRID_RESULTS_COMPATIBLE};
 use crate::plugin_editor::PluginEditor;
 use crate::plugins::note::{NoteExternalOpen, NotePluginSettings};
@@ -346,6 +348,9 @@ pub struct LauncherApp {
     pub settings_editor: SettingsEditor,
     pub plugin_editor: PluginEditor,
     pub settings_path: String,
+    pub multi_manager: MultiManagerState,
+    pub multi_manager_dialog: MultiManagerDialog,
+    pub multi_manager_settings_dialog: MultiManagerSettingsDialog,
     /// Hold watchers so the `RecommendedWatcher` instances remain active.
     #[allow(dead_code)] // required to keep watchers alive
     watchers: Vec<RecommendedWatcher>,
@@ -1036,6 +1041,8 @@ impl LauncherApp {
             .unwrap_or(NoteExternalOpen::Wezterm);
 
         let settings_editor = SettingsEditor::new_with_plugins(&settings);
+        let multi_manager =
+            MultiManagerState::load_or_default(&settings.multi_manager, &settings_path);
         let plugin_editor = PluginEditor::new(&settings);
         let actions_by_id = actions
             .iter()
@@ -1062,6 +1069,9 @@ impl LauncherApp {
             settings_editor,
             plugin_editor,
             settings_path,
+            multi_manager,
+            multi_manager_dialog: MultiManagerDialog::default(),
+            multi_manager_settings_dialog: MultiManagerSettingsDialog::default(),
             watchers,
             dashboard,
             dashboard_data_cache,

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1316,6 +1316,15 @@ impl eframe::App for LauncherApp {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        self.multi_manager.shutdown();
+        let multi_manager_save_on_exit = crate::settings::Settings::load(&self.settings_path)
+            .map(|settings| settings.multi_manager.save_on_exit)
+            .unwrap_or(true);
+        if multi_manager_save_on_exit {
+            if let Err(err) = self.multi_manager.save() {
+                self.report_error("multi_manager.save_on_exit", err);
+            }
+        }
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;

--- a/src/multi_manager/mod.rs
+++ b/src/multi_manager/mod.rs
@@ -2,6 +2,7 @@ pub mod bindings;
 pub mod commands;
 pub mod model;
 pub mod runtime;
+pub mod state;
 pub mod store;
 pub mod ui;
 pub mod win;

--- a/src/multi_manager/model.rs
+++ b/src/multi_manager/model.rs
@@ -145,3 +145,9 @@ pub enum PendingCaptureAction {
         workspace_id: String,
     },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RecaptureQueueItem {
+    #[serde(default)]
+    pub workspace_id: String,
+}

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -66,6 +66,15 @@ pub struct MultiManagerRuntime {
 }
 
 impl MultiManagerRuntime {
+    pub fn inactive(workspaces: Arc<Mutex<Vec<MmWorkspace>>>) -> Self {
+        Self {
+            workspaces,
+            control: Arc::new(RuntimeControl::new(false)),
+            last_hotkey_info: Arc::new(Mutex::new(None)),
+            join_handle: None,
+        }
+    }
+
     pub fn start(workspaces: Arc<Mutex<Vec<MmWorkspace>>>, settings: MultiManagerSettings) -> Self {
         let control = Arc::new(RuntimeControl::new(settings.enabled));
         let last_hotkey_info = Arc::new(Mutex::new(None));

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -1,0 +1,247 @@
+use crate::multi_manager::model::{MmWorkspace, PendingCaptureAction, RecaptureQueueItem};
+use crate::multi_manager::runtime::MultiManagerRuntime;
+use crate::multi_manager::store;
+use crate::settings::MultiManagerSettings;
+use anyhow::{Context, Result};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
+
+pub struct MultiManagerState {
+    pub dirty: bool,
+    pub pending_capture: Option<PendingCaptureAction>,
+    pub recapture_queue: VecDeque<RecaptureQueueItem>,
+    pub recapture_active: bool,
+    pub workspaces: Arc<Mutex<Vec<MmWorkspace>>>,
+    pub runtime: MultiManagerRuntime,
+    pub last_hotkey_info: Arc<Mutex<Option<(String, Instant)>>>,
+    pub workspace_path: PathBuf,
+    pub bindings_path: PathBuf,
+    pub auto_save: bool,
+    save_debounce: Duration,
+    dirty_since: Option<Instant>,
+    last_save_attempt: Option<Instant>,
+}
+
+impl MultiManagerState {
+    pub fn load_or_default(settings: &MultiManagerSettings, settings_path: &str) -> Self {
+        let settings_dir = Path::new(settings_path)
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+        let workspace_path = resolve_relative_to(settings_dir, &settings.workspaces_path);
+        let bindings_path = resolve_relative_to(settings_dir, &settings.bindings_path);
+        let workspaces = Arc::new(Mutex::new(store::load_or_default(&workspace_path)));
+        let runtime = if settings.enabled {
+            MultiManagerRuntime::start(Arc::clone(&workspaces), settings.clone())
+        } else {
+            MultiManagerRuntime::inactive(Arc::clone(&workspaces))
+        };
+        let last_hotkey_info = Arc::clone(&runtime.last_hotkey_info);
+
+        Self {
+            dirty: false,
+            pending_capture: None,
+            recapture_queue: VecDeque::new(),
+            recapture_active: false,
+            workspaces,
+            runtime,
+            last_hotkey_info,
+            workspace_path,
+            bindings_path,
+            auto_save: settings.auto_save,
+            save_debounce: AUTO_SAVE_DEBOUNCE,
+            dirty_since: None,
+            last_save_attempt: None,
+        }
+    }
+
+    pub fn save(&mut self) -> Result<()> {
+        let workspaces = self
+            .workspaces
+            .lock()
+            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))?;
+        store::save_workspaces(&self.workspace_path, &workspaces).with_context(|| {
+            format!(
+                "failed to save MultiManager workspaces to {}",
+                self.workspace_path.display()
+            )
+        })?;
+        self.dirty = false;
+        self.dirty_since = None;
+        self.last_save_attempt = Some(Instant::now());
+        Ok(())
+    }
+
+    pub fn reload(&mut self) -> Result<()> {
+        let loaded = store::load_workspaces(&self.workspace_path)?;
+        let mut workspaces = self
+            .workspaces
+            .lock()
+            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))?;
+        *workspaces = loaded;
+        self.dirty = false;
+        self.dirty_since = None;
+        Ok(())
+    }
+
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+        if self.dirty_since.is_none() {
+            self.dirty_since = Some(Instant::now());
+        }
+    }
+
+    pub fn save_debounced(&mut self) {
+        self.mark_dirty();
+        self.maybe_auto_save();
+    }
+
+    pub fn maybe_auto_save(&mut self) {
+        if !self.auto_save || !self.dirty {
+            return;
+        }
+        if self
+            .dirty_since
+            .is_some_and(|dirty_since| dirty_since.elapsed() >= self.save_debounce)
+        {
+            if let Err(err) = self.save() {
+                tracing::error!(error = %err, "failed to auto-save MultiManager workspaces");
+                self.last_save_attempt = Some(Instant::now());
+            }
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        self.runtime.shutdown();
+    }
+
+    pub fn with_workspace_mut<R>(
+        &mut self,
+        id: &str,
+        f: impl FnOnce(&mut MmWorkspace) -> R,
+    ) -> Option<R> {
+        let result = {
+            let mut workspaces = self.workspaces.lock().ok()?;
+            let workspace = workspaces.iter_mut().find(|workspace| workspace.id == id)?;
+            f(workspace)
+        };
+        self.mark_dirty();
+        Some(result)
+    }
+
+    #[cfg(test)]
+    fn force_debounce_elapsed(&mut self) {
+        self.dirty_since = Some(Instant::now() - self.save_debounce - Duration::from_millis(1));
+    }
+}
+
+fn resolve_relative_to(base: &Path, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::multi_manager::model::MmWorkspace;
+
+    #[test]
+    fn default_state_resolves_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        assert_eq!(
+            state.workspace_path,
+            dir.path().join("multi_manager_workspaces.json")
+        );
+        assert_eq!(
+            state.bindings_path,
+            dir.path().join("multi_manager_bindings.json")
+        );
+    }
+
+    #[test]
+    fn dirty_flag_changes_after_mutation() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.workspaces.lock().unwrap().push(MmWorkspace {
+            id: "a".into(),
+            ..Default::default()
+        });
+        state.with_workspace_mut("a", |workspace| workspace.name = "changed".into());
+        assert!(state.dirty);
+    }
+
+    #[test]
+    fn autosave_clears_dirty_after_successful_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                auto_save: true,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.workspaces.lock().unwrap().push(MmWorkspace {
+            id: "a".into(),
+            ..Default::default()
+        });
+        state.mark_dirty();
+        state.force_debounce_elapsed();
+        state.maybe_auto_save();
+        assert!(!state.dirty);
+        assert!(state.workspace_path.exists());
+    }
+
+    #[test]
+    fn save_on_exit_path_can_be_called_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.shutdown();
+        state.save().unwrap();
+    }
+
+    #[test]
+    fn runtime_shutdown_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.shutdown();
+        state.shutdown();
+    }
+}

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -1,1 +1,9 @@
+#[derive(Debug, Default)]
+pub struct MultiManagerDialog {
+    pub open: bool,
+}
 
+#[derive(Debug, Default)]
+pub struct MultiManagerSettingsDialog {
+    pub open: bool,
+}


### PR DESCRIPTION
### Motivation
- Provide a launcher-owned container for MultiManager runtime and data to keep launcher logic from being bloated with MultiManager internals.
- Ensure workspace and bindings paths are resolved relative to the launcher settings file and allow the runtime to be started only when enabled.
- Track dirty/autosave metadata and lifecycle so workspaces can be saved without blocking or scattering logic across unrelated modules.

### Description
- Add `MultiManagerState` in `src/multi_manager/state.rs` that owns `dirty`, `pending_capture`, `recapture_queue`, `recapture_active`, `workspaces: Arc<Mutex<Vec<MmWorkspace>>>`, `runtime: MultiManagerRuntime`, `last_hotkey_info`, resolved `workspace_path` and `bindings_path`, `auto_save` and debounce metadata, plus methods `load_or_default`, `save`, `reload`, `mark_dirty`, `save_debounced`, `maybe_auto_save`, `shutdown`, and `with_workspace_mut` and helper `resolve_relative_to`.
- Add `MultiManagerRuntime::inactive` to `src/multi_manager/runtime.rs` so state can be created without spawning the runtime when `enabled` is false.
- Add `RecaptureQueueItem` to `src/multi_manager/model.rs` and small dialog placeholder structs `MultiManagerDialog` and `MultiManagerSettingsDialog` in `src/multi_manager/ui.rs` to hold launcher-owned dialogs.
- Wire launcher UI to own the state and dialogs: add `pub multi_manager: MultiManagerState`, `pub multi_manager_dialog: MultiManagerDialog`, and `pub multi_manager_settings_dialog: MultiManagerSettingsDialog` to `LauncherApp` and initialize `multi_manager` from `settings.multi_manager` in `LauncherApp::new`.
- Add lifecycle handling in `on_exit` (`src/gui/render.rs`) to `shutdown` the runtime and conditionally `save` workspaces when `settings.multi_manager.save_on_exit` is true, reporting errors via existing launcher error reporting.
- Add unit tests in `src/multi_manager/state.rs` for path resolution, dirty mutation, autosave clearing dirty, save-on-exit path, and idempotent runtime shutdown.

### Testing
- Ran `git diff --check` which passed without issues.
- Ran `cargo fmt --check` as part of formatting changes which completed successfully.
- Attempted `cargo test multi_manager::state --lib`, but the workspace build failed in this Linux environment due to unrelated platform-specific compile/system dependencies (missing Windows/x11 system libs and platform crates), so the new unit tests could not be executed here; the tests are targeted and should pass when run in an appropriate environment or CI with required system deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eec96fa64833289513f5b657d65c9)