### PR TITLE
Add deterministic MultiManager command search tests

### DIFF
--- a/src/multi_manager/commands.rs
+++ b/src/multi_manager/commands.rs
@@ -79,6 +79,7 @@ mod tests {
             "mm:save-bindings",
             "mm:restore-bindings",
             "mm:recapture-all",
+            "mm:import",
         ];
 
         for expected_action in expected {
@@ -120,9 +121,11 @@ mod tests {
     }
 
     #[test]
-    fn mm_save_returns_save() {
+    fn mm_save_returns_save_and_save_bindings() {
         let actions = search_mm_commands("mm save");
-        assert!(actions.iter().any(|a| a.action == "mm:save"));
+        let action_ids: Vec<_> = actions.iter().map(|a| a.action.as_str()).collect();
+
+        assert_eq!(action_ids, ["mm:save", "mm:save-bindings"]);
     }
 
     #[test]
@@ -134,7 +137,29 @@ mod tests {
     #[test]
     fn mm_recapture_all_returns_recapture_all() {
         let actions = search_mm_commands("mm recapture all");
-        assert!(actions.iter().any(|a| a.action == "mm:recapture-all"));
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:recapture-all");
+    }
+
+    #[test]
+    fn mm_save_bindings_returns_save_bindings() {
+        let actions = search_mm_commands("mm save bindings");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:save-bindings");
+    }
+
+    #[test]
+    fn mm_restore_bindings_returns_restore_bindings() {
+        let actions = search_mm_commands("mm restore bindings");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:restore-bindings");
+    }
+
+    #[test]
+    fn mm_commands_are_case_insensitive() {
+        let actions = search_mm_commands("MM RECONNECT");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:reconnect");
     }
 
     #[test]
@@ -149,6 +174,13 @@ mod tests {
         let actions = search_mm_commands("mm reconnect");
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].action, "mm:reconnect");
+    }
+
+    #[test]
+    fn mm_import_returns_import() {
+        let actions = search_mm_commands("mm import");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "mm:import");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure `search_mm_commands()` has deterministic, parser-level coverage for every public `mm` command.
- Lock down intended partial-query behavior for `mm save` so caller expectations are stable.
- Verify case-insensitive matching and add coverage for `mm import`, while keeping tests safe for non-Windows CI.

### Description

- Added tests that assert `search_mm_commands("mm save")` returns both `"mm:save"` and `"mm:save-bindings"` in catalog order via `mm_save_returns_save_and_save_bindings`.
- Added specific tests `mm_save_bindings_returns_save_bindings` and `mm_restore_bindings_returns_restore_bindings` to verify exact-match behavior for multi-word commands.
- Added `mm_commands_are_case_insensitive` test to validate case-insensitive matching (e.g. `"MM RECONNECT" -> "mm:reconnect"`).
- Included `mm:import` in the public-catalog verification and added `mm_import_returns_import` to ensure advertised commands have parser coverage, and tightened a few existing assertions to deterministic equality checks.

### Testing

- Ran `rustfmt --check src/multi_manager/commands.rs` which passed for the modified file.
- Ran `git diff --check` which produced no trailing-whitespace or diff-check issues for the change.
- Attempted `cargo test multi_manager::commands` but the run was blocked in this Linux environment by `alsa-sys` requiring the system `alsa.pc` pkg-config file (test code itself is platform-agnostic and only exercises string/catalog behavior).
- Noted that a repository-wide `cargo fmt --check` reported unrelated formatting differences outside the touched file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e2bbebe08332b0a56db77d25d925)