### PR TITLE
Mark programmatic note insertions dirty

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1659,6 +1659,7 @@ impl NotePanel {
                     egui::text::CCursor::new(cursor),
                 )));
             state.store(ctx, id);
+            self.mark_content_changed(ctx.input(|i| i.time));
             return;
         }
 
@@ -1677,6 +1678,7 @@ impl NotePanel {
                 egui::text::CCursor::new(cursor),
             )));
         state.store(ctx, id);
+        self.mark_content_changed(ctx.input(|i| i.time));
     }
 
     pub fn set_link_new_name(&mut self, name: impl Into<String>) {
@@ -2147,6 +2149,60 @@ mod tests {
         panel.insert_link(&ctx, id);
         assert_eq!(panel.note.content, "hello [world](http://example.com)");
         assert!(panel.pending_selection.is_none());
+    }
+
+    #[test]
+    fn programmatic_selection_insertion_marks_derived_dirty_and_preserves_cursor() {
+        let ctx = egui::Context::default();
+        let mut panel = NotePanel::from_note(empty_note("hello world"));
+        let id = egui::Id::new("note_content");
+        panel.pending_selection = Some((6, 11));
+        assert!(!panel.fast_derived_dirty);
+        assert!(!panel.heavy_recompute_requested);
+
+        panel.insert_text_at_cursor_or_selection(&ctx, id, "[[Other]]");
+
+        assert_eq!(panel.note.content, "hello [[Other]]");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let idx = state.cursor.char_range().unwrap().primary.index;
+        assert_eq!(idx, "hello [[Other]]".chars().count());
+        assert!(panel.fast_derived_dirty);
+        assert!(panel.heavy_recompute_requested);
+        assert!(panel.last_edit_at_secs.is_some());
+
+        panel.refresh_fast_derived();
+        assert_eq!(panel.derived.wiki_links, vec!["Other".to_string()]);
+        assert!(!panel.fast_derived_dirty);
+    }
+
+    #[test]
+    fn programmatic_cursor_insertion_marks_derived_dirty_and_preserves_cursor() {
+        let ctx = egui::Context::default();
+        let mut panel = NotePanel::from_note(empty_note("hello "));
+        let id = egui::Id::new("note_content");
+        let mut state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap_or_default();
+        state
+            .cursor
+            .set_char_range(Some(egui::text::CCursorRange::one(
+                egui::text::CCursor::new(6),
+            )));
+        state.store(&ctx, id);
+        assert!(!panel.fast_derived_dirty);
+        assert!(!panel.heavy_recompute_requested);
+
+        panel.insert_text_at_cursor_or_selection(&ctx, id, "[[Other]]");
+
+        assert_eq!(panel.note.content, "hello [[Other]]");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let idx = state.cursor.char_range().unwrap().primary.index;
+        assert_eq!(idx, "hello [[Other]]".chars().count());
+        assert!(panel.fast_derived_dirty);
+        assert!(panel.heavy_recompute_requested);
+        assert!(panel.last_edit_at_secs.is_some());
+
+        panel.refresh_fast_derived();
+        assert_eq!(panel.derived.wiki_links, vec!["Other".to_string()]);
+        assert!(!panel.fast_derived_dirty);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Programmatic text insertions (selection replacement and plain cursor insertion) should notify the panel that content changed so derived views (fast and heavy) are refreshed, while preserving existing cursor placement and state-storage semantics.

### Description
- Call `self.mark_content_changed(ctx.input(|i| i.time));` immediately after `state.store(ctx, id)` in the selection-replacement branch of `insert_text_at_cursor_or_selection` and then return as before.
- Call `self.mark_content_changed(ctx.input(|i| i.time));` immediately after `state.store(ctx, id)` in the plain cursor-insertion branch of `insert_text_at_cursor_or_selection`.
- Add two unit tests: `programmatic_selection_insertion_marks_derived_dirty_and_preserves_cursor` and `programmatic_cursor_insertion_marks_derived_dirty_and_preserves_cursor` that assert cursor placement remains correct and that `fast_derived_dirty`, `heavy_recompute_requested`, and `last_edit_at_secs` are set and that `refresh_fast_derived()` reflects the inserted wiki link.
- Existing cursor lookup, `insert_str`/`replace_range`, cursor update, and `state.store` behavior remain unchanged.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Added unit tests for both insertion branches in `src/gui/note_panel.rs` but attempts to run `cargo test` in this environment failed during dependency compilation because `alsa-sys` could not find the system `alsa` library (`alsa.pc`), so the new tests could not be executed here.
- The code changes and tests are local to the note panel logic and preserve current cursor/store semantics; test execution should succeed in CI or a developer environment with the required system libraries installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330ca310748332ad40c289962512f5)