### PR TITLE
Add top-level window enumeration for MultiManager

### DIFF
--- a/src/multi_manager/win.rs
+++ b/src/multi_manager/win.rs
@@ -11,6 +11,16 @@ pub struct CapturedWindow {
     pub process_path: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumeratedWindow {
+    pub hwnd: usize,
+    pub title: String,
+    pub executable: String,
+    pub class_name: String,
+    pub process_path: String,
+    pub rect: MmRect,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaptureKeyAction {
     Confirm,
@@ -88,6 +98,14 @@ fn rect_from_win32(rect: windows::Win32::Foundation::RECT) -> MmRect {
         w: rect.right - rect.left,
         h: rect.bottom - rect.top,
     }
+}
+
+fn executable_from_process_path(process_path: &str) -> Option<String> {
+    process_path
+        .rsplit(['\\', '/'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 #[cfg(windows)]
@@ -232,13 +250,7 @@ pub fn window_process_path(_hwnd: usize) -> Option<String> {
 
 #[cfg(windows)]
 pub fn window_executable(hwnd: usize) -> Option<String> {
-    use std::path::Path;
-
-    window_process_path(hwnd).and_then(|process_path| {
-        Path::new(&process_path)
-            .file_name()
-            .map(|name| name.to_string_lossy().to_string())
-    })
+    window_process_path(hwnd).and_then(|process_path| executable_from_process_path(&process_path))
 }
 
 #[cfg(not(windows))]
@@ -255,6 +267,77 @@ pub fn is_valid_window(hwnd: usize) -> bool {
 #[cfg(not(windows))]
 pub fn is_valid_window(_hwnd: usize) -> bool {
     false
+}
+
+#[cfg(windows)]
+pub fn enumerate_top_level_windows() -> anyhow::Result<Vec<EnumeratedWindow>> {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindow, GetWindowLongPtrW, IsWindow, IsWindowVisible, GWL_EXSTYLE,
+        GW_OWNER, WS_EX_TOOLWINDOW,
+    };
+
+    struct Ctx {
+        windows: Vec<EnumeratedWindow>,
+    }
+
+    fn hwnd_to_usize(hwnd: HWND) -> usize {
+        hwnd.0 as usize
+    }
+
+    unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let ctx = unsafe { &mut *(lparam.0 as *mut Ctx) };
+        if hwnd.0.is_null() || !unsafe { IsWindow(hwnd) }.as_bool() {
+            return BOOL(1);
+        }
+        if !unsafe { IsWindowVisible(hwnd) }.as_bool() {
+            return BOOL(1);
+        }
+        if !unsafe { GetWindow(hwnd, GW_OWNER) }
+            .unwrap_or_default()
+            .0
+            .is_null()
+        {
+            return BOOL(1);
+        }
+        let ex_style = unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) } as u32;
+        if ex_style & WS_EX_TOOLWINDOW.0 != 0 {
+            return BOOL(1);
+        }
+
+        let hwnd_value = hwnd_to_usize(hwnd);
+        let Some(title) = window_title(hwnd_value).filter(|title| !title.trim().is_empty()) else {
+            return BOOL(1);
+        };
+        let Some(rect) = window_rect(hwnd_value) else {
+            return BOOL(1);
+        };
+
+        ctx.windows.push(EnumeratedWindow {
+            hwnd: hwnd_value,
+            title,
+            executable: window_executable(hwnd_value).unwrap_or_default(),
+            class_name: window_class_name(hwnd_value).unwrap_or_default(),
+            process_path: window_process_path(hwnd_value).unwrap_or_default(),
+            rect,
+        });
+        BOOL(1)
+    }
+
+    let mut ctx = Ctx {
+        windows: Vec::new(),
+    };
+    unsafe {
+        let ctx_ptr = &mut ctx as *mut Ctx;
+        EnumWindows(Some(enum_cb), LPARAM(ctx_ptr as isize))
+            .map_err(|err| anyhow!("failed to enumerate top-level windows: {err}"))?;
+    }
+    Ok(ctx.windows)
+}
+
+#[cfg(not(windows))]
+pub fn enumerate_top_level_windows() -> anyhow::Result<Vec<EnumeratedWindow>> {
+    Ok(Vec::new())
 }
 
 #[cfg(windows)]
@@ -349,6 +432,21 @@ mod tests {
         assert!(!hotkey_pressed_with("Ctrl+", down));
     }
 
+    #[test]
+    fn executable_from_process_path_handles_common_path_styles() {
+        assert_eq!(
+            executable_from_process_path(r"C:\Program Files\App\app.exe"),
+            Some("app.exe".to_string())
+        );
+        assert_eq!(
+            executable_from_process_path("/usr/bin/app"),
+            Some("app".to_string())
+        );
+        assert_eq!(executable_from_process_path("app"), Some("app".to_string()));
+        assert_eq!(executable_from_process_path(""), None);
+        assert_eq!(executable_from_process_path(r"C:\Program Files\App\"), None);
+    }
+
     #[cfg(windows)]
     #[test]
     #[ignore = "Windows smoke test checklist: use a real, non-elevated application window HWND and verify minimized windows restore, the window is brought foreground, it is not left topmost, and elevated/inaccessible windows surface an error."]
@@ -383,6 +481,9 @@ mod tests {
     #[test]
     fn non_windows_capture_and_query_stubs_are_safe() {
         assert!(active_window().is_none());
+        assert!(enumerate_top_level_windows()
+            .expect("non-Windows enumeration stub must succeed")
+            .is_empty());
         assert!(window_rect(1).is_none());
         assert!(window_title(1).is_none());
         assert!(!is_valid_window(1));


### PR DESCRIPTION
### Motivation
- Provide a way to enumerate top-level application windows and collect metadata needed by the MultiManager code-paths (hwnd, title, executable, class, process path, rect). 
- Reuse existing Win32 helpers instead of duplicating conversion and path handling logic.

### Description
- Added a public `EnumeratedWindow` struct containing `hwnd`, `title`, `executable`, `class_name`, `process_path`, and `rect`.
- Added `fn executable_from_process_path(process_path: &str) -> Option<String>` and re-used it from `window_executable` to extract executable names from process paths.
- Implemented `enumerate_top_level_windows() -> anyhow::Result<Vec<EnumeratedWindow>>` for Windows using `EnumWindows` and Win32 APIs, applying these filters: skip invalid HWNDs, skip invisible windows via `IsWindowVisible`, skip owned windows via `GetWindow(hwnd, GW_OWNER)`, skip tool windows via `GetWindowLongPtrW`/`WS_EX_TOOLWINDOW`, and skip windows with empty titles; window title, rect, class, executable and process path are read via the existing helpers.
- Provided a non-Windows stub `enumerate_top_level_windows()` that returns `Ok(Vec::new())`.
- Reused patterns and checks from `src/windows_layout.rs` (filtering and Win32 calls) rather than duplicating complex conversion logic.
- Added unit tests: `executable_from_process_path_handles_common_path_styles` and an assertion in the non-Windows tests that the enumeration stub returns an empty vector.

### Testing
- Ran formatting and static checks: `rustfmt --check src/multi_manager/win.rs` (passed) and `git diff --check` (passed).
- Added unit tests for the new helper and non-Windows stub; running the full `cargo test -q multi_manager::win::tests` in this Linux environment could not complete because the workspace build pulls platform-specific crates and system libraries (errors surfaced from `alsa-sys`, `x11` and attempts to compile Windows-specific `windows::Win32` code on Linux), so the test run failed in this environment; the new pure-unit tests are present and should run successfully on the appropriate platform/CI that can compile the crate (or when running tests targeting only this module on Windows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3074fcaec08332ae09bd615bfc7dae)