### PR TITLE
Harden MultiManager HWND snapshot restore

### DIFF
--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -1,5 +1,6 @@
-use crate::multi_manager::model::MmWorkspace;
-use crate::multi_manager::win;
+use crate::multi_manager::model::{MmWindow, MmWorkspace};
+use crate::multi_manager::reconnect;
+use crate::multi_manager::win::{self, EnumeratedWindow};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -20,6 +21,9 @@ pub struct WindowBindingSnapshot {
     pub title: String,
     pub alias: Option<String>,
     pub hwnd: usize,
+    pub executable: Option<String>,
+    pub class_name: Option<String>,
+    pub process_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,6 +49,9 @@ pub fn save_bindings(path: &Path, workspaces: &[MmWorkspace]) -> Result<()> {
                     title: window.title.clone(),
                     alias: (!window.alias.is_empty()).then(|| window.alias.clone()),
                     hwnd: window.hwnd,
+                    executable: non_empty_string(&window.executable),
+                    class_name: non_empty_string(&window.class_name),
+                    process_path: non_empty_string(&window.process_path),
                 })
                 .collect(),
         })
@@ -62,13 +69,14 @@ pub fn load_bindings(path: &Path) -> Result<Vec<WorkspaceBindingSnapshot>> {
 }
 
 pub fn restore_bindings(workspaces: &mut [MmWorkspace], snapshots: &[WorkspaceBindingSnapshot]) {
-    restore_bindings_with_validator(workspaces, snapshots, win::is_valid_window);
+    let live = win::enumerate_top_level_windows().unwrap_or_default();
+    restore_bindings_with_windows(workspaces, snapshots, &live);
 }
 
-fn restore_bindings_with_validator(
+fn restore_bindings_with_windows(
     workspaces: &mut [MmWorkspace],
     snapshots: &[WorkspaceBindingSnapshot],
-    is_valid: impl Fn(usize) -> bool,
+    live: &[EnumeratedWindow],
 ) {
     for snapshot in snapshots {
         let workspace_index = snapshot
@@ -86,11 +94,17 @@ fn restore_bindings_with_validator(
         };
         let workspace = &mut workspaces[workspace_index];
         for window_snapshot in &snapshot.windows {
-            if window_snapshot.hwnd == 0 || !is_valid(window_snapshot.hwnd) {
+            let Some(window_index) = find_window_index(workspace, window_snapshot) else {
                 continue;
-            }
-            if let Some(window_index) = find_window_index(workspace, window_snapshot) {
-                workspace.windows[window_index].hwnd = window_snapshot.hwnd;
+            };
+            let saved_window = window_from_snapshot(window_snapshot);
+            let (_, hwnd) = reconnect::match_saved_window_against_candidates(&saved_window, live);
+            if let Some(hwnd) = hwnd {
+                workspace.windows[window_index].hwnd = hwnd;
+                workspace.windows[window_index].valid = true;
+            } else if workspace.windows[window_index].hwnd == window_snapshot.hwnd {
+                workspace.windows[window_index].hwnd = 0;
+                workspace.windows[window_index].valid = false;
             }
         }
     }
@@ -119,6 +133,22 @@ fn find_window_index(workspace: &MmWorkspace, snapshot: &WindowBindingSnapshot) 
         }
     }
     (snapshot.window_index < workspace.windows.len()).then_some(snapshot.window_index)
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    (!value.trim().is_empty()).then(|| value.to_string())
+}
+
+fn window_from_snapshot(snapshot: &WindowBindingSnapshot) -> MmWindow {
+    MmWindow {
+        alias: snapshot.alias.clone().unwrap_or_default(),
+        title: snapshot.title.clone(),
+        executable: snapshot.executable.clone().unwrap_or_default(),
+        class_name: snapshot.class_name.clone().unwrap_or_default(),
+        process_path: snapshot.process_path.clone().unwrap_or_default(),
+        hwnd: snapshot.hwnd,
+        ..Default::default()
+    }
 }
 
 pub fn duplicate_hwnds(workspaces: &[MmWorkspace]) -> Vec<DuplicateHwnd> {
@@ -189,6 +219,28 @@ mod tests {
         }
     }
 
+    fn live(
+        hwnd: usize,
+        title: &str,
+        executable: &str,
+        class_name: &str,
+        process_path: &str,
+    ) -> EnumeratedWindow {
+        EnumeratedWindow {
+            hwnd,
+            title: title.into(),
+            executable: executable.into(),
+            class_name: class_name.into(),
+            process_path: process_path.into(),
+            rect: crate::multi_manager::model::MmRect {
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100,
+            },
+        }
+    }
+
     #[test]
     fn binding_save_omits_invalid_hwnds() {
         let dir = tempfile::tempdir().unwrap();
@@ -201,34 +253,36 @@ mod tests {
     #[test]
     fn restore_prefers_workspace_id_over_name() {
         let mut workspaces = vec![
-            ws("target", "same", vec![win("", "", 0)]),
-            ws("other", "old", vec![win("", "", 0)]),
+            ws("target", "same", vec![win("", "Doc", 0)]),
+            ws("other", "old", vec![win("", "Doc", 0)]),
         ];
         let snapshots = vec![WorkspaceBindingSnapshot {
             workspace_id: Some("target".into()),
             workspace_name: "old".into(),
             windows: vec![WindowBindingSnapshot {
                 hwnd: 7,
+                title: "Doc".into(),
                 ..Default::default()
             }],
         }];
-        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| true);
+        restore_bindings_with_windows(&mut workspaces, &snapshots, &[live(7, "Doc", "", "", "")]);
         assert_eq!(workspaces[0].windows[0].hwnd, 7);
         assert_eq!(workspaces[1].windows[0].hwnd, 0);
     }
 
     #[test]
     fn restore_falls_back_to_name_when_id_absent() {
-        let mut workspaces = vec![ws("id", "name", vec![win("", "", 0)])];
+        let mut workspaces = vec![ws("id", "name", vec![win("", "Doc", 0)])];
         let snapshots = vec![WorkspaceBindingSnapshot {
             workspace_id: None,
             workspace_name: "name".into(),
             windows: vec![WindowBindingSnapshot {
                 hwnd: 8,
+                title: "Doc".into(),
                 ..Default::default()
             }],
         }];
-        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| true);
+        restore_bindings_with_windows(&mut workspaces, &snapshots, &[live(8, "Doc", "", "", "")]);
         assert_eq!(workspaces[0].windows[0].hwnd, 8);
     }
 
@@ -243,8 +297,84 @@ mod tests {
                 ..Default::default()
             }],
         }];
-        restore_bindings_with_validator(&mut workspaces, &snapshots, |_| false);
+        restore_bindings_with_windows(&mut workspaces, &snapshots, &[]);
         assert_eq!(workspaces[0].windows[0].hwnd, 0);
+    }
+
+    #[test]
+    fn old_snapshots_without_metadata_still_load() {
+        let json = r#"[{
+            "workspace_id": "id",
+            "workspace_name": "name",
+            "windows": [{
+                "window_id": 0,
+                "window_index": 0,
+                "title": "Legacy",
+                "alias": "legacy",
+                "hwnd": 42
+            }]
+        }]"#;
+
+        let snapshots: Vec<WorkspaceBindingSnapshot> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(snapshots[0].windows[0].executable, None);
+        assert_eq!(snapshots[0].windows[0].class_name, None);
+        assert_eq!(snapshots[0].windows[0].process_path, None);
+    }
+
+    #[test]
+    fn reused_hwnd_with_mismatched_metadata_is_not_restored() {
+        let mut workspaces = vec![ws("id", "name", vec![win("", "Doc", 44)])];
+        let snapshots = vec![WorkspaceBindingSnapshot {
+            workspace_id: Some("id".into()),
+            workspace_name: "name".into(),
+            windows: vec![WindowBindingSnapshot {
+                hwnd: 44,
+                title: "Doc".into(),
+                executable: Some("editor.exe".into()),
+                class_name: Some("Editor".into()),
+                process_path: Some("C:/Apps/editor.exe".into()),
+                ..Default::default()
+            }],
+        }];
+
+        restore_bindings_with_windows(
+            &mut workspaces,
+            &snapshots,
+            &[live(44, "Other", "other.exe", "Other", "C:/Other.exe")],
+        );
+
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+        assert!(!workspaces[0].windows[0].valid);
+    }
+
+    #[test]
+    fn fallback_reconnect_can_restore_safe_replacement() {
+        let mut workspaces = vec![ws("id", "name", vec![win("", "Doc", 0)])];
+        let snapshots = vec![WorkspaceBindingSnapshot {
+            workspace_id: Some("id".into()),
+            workspace_name: "name".into(),
+            windows: vec![WindowBindingSnapshot {
+                hwnd: 44,
+                title: "Doc".into(),
+                executable: Some("editor.exe".into()),
+                class_name: Some("Editor".into()),
+                process_path: Some("C:/Apps/editor.exe".into()),
+                ..Default::default()
+            }],
+        }];
+
+        restore_bindings_with_windows(
+            &mut workspaces,
+            &snapshots,
+            &[
+                live(44, "Other", "other.exe", "Other", "C:/Other.exe"),
+                live(55, "Doc", "editor.exe", "Editor", "C:/Apps/editor.exe"),
+            ],
+        );
+
+        assert_eq!(workspaces[0].windows[0].hwnd, 55);
+        assert!(workspaces[0].windows[0].valid);
     }
 
     #[test]

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -1,8 +1,8 @@
 use crate::gui::LauncherApp;
 use crate::multi_manager::bindings;
 use crate::multi_manager::model::{
-    new_workspace_id, MmHotkey, MmHotkeyValidation, MmRect, MmWindow, MmWorkspace,
-    PendingCaptureAction,
+    MmHotkey, MmHotkeyValidation, MmRect, MmWindow, MmWorkspace, PendingCaptureAction,
+    new_workspace_id,
 };
 use crate::multi_manager::win;
 use eframe::egui;
@@ -70,10 +70,10 @@ impl MultiManagerDialog {
                         if ui.button("Reload").clicked() {
                             self.confirm.reload = true;
                         }
-                        if ui.button("Save Bindings").clicked() {
+                        if ui.button("Save HWND Snapshot").clicked() {
                             app.multi_manager_save_bindings();
                         }
-                        if ui.button("Restore Bindings").clicked() {
+                        if ui.button("Restore HWND Snapshot").clicked() {
                             app.multi_manager_restore_bindings();
                         }
                         if ui.button("Reconnect Windows").clicked() {


### PR DESCRIPTION
### Motivation

- Capture additional identity metadata (executable, class name, process path) with saved HWND snapshots to make restores safer and more accurate.
- Ensure saved HWNDs are only reused when the live window identity matches the saved snapshot to avoid binding wrong windows to workspaces.
- Reuse the shared reconnect matcher to avoid duplicating scoring/identity logic and to fall back to safe reconnect matches when saved HWND identity fails.
- Make the UI labels clearer about what is being saved/restored by renaming the actions to snapshot-focused wording.

### Description

- Extended `WindowBindingSnapshot` with optional `executable: Option<String>`, `class_name: Option<String>`, and `process_path: Option<String>` while keeping serde compatibility for older files by using `Option` fields. (`src/multi_manager/bindings.rs`).
- Populated the new snapshot metadata when saving via a `non_empty_string` helper so empty values are omitted from the JSON. (`save_bindings`).
- Reworked restore flow: enumerate live windows and pass a `MmWindow`-shaped representation of the saved snapshot into `reconnect::match_saved_window_against_candidates` so a saved HWND is only trusted if the live identity matches; otherwise clear the stale HWND and fall back to the reconnect matcher to pick a safe replacement. (`restore_bindings_with_windows`, `window_from_snapshot`).
- Reused helpers from `src/multi_manager/reconnect.rs` instead of duplicating identity/score logic by calling `match_saved_window_against_candidates` for matching. (`use crate::multi_manager::reconnect`).
- Updated UI labels from `Save Bindings`/`Restore Bindings` to `Save HWND Snapshot`/`Restore HWND Snapshot`. (`src/multi_manager/ui.rs`).
- Added unit tests in `src/multi_manager/bindings.rs` covering legacy snapshot loading, skipping invalid HWNDs, rejecting reused HWNDs with mismatched metadata, and fallback reconnect restoring a safe replacement.

### Testing

- Ran `cargo fmt` successfully to format the code.
- Attempted `cargo test -q bindings -- --nocapture`; the run failed to complete in this Linux environment because the full crate build pulls Windows-specific code that requires the `windows` crate and platform system libraries and therefore does not compile for the host target; installing Linux system packages (`libasound2-dev`, `libxi-dev`, `libx11-dev`, `libxtst-dev`) resolved some build steps but the build still fails due to Windows-only `windows` API usages, so the added unit tests could not be executed end-to-end here.
- The repository-level changes are self-contained to `src/multi_manager/bindings.rs` and `src/multi_manager/ui.rs` and include new unit tests that should run on a Windows CI runner (or when building with appropriate target/features) where the `windows` crate builds successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308e9f87e883329348ba795d42b7ac)