### PR TITLE
Add MultiManager troubleshooting subsection to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,4 +553,13 @@ cargo build --release
 * Run `tab cache` to rebuild the UI Automation cache.
 * Some browsers / window states may block UIA access; the plugin may fall back to click simulation.
 
+### MultiManager cannot find or move a window
+
+* Run `mm reconnect` after restarting apps or the launcher so MultiManager can refresh stale window handles.
+* Use `mm recapture all` when a window is missing, closed and reopened, or ambiguous.
+* Ensure the target app is not running elevated while Multi Launcher is running non-elevated.
+* Check whether the workspace or window is disabled before sending, restoring, or moving it.
+* Use **Refresh Titles** if a captured app changed its window title.
+* If capture keeps selecting the launcher, keep `ignore_launcher_window_on_capture` enabled, focus the target window, and then press `Enter`.
+
 ---


### PR DESCRIPTION
### Motivation

* Provide concise, user-facing troubleshooting guidance for MultiManager window lookup and movement failures, emphasizing reconnect/recapture flows, elevation mismatch, and accidental launcher capture.

### Description

* Add a new "### MultiManager cannot find or move a window" subsection to `README.md` that documents running `mm reconnect`, using `mm recapture all`, ensuring no elevation mismatch between the launcher and the target app, checking for disabled workspaces or windows, using `Refresh Titles` for changed titles, and keeping `ignore_launcher_window_on_capture` enabled with the target focused to avoid capturing the launcher.

### Testing

* Ran `git diff --check` on the repository and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e5b0eb34833282dba05de26fd8b1)