### PR TITLE
Add MultiManager auto reconnect settings

### DIFF
--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -1,5 +1,5 @@
 use crate::multi_manager::model::{MmHotkey, MmRect, MmWorkspace};
-use crate::multi_manager::win;
+use crate::multi_manager::{reconnect, win};
 use crate::settings::MultiManagerSettings;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -82,12 +82,25 @@ impl MultiManagerRuntime {
         let thread_control = Arc::clone(&control);
         let thread_last_hotkey_info = Arc::clone(&last_hotkey_info);
         let poll = Duration::from_millis(settings.hotkey_poll_ms);
+        let reconnect_interval = Duration::from_millis(settings.auto_reconnect_interval_ms);
+        let auto_reconnect_missing_windows = settings.auto_reconnect_missing_windows;
         let join_handle = thread::spawn(move || {
             let mut debounce = HashMap::new();
+            let mut last_reconnect = Instant::now() - reconnect_interval;
             let win_ops = WinWindowOps;
             let hotkey_ops = WinHotkeyOps;
             while !thread_control.shutdown.load(Ordering::Relaxed) {
                 thread::sleep(poll);
+                let now = Instant::now();
+                maybe_runtime_reconnect(
+                    &thread_workspaces,
+                    &thread_control,
+                    auto_reconnect_missing_windows,
+                    &mut last_reconnect,
+                    reconnect_interval,
+                    now,
+                    || win::enumerate_top_level_windows().unwrap_or_default(),
+                );
                 if let Ok(mut workspaces) = thread_workspaces.lock() {
                     runtime_tick(
                         &mut workspaces,
@@ -97,7 +110,7 @@ impl MultiManagerRuntime {
                         DEFAULT_DEBOUNCE,
                         &win_ops,
                         &hotkey_ops,
-                        Instant::now(),
+                        now,
                     );
                 }
             }
@@ -273,6 +286,42 @@ fn hotkey_sequence(hotkey: &MmHotkey) -> Option<String> {
     Some(parts.join("+"))
 }
 
+pub fn maybe_runtime_reconnect(
+    workspaces: &Arc<Mutex<Vec<MmWorkspace>>>,
+    control: &RuntimeControl,
+    auto_reconnect_missing_windows: bool,
+    last_reconnect: &mut Instant,
+    reconnect_interval: Duration,
+    now: Instant,
+    enumerate: impl FnOnce() -> Vec<win::EnumeratedWindow>,
+) -> bool {
+    if !control.enabled.load(Ordering::Relaxed)
+        || !auto_reconnect_missing_windows
+        || control.capture_pending.load(Ordering::Relaxed)
+        || now.duration_since(*last_reconnect) < reconnect_interval
+    {
+        return false;
+    }
+
+    let needs_reconnect = workspaces
+        .lock()
+        .map(|workspaces| reconnect::needs_reconnect(&workspaces))
+        .unwrap_or(false);
+    if !needs_reconnect {
+        *last_reconnect = now;
+        return false;
+    }
+
+    let live = enumerate();
+    if let Ok(mut workspaces) = workspaces.lock() {
+        reconnect::reconnect_workspaces_with_windows(&mut workspaces, &live);
+        *last_reconnect = now;
+        true
+    } else {
+        false
+    }
+}
+
 pub fn runtime_tick(
     workspaces: &mut [MmWorkspace],
     control: &RuntimeControl,
@@ -311,6 +360,7 @@ pub fn runtime_tick(
 mod tests {
     use super::*;
     use crate::multi_manager::model::{MmHotkey, MmWindow};
+    use crate::multi_manager::win::EnumeratedWindow;
     use std::cell::RefCell;
 
     fn rect(x: i32) -> MmRect {
@@ -352,6 +402,17 @@ mod tests {
             home_rect: Some(home),
             target_rect: Some(target),
             ..MmWindow::default()
+        }
+    }
+
+    fn live(hwnd: usize, title: &str) -> EnumeratedWindow {
+        EnumeratedWindow {
+            hwnd,
+            title: title.into(),
+            executable: "app.exe".into(),
+            class_name: "AppClass".into(),
+            process_path: "C:/app.exe".into(),
+            rect: rect(0),
         }
     }
 
@@ -480,6 +541,133 @@ mod tests {
         );
         assert!(ops.moves.borrow().is_empty());
         assert!(info.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn runtime_reconnect_skipped_during_capture() {
+        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
+        workspaces.lock().unwrap()[0].windows[0].hwnd = 0;
+        let control = RuntimeControl::new(true);
+        control.capture_pending.store(true, Ordering::Relaxed);
+        let now = Instant::now();
+        let mut last = now - Duration::from_secs(10);
+        let enumerated = RefCell::new(false);
+
+        let reconnected = maybe_runtime_reconnect(
+            &workspaces,
+            &control,
+            true,
+            &mut last,
+            Duration::from_millis(1),
+            now,
+            || {
+                *enumerated.borrow_mut() = true;
+                vec![live(10, "anything")]
+            },
+        );
+
+        assert!(!reconnected);
+        assert!(!*enumerated.borrow());
+    }
+
+    #[test]
+    fn runtime_reconnect_does_not_enumerate_when_all_windows_are_valid() {
+        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
+        let control = RuntimeControl::new(true);
+        let now = Instant::now();
+        let mut last = now - Duration::from_secs(10);
+        let enumerated = RefCell::new(false);
+
+        let reconnected = maybe_runtime_reconnect(
+            &workspaces,
+            &control,
+            true,
+            &mut last,
+            Duration::from_millis(1),
+            now,
+            || {
+                *enumerated.borrow_mut() = true;
+                Vec::new()
+            },
+        );
+
+        assert!(!reconnected);
+        assert!(!*enumerated.borrow());
+    }
+
+    #[test]
+    fn runtime_reconnect_assigns_missing_window_from_unique_candidate() {
+        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
+        {
+            let mut locked = workspaces.lock().unwrap();
+            locked[0].windows[0].hwnd = 0;
+            locked[0].windows[0].title = "Notes".into();
+            locked[0].windows[0].executable = "app.exe".into();
+            locked[0].windows[0].class_name = "AppClass".into();
+            locked[0].windows[0].process_path = "C:/app.exe".into();
+        }
+        let control = RuntimeControl::new(true);
+        let now = Instant::now();
+        let mut last = now - Duration::from_secs(10);
+
+        let reconnected = maybe_runtime_reconnect(
+            &workspaces,
+            &control,
+            true,
+            &mut last,
+            Duration::from_millis(1),
+            now,
+            || vec![live(42, "Notes")],
+        );
+
+        assert!(reconnected);
+        assert_eq!(workspaces.lock().unwrap()[0].windows[0].hwnd, 42);
+    }
+
+    #[test]
+    fn runtime_hotkey_toggle_works_after_reconnect_assigns_hwnd() {
+        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
+        {
+            let mut locked = workspaces.lock().unwrap();
+            locked[0].windows = vec![window(0, true, rect(1), rect(11))];
+            locked[0].windows[0].title = "Notes".into();
+            locked[0].windows[0].executable = "app.exe".into();
+            locked[0].windows[0].class_name = "AppClass".into();
+            locked[0].windows[0].process_path = "C:/app.exe".into();
+        }
+        let control = RuntimeControl::new(true);
+        let now = Instant::now();
+        let mut last = now - Duration::from_secs(10);
+        assert!(maybe_runtime_reconnect(
+            &workspaces,
+            &control,
+            true,
+            &mut last,
+            Duration::from_millis(1),
+            now,
+            || vec![live(42, "Notes")],
+        ));
+
+        let info = Arc::new(Mutex::new(None));
+        let mut debounce = HashMap::new();
+        let mut ops = FakeWindowOps::default();
+        ops.at_home.insert(42, rect(1));
+        runtime_tick(
+            &mut workspaces.lock().unwrap(),
+            &control,
+            &info,
+            &mut debounce,
+            DEFAULT_DEBOUNCE,
+            &ops,
+            &FakeHotkeyOps(true),
+            now + Duration::from_secs(1),
+        );
+
+        assert_eq!(*ops.moves.borrow(), vec![(42, rect(11))]);
+        assert_eq!(
+            info.lock().unwrap().as_ref().map(|(id, _)| id.as_str()),
+            Some("ws")
+        );
     }
 
     #[test]

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -1,6 +1,6 @@
 use crate::multi_manager::model::{MmWorkspace, PendingCaptureAction, RecaptureQueueItem};
 use crate::multi_manager::runtime::MultiManagerRuntime;
-use crate::multi_manager::store;
+use crate::multi_manager::{reconnect, store};
 use crate::settings::MultiManagerSettings;
 use anyhow::{Context, Result};
 use std::collections::VecDeque;
@@ -22,6 +22,9 @@ pub struct MultiManagerState {
     pub workspace_path: PathBuf,
     pub bindings_path: PathBuf,
     pub auto_save: bool,
+    pub auto_reconnect_on_load: bool,
+    pub auto_reconnect_missing_windows: bool,
+    pub reconnect_interval: Duration,
     save_debounce: Duration,
     dirty_since: Option<Instant>,
     last_save_attempt: Option<Instant>,
@@ -34,7 +37,11 @@ impl MultiManagerState {
             .unwrap_or_else(|| Path::new("."));
         let workspace_path = resolve_relative_to(settings_dir, &settings.workspaces_path);
         let bindings_path = resolve_relative_to(settings_dir, &settings.bindings_path);
-        let workspaces = Arc::new(Mutex::new(store::load_or_default(&workspace_path)));
+        let mut loaded = store::load_or_default(&workspace_path);
+        if settings.auto_reconnect_on_load {
+            reconnect::reconnect_workspaces(&mut loaded);
+        }
+        let workspaces = Arc::new(Mutex::new(loaded));
         let runtime = if settings.enabled {
             MultiManagerRuntime::start(Arc::clone(&workspaces), settings.clone())
         } else {
@@ -54,6 +61,9 @@ impl MultiManagerState {
             workspace_path,
             bindings_path,
             auto_save: settings.auto_save,
+            auto_reconnect_on_load: settings.auto_reconnect_on_load,
+            auto_reconnect_missing_windows: settings.auto_reconnect_missing_windows,
+            reconnect_interval: Duration::from_millis(settings.auto_reconnect_interval_ms),
             save_debounce: AUTO_SAVE_DEBOUNCE,
             dirty_since: None,
             last_save_attempt: None,
@@ -78,7 +88,10 @@ impl MultiManagerState {
     }
 
     pub fn reload(&mut self) -> Result<()> {
-        let loaded = store::load_workspaces(&self.workspace_path)?;
+        let mut loaded = store::load_workspaces(&self.workspace_path)?;
+        if self.auto_reconnect_on_load {
+            reconnect::reconnect_workspaces(&mut loaded);
+        }
         let mut workspaces = self
             .workspaces
             .lock()

--- a/src/settings/defaults.rs
+++ b/src/settings/defaults.rs
@@ -112,3 +112,6 @@ pub fn default_multi_manager_bindings_path() -> String {
 pub fn default_multi_manager_hotkey_poll_ms() -> u64 {
     50
 }
+pub fn default_multi_manager_reconnect_interval_ms() -> u64 {
+    3000
+}

--- a/src/settings/model.rs
+++ b/src/settings/model.rs
@@ -294,6 +294,12 @@ pub struct MultiManagerSettings {
     pub show_force_recapture_prompt: bool,
     #[serde(default = "default_multi_manager_hotkey_poll_ms")]
     pub hotkey_poll_ms: u64,
+    #[serde(default = "default_true")]
+    pub auto_reconnect_on_load: bool,
+    #[serde(default = "default_true")]
+    pub auto_reconnect_missing_windows: bool,
+    #[serde(default = "default_multi_manager_reconnect_interval_ms")]
+    pub auto_reconnect_interval_ms: u64,
     #[serde(default)]
     pub hide_launcher_before_toggle: bool,
     #[serde(default = "default_true")]
@@ -311,6 +317,9 @@ impl Default for MultiManagerSettings {
             developer_debugging: false,
             show_force_recapture_prompt: false,
             hotkey_poll_ms: default_multi_manager_hotkey_poll_ms(),
+            auto_reconnect_on_load: true,
+            auto_reconnect_missing_windows: true,
+            auto_reconnect_interval_ms: default_multi_manager_reconnect_interval_ms(),
             hide_launcher_before_toggle: false,
             ignore_launcher_window_on_capture: true,
         }
@@ -572,6 +581,17 @@ mod tests {
     }
 
     #[test]
+    fn multi_manager_reconnect_settings_round_trip_serialization() {
+        let mut settings = Settings::default();
+        settings.multi_manager.auto_reconnect_on_load = false;
+        settings.multi_manager.auto_reconnect_missing_windows = false;
+        settings.multi_manager.auto_reconnect_interval_ms = 7500;
+        let json = serde_json::to_string(&settings).expect("serialize settings");
+        let restored: Settings = serde_json::from_str(&json).expect("deserialize settings");
+        assert_eq!(restored.multi_manager, settings.multi_manager);
+    }
+
+    #[test]
     fn query_results_layout_defaults_are_backward_compatible() {
         let parsed: Settings = serde_json::from_str("{}").expect("settings should deserialize");
         assert_eq!(
@@ -609,6 +629,9 @@ mod tests {
                 "developer_debugging": parsed.multi_manager.developer_debugging,
                 "show_force_recapture_prompt": parsed.multi_manager.show_force_recapture_prompt,
                 "hotkey_poll_ms": parsed.multi_manager.hotkey_poll_ms,
+                "auto_reconnect_on_load": parsed.multi_manager.auto_reconnect_on_load,
+                "auto_reconnect_missing_windows": parsed.multi_manager.auto_reconnect_missing_windows,
+                "auto_reconnect_interval_ms": parsed.multi_manager.auto_reconnect_interval_ms,
                 "hide_launcher_before_toggle": parsed.multi_manager.hide_launcher_before_toggle,
                 "ignore_launcher_window_on_capture": parsed.multi_manager.ignore_launcher_window_on_capture,
             },
@@ -622,7 +645,7 @@ mod tests {
         });
         assert_eq!(
             serde_json::to_string_pretty(&snapshot).unwrap(),
-            "{\n  \"multi_manager\": {\n    \"auto_save\": true,\n    \"bindings_path\": \"multi_manager_bindings.json\",\n    \"developer_debugging\": false,\n    \"enabled\": true,\n    \"hide_launcher_before_toggle\": false,\n    \"hotkey_poll_ms\": 50,\n    \"ignore_launcher_window_on_capture\": true,\n    \"save_on_exit\": true,\n    \"show_force_recapture_prompt\": false,\n    \"workspaces_path\": \"multi_manager_workspaces.json\"\n  },\n  \"note_show_details\": false,\n  \"query_results_layout\": {\n    \"cols\": 2,\n    \"enabled\": false,\n    \"plugin_opt_out\": [],\n    \"respect_plugin_capability\": true,\n    \"rows\": 3\n  },\n  \"show_error_toasts\": true,\n  \"show_inline_errors\": true\n}"
+            "{\n  \"multi_manager\": {\n    \"auto_reconnect_interval_ms\": 3000,\n    \"auto_reconnect_missing_windows\": true,\n    \"auto_reconnect_on_load\": true,\n    \"auto_save\": true,\n    \"bindings_path\": \"multi_manager_bindings.json\",\n    \"developer_debugging\": false,\n    \"enabled\": true,\n    \"hide_launcher_before_toggle\": false,\n    \"hotkey_poll_ms\": 50,\n    \"ignore_launcher_window_on_capture\": true,\n    \"save_on_exit\": true,\n    \"show_force_recapture_prompt\": false,\n    \"workspaces_path\": \"multi_manager_workspaces.json\"\n  },\n  \"note_show_details\": false,\n  \"query_results_layout\": {\n    \"cols\": 2,\n    \"enabled\": false,\n    \"plugin_opt_out\": [],\n    \"respect_plugin_capability\": true,\n    \"rows\": 3\n  },\n  \"show_error_toasts\": true,\n  \"show_inline_errors\": true\n}"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Provide automatic workspace HWND reconnection on load and periodically at runtime to restore missing windows without user intervention.
- Allow configuring whether to auto-reconnect on load, whether runtime reconnecting should target missing windows, and how often to attempt reconnects.
- Keep HWND-only changes from causing a settings save because `hwnd` is skipped during serialization.

### Description
- Added `auto_reconnect_on_load: bool`, `auto_reconnect_missing_windows: bool`, and `auto_reconnect_interval_ms: u64` to `MultiManagerSettings` with `#[serde(default = "...")]` helpers and updated `Default` to enable them and set a 3000ms interval default.
- Updated settings serialization/backcompat tests and added a round-trip test for the new reconnect fields in `src/settings/model.rs`.
- Extended `MultiManagerState` with `auto_reconnect_on_load`, `auto_reconnect_missing_windows`, and `reconnect_interval` fields, and changed `load_or_default` and `reload` to call `reconnect::reconnect_workspaces` on the loaded vector when `auto_reconnect_on_load` is enabled so HWND-only updates do not mark the state dirty.
- Added a lightweight runtime reconnect flow in `src/multi_manager/runtime.rs` via `maybe_runtime_reconnect` and integrated it into the runtime thread before hotkey checks; the helper checks `reconnect::needs_reconnect` while locked, drops the lock to enumerate live windows, then re-locks briefly to apply reconnect results, and avoids emitting UI toasts from the runtime thread.
- Added pure-helper unit tests for runtime reconnect behavior covering capture-skip, no-enumeration when windows are valid, unique-candidate assignment, and hotkey/toggle behavior after reconnect assigns an `HWND`.

### Testing
- Ran `git diff --check` which produced no issues.
- Attempted `cargo test runtime_reconnect --lib`, but the test run could not complete in this environment due to platform-specific build failures: initial dependency native packages were installed to satisfy ALSA/X11 build steps, however subsequent compilation failed because of non-Windows `windows::Win32`/`windows::core` platform-gated symbols being unresolved on the Linux CI host, so the new unit tests were added but not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307dd835488332945fb1dd3ab1bf6c)