### PR TITLE
Add MultiManager background capture session

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::multi_manager::bindings;
+use crate::multi_manager::capture;
 use crate::multi_manager::model::{PendingCaptureAction, RecaptureQueueItem};
-use crate::multi_manager::win::{self, CaptureKeyAction};
+use crate::multi_manager::win::{self, CaptureKeyAction, CapturedWindow};
 use std::sync::atomic::Ordering;
 
 impl LauncherApp {
@@ -167,6 +168,7 @@ impl LauncherApp {
             self.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureWorkspace {
                 workspace_id: workspace_id.to_string(),
             });
+            self.multi_manager.capture_session = None;
             self.multi_manager
                 .runtime
                 .control
@@ -224,6 +226,7 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_cancel_capture(&mut self) {
+        self.multi_manager.capture_session = None;
         self.multi_manager.pending_capture = None;
         self.multi_manager.recapture_active = false;
         self.multi_manager.recapture_queue.clear();
@@ -262,26 +265,37 @@ impl LauncherApp {
             }
         }
         if self.multi_manager.pending_capture.is_none() {
+            self.multi_manager.capture_session = None;
             return;
         }
-        ctx.request_repaint();
-        match win::poll_capture_keys() {
-            Some(CaptureKeyAction::Cancel) => self.multi_manager_cancel_capture(),
-            Some(CaptureKeyAction::Skip) => {
-                if self.multi_manager.recapture_active {
-                    self.multi_manager.pending_capture = None;
+        if self.multi_manager.capture_session.is_none() {
+            self.multi_manager.capture_session = Some(capture::start_capture_session(ctx.clone()));
+        }
+
+        let event = self
+            .multi_manager
+            .capture_session
+            .as_ref()
+            .and_then(|session| session.rx.try_recv().ok());
+        if let Some(event) = event {
+            self.multi_manager.capture_session = None;
+            match event.action {
+                CaptureKeyAction::Cancel => self.multi_manager_cancel_capture(),
+                CaptureKeyAction::Skip => {
+                    if self.multi_manager.recapture_active {
+                        self.multi_manager.pending_capture = None;
+                    }
                 }
+                CaptureKeyAction::Confirm => self.multi_manager_complete_capture(event.captured),
             }
-            Some(CaptureKeyAction::Confirm) => self.multi_manager_complete_capture(),
-            None => {}
         }
     }
 
-    fn multi_manager_complete_capture(&mut self) {
+    fn multi_manager_complete_capture(&mut self, captured: Option<CapturedWindow>) {
         let Some(action) = self.multi_manager.pending_capture.clone() else {
             return;
         };
-        let Some(captured) = win::active_window() else {
+        let Some(captured) = captured else {
             self.report_error_message("multi_manager.capture", "No active window to capture");
             return;
         };
@@ -332,6 +346,7 @@ impl LauncherApp {
                 }
             }
         }
+        self.multi_manager.capture_session = None;
         self.multi_manager.pending_capture = None;
         if !self.multi_manager.recapture_active {
             self.multi_manager
@@ -397,7 +412,7 @@ mod tests {
     use crate::plugin::PluginManager;
     use crate::settings::Settings;
     use std::collections::VecDeque;
-    use std::sync::{atomic::AtomicBool, Arc};
+    use std::sync::{Arc, atomic::AtomicBool};
 
     fn test_app() -> LauncherApp {
         let ctx = eframe::egui::Context::default();

--- a/src/multi_manager/capture.rs
+++ b/src/multi_manager/capture.rs
@@ -81,7 +81,7 @@ impl CaptureKeyEdgeDetector {
     }
 }
 
-pub fn start_capture_session(ctx: egui::Context) -> CaptureSession {
+pub fn start_capture_session(ctx: eframe::egui::Context) -> CaptureSession {
     let (tx, rx) = mpsc::channel();
     let cancel = Arc::new(AtomicBool::new(false));
     let thread_cancel = Arc::clone(&cancel);

--- a/src/multi_manager/capture.rs
+++ b/src/multi_manager/capture.rs
@@ -1,0 +1,177 @@
+use crate::multi_manager::win::{self, CaptureKeyAction, CapturedWindow};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(12);
+const VK_ENTER: u32 = 0x0D;
+const VK_ESCAPE: u32 = 0x1B;
+const VK_S: u32 = 0x53;
+
+#[derive(Debug, Clone)]
+pub struct CaptureEvent {
+    pub action: CaptureKeyAction,
+    pub captured: Option<CapturedWindow>,
+}
+
+pub struct CaptureSession {
+    pub rx: mpsc::Receiver<CaptureEvent>,
+    cancel: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl Drop for CaptureSession {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureKeySnapshot {
+    pub enter: bool,
+    pub escape: bool,
+    pub s: bool,
+}
+
+impl CaptureKeySnapshot {
+    fn any_down(self) -> bool {
+        self.enter || self.escape || self.s
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureKeyEdgeDetector {
+    armed: bool,
+    previous: CaptureKeySnapshot,
+}
+
+impl CaptureKeyEdgeDetector {
+    pub fn new(initial: CaptureKeySnapshot) -> Self {
+        Self {
+            armed: !initial.any_down(),
+            previous: initial,
+        }
+    }
+
+    pub fn update(&mut self, current: CaptureKeySnapshot) -> Option<CaptureKeyAction> {
+        if !self.armed {
+            self.previous = current;
+            if !current.any_down() {
+                self.armed = true;
+            }
+            return None;
+        }
+
+        let action = if current.enter && !self.previous.enter {
+            Some(CaptureKeyAction::Confirm)
+        } else if current.escape && !self.previous.escape {
+            Some(CaptureKeyAction::Cancel)
+        } else if current.s && !self.previous.s {
+            Some(CaptureKeyAction::Skip)
+        } else {
+            None
+        };
+        self.previous = current;
+        action
+    }
+}
+
+pub fn start_capture_session(ctx: egui::Context) -> CaptureSession {
+    let (tx, rx) = mpsc::channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let thread_cancel = Arc::clone(&cancel);
+    let join = thread::spawn(move || {
+        let mut detector = CaptureKeyEdgeDetector::new(current_snapshot());
+        while !thread_cancel.load(Ordering::Relaxed) {
+            thread::sleep(POLL_INTERVAL);
+            if let Some(action) = detector.update(current_snapshot()) {
+                let captured = (action == CaptureKeyAction::Confirm)
+                    .then(win::active_window)
+                    .flatten();
+                let _ = tx.send(CaptureEvent { action, captured });
+                ctx.request_repaint();
+                break;
+            }
+        }
+    });
+
+    CaptureSession {
+        rx,
+        cancel,
+        join: Some(join),
+    }
+}
+
+fn current_snapshot() -> CaptureKeySnapshot {
+    CaptureKeySnapshot {
+        enter: win::capture_key_is_down(VK_ENTER),
+        escape: win::capture_key_is_down(VK_ESCAPE),
+        s: win::capture_key_is_down(VK_S),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(enter: bool, escape: bool, s: bool) -> CaptureKeySnapshot {
+        CaptureKeySnapshot { enter, escape, s }
+    }
+
+    #[test]
+    fn enter_down_once_produces_exactly_one_confirm_event() {
+        let mut detector = CaptureKeyEdgeDetector::new(snap(false, false, false));
+        assert_eq!(
+            detector.update(snap(true, false, false)),
+            Some(CaptureKeyAction::Confirm)
+        );
+        assert_eq!(detector.update(snap(true, false, false)), None);
+        assert_eq!(detector.update(snap(false, false, false)), None);
+    }
+
+    #[test]
+    fn holding_enter_does_not_repeat_confirm_events() {
+        let mut detector = CaptureKeyEdgeDetector::new(snap(false, false, false));
+        assert_eq!(
+            detector.update(snap(true, false, false)),
+            Some(CaptureKeyAction::Confirm)
+        );
+        for _ in 0..5 {
+            assert_eq!(detector.update(snap(true, false, false)), None);
+        }
+    }
+
+    #[test]
+    fn escape_produces_cancel() {
+        let mut detector = CaptureKeyEdgeDetector::new(snap(false, false, false));
+        assert_eq!(
+            detector.update(snap(false, true, false)),
+            Some(CaptureKeyAction::Cancel)
+        );
+    }
+
+    #[test]
+    fn s_produces_skip() {
+        let mut detector = CaptureKeyEdgeDetector::new(snap(false, false, false));
+        assert_eq!(
+            detector.update(snap(false, false, true)),
+            Some(CaptureKeyAction::Skip)
+        );
+    }
+
+    #[test]
+    fn keys_held_at_session_start_are_ignored_until_released() {
+        let mut detector = CaptureKeyEdgeDetector::new(snap(true, false, false));
+        assert_eq!(detector.update(snap(true, false, false)), None);
+        assert_eq!(detector.update(snap(false, false, false)), None);
+        assert_eq!(
+            detector.update(snap(true, false, false)),
+            Some(CaptureKeyAction::Confirm)
+        );
+    }
+}

--- a/src/multi_manager/mod.rs
+++ b/src/multi_manager/mod.rs
@@ -1,4 +1,5 @@
 pub mod bindings;
+pub mod capture;
 pub mod commands;
 pub mod model;
 pub mod runtime;

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -15,6 +15,7 @@ pub struct MultiManagerState {
     pub pending_capture: Option<PendingCaptureAction>,
     pub recapture_queue: VecDeque<RecaptureQueueItem>,
     pub recapture_active: bool,
+    pub capture_session: Option<crate::multi_manager::capture::CaptureSession>,
     pub workspaces: Arc<Mutex<Vec<MmWorkspace>>>,
     pub runtime: MultiManagerRuntime,
     pub last_hotkey_info: Arc<Mutex<Option<(String, Instant)>>>,
@@ -46,6 +47,7 @@ impl MultiManagerState {
             pending_capture: None,
             recapture_queue: VecDeque::new(),
             recapture_active: false,
+            capture_session: None,
             workspaces,
             runtime,
             last_hotkey_info,
@@ -115,6 +117,7 @@ impl MultiManagerState {
     }
 
     pub fn shutdown(&mut self) {
+        self.capture_session = None;
         self.runtime.shutdown();
     }
 

--- a/src/multi_manager/win.rs
+++ b/src/multi_manager/win.rs
@@ -88,13 +88,13 @@ fn rect_from_win32(rect: windows::Win32::Foundation::RECT) -> MmRect {
 }
 
 #[cfg(windows)]
-fn key_is_down(vk: u32) -> bool {
+pub(crate) fn capture_key_is_down(vk: u32) -> bool {
     use windows::Win32::UI::Input::KeyboardAndMouse::GetAsyncKeyState;
     unsafe { (GetAsyncKeyState(vk as i32) as u16 & 0x8000) != 0 }
 }
 
 #[cfg(not(windows))]
-fn key_is_down(_vk: u32) -> bool {
+pub(crate) fn capture_key_is_down(_vk: u32) -> bool {
     false
 }
 
@@ -200,7 +200,7 @@ pub fn is_window_at_rect(hwnd: usize, rect: MmRect) -> bool {
 }
 
 pub fn is_hotkey_pressed(sequence: &str) -> bool {
-    hotkey_pressed_with(sequence, key_is_down)
+    hotkey_pressed_with(sequence, capture_key_is_down)
 }
 
 pub fn poll_capture_keys() -> Option<CaptureKeyAction> {


### PR DESCRIPTION
### Motivation
- Decouple capture key polling from `egui` repaint cadence so capture works while another app (e.g. Notepad) has focus. 
- Provide a one-shot background listener that detects key-down edges for Enter, Escape, and `S` and prevents the initiating key from immediately confirming. 
- Ensure the listener thread is cancellable and is dropped before runtime shutdown to avoid leaking background threads. 

### Description
- Add `src/multi_manager/capture.rs` implementing `CaptureEvent`, `CaptureSession`, `start_capture_session`, a `CaptureKeyEdgeDetector`, and unit tests for edge-detection behavior. The session spawns a thread that polls keys every ~12 ms and sends a single `CaptureEvent` over an `mpsc` channel before requesting a repaint and exiting. 
- Reuse existing Windows key-state logic by exposing a `pub(crate) fn capture_key_is_down` in `src/multi_manager/win.rs` and update `is_hotkey_pressed` to call it to avoid duplicating unsafe Win32 calls. 
- Wire the UI to use the background session by adding `pub capture_session: Option<crate::multi_manager::capture::CaptureSession>` to `MultiManagerState`, initializing it to `None`, starting the session with `capture::start_capture_session(ctx.clone())` while a capture is pending, consuming one-shot events via `session.rx.try_recv()`, and passing the captured window to `multi_manager_complete_capture`. 
- Ensure lifetime/cancellation semantics by setting `capture_session = None` on cancel/complete and clearing it in `MultiManagerState::shutdown`, and implement `Drop` for `CaptureSession` to set the cancel flag and join the thread without panicking on join errors. 

### Testing
- Attempted `cargo test capture --lib` to run the new unit tests, but the build failed due to a missing system dependency required by `alsa-sys` (`alsa.pc`), so the new tests could not be executed in this environment. 
- Ran formatting/checks: `cargo fmt` was executed during development, but `cargo fmt --check` flags pre-existing formatting differences in unrelated files in the repository. 
- Ran `git diff --check` (no issues for these changes) and committed the patch; the `CaptureKeyEdgeDetector` unit tests are present in `src/multi_manager/capture.rs` and are expected to validate edge detection once the project builds in a suitable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4adbd398833281005a2af3a6f05b)