### PR TITLE
Capture window identity metadata

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -602,6 +602,9 @@ mod tests {
                 w: 100,
                 h: 100,
             },
+            executable: format!("{title}.exe"),
+            class_name: format!("{title}Class"),
+            process_path: format!("C:/Apps/{title}.exe"),
         }
     }
 

--- a/src/multi_manager/apply_capture.rs
+++ b/src/multi_manager/apply_capture.rs
@@ -29,6 +29,9 @@ pub fn apply_capture_to_workspaces(
                 hwnd: captured.hwnd,
                 home_rect: Some(captured.rect),
                 target_rect: Some(captured.rect),
+                executable: captured.executable,
+                class_name: captured.class_name,
+                process_path: captured.process_path,
                 valid: true,
                 ..Default::default()
             });
@@ -50,6 +53,9 @@ pub fn apply_capture_to_workspaces(
 
             window.hwnd = captured.hwnd;
             window.title = captured.title.clone();
+            window.executable = captured.executable;
+            window.class_name = captured.class_name;
+            window.process_path = captured.process_path;
             window.valid = true;
             if window.alias.trim().is_empty() {
                 window.alias = captured.title;
@@ -76,10 +82,31 @@ mod tests {
     }
 
     fn captured(hwnd: usize, title: &str, rect: MmRect) -> CapturedWindow {
+        captured_with_metadata(
+            hwnd,
+            title,
+            rect,
+            &format!("{title}.exe"),
+            &format!("{title}Class"),
+            &format!("C:/Apps/{title}.exe"),
+        )
+    }
+
+    fn captured_with_metadata(
+        hwnd: usize,
+        title: &str,
+        rect: MmRect,
+        executable: &str,
+        class_name: &str,
+        process_path: &str,
+    ) -> CapturedWindow {
         CapturedWindow {
             hwnd,
             title: title.to_string(),
             rect,
+            executable: executable.to_string(),
+            class_name: class_name.to_string(),
+            process_path: process_path.to_string(),
         }
     }
 
@@ -103,6 +130,9 @@ mod tests {
         assert_eq!(window.hwnd, 7);
         assert_eq!(window.home_rect, Some(capture_rect));
         assert_eq!(window.target_rect, Some(capture_rect));
+        assert_eq!(window.executable, "Editor.exe");
+        assert_eq!(window.class_name, "EditorClass");
+        assert_eq!(window.process_path, "C:/Apps/Editor.exe");
         assert!(window.valid);
     }
 
@@ -161,6 +191,9 @@ mod tests {
         assert_eq!(result, ApplyCaptureResult::Applied);
         assert_eq!(workspaces[0].windows[0].hwnd, 99);
         assert_eq!(workspaces[0].windows[0].title, "New");
+        assert_eq!(workspaces[0].windows[0].executable, "New.exe");
+        assert_eq!(workspaces[0].windows[0].class_name, "NewClass");
+        assert_eq!(workspaces[0].windows[0].process_path, "C:/Apps/New.exe");
         assert!(workspaces[0].windows[0].valid);
     }
 
@@ -190,6 +223,55 @@ mod tests {
         assert_eq!(result, ApplyCaptureResult::Applied);
         assert_eq!(workspaces[0].windows[0].home_rect, Some(home));
         assert_eq!(workspaces[0].windows[0].target_rect, Some(target));
+    }
+
+    #[test]
+    fn recapturing_preserves_rectangles_but_updates_identity_metadata() {
+        let home = rect(10, 20, 300, 400);
+        let target = rect(50, 60, 700, 800);
+        let mut workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: vec![MmWindow {
+                alias: "Stable Alias".into(),
+                title: "Old Title".into(),
+                hwnd: 11,
+                executable: "old.exe".into(),
+                class_name: "OldClass".into(),
+                process_path: "C:/Old/old.exe".into(),
+                home_rect: Some(home),
+                target_rect: Some(target),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let result = apply_capture_to_workspaces(
+            &mut workspaces,
+            &PendingCaptureAction::RecaptureWindow {
+                workspace_id: "w".into(),
+                window_index: 0,
+            },
+            captured_with_metadata(
+                22,
+                "New Title",
+                rect(1, 2, 3, 4),
+                "new.exe",
+                "NewClass",
+                "C:/New/new.exe",
+            ),
+        );
+
+        let window = &workspaces[0].windows[0];
+        assert_eq!(result, ApplyCaptureResult::Applied);
+        assert_eq!(window.alias, "Stable Alias");
+        assert_eq!(window.hwnd, 22);
+        assert_eq!(window.title, "New Title");
+        assert_eq!(window.executable, "new.exe");
+        assert_eq!(window.class_name, "NewClass");
+        assert_eq!(window.process_path, "C:/New/new.exe");
+        assert_eq!(window.home_rect, Some(home));
+        assert_eq!(window.target_rect, Some(target));
+        assert!(window.valid);
     }
 
     #[test]

--- a/src/multi_manager/win.rs
+++ b/src/multi_manager/win.rs
@@ -6,6 +6,9 @@ pub struct CapturedWindow {
     pub hwnd: usize,
     pub title: String,
     pub rect: MmRect,
+    pub executable: String,
+    pub class_name: String,
+    pub process_path: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -111,6 +114,9 @@ pub fn active_window() -> Option<CapturedWindow> {
         hwnd: hwnd_value,
         title: window_title(hwnd_value)?,
         rect: window_rect(hwnd_value)?,
+        executable: window_executable(hwnd_value).unwrap_or_default(),
+        class_name: window_class_name(hwnd_value).unwrap_or_default(),
+        process_path: window_process_path(hwnd_value).unwrap_or_default(),
     })
 }
 
@@ -154,6 +160,89 @@ pub fn window_title(hwnd: usize) -> Option<String> {
 
 #[cfg(not(windows))]
 pub fn window_title(_hwnd: usize) -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
+pub fn window_class_name(hwnd: usize) -> Option<String> {
+    use windows::Win32::UI::WindowsAndMessaging::GetClassNameW;
+
+    let mut buffer = vec![0u16; 256];
+    let copied = unsafe { GetClassNameW(hwnd_from_usize(hwnd), &mut buffer) };
+    if copied <= 0 {
+        return None;
+    }
+    Some(String::from_utf16_lossy(&buffer[..copied as usize]))
+}
+
+#[cfg(not(windows))]
+pub fn window_class_name(_hwnd: usize) -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
+pub fn window_process_path(hwnd: usize) -> Option<String> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    use windows::core::PWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+
+    let mut pid = 0u32;
+    unsafe {
+        let _ = GetWindowThreadProcessId(hwnd_from_usize(hwnd), Some(&mut pid));
+    }
+    if pid == 0 {
+        return None;
+    }
+
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+    let mut buffer = vec![0u16; 1024];
+    let mut size = buffer.len() as u32;
+    let result = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            PWSTR(buffer.as_mut_ptr()),
+            &mut size,
+        )
+    };
+    let _ = unsafe { CloseHandle(handle) };
+
+    if result.is_err() || size == 0 {
+        return None;
+    }
+
+    Some(
+        OsString::from_wide(&buffer[..size as usize])
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+#[cfg(not(windows))]
+pub fn window_process_path(_hwnd: usize) -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
+pub fn window_executable(hwnd: usize) -> Option<String> {
+    use std::path::Path;
+
+    window_process_path(hwnd).and_then(|process_path| {
+        Path::new(&process_path)
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+    })
+}
+
+#[cfg(not(windows))]
+pub fn window_executable(_hwnd: usize) -> Option<String> {
     None
 }
 


### PR DESCRIPTION
### Motivation
- Include additional identity metadata for captured windows so the multi-manager can record and update executable, class name, and full process path for Windows targets.
- Provide helpers to read that metadata from Win32 APIs so captures and recaptures can populate these fields automatically.

### Description
- Extended `CapturedWindow` (`src/multi_manager/win.rs`) with `executable: String`, `class_name: String`, and `process_path: String`, and updated `active_window()` to populate them (falling back to empty strings when unavailable). 
- Added Windows helper functions `window_class_name(hwnd: usize) -> Option<String>`, `window_process_path(hwnd: usize) -> Option<String>`, and `window_executable(hwnd: usize) -> Option<String>` implemented with `GetClassNameW`, `GetWindowThreadProcessId`, `OpenProcess`, and `QueryFullProcessImageNameW`, with non-Windows stubs returning `None`.
- Updated apply/recapture logic in `apply_capture_to_workspaces` (`src/multi_manager/apply_capture.rs`) to persist `executable`, `class_name`, and `process_path` when adding a window, and to update `hwnd`, `title`, and identity metadata on recapture while preserving existing `alias` (unless blank), `home_rect`, and `target_rect`.
- Updated test constructors and GUI test helper constructors to build `CapturedWindow` with the new metadata and added a unit test `recapturing_preserves_rectangles_but_updates_identity_metadata` that asserts rectangles are preserved while identity metadata is updated.

### Testing
- Added unit tests in `src/multi_manager/apply_capture.rs` covering capture, recapture, and the new identity-metadata behavior (these tests are included in the change set).
- Attempted to run `cargo test apply_capture --lib` in the CI/dev environment but the build aborted due to a system dependency failure unrelated to these changes: `alsa-sys` could not find the `alsa.pc` pkg-config file, so the test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307290b52483329b0d4c5560de2590)