### PR TITLE
Invalidate note link menu caches after note writes

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1222,6 +1222,8 @@ impl NotePanel {
                 self.refresh_fast_derived();
                 self.refresh_heavy_derived(true);
                 self.finish_save(app);
+                self.link_menu_targets_version = None;
+                self.invalidate_link_menu_results();
             }
             Ok(false) => {
                 self.overwrite_prompt = true;
@@ -1725,6 +1727,8 @@ impl NotePanel {
                     );
                     return;
                 }
+                self.link_menu_targets_version = None;
+                self.invalidate_link_menu_results();
                 target_slug = slugify(normalized_name);
                 link_target = target_slug.clone();
             }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1693,15 +1693,15 @@ impl NotePanel {
         id: egui::Id,
         app: &mut LauncherApp,
     ) {
-        let normalized_name = self.link_new_name.trim();
+        let normalized_name = self.link_new_name.trim().to_string();
         if normalized_name.is_empty() {
             return;
         }
 
-        let mut target_slug = slugify(normalized_name);
+        let mut target_slug = slugify(&normalized_name);
         let mut link_target = normalized_name.to_string();
 
-        match resolve_note_query(normalized_name) {
+        match resolve_note_query(&normalized_name) {
             NoteTarget::Resolved(slug) => {
                 target_slug = slug.clone();
                 if let Some(note) = load_notes()
@@ -1720,7 +1720,7 @@ impl NotePanel {
                 }
             }
             NoteTarget::Broken => {
-                if let Err(err) = append_note(normalized_name, "") {
+                if let Err(err) = append_note(&normalized_name, "") {
                     app.report_error(
                         "ui operation",
                         format!("Failed to create note while linking: {err}"),
@@ -1729,7 +1729,7 @@ impl NotePanel {
                 }
                 self.link_menu_targets_version = None;
                 self.invalidate_link_menu_results();
-                target_slug = slugify(normalized_name);
+                target_slug = slugify(&normalized_name);
                 link_target = target_slug.clone();
             }
         }


### PR DESCRIPTION
### Motivation
- Ensure the note link context menu reflects newly created or updated notes immediately after a successful note write. 
- Avoid stale link menu results when a note is created via the link dialog or when an existing note is saved. 

### Description
- In `src/gui/note_panel.rs` add explicit invalidation after the successful save path in `save`: set `self.link_menu_targets_version = None;` and call `self.invalidate_link_menu_results();` immediately after `self.refresh_fast_derived();`, `self.refresh_heavy_derived(true);`, and `self.finish_save(app);`. 
- In `src/gui/note_panel.rs` add the same explicit invalidation after a successful `append_note(...)` in `insert_or_create_note_link`, and leave the early error/return path untouched so invalidation only runs on success. 
- Preserve the existing `note_version()`-based cache key and the `refresh_*_if_needed` logic so these explicit invalidations complement (do not replace) the versioned caching. 

### Testing
- Ran `cargo test note_panel --lib`, which could not complete due to a missing system dependency (`alsa` / `alsa.pc`) required by `alsa-sys`. 
- Ran `cargo fmt --check`, which reported repository-wide formatting diffs unrelated to the functional change. 
- Ran `rustfmt --check src/gui/note_panel.rs`, which reported pre-existing import-order formatting differences in the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a331206407c8332ba6546121a3ef2c9)