### PR TITLE
Add MultiManager capture reducer

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::multi_manager::apply_capture::{self, ApplyCaptureResult};
 use crate::multi_manager::bindings;
 use crate::multi_manager::capture;
 use crate::multi_manager::model::{PendingCaptureAction, RecaptureQueueItem};
@@ -406,35 +407,29 @@ impl LauncherApp {
             return;
         }
         let keep_pending = matches!(action, PendingCaptureAction::CaptureMultipleWindows { .. });
-        match action {
-            PendingCaptureAction::CaptureOneWindow { workspace_id }
-            | PendingCaptureAction::CaptureMultipleWindows { workspace_id } => {
-                let window = crate::multi_manager::model::MmWindow {
-                    alias: captured.title.clone(),
-                    title: captured.title,
-                    hwnd: captured.hwnd,
-                    home_rect: Some(captured.rect),
-                    target_rect: Some(captured.rect),
-                    ..Default::default()
-                };
-                self.multi_manager
-                    .with_workspace_mut(&workspace_id, |workspace| workspace.windows.push(window));
+        let result = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .map(|mut workspaces| {
+                apply_capture::apply_capture_to_workspaces(&mut workspaces, &action, captured)
+            })
+            .unwrap_or(ApplyCaptureResult::MissingWorkspace);
+        match result {
+            ApplyCaptureResult::Applied => self.multi_manager.mark_dirty(),
+            ApplyCaptureResult::MissingWorkspace => {
+                self.report_error_message(
+                    "multi_manager.capture",
+                    "Failed to apply capture: workspace not found",
+                );
+                return;
             }
-            PendingCaptureAction::RecaptureWindow {
-                workspace_id,
-                window_index,
-            } => {
-                self.multi_manager
-                    .with_workspace_mut(&workspace_id, |workspace| {
-                        if let Some(window) = workspace.windows.get_mut(window_index) {
-                            window.title = captured.title.clone();
-                            window.alias = captured.title;
-                            window.hwnd = captured.hwnd;
-                            window.home_rect = Some(captured.rect);
-                            window.target_rect = Some(captured.rect);
-                            window.valid = true;
-                        }
-                    });
+            ApplyCaptureResult::MissingWindow => {
+                self.report_error_message(
+                    "multi_manager.capture",
+                    "Failed to apply capture: window not found",
+                );
+                return;
             }
         }
         self.multi_manager.capture_session = None;
@@ -506,8 +501,8 @@ mod tests {
     use crate::settings::Settings;
     use std::collections::VecDeque;
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     };
 
     fn test_app() -> LauncherApp {
@@ -599,12 +594,13 @@ mod tests {
         app.multi_manager_complete_capture(Some(captured(7, "Editor")));
 
         assert_eq!(app.multi_manager.pending_capture, None);
-        assert!(!app
-            .multi_manager
-            .runtime
-            .control
-            .capture_pending
-            .load(Ordering::Relaxed));
+        assert!(
+            !app.multi_manager
+                .runtime
+                .control
+                .capture_pending
+                .load(Ordering::Relaxed)
+        );
         let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
         assert_eq!(workspaces[0].windows.len(), 1);
         assert_eq!(workspaces[0].windows[0].title, "Editor");
@@ -638,12 +634,13 @@ mod tests {
                 workspace_id: "w".into()
             })
         );
-        assert!(app
-            .multi_manager
-            .runtime
-            .control
-            .capture_pending
-            .load(Ordering::Relaxed));
+        assert!(
+            app.multi_manager
+                .runtime
+                .control
+                .capture_pending
+                .load(Ordering::Relaxed)
+        );
         let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
         assert_eq!(workspaces[0].windows.len(), 2);
         assert_eq!(workspaces[0].windows[0].title, "One");

--- a/src/multi_manager/apply_capture.rs
+++ b/src/multi_manager/apply_capture.rs
@@ -1,0 +1,261 @@
+use crate::multi_manager::model::{MmWindow, MmWorkspace, PendingCaptureAction};
+use crate::multi_manager::win::CapturedWindow;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyCaptureResult {
+    Applied,
+    MissingWorkspace,
+    MissingWindow,
+}
+
+pub fn apply_capture_to_workspaces(
+    workspaces: &mut [MmWorkspace],
+    action: &PendingCaptureAction,
+    captured: CapturedWindow,
+) -> ApplyCaptureResult {
+    match action {
+        PendingCaptureAction::CaptureOneWindow { workspace_id }
+        | PendingCaptureAction::CaptureMultipleWindows { workspace_id } => {
+            let Some(workspace) = workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == *workspace_id)
+            else {
+                return ApplyCaptureResult::MissingWorkspace;
+            };
+
+            workspace.windows.push(MmWindow {
+                alias: captured.title.clone(),
+                title: captured.title,
+                hwnd: captured.hwnd,
+                home_rect: Some(captured.rect),
+                target_rect: Some(captured.rect),
+                valid: true,
+                ..Default::default()
+            });
+            ApplyCaptureResult::Applied
+        }
+        PendingCaptureAction::RecaptureWindow {
+            workspace_id,
+            window_index,
+        } => {
+            let Some(workspace) = workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == *workspace_id)
+            else {
+                return ApplyCaptureResult::MissingWorkspace;
+            };
+            let Some(window) = workspace.windows.get_mut(*window_index) else {
+                return ApplyCaptureResult::MissingWindow;
+            };
+
+            window.hwnd = captured.hwnd;
+            window.title = captured.title.clone();
+            window.valid = true;
+            if window.alias.trim().is_empty() {
+                window.alias = captured.title;
+            }
+            ApplyCaptureResult::Applied
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::multi_manager::model::MmRect;
+
+    fn workspace(id: &str) -> MmWorkspace {
+        MmWorkspace {
+            id: id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn rect(x: i32, y: i32, w: i32, h: i32) -> MmRect {
+        MmRect { x, y, w, h }
+    }
+
+    fn captured(hwnd: usize, title: &str, rect: MmRect) -> CapturedWindow {
+        CapturedWindow {
+            hwnd,
+            title: title.to_string(),
+            rect,
+        }
+    }
+
+    #[test]
+    fn capture_one_window_appends_one_mm_window() {
+        let capture_rect = rect(1, 2, 300, 400);
+        let mut workspaces = vec![workspace("w")];
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::CaptureOneWindow {
+                workspace_id: "w".into(),
+            },
+            captured(7, "Editor", capture_rect),
+        );
+
+        assert_eq!(result, ApplyCaptureResult::Applied);
+        assert_eq!(workspaces[0].windows.len(), 1);
+        let window = &workspaces[0].windows[0];
+        assert_eq!(window.alias, "Editor");
+        assert_eq!(window.title, "Editor");
+        assert_eq!(window.hwnd, 7);
+        assert_eq!(window.home_rect, Some(capture_rect));
+        assert_eq!(window.target_rect, Some(capture_rect));
+        assert!(window.valid);
+    }
+
+    #[test]
+    fn capture_multiple_windows_appends_one_mm_window_per_call() {
+        let mut workspaces = vec![workspace("w")];
+        let action = PendingCaptureAction::CaptureMultipleWindows {
+            workspace_id: "w".into(),
+        };
+
+        assert_eq!(
+            apply_capture_to_workspaces(
+                &mut workspaces,
+                &action,
+                captured(1, "One", rect(0, 0, 10, 10))
+            ),
+            ApplyCaptureResult::Applied
+        );
+        assert_eq!(
+            apply_capture_to_workspaces(
+                &mut workspaces,
+                &action,
+                captured(2, "Two", rect(10, 10, 20, 20))
+            ),
+            ApplyCaptureResult::Applied
+        );
+
+        assert_eq!(workspaces[0].windows.len(), 2);
+        assert_eq!(workspaces[0].windows[0].title, "One");
+        assert_eq!(workspaces[0].windows[1].title, "Two");
+    }
+
+    #[test]
+    fn recapturing_updates_hwnd_and_title() {
+        let mut workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: vec![MmWindow {
+                title: "Old".into(),
+                alias: "Alias".into(),
+                hwnd: 1,
+                valid: false,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 0,
+            },
+            captured(99, "New", rect(0, 0, 50, 50)),
+        );
+
+        assert_eq!(result, ApplyCaptureResult::Applied);
+        assert_eq!(workspaces[0].windows[0].hwnd, 99);
+        assert_eq!(workspaces[0].windows[0].title, "New");
+        assert!(workspaces[0].windows[0].valid);
+    }
+
+    #[test]
+    fn recapturing_preserves_existing_home_and_target_rectangles() {
+        let home = rect(1, 1, 100, 100);
+        let target = rect(2, 2, 200, 200);
+        let mut workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: vec![MmWindow {
+                home_rect: Some(home),
+                target_rect: Some(target),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 0,
+            },
+            captured(99, "New", rect(9, 9, 900, 900)),
+        );
+
+        assert_eq!(result, ApplyCaptureResult::Applied);
+        assert_eq!(workspaces[0].windows[0].home_rect, Some(home));
+        assert_eq!(workspaces[0].windows[0].target_rect, Some(target));
+    }
+
+    #[test]
+    fn missing_workspace_returns_missing_workspace() {
+        let mut workspaces = vec![workspace("other")];
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::CaptureOneWindow {
+                workspace_id: "missing".into(),
+            },
+            captured(1, "Window", rect(0, 0, 1, 1)),
+        );
+
+        assert_eq!(result, ApplyCaptureResult::MissingWorkspace);
+    }
+
+    #[test]
+    fn missing_recapture_index_returns_missing_window() {
+        let mut workspaces = vec![workspace("w")];
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 1,
+            },
+            captured(1, "Window", rect(0, 0, 1, 1)),
+        );
+
+        assert_eq!(result, ApplyCaptureResult::MissingWindow);
+    }
+
+    #[test]
+    fn recapture_only_fills_alias_when_existing_alias_is_blank() {
+        let mut workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: vec![
+                MmWindow {
+                    alias: "Custom".into(),
+                    ..Default::default()
+                },
+                MmWindow {
+                    alias: " \t ".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }];
+
+        apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 0,
+            },
+            captured(1, "New A", rect(0, 0, 1, 1)),
+        );
+        apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 1,
+            },
+            captured(2, "New B", rect(0, 0, 1, 1)),
+        );
+
+        assert_eq!(workspaces[0].windows[0].alias, "Custom");
+        assert_eq!(workspaces[0].windows[1].alias, "New B");
+    }
+}

--- a/src/multi_manager/mod.rs
+++ b/src/multi_manager/mod.rs
@@ -1,3 +1,4 @@
+pub mod apply_capture;
 pub mod bindings;
 pub mod capture;
 pub mod commands;


### PR DESCRIPTION
### Motivation

- Factor workspace mutation for capture actions into a pure reducer so captures can be tested without egui or Windows APIs.
- Ensure new captures initialize `home_rect` and `target_rect` from the captured rectangle and recaptures update only identity/status without destroying saved layouts.
- Keep launcher-window ignore policy in the GUI layer because it depends on app settings and runtime launcher HWND state.

### Description

- Add `src/multi_manager/apply_capture.rs` implementing `#[derive(Debug, Clone, Copy, PartialEq, Eq)] pub enum ApplyCaptureResult { Applied, MissingWorkspace, MissingWindow }` and `pub fn apply_capture_to_workspaces(...)`.
- Implement `CaptureOneWindow` and `CaptureMultipleWindows` to append an `MmWindow` with `alias` = `captured.title.clone()`, `title`, `hwnd`, `home_rect` and `target_rect` set to the captured rect, `valid = true`, and `..Default::default()` for remaining fields.
- Implement `RecaptureWindow` to locate the existing window and update only `hwnd`, `title`, and `valid`, set `alias` to the captured title only if blank, and preserve `home_rect` and `target_rect`.
- Register the module in `src/multi_manager/mod.rs` and update `src/gui/multi_manager_actions.rs` to call the reducer and handle `ApplyCaptureResult`, leaving launcher-ignore checks in the GUI logic.
- Add unit tests in `src/multi_manager/apply_capture.rs` covering single capture, multi-capture, recapture identity updates, rectangle preservation, missing workspace/window errors, and conditional alias fill.

### Testing

- Ran `git diff --check`, which passed.
- Ran `cargo test apply_capture` to exercise the new unit tests, but the build failed due to a missing system `alsa` pkg-config/library required by the `alsa-sys` crate in this container, so tests could not complete here.
- The new unit tests are included with the reducer and should run successfully in an environment with the required system dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd68c2b4c8332abb825d400fc47b5)