### PR TITLE
Improve launcher capture filtering

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -234,6 +234,12 @@ impl LauncherApp {
             .store(false, Ordering::Relaxed);
     }
 
+    fn is_launcher_capture(&self, captured: &crate::multi_manager::win::CapturedWindow) -> bool {
+        self.launcher_hwnd == Some(captured.hwnd)
+            || captured.title.contains("Multi Lnchr")
+            || captured.title.contains("Multi Launcher")
+    }
+
     pub fn multi_manager_poll_capture(&mut self, ctx: &eframe::egui::Context) {
         if self.multi_manager.pending_capture.is_none() && self.multi_manager.recapture_active {
             if let Some(item) = self.multi_manager.recapture_queue.pop_front() {
@@ -282,7 +288,7 @@ impl LauncherApp {
         if self
             .multi_manager_settings
             .ignore_launcher_window_on_capture
-            && self.launcher_hwnd == Some(captured.hwnd)
+            && self.is_launcher_capture(&captured)
         {
             self.report_error_message(
                 "multi_manager.capture",
@@ -385,8 +391,53 @@ pub(crate) fn build_recapture_queue(
 #[cfg(test)]
 mod tests {
     use super::build_recapture_queue;
-    use crate::multi_manager::model::{MmWindow, MmWorkspace};
+    use crate::gui::LauncherApp;
+    use crate::multi_manager::model::{MmRect, MmWindow, MmWorkspace};
+    use crate::multi_manager::win::CapturedWindow;
+    use crate::plugin::PluginManager;
+    use crate::settings::Settings;
     use std::collections::VecDeque;
+    use std::sync::{atomic::AtomicBool, Arc};
+
+    fn test_app() -> LauncherApp {
+        let ctx = eframe::egui::Context::default();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("actions.json");
+        std::fs::write(&path, "[]").expect("write actions file");
+        LauncherApp::new(
+            &ctx,
+            Arc::new(Vec::new()),
+            0,
+            PluginManager::new(),
+            path.to_string_lossy().to_string(),
+            tempdir
+                .path()
+                .join("settings.json")
+                .to_string_lossy()
+                .to_string(),
+            Settings::default(),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    fn captured(hwnd: usize, title: &str) -> CapturedWindow {
+        CapturedWindow {
+            hwnd,
+            title: title.to_string(),
+            rect: MmRect {
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100,
+            },
+        }
+    }
 
     #[test]
     fn recapture_queue_skips_cancels_and_advances() {
@@ -409,5 +460,35 @@ mod tests {
         assert_eq!(queue.pop_front().unwrap().window_index, 1); // queue advanced
         queue.clear(); // Escape cancels remaining queue
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn is_launcher_capture_matches_launcher_hwnd() {
+        let mut app = test_app();
+        app.launcher_hwnd = Some(42);
+
+        assert!(app.is_launcher_capture(&captured(42, "Notepad")));
+    }
+
+    #[test]
+    fn is_launcher_capture_matches_multi_lnchr_title() {
+        let app = test_app();
+
+        assert!(app.is_launcher_capture(&captured(100, "Multi Lnchr")));
+    }
+
+    #[test]
+    fn is_launcher_capture_matches_multi_launcher_title() {
+        let app = test_app();
+
+        assert!(app.is_launcher_capture(&captured(100, "Multi Launcher")));
+    }
+
+    #[test]
+    fn is_launcher_capture_ignores_unrelated_capture() {
+        let mut app = test_app();
+        app.launcher_hwnd = Some(42);
+
+        assert!(!app.is_launcher_capture(&captured(100, "Notepad")));
     }
 }

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -624,6 +624,9 @@ impl eframe::App for LauncherApp {
         use egui::*;
 
         // tracing::debug!("LauncherApp::update called");
+        if let Some(hwnd) = crate::window_manager::get_hwnd(_frame) {
+            self.launcher_hwnd = Some(hwnd.0 as usize);
+        }
         if self.enable_toasts {
             self.toasts.show(ctx);
         }


### PR DESCRIPTION
### Motivation
- Prevent MultiManager from capturing the launcher's own window when the user presses Enter while the launcher is focused. 
- Use a robust check (HWND + known title variants) so the launcher can be ignored even when its window handle or titles vary.

### Description
- Track the current launcher HWND at the start of the main egui update loop by calling `crate::window_manager::get_hwnd(_frame)` and storing it in `self.launcher_hwnd` (`src/gui/render.rs`).
- Add `fn is_launcher_capture(&self, captured: &crate::multi_manager::win::CapturedWindow) -> bool` on `LauncherApp` that returns true when `self.launcher_hwnd == Some(captured.hwnd)` or the captured title contains `"Multi Lnchr"` or `"Multi Launcher"` (`src/gui/multi_manager_actions.rs`).
- Use the helper in `multi_manager_complete_capture` when `self.multi_manager_settings.ignore_launcher_window_on_capture` is enabled, preserving the existing error message `"Ignoring launcher window; focus another window and press Enter"`.
- Add unit tests for `is_launcher_capture` with synthetic `CapturedWindow` values that cover HWND match, both title variants, and an unrelated capture.

### Testing
- Ran `rustfmt --check src/gui/render.rs src/gui/multi_manager_actions.rs`, which passed.
- Ran `git diff --check`, which reported no whitespace/diff issues.
- Attempted `cargo test is_launcher_capture -- --nocapture`; tests are present but the project cannot complete lib test compilation in this Linux environment because the codebase imports Windows-only APIs from the `windows` crate (and other platform native dependencies), so the test run failed due to platform/system library issues despite installing several native Linux dev packages; the `is_launcher_capture` unit tests are pure and should pass on CI/Windows or in an environment where the crate builds successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f45aa3a08833281305002172d9a4d)