### PR TITLE
Refactor MultiManager capture actions

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -165,7 +165,7 @@ impl LauncherApp {
 
     pub fn multi_manager_start_capture(&mut self, workspace_id: &str) {
         if self.multi_manager_workspace_exists(workspace_id) {
-            self.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureWorkspace {
+            self.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureOneWindow {
                 workspace_id: workspace_id.to_string(),
             });
             self.multi_manager.capture_session = None;
@@ -174,7 +174,7 @@ impl LauncherApp {
                 .control
                 .capture_pending
                 .store(true, Ordering::Relaxed);
-            self.add_success_toast("Started MultiManager workspace capture");
+            self.add_success_toast("Started MultiManager active window capture");
         } else {
             self.report_error_message(
                 "multi_manager.capture",
@@ -183,6 +183,101 @@ impl LauncherApp {
                 ),
             );
         }
+    }
+
+    pub fn multi_manager_start_capture_one(&mut self, workspace_id: &str, ctx: &egui::Context) {
+        self.multi_manager_start_capture_session(
+            workspace_id,
+            None,
+            PendingCaptureAction::CaptureOneWindow {
+                workspace_id: workspace_id.to_string(),
+            },
+            ctx,
+            "Started MultiManager active window capture",
+        );
+    }
+
+    pub fn multi_manager_start_capture_multiple(
+        &mut self,
+        workspace_id: &str,
+        ctx: &egui::Context,
+    ) {
+        self.multi_manager_start_capture_session(
+            workspace_id,
+            None,
+            PendingCaptureAction::CaptureMultipleWindows {
+                workspace_id: workspace_id.to_string(),
+            },
+            ctx,
+            "Started MultiManager multi-window capture",
+        );
+    }
+
+    pub fn multi_manager_start_recapture_window(
+        &mut self,
+        workspace_id: &str,
+        index: usize,
+        ctx: &egui::Context,
+    ) {
+        self.multi_manager_start_capture_session(
+            workspace_id,
+            Some(index),
+            PendingCaptureAction::RecaptureWindow {
+                workspace_id: workspace_id.to_string(),
+                window_index: index,
+            },
+            ctx,
+            "Started MultiManager window recapture",
+        );
+    }
+
+    fn multi_manager_start_capture_session(
+        &mut self,
+        workspace_id: &str,
+        window_index: Option<usize>,
+        action: PendingCaptureAction,
+        ctx: &egui::Context,
+        success_message: &str,
+    ) {
+        let valid = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .map(|workspaces| {
+                workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == workspace_id)
+                    .is_some_and(|workspace| {
+                        window_index.is_none_or(|index| index < workspace.windows.len())
+                    })
+            })
+            .unwrap_or(false);
+
+        if !valid {
+            self.report_error_message(
+                "multi_manager.capture",
+                match window_index {
+                    Some(index) => format!(
+                        "Failed to start MultiManager recapture: window {} not found in workspace {workspace_id}",
+                        index + 1
+                    ),
+                    None => format!(
+                        "Failed to start MultiManager capture: workspace not found: {workspace_id}"
+                    ),
+                },
+            );
+            return;
+        }
+
+        self.multi_manager.pending_capture = Some(action);
+        self.multi_manager.capture_session = None;
+        self.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+        self.multi_manager.capture_session = Some(capture::start_capture_session(ctx.clone()));
+        self.add_success_toast(success_message);
     }
 
     pub fn multi_manager_set_workspace_disabled(&mut self, workspace_id: &str, disabled: bool) {
@@ -248,7 +343,7 @@ impl LauncherApp {
             if let Some(item) = self.multi_manager.recapture_queue.pop_front() {
                 self.multi_manager.pending_capture = Some(PendingCaptureAction::RecaptureWindow {
                     workspace_id: item.workspace_id,
-                    window_id: item.window_index.to_string(),
+                    window_index: item.window_index,
                 });
                 self.multi_manager
                     .runtime
@@ -310,8 +405,10 @@ impl LauncherApp {
             );
             return;
         }
+        let keep_pending = matches!(action, PendingCaptureAction::CaptureMultipleWindows { .. });
         match action {
-            PendingCaptureAction::CaptureWorkspace { workspace_id } => {
+            PendingCaptureAction::CaptureOneWindow { workspace_id }
+            | PendingCaptureAction::CaptureMultipleWindows { workspace_id } => {
                 let window = crate::multi_manager::model::MmWindow {
                     alias: captured.title.clone(),
                     title: captured.title,
@@ -323,32 +420,28 @@ impl LauncherApp {
                 self.multi_manager
                     .with_workspace_mut(&workspace_id, |workspace| workspace.windows.push(window));
             }
-            PendingCaptureAction::CaptureWindow {
+            PendingCaptureAction::RecaptureWindow {
                 workspace_id,
-                window_id,
-            }
-            | PendingCaptureAction::RecaptureWindow {
-                workspace_id,
-                window_id,
+                window_index,
             } => {
-                if let Ok(index) = window_id.parse::<usize>() {
-                    self.multi_manager
-                        .with_workspace_mut(&workspace_id, |workspace| {
-                            if let Some(window) = workspace.windows.get_mut(index) {
-                                window.title = captured.title.clone();
-                                window.alias = captured.title;
-                                window.hwnd = captured.hwnd;
-                                window.home_rect = Some(captured.rect);
-                                window.target_rect = Some(captured.rect);
-                                window.valid = true;
-                            }
-                        });
-                }
+                self.multi_manager
+                    .with_workspace_mut(&workspace_id, |workspace| {
+                        if let Some(window) = workspace.windows.get_mut(window_index) {
+                            window.title = captured.title.clone();
+                            window.alias = captured.title;
+                            window.hwnd = captured.hwnd;
+                            window.home_rect = Some(captured.rect);
+                            window.target_rect = Some(captured.rect);
+                            window.valid = true;
+                        }
+                    });
             }
         }
         self.multi_manager.capture_session = None;
-        self.multi_manager.pending_capture = None;
-        if !self.multi_manager.recapture_active {
+        if !keep_pending {
+            self.multi_manager.pending_capture = None;
+        }
+        if !self.multi_manager.recapture_active && !keep_pending {
             self.multi_manager
                 .runtime
                 .control
@@ -407,12 +500,15 @@ pub(crate) fn build_recapture_queue(
 mod tests {
     use super::build_recapture_queue;
     use crate::gui::LauncherApp;
-    use crate::multi_manager::model::{MmRect, MmWindow, MmWorkspace};
+    use crate::multi_manager::model::{MmRect, MmWindow, MmWorkspace, PendingCaptureAction};
     use crate::multi_manager::win::CapturedWindow;
     use crate::plugin::PluginManager;
     use crate::settings::Settings;
     use std::collections::VecDeque;
-    use std::sync::{Arc, atomic::AtomicBool};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     fn test_app() -> LauncherApp {
         let ctx = eframe::egui::Context::default();
@@ -475,6 +571,126 @@ mod tests {
         assert_eq!(queue.pop_front().unwrap().window_index, 1); // queue advanced
         queue.clear(); // Escape cancels remaining queue
         assert!(queue.is_empty());
+    }
+
+    fn set_workspaces(app: &mut LauncherApp, workspaces: Vec<MmWorkspace>) {
+        *app.multi_manager.workspaces.lock().expect("workspaces") = workspaces;
+    }
+
+    #[test]
+    fn one_window_capture_clears_pending_state_after_success() {
+        let mut app = test_app();
+        set_workspaces(
+            &mut app,
+            vec![MmWorkspace {
+                id: "w".into(),
+                ..Default::default()
+            }],
+        );
+        app.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureOneWindow {
+            workspace_id: "w".into(),
+        });
+        app.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+
+        app.multi_manager_complete_capture(Some(captured(7, "Editor")));
+
+        assert_eq!(app.multi_manager.pending_capture, None);
+        assert!(!app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
+        let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
+        assert_eq!(workspaces[0].windows.len(), 1);
+        assert_eq!(workspaces[0].windows[0].title, "Editor");
+    }
+
+    #[test]
+    fn multi_window_capture_preserves_pending_state_across_confirms() {
+        let mut app = test_app();
+        set_workspaces(
+            &mut app,
+            vec![MmWorkspace {
+                id: "w".into(),
+                ..Default::default()
+            }],
+        );
+        app.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureMultipleWindows {
+            workspace_id: "w".into(),
+        });
+        app.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+
+        app.multi_manager_complete_capture(Some(captured(1, "One")));
+        app.multi_manager_complete_capture(Some(captured(2, "Two")));
+
+        assert_eq!(
+            app.multi_manager.pending_capture,
+            Some(PendingCaptureAction::CaptureMultipleWindows {
+                workspace_id: "w".into()
+            })
+        );
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
+        let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
+        assert_eq!(workspaces[0].windows.len(), 2);
+        assert_eq!(workspaces[0].windows[0].title, "One");
+        assert_eq!(workspaces[0].windows[1].title, "Two");
+    }
+
+    #[test]
+    fn recapture_updates_existing_index_without_appending() {
+        let mut app = test_app();
+        set_workspaces(
+            &mut app,
+            vec![MmWorkspace {
+                id: "w".into(),
+                windows: vec![
+                    MmWindow {
+                        title: "Keep".into(),
+                        alias: "Keep".into(),
+                        hwnd: 10,
+                        ..Default::default()
+                    },
+                    MmWindow {
+                        title: "Old".into(),
+                        alias: "Old".into(),
+                        hwnd: 11,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+        );
+        app.multi_manager.pending_capture = Some(PendingCaptureAction::RecaptureWindow {
+            workspace_id: "w".into(),
+            window_index: 1,
+        });
+        app.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+
+        app.multi_manager_complete_capture(Some(captured(22, "New")));
+
+        let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
+        assert_eq!(workspaces[0].windows.len(), 2);
+        assert_eq!(workspaces[0].windows[0].title, "Keep");
+        assert_eq!(workspaces[0].windows[1].title, "New");
+        assert_eq!(workspaces[0].windows[1].hwnd, 22);
     }
 
     #[test]

--- a/src/multi_manager/model.rs
+++ b/src/multi_manager/model.rs
@@ -162,16 +162,15 @@ impl Default for MmWorkspace {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum PendingCaptureAction {
-    CaptureWorkspace {
+    CaptureOneWindow {
         workspace_id: String,
     },
-    CaptureWindow {
+    CaptureMultipleWindows {
         workspace_id: String,
-        window_id: String,
     },
     RecaptureWindow {
         workspace_id: String,
-        window_id: String,
+        window_index: usize,
     },
 }
 

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -137,15 +137,24 @@ impl MultiManagerDialog {
     fn capture_banner(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp) {
         if let Some(action) = &app.multi_manager.pending_capture {
             ui.colored_label(egui::Color32::LIGHT_BLUE, "Capture mode active: press Enter to capture active window, S to skip current item, or Escape to cancel remaining queue.");
-            if let PendingCaptureAction::RecaptureWindow {
-                workspace_id,
-                window_id,
-            } = action
-            {
-                ui.label(format!(
-                    "Recapturing workspace {workspace_id}, window {}",
-                    window_id.parse::<usize>().map(|i| i + 1).unwrap_or(1)
-                ));
+            match action {
+                PendingCaptureAction::CaptureOneWindow { workspace_id } => {
+                    ui.label(format!("Capturing one window for workspace {workspace_id}"));
+                }
+                PendingCaptureAction::CaptureMultipleWindows { workspace_id } => {
+                    ui.label(format!(
+                        "Capturing multiple windows for workspace {workspace_id}; press Escape when done"
+                    ));
+                }
+                PendingCaptureAction::RecaptureWindow {
+                    workspace_id,
+                    window_index,
+                } => {
+                    ui.label(format!(
+                        "Recapturing workspace {workspace_id}, window {}",
+                        window_index + 1
+                    ));
+                }
             }
         }
     }
@@ -230,10 +239,10 @@ impl MultiManagerDialog {
                     }
                     ui.horizontal_wrapped(|ui| {
                         if ui.button("Capture Active Window").clicked() {
-                            app.multi_manager_start_capture(id);
+                            app.multi_manager_start_capture_one(id, ui.ctx());
                         }
                         if ui.button("Capture Multiple Windows").clicked() {
-                            app.multi_manager_start_capture(id);
+                            app.multi_manager_start_capture_multiple(id, ui.ctx());
                         }
                         if ui.button("Send Home").clicked() {
                             app.multi_manager_send_home(id);
@@ -357,16 +366,7 @@ impl MultiManagerDialog {
                         move_window(&win, false);
                     }
                     if ui.button("Recapture").clicked() {
-                        app.multi_manager.pending_capture =
-                            Some(PendingCaptureAction::CaptureWindow {
-                                workspace_id: id.into(),
-                                window_id: index.to_string(),
-                            });
-                        app.multi_manager
-                            .runtime
-                            .control
-                            .capture_pending
-                            .store(true, Ordering::Relaxed);
+                        app.multi_manager_start_recapture_window(id, index, ui.ctx());
                     }
                     if ui.button("Swap Home/Target").clicked() {
                         app.multi_manager.with_workspace_mut(id, |w| {


### PR DESCRIPTION
### Motivation
- Make capture intent explicit so each capture button starts the correct behavior (single, multi, or recapture by index). 
- Simplify capture flow so multi-window capture can persist across repeated Confirm events while one-shot capture clears pending state.

### Description
- Replaced `PendingCaptureAction::{CaptureWorkspace, CaptureWindow, RecaptureWindow(window_id: String)}` with explicit variants `CaptureOneWindow { workspace_id: String }`, `CaptureMultipleWindows { workspace_id: String }`, and `RecaptureWindow { workspace_id: String, window_index: usize }` in `src/multi_manager/model.rs`.
- Added public start methods in `src/gui/multi_manager_actions.rs`: `multi_manager_start_capture_one`, `multi_manager_start_capture_multiple`, and `multi_manager_start_recapture_window`, plus a shared helper `multi_manager_start_capture_session` that validates workspace/window targets, clears old session, sets `pending_capture`, sets `runtime.control.capture_pending` to true, starts a fresh `capture::start_capture_session(ctx.clone())`, and emits a success/error toast.
- Updated capture polling/completion logic in `src/gui/multi_manager_actions.rs` to: treat `CaptureOneWindow` as a one-shot (clears pending after confirm), treat `CaptureMultipleWindows` as persistent across confirms (keeps `pending_capture` and `capture_pending` true), and treat `RecaptureWindow` as updating an existing row by `window_index` rather than appending.
- Rewired UI in `src/multi_manager/ui.rs` so the workspace buttons call the new start methods: `Capture Active Window` → `multi_manager_start_capture_one(...)`, `Capture Multiple Windows` → `multi_manager_start_capture_multiple(...)`, and per-window `Recapture` → `multi_manager_start_recapture_window(...)`.
- Updated capture banner copy to reflect the explicit modes and added unit tests that exercise one-window capture, multi-window repeated confirms, and recapture-by-index behavior.

### Testing
- Ran `rustfmt --check src/gui/multi_manager_actions.rs src/multi_manager/model.rs src/multi_manager/ui.rs` and `git diff --check`, both reported clean/OK.
- Added unit tests in the `multi_manager` module: `one_window_capture_clears_pending_state_after_success`, `multi_window_capture_preserves_pending_state_across_confirms`, and `recapture_updates_existing_index_without_appending` (located alongside existing `multi_manager` tests).
- Attempted `cargo test multi_manager_actions --lib`; tests could not complete due to repository-wide platform/build dependencies on system libraries and Windows-only APIs (errors around `windows::Win32`, `x11`, and related native pkg-config items), so CI/local test execution for these changes is blocked by unrelated environment requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd0335c988332a3daad2c617f51a8)