### PR TITLE
Add explicit MultiManager settings save action

### DIFF
--- a/src/multi_manager/mod.rs
+++ b/src/multi_manager/mod.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod model;
 pub mod reconnect;
 pub mod runtime;
+pub mod settings;
 pub mod state;
 pub mod store;
 pub mod ui;

--- a/src/multi_manager/settings.rs
+++ b/src/multi_manager/settings.rs
@@ -1,0 +1,51 @@
+/// Save only the MultiManager settings block to the full settings file.
+pub fn save_multi_manager_settings(
+    settings_path: &str,
+    multi_manager: crate::settings::MultiManagerSettings,
+) -> anyhow::Result<()> {
+    let mut settings = crate::settings::Settings::load(settings_path)?;
+    settings.multi_manager = multi_manager;
+    settings.save(settings_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::save_multi_manager_settings;
+    use crate::settings::{MultiManagerSettings, Settings};
+
+    #[test]
+    fn save_multi_manager_settings_preserves_unrelated_settings() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings_path = dir.path().join("settings.json");
+        let settings_path = settings_path.to_string_lossy().to_string();
+
+        let mut original = Settings::default();
+        original.hotkey = Some("Ctrl+Alt+M".to_string());
+        original
+            .save(&settings_path)
+            .expect("save original settings");
+
+        let updated = MultiManagerSettings {
+            enabled: false,
+            workspaces_path: "updated_workspaces.json".to_string(),
+            bindings_path: "updated_bindings.json".to_string(),
+            auto_save: false,
+            save_on_exit: false,
+            developer_debugging: true,
+            show_force_recapture_prompt: true,
+            hotkey_poll_ms: 250,
+            auto_reconnect_on_load: false,
+            auto_reconnect_missing_windows: false,
+            auto_reconnect_interval_ms: 10_000,
+            hide_launcher_before_toggle: true,
+            ignore_launcher_window_on_capture: false,
+        };
+
+        save_multi_manager_settings(&settings_path, updated.clone())
+            .expect("save multi manager settings");
+
+        let restored = Settings::load(&settings_path).expect("reload settings");
+        assert_eq!(restored.hotkey, Some("Ctrl+Alt+M".to_string()));
+        assert_eq!(restored.multi_manager, updated);
+    }
+}

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -637,6 +637,17 @@ impl MultiManagerSettingsDialog {
                         .auto_reconnect_interval_ms
                         .store(s.auto_reconnect_interval_ms, Ordering::Relaxed);
                 }
+                ui.separator();
+                if ui.button("Save MultiManager Settings").clicked() {
+                    match crate::multi_manager::settings::save_multi_manager_settings(
+                        &app.settings_path,
+                        app.multi_manager_settings.clone(),
+                    ) {
+                        Ok(()) => app.add_success_toast("Saved MultiManager settings"),
+                        Err(err) => app
+                            .report_error_message("multi_manager.settings.save", format!("{err}")),
+                    }
+                }
             });
         self.open = open;
     }


### PR DESCRIPTION
### Motivation
- Allow users to persist changes made in the standalone MultiManager settings dialog without overwriting unrelated global settings.
- Provide an explicit, testable save path rather than auto-saving on every UI change to avoid accidental config mutation.
- Surface clear success and stable error handling when saving only the `multi_manager` block.

### Description
- Add `save_multi_manager_settings(settings_path: &str, multi_manager: crate::settings::MultiManagerSettings) -> anyhow::Result<()>` in `src/multi_manager/settings.rs` which loads the full settings file, replaces only `settings.multi_manager`, and writes the file back using `Settings::save`.
- Add a unit test `save_multi_manager_settings_preserves_unrelated_settings` that writes a temporary `settings.json`, updates only the `MultiManagerSettings`, reloads, and asserts unrelated fields (e.g. `hotkey`) are preserved and `multi_manager` equals the updated value.
- Wire the helper into the UI by adding a `Save MultiManager Settings` button inside `MultiManagerSettingsDialog::ui` in `src/multi_manager/ui.rs`, showing a success toast `Saved MultiManager settings` on success and calling `app.report_error_message("multi_manager.settings.save", ...)` on failure.
- Preserve existing live-apply behavior so runtime flags (hotkey polling, auto-reconnect, enabled, etc.) continue to update immediately when UI controls change.

### Testing
- Added the pure-file unit test `save_multi_manager_settings_preserves_unrelated_settings` and attempted to run `cargo test save_multi_manager_settings_preserves_unrelated_settings` in CI/dev environment.
- The test could not complete because the build failed due to a missing system dependency required by `alsa-sys` (`alsa.pc`), producing a build error unrelated to the new code; no test assertions were reached in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31df564bb88332b9fca268e19dc024)