### PR TITLE
Update MultiManager window move handling

### DIFF
--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -430,6 +430,37 @@ mod tests {
     }
 
     #[test]
+    fn send_home_uses_window_rect_before_workspace_fallback() {
+        let mut ws = workspace();
+        ws.home_rect = Some(rect(99));
+        ws.windows[1].home_rect = None;
+        let ops = FakeWindowOps::default();
+        send_workspace_home_with(&ws, &ops);
+        assert_eq!(*ops.moves.borrow(), vec![(1, rect(1)), (2, rect(99))]);
+    }
+
+    #[test]
+    fn send_target_uses_window_rect_before_workspace_fallback() {
+        let mut ws = workspace();
+        ws.target_rect = Some(rect(88));
+        ws.windows[0].target_rect = None;
+        let ops = FakeWindowOps::default();
+        send_workspace_target_with(&ws, &ops);
+        assert_eq!(*ops.moves.borrow(), vec![(1, rect(88)), (2, rect(12))]);
+    }
+
+    #[test]
+    fn movement_skips_disabled_invalid_and_zero_handle_windows() {
+        let mut ws = workspace();
+        ws.windows[0].disabled = true;
+        ws.windows[1].hwnd = 0;
+        ws.windows.push(window(3, false, rect(3), rect(13)));
+        let ops = FakeWindowOps::default();
+        send_workspace_target_with(&ws, &ops);
+        assert!(ops.moves.borrow().is_empty());
+    }
+
+    #[test]
     fn runtime_skips_when_capture_pending_is_true() {
         let mut workspaces = vec![workspace()];
         let control = RuntimeControl::new(true);

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -390,10 +390,10 @@ impl MultiManagerDialog {
                         capture_rect(app, id, index, false);
                     }
                     if ui.button("Move Home").clicked() {
-                        move_window(&win, true);
+                        move_window(app, &win, true);
                     }
                     if ui.button("Move Target").clicked() {
-                        move_window(&win, false);
+                        move_window(app, &win, false);
                     }
                     if ui.button("Recapture").clicked() {
                         app.multi_manager_start_recapture_window(id, index, ui.ctx());
@@ -749,9 +749,11 @@ fn set_window_rect(
     }
     Ok(())
 }
-fn move_window(w: &MmWindow, home: bool) {
+fn move_window(app: &mut LauncherApp, w: &MmWindow, home: bool) {
     if let Some(r) = if home { w.home_rect } else { w.target_rect } {
-        let _ = win::move_window_to_rect(w.hwnd, r);
+        if let Err(err) = win::move_window_to_rect(w.hwnd, r) {
+            app.report_error_message("multi_manager.move_window", format!("{err}"));
+        }
     }
 }
 

--- a/src/multi_manager/win.rs
+++ b/src/multi_manager/win.rs
@@ -1,5 +1,5 @@
 use crate::multi_manager::model::MmRect;
-use anyhow::{Error, anyhow};
+use anyhow::{anyhow, Error};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapturedWindow {
@@ -171,7 +171,8 @@ pub fn is_valid_window(_hwnd: usize) -> bool {
 #[cfg(windows)]
 pub fn move_window_to_rect(hwnd: usize, rect: MmRect) -> Result<(), MmWindowError> {
     use windows::Win32::UI::WindowsAndMessaging::{
-        IsIconic, MoveWindow, SW_RESTORE, ShowWindowAsync,
+        BringWindowToTop, IsIconic, SetForegroundWindow, SetWindowPos, ShowWindowAsync,
+        HWND_NOTOPMOST, HWND_TOPMOST, SWP_SHOWWINDOW, SW_RESTORE,
     };
 
     if !is_valid_window(hwnd) {
@@ -183,8 +184,29 @@ pub fn move_window_to_rect(hwnd: usize, rect: MmRect) -> Result<(), MmWindowErro
         if IsIconic(hwnd).as_bool() {
             let _ = ShowWindowAsync(hwnd, SW_RESTORE);
         }
-        MoveWindow(hwnd, rect.x, rect.y, rect.w, rect.h, true)
-            .map_err(|err| anyhow!("failed to move window to rect: {err}"))
+        let _ = BringWindowToTop(hwnd);
+        let _ = SetForegroundWindow(hwnd);
+
+        SetWindowPos(
+            hwnd,
+            HWND_TOPMOST,
+            rect.x,
+            rect.y,
+            rect.w,
+            rect.h,
+            SWP_SHOWWINDOW,
+        )
+        .map_err(|err| anyhow!("failed to move window to rect as temporary topmost: {err}"))?;
+        SetWindowPos(
+            hwnd,
+            HWND_NOTOPMOST,
+            rect.x,
+            rect.y,
+            rect.w,
+            rect.h,
+            SWP_SHOWWINDOW,
+        )
+        .map_err(|err| anyhow!("failed to remove temporary topmost after move: {err}"))
     }
 }
 
@@ -236,6 +258,20 @@ mod tests {
         assert!(!hotkey_pressed_with("Ctrl+NoSuchKey", down));
         assert!(!hotkey_pressed_with("Ctrl+A+B", down));
         assert!(!hotkey_pressed_with("Ctrl+", down));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "Windows smoke test checklist: use a real, non-elevated application window HWND and verify minimized windows restore, the window is brought foreground, it is not left topmost, and elevated/inaccessible windows surface an error."]
+    fn windows_move_window_to_rect_smoke_checklist() {
+        // Manual checklist for move_window_to_rect:
+        // 1. Capture a normal application HWND and minimize it.
+        // 2. Call move_window_to_rect(hwnd, target_rect) and verify the window is restored.
+        // 3. Verify the window is brought to the foreground/top for the move.
+        // 4. Open another always-on-top candidate afterward and verify the moved window was
+        //    returned to NOTOPMOST rather than remaining permanently topmost.
+        // 5. Try an elevated/inaccessible target from a non-elevated launcher and verify the
+        //    returned error is surfaced by the UI as multi_manager.move_window.
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
### Motivation
- Ensure Windows window moves reliably by restoring minimized windows, bringing them to foreground/top, and using a temporary topmost move to avoid `MoveWindow` problems and focus issues.
- Surface movement errors to the UI so manual moves report failures to the user instead of being silently ignored.
- Preserve testability by keeping `runtime::WindowOps` routed through `win::move_window_to_rect` and provide unit tests for movement-decision logic.

### Description
- Replace `MoveWindow` with a `SetWindowPos` temporary-topmost sequence: call `SetWindowPos(hwnd, HWND_TOPMOST, ...)` followed immediately by `SetWindowPos(hwnd, HWND_NOTOPMOST, ...)` to avoid leaving windows permanently topmost in `src/multi_manager/win.rs`.
- Before moving, validate the handle with `is_valid_window(hwnd)`, restore minimized windows with `ShowWindowAsync(hwnd, SW_RESTORE)` if `IsIconic(hwnd)` is true, call `BringWindowToTop(hwnd)`, and call `SetForegroundWindow(hwnd)`.
- Preserve the non-Windows stub which returns an unsupported-platform error for `move_window_to_rect`.
- Update UI move actions so manual move button logic passes errors from `win::move_window_to_rect` into `app.report_error_message("multi_manager.move_window", format!("{err}"))` in `src/multi_manager/ui.rs`.
- Keep `runtime::WindowOps` implementation using `win::move_window_to_rect` so fake `WindowOps` can still be used in unit tests in `src/multi_manager/runtime.rs`.
- Add runtime unit tests (using a `FakeWindowOps`) that cover movement invocation decisions (workspace vs per-window fallback rects and skipping disabled/invalid/zero-handle windows), and add an ignored Windows smoke-test checklist in `win.rs` documenting manual validation steps for restore/foreground/topmost removal/elevated-window error surfacing.

### Testing
- Ran code formatting with `rustfmt` and checked diffs with `git diff --check` successfully.
- Ran `cargo test multi_manager` in this Linux environment but the build failed before the module tests could run due to crate-wide Windows API resolution/build errors (`windows::Win32` / `windows::core` imports) when compiling other platform-gated code; therefore the newly added unit tests could not be executed here.
- An ignored Windows smoke-test was added for manual verification of minimized restore, foreground/top behavior, topmost removal, and elevated-window error surfacing on an actual Windows environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306f25101083328cee6a8fb862c507)