### PR TITLE
docs: document MultiManager data files and `multi_manager.*` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,27 @@ Notable settings (high impact):
 * `follow_mouse`, `always_on_top`, `hide_after_run`
 * screenshot settings (`screenshot_dir`, `screenshot_auto_save`, `screenshot_use_editor`)
 * dashboard settings (`dashboard.*`)
+* MultiManager settings (`multi_manager.*`)
+
+MultiManager paths can be customized under the `multi_manager` settings object:
+
+```json
+{
+  "multi_manager": {
+    "enabled": true,
+    "workspaces_path": "multi_manager_workspaces.json",
+    "bindings_path": "multi_manager_bindings.json",
+    "auto_save": true,
+    "save_on_exit": true,
+    "auto_reconnect_on_load": true,
+    "auto_reconnect_missing_windows": true,
+    "auto_reconnect_interval_ms": 3000,
+    "ignore_launcher_window_on_capture": true
+  }
+}
+```
+
+`workspaces_path` controls where MultiManager stores workspace state, and `bindings_path` controls the optional live-window binding snapshot location. `ignore_launcher_window_on_capture` is a safety setting that helps prevent capture flows from saving the launcher window instead of the intended target window.
 
 Disable the default hotkey entirely (useful if you bind your own trigger elsewhere):
 
@@ -483,8 +504,8 @@ These are created/updated as you use the app (typically in the working directory
 * `calc_history.json` — calculator history
 * `fav.json` — favorites
 * `layouts.json` — window layouts
-* `multi_manager_workspaces.json` — MultiManager workspaces
-* `multi_manager_bindings.json` — MultiManager HWND binding snapshots
+* `multi_manager_workspaces.json` — stores MultiManager workspaces, captured windows, aliases, hotkeys, and home/target rectangles
+* `multi_manager_bindings.json` — optional HWND binding snapshot used to restore live window handles
 * `mouse_gestures.json` — mouse gestures
 * `mouse_gestures_usage.json` — mouse gesture usage stats
 * `calendar/events.json` — calendar events


### PR DESCRIPTION
### Motivation

* Explain where MultiManager persists workspace and HWND binding state so users can back up or customize paths. 
* Provide a minimal `multi_manager` settings example that matches the runtime settings structure. 
* Clarify the `ignore_launcher_window_on_capture` safety option so users understand its purpose.

### Description

* Add `MultiManager settings (`multi_manager.*`)` to the README notable configuration list and insert a minimal JSON example using the actual setting names. 
* Update the Data files section to describe `multi_manager_workspaces.json` as storing workspaces, captured windows, aliases, hotkeys, and home/target rectangles and to describe `multi_manager_bindings.json` as the optional HWND binding snapshot. 
* Add a brief explanation of `ignore_launcher_window_on_capture` as a safety setting that helps avoid capturing the launcher window instead of the intended target. 
* Ensure the example fields correspond to the settings struct fields such as `enabled`, `workspaces_path`, `bindings_path`, `auto_save`, `save_on_exit`, `auto_reconnect_on_load`, `auto_reconnect_missing_windows`, `auto_reconnect_interval_ms`, and `ignore_launcher_window_on_capture`.

### Testing

* Confirmed field names and defaults by inspecting `src/settings/model.rs` and verified the example uses the actual struct field names. 
* Ran `rg -n "workspaces_path|bindings_path|auto_reconnect_interval_ms|ignore_launcher_window_on_capture|MultiManager settings|multi_manager_workspaces.json|multi_manager_bindings.json" README.md src/settings/model.rs` to validate the README changes and found the expected matches. 
* No code changes or unit tests were required since this is a documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d89a88a483328f133ff0bf3d6b5d)