### PR TITLE
Add MultiManager window binding support

### DIFF
--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -484,6 +484,10 @@ impl LauncherApp {
             self.multi_manager_save();
         } else if a.action == "mm:reload" {
             self.multi_manager_reload();
+        } else if a.action == "mm:save-bindings" {
+            self.multi_manager_save_bindings();
+        } else if a.action == "mm:restore-bindings" {
+            self.multi_manager_restore_bindings();
         } else if a.action == "mm:import" {
             self.multi_manager_import();
         } else if a.action == "mm:recapture-all" {

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::multi_manager::model::{MmWindow, PendingCaptureAction, RecaptureQueueItem};
+use crate::multi_manager::bindings;
+use crate::multi_manager::model::{PendingCaptureAction, RecaptureQueueItem};
 use crate::multi_manager::win::{self, CaptureKeyAction};
 use std::sync::atomic::Ordering;
 
@@ -40,13 +41,13 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_start_recapture_all(&mut self) {
-        let workspace_ids = self.multi_manager.workspaces.lock().ok().map(|workspaces| {
-            workspaces
-                .iter()
-                .map(|workspace| workspace.id.clone())
-                .collect::<Vec<_>>()
-        });
-        let Some(workspace_ids) = workspace_ids else {
+        let queue = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .ok()
+            .map(|workspaces| build_recapture_queue(&workspaces));
+        let Some(queue) = queue else {
             self.report_error_message(
                 "multi_manager.recapture",
                 "Failed to lock MultiManager workspaces for recapture",
@@ -54,20 +55,79 @@ impl LauncherApp {
             return;
         };
 
-        if workspace_ids.is_empty() {
+        if queue.is_empty() {
             self.report_error_message(
                 "multi_manager.recapture",
-                "No MultiManager workspaces to recapture",
+                "No invalid or missing MultiManager window bindings to recapture",
             );
             return;
         }
 
-        self.multi_manager.recapture_queue = workspace_ids
-            .into_iter()
-            .map(|workspace_id| RecaptureQueueItem { workspace_id })
-            .collect();
+        self.multi_manager.recapture_queue = queue.into();
         self.multi_manager.recapture_active = true;
-        self.add_success_toast("Started MultiManager recapture for all workspaces");
+        self.add_success_toast("Started MultiManager window recapture queue");
+    }
+
+    pub fn multi_manager_save_bindings(&mut self) {
+        let result = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))
+            .and_then(|workspaces| {
+                bindings::save_bindings(&self.multi_manager.bindings_path, &workspaces)
+            });
+        match result {
+            Ok(()) => self.add_success_toast("Saved MultiManager window bindings"),
+            Err(err) => self.report_error_message(
+                "multi_manager.bindings",
+                format!("Failed to save bindings: {err}"),
+            ),
+        }
+    }
+
+    pub fn multi_manager_restore_bindings(&mut self) {
+        match bindings::load_bindings(&self.multi_manager.bindings_path) {
+            Ok(snapshots) => {
+                let restored =
+                    self.multi_manager.workspaces.lock().map(|mut workspaces| {
+                        bindings::restore_bindings(&mut workspaces, &snapshots)
+                    });
+                match restored {
+                    Ok(()) => {
+                        self.multi_manager.mark_dirty();
+                        self.add_success_toast("Restored MultiManager window bindings");
+                    }
+                    Err(_) => self.report_error_message(
+                        "multi_manager.bindings",
+                        "Failed to lock workspaces for binding restore",
+                    ),
+                }
+            }
+            Err(err) => self.report_error_message(
+                "multi_manager.bindings",
+                format!("Failed to load bindings: {err}"),
+            ),
+        }
+    }
+
+    pub fn multi_manager_refresh_titles(&mut self) {
+        let changed = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .map(|mut workspaces| bindings::refresh_titles(&mut workspaces));
+        match changed {
+            Ok(true) => {
+                self.multi_manager.mark_dirty();
+                self.add_success_toast("Refreshed MultiManager window titles");
+            }
+            Ok(false) => self.add_success_toast("MultiManager window titles already current"),
+            Err(_) => self.report_error_message(
+                "multi_manager.titles",
+                "Failed to lock workspaces for title refresh",
+            ),
+        }
     }
 
     pub fn multi_manager_toggle_workspace(&mut self, workspace_id: &str) {
@@ -171,10 +231,10 @@ impl LauncherApp {
     pub fn multi_manager_poll_capture(&mut self, ctx: &eframe::egui::Context) {
         if self.multi_manager.pending_capture.is_none() && self.multi_manager.recapture_active {
             if let Some(item) = self.multi_manager.recapture_queue.pop_front() {
-                self.multi_manager.pending_capture =
-                    Some(PendingCaptureAction::RecaptureWorkspace {
-                        workspace_id: item.workspace_id,
-                    });
+                self.multi_manager.pending_capture = Some(PendingCaptureAction::RecaptureWindow {
+                    workspace_id: item.workspace_id,
+                    window_id: item.window_index.to_string(),
+                });
                 self.multi_manager
                     .runtime
                     .control
@@ -225,9 +285,8 @@ impl LauncherApp {
             return;
         }
         match action {
-            PendingCaptureAction::CaptureWorkspace { workspace_id }
-            | PendingCaptureAction::RecaptureWorkspace { workspace_id } => {
-                let window = MmWindow {
+            PendingCaptureAction::CaptureWorkspace { workspace_id } => {
+                let window = crate::multi_manager::model::MmWindow {
                     alias: captured.title.clone(),
                     title: captured.title,
                     hwnd: captured.hwnd,
@@ -236,11 +295,13 @@ impl LauncherApp {
                     ..Default::default()
                 };
                 self.multi_manager
-                    .with_workspace_mut(&workspace_id, |workspace| {
-                        workspace.windows.push(window);
-                    });
+                    .with_workspace_mut(&workspace_id, |workspace| workspace.windows.push(window));
             }
             PendingCaptureAction::CaptureWindow {
+                workspace_id,
+                window_id,
+            }
+            | PendingCaptureAction::RecaptureWindow {
                 workspace_id,
                 window_id,
             } => {
@@ -289,5 +350,58 @@ impl LauncherApp {
                 options: ToastOptions::default().duration_in_seconds(self.toast_duration as f64),
             });
         }
+    }
+}
+
+pub(crate) fn build_recapture_queue(
+    workspaces: &[crate::multi_manager::model::MmWorkspace],
+) -> Vec<RecaptureQueueItem> {
+    workspaces
+        .iter()
+        .flat_map(|workspace| {
+            workspace
+                .windows
+                .iter()
+                .enumerate()
+                .filter_map(|(window_index, window)| {
+                    (window.hwnd == 0 || !win::is_valid_window(window.hwnd)).then(|| {
+                        RecaptureQueueItem {
+                            workspace_id: workspace.id.clone(),
+                            window_index,
+                        }
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_recapture_queue;
+    use crate::multi_manager::model::{MmWindow, MmWorkspace};
+    use std::collections::VecDeque;
+
+    #[test]
+    fn recapture_queue_skips_cancels_and_advances() {
+        let workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: vec![
+                MmWindow {
+                    hwnd: 0,
+                    ..Default::default()
+                },
+                MmWindow {
+                    hwnd: 0,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }];
+        let mut queue: VecDeque<_> = build_recapture_queue(&workspaces).into();
+        assert_eq!(queue.pop_front().unwrap().window_index, 0); // current item skipped
+        assert_eq!(queue.pop_front().unwrap().window_index, 1); // queue advanced
+        queue.clear(); // Escape cancels remaining queue
+        assert!(queue.is_empty());
     }
 }

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -89,16 +89,21 @@ impl LauncherApp {
     pub fn multi_manager_restore_bindings(&mut self) {
         match bindings::load_bindings(&self.multi_manager.bindings_path) {
             Ok(snapshots) => {
-                let restored =
-                    self.multi_manager.workspaces.lock().map(|mut workspaces| {
-                        bindings::restore_bindings(&mut workspaces, &snapshots)
-                    });
+                let restored = {
+                    match self.multi_manager.workspaces.lock() {
+                        Ok(mut workspaces) => {
+                            bindings::restore_bindings(&mut workspaces, &snapshots);
+                            Ok(())
+                        }
+                        Err(_) => Err(()),
+                    }
+                };
                 match restored {
                     Ok(()) => {
                         self.multi_manager.mark_dirty();
                         self.add_success_toast("Restored MultiManager window bindings");
                     }
-                    Err(_) => self.report_error_message(
+                    Err(()) => self.report_error_message(
                         "multi_manager.bindings",
                         "Failed to lock workspaces for binding restore",
                     ),
@@ -112,18 +117,19 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_refresh_titles(&mut self) {
-        let changed = self
-            .multi_manager
-            .workspaces
-            .lock()
-            .map(|mut workspaces| bindings::refresh_titles(&mut workspaces));
+        let changed = {
+            match self.multi_manager.workspaces.lock() {
+                Ok(mut workspaces) => Ok(bindings::refresh_titles(&mut workspaces)),
+                Err(_) => Err(()),
+            }
+        };
         match changed {
             Ok(true) => {
                 self.multi_manager.mark_dirty();
                 self.add_success_toast("Refreshed MultiManager window titles");
             }
             Ok(false) => self.add_success_toast("MultiManager window titles already current"),
-            Err(_) => self.report_error_message(
+            Err(()) => self.report_error_message(
                 "multi_manager.titles",
                 "Failed to lock workspaces for title refresh",
             ),

--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -1,1 +1,275 @@
+use crate::multi_manager::model::MmWorkspace;
+use crate::multi_manager::win;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WorkspaceBindingSnapshot {
+    pub workspace_id: Option<String>,
+    pub workspace_name: String,
+    #[serde(default)]
+    pub windows: Vec<WindowBindingSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WindowBindingSnapshot {
+    pub window_id: usize,
+    pub window_index: usize,
+    pub title: String,
+    pub alias: Option<String>,
+    pub hwnd: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateHwnd {
+    pub hwnd: usize,
+    pub locations: Vec<(usize, usize)>,
+}
+
+pub fn save_bindings(path: &Path, workspaces: &[MmWorkspace]) -> Result<()> {
+    let snapshots = workspaces
+        .iter()
+        .map(|workspace| WorkspaceBindingSnapshot {
+            workspace_id: (!workspace.id.is_empty()).then(|| workspace.id.clone()),
+            workspace_name: workspace.name.clone(),
+            windows: workspace
+                .windows
+                .iter()
+                .enumerate()
+                .filter(|(_, window)| window.hwnd != 0 && win::is_valid_window(window.hwnd))
+                .map(|(index, window)| WindowBindingSnapshot {
+                    window_id: index,
+                    window_index: index,
+                    title: window.title.clone(),
+                    alias: (!window.alias.is_empty()).then(|| window.alias.clone()),
+                    hwnd: window.hwnd,
+                })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&snapshots)?)
+        .with_context(|| format!("write {}", path.display()))
+}
+
+pub fn load_bindings(path: &Path) -> Result<Vec<WorkspaceBindingSnapshot>> {
+    let data = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&data).with_context(|| format!("parse {}", path.display()))
+}
+
+pub fn restore_bindings(workspaces: &mut [MmWorkspace], snapshots: &[WorkspaceBindingSnapshot]) {
+    restore_bindings_with_validator(workspaces, snapshots, win::is_valid_window);
+}
+
+fn restore_bindings_with_validator(
+    workspaces: &mut [MmWorkspace],
+    snapshots: &[WorkspaceBindingSnapshot],
+    is_valid: impl Fn(usize) -> bool,
+) {
+    for snapshot in snapshots {
+        let workspace_index = snapshot
+            .workspace_id
+            .as_deref()
+            .and_then(|id| (!id.is_empty()).then_some(id))
+            .and_then(|id| workspaces.iter().position(|workspace| workspace.id == id))
+            .or_else(|| {
+                workspaces
+                    .iter()
+                    .position(|workspace| workspace.name == snapshot.workspace_name)
+            });
+        let Some(workspace_index) = workspace_index else {
+            continue;
+        };
+        let workspace = &mut workspaces[workspace_index];
+        for window_snapshot in &snapshot.windows {
+            if window_snapshot.hwnd == 0 || !is_valid(window_snapshot.hwnd) {
+                continue;
+            }
+            if let Some(window_index) = find_window_index(workspace, window_snapshot) {
+                workspace.windows[window_index].hwnd = window_snapshot.hwnd;
+            }
+        }
+    }
+}
+
+fn find_window_index(workspace: &MmWorkspace, snapshot: &WindowBindingSnapshot) -> Option<usize> {
+    if snapshot.window_id < workspace.windows.len() {
+        return Some(snapshot.window_id);
+    }
+    if let Some(alias) = snapshot.alias.as_deref().filter(|alias| !alias.is_empty()) {
+        if let Some(index) = workspace
+            .windows
+            .iter()
+            .position(|window| window.alias == alias)
+        {
+            return Some(index);
+        }
+    }
+    if !snapshot.title.is_empty() {
+        if let Some(index) = workspace
+            .windows
+            .iter()
+            .position(|window| window.title == snapshot.title)
+        {
+            return Some(index);
+        }
+    }
+    (snapshot.window_index < workspace.windows.len()).then_some(snapshot.window_index)
+}
+
+pub fn duplicate_hwnds(workspaces: &[MmWorkspace]) -> Vec<DuplicateHwnd> {
+    let mut map: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
+    for (workspace_index, workspace) in workspaces.iter().enumerate() {
+        for (window_index, window) in workspace.windows.iter().enumerate() {
+            if window.hwnd != 0 {
+                map.entry(window.hwnd)
+                    .or_default()
+                    .push((workspace_index, window_index));
+            }
+        }
+    }
+    let mut duplicates = map
+        .into_iter()
+        .filter_map(|(hwnd, locations)| {
+            (locations.len() > 1).then_some(DuplicateHwnd { hwnd, locations })
+        })
+        .collect::<Vec<_>>();
+    duplicates.sort_by_key(|duplicate| duplicate.hwnd);
+    duplicates
+}
+
+pub fn refresh_titles_with(
+    workspaces: &mut [MmWorkspace],
+    is_valid: impl Fn(usize) -> bool,
+    title: impl Fn(usize) -> Option<String>,
+) -> bool {
+    let mut changed = false;
+    for workspace in workspaces {
+        for window in &mut workspace.windows {
+            if window.hwnd != 0 && is_valid(window.hwnd) {
+                if let Some(new_title) = title(window.hwnd) {
+                    if window.title != new_title {
+                        window.title = new_title;
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+    changed
+}
+
+pub fn refresh_titles(workspaces: &mut [MmWorkspace]) -> bool {
+    refresh_titles_with(workspaces, win::is_valid_window, win::window_title)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::multi_manager::model::{MmWindow, MmWorkspace};
+
+    fn ws(id: &str, name: &str, windows: Vec<MmWindow>) -> MmWorkspace {
+        MmWorkspace {
+            id: id.into(),
+            name: name.into(),
+            windows,
+            ..Default::default()
+        }
+    }
+    fn win(alias: &str, title: &str, hwnd: usize) -> MmWindow {
+        MmWindow {
+            alias: alias.into(),
+            title: title.into(),
+            hwnd,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn binding_save_omits_invalid_hwnds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bindings.json");
+        save_bindings(&path, &[ws("id", "name", vec![win("a", "t", 123)])]).unwrap();
+        let loaded = load_bindings(&path).unwrap();
+        assert!(loaded[0].windows.is_empty());
+    }
+
+    #[test]
+    fn restore_prefers_workspace_id_over_name() {
+        let mut workspaces = vec![
+            ws("target", "same", vec![win("", "", 0)]),
+            ws("other", "old", vec![win("", "", 0)]),
+        ];
+        let snapshots = vec![WorkspaceBindingSnapshot {
+            workspace_id: Some("target".into()),
+            workspace_name: "old".into(),
+            windows: vec![WindowBindingSnapshot {
+                hwnd: 7,
+                ..Default::default()
+            }],
+        }];
+        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| true);
+        assert_eq!(workspaces[0].windows[0].hwnd, 7);
+        assert_eq!(workspaces[1].windows[0].hwnd, 0);
+    }
+
+    #[test]
+    fn restore_falls_back_to_name_when_id_absent() {
+        let mut workspaces = vec![ws("id", "name", vec![win("", "", 0)])];
+        let snapshots = vec![WorkspaceBindingSnapshot {
+            workspace_id: None,
+            workspace_name: "name".into(),
+            windows: vec![WindowBindingSnapshot {
+                hwnd: 8,
+                ..Default::default()
+            }],
+        }];
+        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| true);
+        assert_eq!(workspaces[0].windows[0].hwnd, 8);
+    }
+
+    #[test]
+    fn invalid_hwnds_are_not_restored() {
+        let mut workspaces = vec![ws("id", "name", vec![win("", "", 0)])];
+        let snapshots = vec![WorkspaceBindingSnapshot {
+            workspace_id: Some("id".into()),
+            workspace_name: "name".into(),
+            windows: vec![WindowBindingSnapshot {
+                hwnd: 9,
+                ..Default::default()
+            }],
+        }];
+        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| false);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+    }
+
+    #[test]
+    fn duplicate_hwnd_detection_reports_all_duplicates() {
+        let duplicates = duplicate_hwnds(&[
+            ws("a", "a", vec![win("", "", 5)]),
+            ws(
+                "b",
+                "b",
+                vec![win("", "", 5), win("", "", 6), win("", "", 5)],
+            ),
+        ]);
+        assert_eq!(duplicates[0].hwnd, 5);
+        assert_eq!(duplicates[0].locations, vec![(0, 0), (1, 0), (1, 2)]);
+    }
+
+    #[test]
+    fn title_refresh_preserves_aliases() {
+        let mut workspaces = vec![ws("id", "name", vec![win("alias", "old", 4)])];
+        assert!(refresh_titles_with(
+            &mut workspaces,
+            |_| true,
+            |_| Some("new".into())
+        ));
+        assert_eq!(workspaces[0].windows[0].title, "new");
+        assert_eq!(workspaces[0].windows[0].alias, "alias");
+    }
+}

--- a/src/multi_manager/commands.rs
+++ b/src/multi_manager/commands.rs
@@ -1,10 +1,20 @@
 use crate::actions::Action;
 
-const COMMANDS: [(&str, &str, &str); 6] = [
+const COMMANDS: [(&str, &str, &str); 8] = [
     ("mm", "Open MultiManager", "mm:open"),
     ("mm settings", "Open MultiManager settings", "mm:settings"),
     ("mm save", "Save MultiManager workspaces", "mm:save"),
     ("mm reload", "Reload MultiManager workspaces", "mm:reload"),
+    (
+        "mm save bindings",
+        "Save MultiManager window bindings",
+        "mm:save-bindings",
+    ),
+    (
+        "mm restore bindings",
+        "Restore MultiManager window bindings",
+        "mm:restore-bindings",
+    ),
     (
         "mm recapture all",
         "Recapture all MultiManager workspaces",

--- a/src/multi_manager/model.rs
+++ b/src/multi_manager/model.rs
@@ -143,8 +143,9 @@ pub enum PendingCaptureAction {
         workspace_id: String,
         window_id: String,
     },
-    RecaptureWorkspace {
+    RecaptureWindow {
         workspace_id: String,
+        window_id: String,
     },
 }
 
@@ -152,4 +153,6 @@ pub enum PendingCaptureAction {
 pub struct RecaptureQueueItem {
     #[serde(default)]
     pub workspace_id: String,
+    #[serde(default)]
+    pub window_index: usize,
 }

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -1,4 +1,5 @@
 use crate::gui::LauncherApp;
+use crate::multi_manager::bindings;
 use crate::multi_manager::model::{
     new_workspace_id, MmHotkey, MmRect, MmWindow, MmWorkspace, PendingCaptureAction,
 };
@@ -65,6 +66,15 @@ impl MultiManagerDialog {
                     if ui.button("Reload").clicked() {
                         self.confirm.reload = true;
                     }
+                    if ui.button("Save Bindings").clicked() {
+                        app.multi_manager_save_bindings();
+                    }
+                    if ui.button("Restore Bindings").clicked() {
+                        app.multi_manager_restore_bindings();
+                    }
+                    if ui.button("Refresh Titles").clicked() {
+                        app.multi_manager_refresh_titles();
+                    }
                     if ui.button("Send All Home").clicked() {
                         send_all(app, true);
                     }
@@ -125,8 +135,18 @@ impl MultiManagerDialog {
     }
 
     fn capture_banner(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp) {
-        if app.multi_manager.pending_capture.is_some() {
-            ui.colored_label(egui::Color32::LIGHT_BLUE, "Capture mode active: press Enter to capture active window, S to skip supported multi-step captures, or Escape to cancel.");
+        if let Some(action) = &app.multi_manager.pending_capture {
+            ui.colored_label(egui::Color32::LIGHT_BLUE, "Capture mode active: press Enter to capture active window, S to skip current item, or Escape to cancel remaining queue.");
+            if let PendingCaptureAction::RecaptureWindow {
+                workspace_id,
+                window_id,
+            } = action
+            {
+                ui.label(format!(
+                    "Recapturing workspace {workspace_id}, window {}",
+                    window_id.parse::<usize>().map(|i| i + 1).unwrap_or(1)
+                ));
+            }
         }
     }
 
@@ -279,6 +299,9 @@ impl MultiManagerDialog {
             }
             ui.label(format!("Original title: {}", win.title));
             ui.label(format!("HWND: {}", win.hwnd));
+            if is_duplicate_hwnd(app, win.hwnd, id, index) {
+                ui.colored_label(egui::Color32::YELLOW, "⚠ duplicate HWND");
+            }
             ui.label(if win.valid { "valid" } else { "invalid" });
             rect_ui(ui, "Home", win.home_rect, |r| {
                 app.multi_manager.with_workspace_mut(id, |w| {
@@ -539,4 +562,35 @@ mod tests {
         assert!(!MultiManagerDialog::default().open);
         assert!(!MultiManagerSettingsDialog::default().open);
     }
+}
+
+fn is_duplicate_hwnd(
+    app: &LauncherApp,
+    hwnd: usize,
+    workspace_id: &str,
+    window_index: usize,
+) -> bool {
+    if hwnd == 0 {
+        return false;
+    }
+    app.multi_manager
+        .workspaces
+        .lock()
+        .map(|workspaces| {
+            bindings::duplicate_hwnds(&workspaces)
+                .into_iter()
+                .any(|duplicate| {
+                    duplicate.hwnd == hwnd
+                        && duplicate
+                            .locations
+                            .into_iter()
+                            .any(|(ws_index, win_index)| {
+                                workspaces
+                                    .get(ws_index)
+                                    .is_some_and(|workspace| workspace.id == workspace_id)
+                                    && win_index == window_index
+                            })
+                })
+        })
+        .unwrap_or(false)
 }


### PR DESCRIPTION
### Motivation
- Port and improve the old MultiManager window binding support so bindings can be saved, loaded, and restored for the embedded MultiManager implementation.
- Provide robust workspace/window identity matching and recapture flows so users can recover invalid or missing HWND bindings reliably.
- Surface helpers for duplicate detection and title refresh to make problematic bindings obvious to users and keep titles current.

### Description
- Added a new module `src/multi_manager/bindings.rs` that defines `WorkspaceBindingSnapshot` and `WindowBindingSnapshot` and implements `save_bindings`, `load_bindings`, `restore_bindings`, `duplicate_hwnds`, and `refresh_titles` (plus testable variants `restore_bindings_with_validator` and `refresh_titles_with`).
- Implemented save/load semantics that include `workspace_id: Option<String>` and `workspace_name: String`, window identity fields (`window_id`, `window_index`, `title`, `alias`, `hwnd`), and filtering so saved bindings only include valid HWNDs per `win::is_valid_window`.
- Restore logic prefers workspace ID match and falls back to workspace name, matches windows by ID first then alias/title/index, and only restores HWNDs validated by `win::is_valid_window`.
- UI and action changes: added `mm save bindings` / `mm restore bindings` commands and action routing (`mm:save-bindings`, `mm:restore-bindings`), added launcher methods `multi_manager_save_bindings`, `multi_manager_restore_bindings`, `multi_manager_refresh_titles`, added Save/Restore/Refresh buttons and duplicate-HWND warning badges in the MultiManager dialog, and reworked recapture-all to queue per-window recapture items via a new `RecaptureWindow` action and `build_recapture_queue` helper; also updated model with `RecaptureWindow` and `RecaptureQueueItem.window_index`.

### Testing
- Unit tests were added covering binding save omission of invalid HWNDs, restore preference for workspace ID over name, fallback-to-name restore, rejection of invalid HWNDs during restore, duplicate HWND detection, title refresh preserving aliases, and recapture queue progression (`src/multi_manager/bindings.rs` and `src/gui/multi_manager_actions.rs`).
- `cargo test multi_manager -- --nocapture` was attempted but could not complete due to platform-specific build issues in unrelated modules (Windows ABI bindings and system libs) in the current environment, so the new unit tests could not be executed end-to-end here.
- Formatting and basic static checks (`cargo fmt` and `git diff --check`) were run successfully prior to the attempted test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f17d4a55c8332ab14eb70e5ae60f6)