### PR TITLE
Add MultiManager reconnect windows action

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -63,7 +63,21 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_reconnect_windows(&mut self) {
-        self.multi_manager_restore_bindings();
+        let summary = match self.multi_manager.workspaces.lock() {
+            Ok(mut workspaces) => {
+                crate::multi_manager::reconnect::reconnect_workspaces(&mut workspaces)
+            }
+            Err(_) => {
+                self.report_error_message(
+                    "multi_manager.reconnect",
+                    "Failed to lock MultiManager workspaces to reconnect windows",
+                );
+                return;
+            }
+        };
+
+        self.multi_manager.mark_dirty();
+        self.add_success_toast(format_reconnect_summary(summary));
     }
 
     pub fn multi_manager_start_recapture_all(&mut self) {
@@ -525,6 +539,15 @@ impl LauncherApp {
     }
 }
 
+pub(crate) fn format_reconnect_summary(
+    summary: crate::multi_manager::reconnect::ReconnectSummary,
+) -> String {
+    format!(
+        "Reconnected MultiManager windows: {} reconnected, {} missing, {} ambiguous",
+        summary.reconnected, summary.missing, summary.ambiguous
+    )
+}
+
 pub(crate) fn build_recapture_queue(
     workspaces: &[crate::multi_manager::model::MmWorkspace],
 ) -> Vec<RecaptureQueueItem> {
@@ -550,7 +573,7 @@ pub(crate) fn build_recapture_queue(
 
 #[cfg(test)]
 mod tests {
-    use super::build_recapture_queue;
+    use super::{build_recapture_queue, format_reconnect_summary};
     use crate::gui::LauncherApp;
     use crate::multi_manager::capture::CaptureEvent;
     use crate::multi_manager::model::{
@@ -561,9 +584,25 @@ mod tests {
     use crate::settings::Settings;
     use std::collections::VecDeque;
     use std::sync::{
-        Arc,
         atomic::{AtomicBool, Ordering},
+        Arc,
     };
+
+    #[test]
+    fn reconnect_summary_format_includes_action_counts() {
+        let summary = crate::multi_manager::reconnect::ReconnectSummary {
+            reconnected: 2,
+            missing: 3,
+            ambiguous: 4,
+            ..Default::default()
+        };
+
+        let text = format_reconnect_summary(summary);
+
+        assert!(text.contains("2 reconnected"));
+        assert!(text.contains("3 missing"));
+        assert!(text.contains("4 ambiguous"));
+    }
 
     fn test_app() -> LauncherApp {
         let ctx = eframe::egui::Context::default();
@@ -660,13 +699,12 @@ mod tests {
         );
 
         assert_eq!(app.multi_manager.pending_capture, None);
-        assert!(
-            !app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(!app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
         let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
         assert_eq!(workspaces[0].windows.len(), 1);
         assert_eq!(workspaces[0].windows[0].title, "Editor");
@@ -706,13 +744,12 @@ mod tests {
                 workspace_id: "w".into()
             })
         );
-        assert!(
-            app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
         let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
         assert_eq!(workspaces[0].windows.len(), 2);
         assert_eq!(workspaces[0].windows[0].title, "One");
@@ -749,13 +786,12 @@ mod tests {
 
         assert_eq!(app.multi_manager.pending_capture, None);
         assert!(app.multi_manager.capture_session.is_none());
-        assert!(
-            !app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(!app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
         let workspaces = app.multi_manager.workspaces.lock().expect("workspaces");
         assert_eq!(workspaces[0].windows.len(), 1);
         assert_eq!(workspaces[0].windows[0].title, "Editor");
@@ -796,13 +832,12 @@ mod tests {
             })
         );
         assert!(app.multi_manager.capture_session.is_some());
-        assert!(
-            app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
     }
 
     #[test]
@@ -835,13 +870,12 @@ mod tests {
         assert_eq!(app.multi_manager.pending_capture, None);
         assert!(app.multi_manager.recapture_active);
         assert_eq!(app.multi_manager.recapture_queue.len(), 1);
-        assert!(
-            app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
     }
 
     #[test]
@@ -878,13 +912,12 @@ mod tests {
         assert!(app.multi_manager.capture_session.is_none());
         assert!(!app.multi_manager.recapture_active);
         assert!(app.multi_manager.recapture_queue.is_empty());
-        assert!(
-            !app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(!app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
     }
 
     #[test]
@@ -917,13 +950,12 @@ mod tests {
         assert!(app.multi_manager.capture_session.is_none());
         assert!(app.multi_manager.recapture_active);
         assert_eq!(app.multi_manager.recapture_queue.len(), 2);
-        assert!(
-            app.multi_manager
-                .runtime
-                .control
-                .capture_pending
-                .load(Ordering::Relaxed)
-        );
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
     }
 
     #[test]

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -63,11 +63,18 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_reconnect_windows(&mut self) {
-        let summary = match self.multi_manager.workspaces.lock() {
-            Ok(mut workspaces) => {
+        let reconnect_result = self
+            .multi_manager
+            .workspaces
+            .lock()
+            .map(|mut workspaces| {
                 crate::multi_manager::reconnect::reconnect_workspaces(&mut workspaces)
-            }
-            Err(_) => {
+            })
+            .map_err(|_| ());
+
+        let summary = match reconnect_result {
+            Ok(summary) => summary,
+            Err(()) => {
                 self.report_error_message(
                     "multi_manager.reconnect",
                     "Failed to lock MultiManager workspaces to reconnect windows",

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -76,6 +76,9 @@ impl MultiManagerDialog {
                         if ui.button("Restore Bindings").clicked() {
                             app.multi_manager_restore_bindings();
                         }
+                        if ui.button("Reconnect Windows").clicked() {
+                            app.multi_manager_reconnect_windows();
+                        }
                         if ui.button("Refresh Titles").clicked() {
                             app.multi_manager_refresh_titles();
                         }

--- a/tests/multi_manager_launcher_actions.rs
+++ b/tests/multi_manager_launcher_actions.rs
@@ -4,7 +4,7 @@ use multi_launcher::gui::{ActivationSource, LauncherApp};
 use multi_launcher::plugin::PluginManager;
 use multi_launcher::settings::{MultiManagerSettings, Settings};
 use std::path::Path;
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::{atomic::AtomicBool, Arc};
 
 fn action(id: &str) -> Action {
     Action {
@@ -101,13 +101,11 @@ fn activating_mm_save_reports_error_without_panicking() {
 
     app.activate_action(action("mm:save"), None, ActivationSource::Enter);
 
-    assert!(
-        app.error
-            .as_deref()
-            .is_some_and(|msg| msg.contains("Failed to save MultiManager workspaces"))
-    );
+    assert!(app
+        .error
+        .as_deref()
+        .is_some_and(|msg| msg.contains("Failed to save MultiManager workspaces")));
 }
-
 
 #[test]
 fn activating_mm_send_all_home_reports_success_without_panicking() {
@@ -122,25 +120,8 @@ fn activating_mm_send_all_home_reports_success_without_panicking() {
 }
 
 #[test]
-fn activating_mm_reconnect_reports_error_without_panicking_when_bindings_missing() {
+fn activating_mm_reconnect_reports_success_without_panicking() {
     let dir = tempfile::tempdir().unwrap();
-    let settings = settings_with_multi_manager_paths(dir.path());
-    let mut app = new_app(settings);
-    app.show_inline_errors = true;
-
-    app.activate_action(action("mm:reconnect"), None, ActivationSource::Enter);
-
-    assert!(
-        app.error
-            .as_deref()
-            .is_some_and(|msg| msg.contains("Failed to load bindings"))
-    );
-}
-
-#[test]
-fn activating_mm_reconnect_reports_success_without_panicking_with_bindings_file() {
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("bindings.json"), "[]").unwrap();
     let settings = settings_with_multi_manager_paths(dir.path());
     let mut app = new_app(settings);
     app.enable_toasts = true;


### PR DESCRIPTION
### Motivation
- Provide a workspace-wide action to reconnect MultiManager windows by re-running the reconnect logic and surface a concise summary to the user.
- Expose the action from the UI so users can trigger reconnects from the MultiManager toolbar and via the existing command routing.

### Description
- Implemented `LauncherApp::multi_manager_reconnect_windows` to lock `self.multi_manager.workspaces`, report a `multi_manager.reconnect` error on lock failure, call `crate::multi_manager::reconnect::reconnect_workspaces(&mut workspaces)`, mark state dirty, and show a success toast with reconnected/missing/ambiguous counts. (see `src/gui/multi_manager_actions.rs`).
- Added `format_reconnect_summary` helper to format the reconnect summary used in the toast. (see `src/gui/multi_manager_actions.rs`).
- Added a `Reconnect Windows` toolbar button in the MultiManager dialog that calls `app.multi_manager_reconnect_windows()`. (see `src/multi_manager/ui.rs`).
- Ensured the `mm reconnect` command is present in the MultiManager command list and that `mm:reconnect` routes to `multi_manager_reconnect_windows()` in the action router (no change required in `src/gui/actions.rs` beyond confirming the routing). (see `src/multi_manager/commands.rs` and `src/gui/actions.rs`).
- Updated tests to cover the summary formatting and to assert activation of `mm:reconnect` does not panic (adjusted `tests/multi_manager_launcher_actions.rs` accordingly). (see `tests/multi_manager_launcher_actions.rs` and `src/gui/multi_manager_actions.rs` tests).

### Testing
- Ran `rustfmt` on the modified files to normalize formatting (succeeded).
- Added unit test `reconnect_summary_format_includes_action_counts` to verify the summary text contains reconnected/missing/ambiguous counts, and updated the launcher activation test to assert `mm:reconnect` activates without panicking.
- Attempted to run `cargo test` for the affected tests, but the build was blocked by a missing system dependency (`alsa.pc` required by `alsa-sys`), so the test run could not complete in this environment; tests should run successfully in an environment with the system ALSA development package (or with `alsa-sys` disabled/available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3081a8c72c833293b69b08a875577b)