### PR TITLE
Add MultiManager launcher actions (send-all-home & reconnect)

### DIFF
--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -484,6 +484,10 @@ impl LauncherApp {
             self.multi_manager_save();
         } else if a.action == "mm:reload" {
             self.multi_manager_reload();
+        } else if a.action == "mm:send-all-home" {
+            self.multi_manager_send_all_home();
+        } else if a.action == "mm:reconnect" {
+            self.multi_manager_reconnect_windows();
         } else if a.action == "mm:save-bindings" {
             self.multi_manager_save_bindings();
         } else if a.action == "mm:restore-bindings" {

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -43,6 +43,26 @@ impl LauncherApp {
         );
     }
 
+    pub fn multi_manager_send_all_home(&mut self) {
+        let workspaces = match self.multi_manager.workspaces.lock() {
+            Ok(workspaces) => workspaces.clone(),
+            Err(_) => {
+                self.report_error_message(
+                    "multi_manager.send_all_home",
+                    "Failed to lock MultiManager workspaces to send all windows home",
+                );
+                return;
+            }
+        };
+
+        crate::multi_manager::runtime::send_all_home(&workspaces);
+        self.add_success_toast("Sent all MultiManager windows home");
+    }
+
+    pub fn multi_manager_reconnect_windows(&mut self) {
+        self.multi_manager_restore_bindings();
+    }
+
     pub fn multi_manager_start_recapture_all(&mut self) {
         let queue = self
             .multi_manager

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -44,15 +44,18 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_send_all_home(&mut self) {
-        let workspaces = match self.multi_manager.workspaces.lock() {
-            Ok(workspaces) => workspaces.clone(),
-            Err(_) => {
-                self.report_error_message(
-                    "multi_manager.send_all_home",
-                    "Failed to lock MultiManager workspaces to send all windows home",
-                );
-                return;
-            }
+        let workspaces = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .ok()
+            .map(|workspaces| workspaces.clone());
+        let Some(workspaces) = workspaces else {
+            self.report_error_message(
+                "multi_manager.send_all_home",
+                "Failed to lock MultiManager workspaces to send all windows home",
+            );
+            return;
         };
 
         crate::multi_manager::runtime::send_all_home(&workspaces);

--- a/src/multi_manager/commands.rs
+++ b/src/multi_manager/commands.rs
@@ -1,10 +1,16 @@
 use crate::actions::Action;
 
-const COMMANDS: [(&str, &str, &str); 8] = [
+const COMMANDS: [(&str, &str, &str); 10] = [
     ("mm", "Open MultiManager", "mm:open"),
     ("mm settings", "Open MultiManager settings", "mm:settings"),
     ("mm save", "Save MultiManager workspaces", "mm:save"),
     ("mm reload", "Reload MultiManager workspaces", "mm:reload"),
+    (
+        "mm send all home",
+        "Send all MultiManager windows home",
+        "mm:send-all-home",
+    ),
+    ("mm reconnect", "Reconnect MultiManager windows", "mm:reconnect"),
     (
         "mm save bindings",
         "Save MultiManager window bindings",
@@ -50,9 +56,9 @@ mod tests {
     use super::search_mm_commands;
 
     #[test]
-    fn mm_returns_open() {
+    fn exact_mm_returns_open_first() {
         let actions = search_mm_commands("mm");
-        assert!(actions.iter().any(|a| a.action == "mm:open"));
+        assert_eq!(actions.first().map(|a| a.action.as_str()), Some("mm:open"));
     }
 
     #[test]
@@ -77,6 +83,18 @@ mod tests {
     fn mm_recapture_all_returns_recapture_all() {
         let actions = search_mm_commands("mm recapture all");
         assert!(actions.iter().any(|a| a.action == "mm:recapture-all"));
+    }
+
+    #[test]
+    fn mm_send_all_home_returns_send_all_home() {
+        let actions = search_mm_commands("mm send all home");
+        assert!(actions.iter().any(|a| a.action == "mm:send-all-home"));
+    }
+
+    #[test]
+    fn mm_reconnect_returns_reconnect() {
+        let actions = search_mm_commands("mm reconnect");
+        assert!(actions.iter().any(|a| a.action == "mm:reconnect"));
     }
 
     #[test]

--- a/tests/multi_manager_launcher_actions.rs
+++ b/tests/multi_manager_launcher_actions.rs
@@ -107,3 +107,45 @@ fn activating_mm_save_reports_error_without_panicking() {
             .is_some_and(|msg| msg.contains("Failed to save MultiManager workspaces"))
     );
 }
+
+
+#[test]
+fn activating_mm_send_all_home_reports_success_without_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    let settings = settings_with_multi_manager_paths(dir.path());
+    let mut app = new_app(settings);
+    app.enable_toasts = true;
+
+    app.activate_action(action("mm:send-all-home"), None, ActivationSource::Enter);
+
+    assert!(app.error.is_none());
+}
+
+#[test]
+fn activating_mm_reconnect_reports_error_without_panicking_when_bindings_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let settings = settings_with_multi_manager_paths(dir.path());
+    let mut app = new_app(settings);
+    app.show_inline_errors = true;
+
+    app.activate_action(action("mm:reconnect"), None, ActivationSource::Enter);
+
+    assert!(
+        app.error
+            .as_deref()
+            .is_some_and(|msg| msg.contains("Failed to load bindings"))
+    );
+}
+
+#[test]
+fn activating_mm_reconnect_reports_success_without_panicking_with_bindings_file() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("bindings.json"), "[]").unwrap();
+    let settings = settings_with_multi_manager_paths(dir.path());
+    let mut app = new_app(settings);
+    app.enable_toasts = true;
+
+    app.activate_action(action("mm:reconnect"), None, ActivationSource::Enter);
+
+    assert!(app.error.is_none());
+}


### PR DESCRIPTION
### Motivation

- Expose two new launcher commands to control MultiManager from the launcher: `mm send all home` and `mm reconnect` to allow sending all windows home and attempting to reconnect window bindings.
- Wire those new commands into launcher activation so selecting the command triggers the corresponding GUI action handlers.
- Add tests to ensure the new commands are discoverable via the `mm` command search and that action activation paths exercise dialog/toast/error reporting.

### Description

- Registered two new commands in `src/multi_manager/commands.rs` and increased the `COMMANDS` array length to include `("mm send all home", "Send all MultiManager windows home", "mm:send-all-home")` and `("mm reconnect", "Reconnect MultiManager windows", "mm:reconnect")`.
- Updated `src/gui/actions.rs` to handle the new action IDs `mm:send-all-home` and `mm:reconnect` by calling the corresponding methods on `LauncherApp`.
- Implemented `multi_manager_send_all_home` and `multi_manager_reconnect_windows` in `src/gui/multi_manager_actions.rs`, where `multi_manager_send_all_home` locks and clones `self.multi_manager.workspaces`, reports an error if the lock fails, calls `crate::multi_manager::runtime::send_all_home(&workspaces)`, and shows a success toast, and `multi_manager_reconnect_windows` delegates to existing binding-restore logic.
- Added unit tests in `src/multi_manager/commands.rs` to assert exact `mm` ordering and that `mm send all home` / `mm reconnect` return expected actions, and added integration-style tests in `tests/multi_manager_launcher_actions.rs` to ensure activation of the new actions does not panic and sets the expected dialog/toast/error state where testable.

### Testing

- Ran `rustfmt` and `git diff --check` to ensure formatting and basic diffs are clean and those checks passed.
- Attempted to run the updated tests with `cargo test --test multi_manager_launcher_actions`, but the build failed due to a missing system dependency (`alsa.pc`) required by the `alsa-sys` crate in the environment, so the test run was blocked and could not complete.
- The new tests and changes are included and should pass in CI or a development environment with the required system libraries installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306b40b9348332b7f73aeecb2ae014)