### PR TITLE
Add note link menu cache tests

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2081,7 +2081,13 @@ mod tests {
     use super::*;
     use crate::{plugin::PluginManager, settings::Settings};
     use eframe::egui;
-    use std::sync::{Arc, atomic::AtomicBool};
+    use std::{
+        fs,
+        sync::{Arc, Mutex, MutexGuard, atomic::AtomicBool},
+    };
+    use tempfile::{TempDir, tempdir};
+
+    static NOTES_ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     fn new_app(ctx: &egui::Context) -> LauncherApp {
         LauncherApp::new(
@@ -2115,10 +2121,138 @@ mod tests {
         }
     }
 
+    struct TempNotesDir {
+        _guard: MutexGuard<'static, ()>,
+        dir: TempDir,
+        previous_notes_dir: Option<String>,
+    }
+
+    impl TempNotesDir {
+        fn new() -> Self {
+            let guard = NOTES_ENV_LOCK.lock().expect("notes env lock");
+            let previous_notes_dir = std::env::var("ML_NOTES_DIR").ok();
+            let dir = tempdir().expect("temp notes dir");
+            unsafe { std::env::set_var("ML_NOTES_DIR", dir.path()) };
+            Self {
+                _guard: guard,
+                dir,
+                previous_notes_dir,
+            }
+        }
+
+        fn write_note(&self, file_name: &str, content: &str) {
+            fs::write(self.dir.path().join(file_name), content).expect("write note markdown");
+        }
+
+        fn refresh_cache(&self) {
+            crate::plugins::note::refresh_cache().unwrap();
+        }
+    }
+
+    impl Drop for TempNotesDir {
+        fn drop(&mut self) {
+            if let Some(previous_notes_dir) = &self.previous_notes_dir {
+                unsafe { std::env::set_var("ML_NOTES_DIR", previous_notes_dir) };
+            } else {
+                unsafe { std::env::remove_var("ML_NOTES_DIR") };
+            }
+            crate::plugins::note::refresh_cache().unwrap();
+        }
+    }
+
+    fn note_with_slug(title: &str, slug: &str) -> Note {
+        Note {
+            title: title.into(),
+            path: std::path::PathBuf::new(),
+            content: format!("# {title}\n\nBody"),
+            tags: Vec::new(),
+            links: Vec::new(),
+            slug: slug.into(),
+            alias: None,
+            entity_refs: Vec::new(),
+        }
+    }
+
     fn render_panel_once(ctx: &egui::Context, panel: &mut NotePanel, app: &mut LauncherApp) {
         let _ = ctx.run(Default::default(), |ctx| {
             panel.ui(ctx, app);
         });
+    }
+
+    #[test]
+    fn link_menu_targets_are_cached_by_note_version() {
+        let notes_dir = TempNotesDir::new();
+        notes_dir.write_note("alpha.md", "# Alpha\n\nAlpha body");
+        notes_dir.write_note("beta.md", "# Beta\n\nBeta body");
+        notes_dir.refresh_cache();
+
+        let mut panel = NotePanel::from_note(note_with_slug("Current", "current"));
+        panel.refresh_link_menu_results_if_needed();
+        let target_refresh_count = panel.link_menu_target_refresh_count;
+
+        panel.refresh_link_menu_results_if_needed();
+
+        assert_eq!(panel.link_menu_target_refresh_count, target_refresh_count);
+    }
+
+    #[test]
+    fn link_menu_search_reuses_targets_but_refreshes_results() {
+        let notes_dir = TempNotesDir::new();
+        notes_dir.write_note("alpha.md", "# Alpha\n\nAlpha body");
+        notes_dir.write_note("beta.md", "# Beta\n\nBeta body");
+        notes_dir.refresh_cache();
+
+        let mut panel = NotePanel::from_note(note_with_slug("Current", "current"));
+        panel.refresh_link_menu_results_if_needed();
+        let target_refresh_count = panel.link_menu_target_refresh_count;
+        let result_refresh_count = panel.link_menu_result_refresh_count;
+
+        panel.link_search = "alp".into();
+        panel.refresh_link_menu_results_if_needed();
+
+        assert_eq!(panel.link_menu_target_refresh_count, target_refresh_count);
+        assert!(panel.link_menu_result_refresh_count > result_refresh_count);
+        assert!(
+            panel
+                .link_menu_results
+                .iter()
+                .any(|result| result.display_title == "Alpha")
+        );
+        assert!(
+            !panel
+                .link_menu_results
+                .iter()
+                .any(|result| result.display_title == "Beta")
+        );
+    }
+
+    #[test]
+    fn link_menu_excludes_current_note_by_slug() {
+        let notes_dir = TempNotesDir::new();
+        notes_dir.write_note("alpha.md", "# Alpha\n\nAlpha body");
+        notes_dir.refresh_cache();
+
+        let mut panel = NotePanel::from_note(note_with_slug("Alpha", "alpha"));
+        let results = panel.link_menu_results_snapshot();
+
+        assert!(!results.iter().any(|result| result.slug == "alpha"));
+    }
+
+    #[test]
+    fn link_menu_targets_refresh_when_note_version_changes() {
+        let notes_dir = TempNotesDir::new();
+        notes_dir.write_note("alpha.md", "# Alpha\n\nAlpha body");
+        notes_dir.refresh_cache();
+
+        let mut panel = NotePanel::from_note(note_with_slug("Current", "current"));
+        let results = panel.link_menu_results_snapshot();
+        assert!(results.iter().any(|result| result.display_title == "Alpha"));
+
+        notes_dir.write_note("beta.md", "# Beta\n\nBeta body");
+        notes_dir.refresh_cache();
+        let results = panel.link_menu_results_snapshot();
+
+        assert!(results.iter().any(|result| result.display_title == "Beta"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Add unit tests that exercise link-menu target/result caching and refresh behavior without relying on UI rendering or full app windows.
- Provide test helpers to isolate note-cache state by using a temporary notes directory and controlling `ML_NOTES_DIR` so tests can mutate the note set and drive `note::refresh_cache()`.

### Description
- Added a `TempNotesDir` test helper that locks a `NOTES_ENV_LOCK`, preserves and restores the previous `ML_NOTES_DIR`, uses `tempfile::tempdir()` for isolated note files, writes markdown fixtures, and calls `crate::plugins::note::refresh_cache()`.
- Introduced `note_with_slug()` helper for constructing `Note` instances with an explicit slug for tests and added a `NOTES_ENV_LOCK` static to serialize env changes.
- Implemented four new tests under the existing `#[cfg(test)] mod tests` that validate caching and refresh behavior: `link_menu_targets_are_cached_by_note_version`, `link_menu_search_reuses_targets_but_refreshes_results`, `link_menu_excludes_current_note_by_slug`, and `link_menu_targets_refresh_when_note_version_changes`.
- Tests use the `#[cfg(test)]` refresh counters on `NotePanel` (`link_menu_target_refresh_count` and `link_menu_result_refresh_count`) to assert caching behavior instead of depending on UI rendering.

### Testing
- Ran the targeted test command `cargo test --lib gui::note_panel::tests::link_menu_` which failed to complete in this environment due to unrelated platform-specific compilation errors referencing Windows-only APIs (`windows::Win32` / `windows::core`).
- Ran `cargo fmt --check` which reported formatting differences in unrelated files in the repository and therefore failed the style check.
- The new tests were added and compile-paths were executed locally up to the repository-wide build, but full test execution was blocked by the unrelated platform and formatting issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a331bfb1214833297b1477810056a66)