### PR TITLE
Add MultiManager test coverage

### DIFF
--- a/src/multi_manager/commands.rs
+++ b/src/multi_manager/commands.rs
@@ -10,7 +10,11 @@ const COMMANDS: [(&str, &str, &str); 10] = [
         "Send all MultiManager windows home",
         "mm:send-all-home",
     ),
-    ("mm reconnect", "Reconnect MultiManager windows", "mm:reconnect"),
+    (
+        "mm reconnect",
+        "Reconnect MultiManager windows",
+        "mm:reconnect",
+    ),
     (
         "mm save bindings",
         "Save MultiManager window bindings",
@@ -88,18 +92,26 @@ mod tests {
     #[test]
     fn mm_send_all_home_returns_send_all_home() {
         let actions = search_mm_commands("mm send all home");
-        assert!(actions.iter().any(|a| a.action == "mm:send-all-home"));
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:send-all-home");
     }
 
     #[test]
     fn mm_reconnect_returns_reconnect() {
         let actions = search_mm_commands("mm reconnect");
-        assert!(actions.iter().any(|a| a.action == "mm:reconnect"));
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:reconnect");
     }
 
     #[test]
-    fn non_mm_input_returns_no_result() {
-        assert!(search_mm_commands("todo list").is_empty());
-        assert!(search_mm_commands("mms").is_empty());
+    fn non_mm_queries_return_no_multi_manager_commands() {
+        for query in ["todo list", "mms", "multi manager", ""] {
+            assert!(
+                search_mm_commands(query)
+                    .iter()
+                    .all(|action| !action.action.starts_with("mm:")),
+                "{query:?} should not return MultiManager commands"
+            );
+        }
     }
 }

--- a/src/multi_manager/model.rs
+++ b/src/multi_manager/model.rs
@@ -324,6 +324,20 @@ mod tests {
     }
 
     #[test]
+    fn hotkey_validation_accepts_valid_key_with_all_modifiers() {
+        let hotkey = MmHotkey {
+            key: "F12".into(),
+            ctrl: true,
+            shift: true,
+            alt: true,
+            win: true,
+        };
+
+        assert_eq!(hotkey.validate(), MmHotkeyValidation::Valid);
+        assert!(hotkey.is_valid());
+    }
+
+    #[test]
     fn hotkey_validation_reports_empty_key_as_missing() {
         let hotkey = MmHotkey::default();
 
@@ -371,6 +385,18 @@ mod tests {
         };
 
         assert_eq!(hotkey.sequence().as_deref(), Some("Ctrl+Shift+Alt+Win+Key"));
+    }
+
+    #[test]
+    fn valid_hotkey_sequence_formats_key_and_modifiers() {
+        let hotkey = MmHotkey {
+            key: "F9".into(),
+            ctrl: true,
+            alt: true,
+            ..MmHotkey::default()
+        };
+
+        assert_eq!(hotkey.sequence().as_deref(), Some("Ctrl+Alt+F9"));
     }
 
     #[test]

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -612,6 +612,32 @@ mod tests {
     }
 
     #[test]
+    fn runtime_reconnect_runs_when_existing_hwnd_is_stale() {
+        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
+        {
+            let mut locked = workspaces.lock().unwrap();
+            locked[0].windows[0].hwnd = 7;
+            locked[0].windows[0].title = "Notes".into();
+            locked[0].windows[0].executable = "app.exe".into();
+            locked[0].windows[0].class_name = "AppClass".into();
+            locked[0].windows[0].process_path = "C:/app.exe".into();
+        }
+        let control = RuntimeControl::new(true);
+        let now = Instant::now();
+        let mut last = now - Duration::from_secs(10);
+        let enumerated = RefCell::new(false);
+
+        let reconnected = maybe_runtime_reconnect(&workspaces, &control, &mut last, now, || {
+            *enumerated.borrow_mut() = true;
+            vec![live(42, "Notes")]
+        });
+
+        assert!(reconnected);
+        assert!(*enumerated.borrow());
+        assert_eq!(workspaces.lock().unwrap()[0].windows[0].hwnd, 42);
+    }
+
+    #[test]
     fn runtime_hotkey_toggle_works_after_reconnect_assigns_hwnd() {
         let workspaces = Arc::new(Mutex::new(vec![workspace()]));
         {
@@ -686,5 +712,17 @@ mod tests {
             now + Duration::from_millis(100),
         );
         assert_eq!(ops.moves.borrow().len(), 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "Manual Windows desktop smoke test: use a visible non-elevated HWND and verify send/toggle restores activation, temporarily uses topmost as needed, and does not leave the window permanently topmost."]
+    fn windows_activation_and_topmost_smoke_checklist() {
+        // Manual checklist for real desktop behavior that fake WindowOps cannot prove:
+        // 1. Capture a normal non-elevated window into a workspace with home/target rects.
+        // 2. Minimize or cover the window, then trigger send target/home and hotkey toggle.
+        // 3. Verify the window is restored/activated for movement.
+        // 4. Verify any temporary topmost behavior is cleared after movement.
+        // 5. Repeat with an elevated/inaccessible window and verify the error is surfaced.
     }
 }

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -617,6 +617,7 @@ mod tests {
         {
             let mut locked = workspaces.lock().unwrap();
             locked[0].windows[0].hwnd = 7;
+            locked[0].windows[0].valid = false;
             locked[0].windows[0].title = "Notes".into();
             locked[0].windows[0].executable = "app.exe".into();
             locked[0].windows[0].class_name = "AppClass".into();

--- a/tests/multi_manager_plugin.rs
+++ b/tests/multi_manager_plugin.rs
@@ -77,7 +77,7 @@ fn non_mm_queries_do_not_call_multi_manager_plugin() {
 #[test]
 fn mm_returns_open() {
     let actions = search_mm_commands("mm");
-    assert!(actions.iter().any(|a| a.action == "mm:open"));
+    assert_eq!(actions.first().map(|a| a.action.as_str()), Some("mm:open"));
 }
 
 #[test]
@@ -94,6 +94,26 @@ fn mm_recapture_all_returns_recapture_all() {
 
 #[test]
 fn non_mm_command_parser_input_returns_no_result() {
-    assert!(search_mm_commands("todo list").is_empty());
-    assert!(search_mm_commands("mms").is_empty());
+    for query in ["todo list", "mms", "multi manager"] {
+        assert!(
+            search_mm_commands(query)
+                .iter()
+                .all(|a| !a.action.starts_with("mm:")),
+            "{query:?} returned a MultiManager command"
+        );
+    }
+}
+
+#[test]
+fn mm_send_all_home_returns_send_all_home() {
+    let actions = search_mm_commands("mm send all home");
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].action, "mm:send-all-home");
+}
+
+#[test]
+fn mm_reconnect_returns_reconnect() {
+    let actions = search_mm_commands("mm reconnect");
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].action, "mm:reconnect");
 }


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for MultiManager hotkey parsing/validation and runtime reconnect behavior to prevent regressions. 
- Ensure the MM command parser returns exact expected actions and that non-`mm` queries do not route to MultiManager. 
- Add a Windows-only manual smoke checklist for activation/topmost behavior that cannot be validated in CI. 

### Description

- Added hotkey unit tests in `src/multi_manager/model.rs` that validate a key with all modifiers and assert the formatted sequence output. 
- Tightened command parser tests in `src/multi_manager/commands.rs` so `mm send all home` and `mm reconnect` assert an exact single-action match and added a stricter non-`mm` query assertion. 
- Added runtime tests in `src/multi_manager/runtime.rs` to cover reconnect behavior when an existing HWND is stale and included a Windows-only `#[ignore]` smoke-checklist test for activation/topmost behavior. 
- Updated plugin-level tests in `tests/multi_manager_plugin.rs` to assert exact `mm:open` ordering and to add explicit assertions for `mm:send-all-home` and `mm:reconnect` and broaden non-`mm` filtering checks. 

### Testing

- Ran code formatting with `rustfmt` on the modified files. 
- Attempted to run the test suite with `cargo test multi_manager --lib --tests`, but the build failed in this environment during dependency compilation because the system ALSA development package was not available (pkg-config could not find `alsa.pc`), so the MultiManager tests were not able to complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309d58bf708332acdf9e8a9e9fac83)