### PR TITLE
Update transitive rand 0.8 lockfile entry to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,7 +3020,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
 ]
 
@@ -3810,7 +3810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4087,9 +4087,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6840,7 +6840,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",


### PR DESCRIPTION
### Motivation
- Bump the old transitive `rand` 0.8.x resolution from `0.8.5` to `0.8.6` to remove the outdated transitive copy while keeping the direct application dependency at `rand = "0.10.1"`.

### Description
- Updated only `Cargo.lock` entries for the transitive `rand` 0.8.x line from `0.8.5` to `0.8.6` (version and checksum), with no changes to `Cargo.toml` or other files.

### Testing
- Ran `cargo update -p rand@0.8.5 --precise 0.8.6` and then verified with `cargo tree -i rand@0.8.5` (no match), `cargo tree -i rand@0.8.6` (transitive resolved), `cargo tree -i rand@0.10.1` (direct dependency present), and `rg`/`git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c4b96b948332a13009c7542daf1f)