### PR TITLE
Unify MultiManager command catalog

### DIFF
--- a/src/multi_manager/commands.rs
+++ b/src/multi_manager/commands.rs
@@ -33,6 +33,18 @@ const COMMANDS: [(&str, &str, &str); 10] = [
     ("mm import", "Import MultiManager workspaces", "mm:import"),
 ];
 
+pub fn all_mm_commands() -> Vec<Action> {
+    COMMANDS
+        .iter()
+        .map(|(command, desc, action)| Action {
+            label: (*command).into(),
+            desc: (*desc).into(),
+            action: (*action).into(),
+            args: None,
+        })
+        .collect()
+}
+
 pub fn search_mm_commands(query: &str) -> Vec<Action> {
     let q = query.trim();
     let q_lc = q.to_ascii_lowercase();
@@ -43,21 +55,57 @@ pub fn search_mm_commands(query: &str) -> Vec<Action> {
         return Vec::new();
     }
 
-    COMMANDS
-        .iter()
-        .filter(|(command, _, _)| command.starts_with(&q_lc))
-        .map(|(command, desc, action)| Action {
-            label: (*command).into(),
-            desc: (*desc).into(),
-            action: (*action).into(),
-            args: None,
-        })
+    all_mm_commands()
+        .into_iter()
+        .filter(|action| action.label.starts_with(&q_lc))
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::search_mm_commands;
+    use crate::plugins::multi_manager::MultiManagerPlugin;
+
+    #[test]
+    fn plugin_commands_include_public_multi_manager_actions() {
+        let actions = MultiManagerPlugin::commands();
+        let expected = [
+            "mm:open",
+            "mm:settings",
+            "mm:save",
+            "mm:reload",
+            "mm:send-all-home",
+            "mm:reconnect",
+            "mm:save-bindings",
+            "mm:restore-bindings",
+            "mm:recapture-all",
+        ];
+
+        for expected_action in expected {
+            assert!(
+                actions
+                    .iter()
+                    .any(|action| action.action == expected_action),
+                "plugin commands should include {expected_action}"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_commands_match_mm_search_public_actions() {
+        let plugin_actions: Vec<_> = MultiManagerPlugin::commands()
+            .into_iter()
+            .filter(|action| action.action.starts_with("mm:"))
+            .map(|action| action.action)
+            .collect();
+        let search_actions: Vec<_> = search_mm_commands("mm")
+            .into_iter()
+            .filter(|action| action.action.starts_with("mm:"))
+            .map(|action| action.action)
+            .collect();
+
+        assert_eq!(plugin_actions, search_actions);
+    }
 
     #[test]
     fn exact_mm_returns_open_first() {

--- a/src/plugins/multi_manager.rs
+++ b/src/plugins/multi_manager.rs
@@ -5,20 +5,7 @@ pub struct MultiManagerPlugin;
 
 impl MultiManagerPlugin {
     pub fn commands() -> Vec<Action> {
-        vec![
-            Action {
-                label: "mm".into(),
-                desc: "MultiManager".into(),
-                action: "query:mm".into(),
-                args: None,
-            },
-            Action {
-                label: "mm settings".into(),
-                desc: "MultiManager settings".into(),
-                action: "query:mm settings".into(),
-                args: None,
-            },
-        ]
+        crate::multi_manager::commands::all_mm_commands()
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent divergence between plugin-level command discovery and search-level command discovery by centralizing the MultiManager command catalog.

### Description
- Added a shared catalog helper `all_mm_commands()` in `src/multi_manager/commands.rs` that builds `Action` entries from the existing `COMMANDS` table.
- Refactored `search_mm_commands()` to reuse `all_mm_commands()` so search and catalog generation cannot drift apart.
- Updated `MultiManagerPlugin::commands()` in `src/plugins/multi_manager.rs` to return `crate::multi_manager::commands::all_mm_commands()` instead of a hard-coded subset.
- Added two unit tests in `src/multi_manager/commands.rs`: `plugin_commands_include_public_multi_manager_actions` and `plugin_commands_match_mm_search_public_actions` to assert expected `mm:*` actions are exposed and to compare the plugin catalog with `search_mm_commands("mm")`.

### Testing
- Ran `rustfmt src/multi_manager/commands.rs src/plugins/multi_manager.rs` which succeeded.
- Ran `cargo test multi_manager::commands` which initially failed due to missing system pkg-config libraries required by native crates (resolved some failures by installing `libasound2-dev`, `libxi-dev`, and `libxtst-dev`).
- Final `cargo test` could not complete in this Linux environment because the repository builds Windows-only `windows::Win32` code on the host target, producing unresolved Win32 imports and compile errors, so the new unit tests could not be executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d96c6ec48332a6e20732b8d94242)