### PR TITLE
Queue MultiManager capture requests until egui context is available

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -211,7 +211,7 @@ impl LauncherApp {
 
     pub fn multi_manager_start_capture(&mut self, workspace_id: &str) {
         if self.multi_manager_workspace_exists(workspace_id) {
-            self.multi_manager.pending_capture = Some(PendingCaptureAction::CaptureOneWindow {
+            self.multi_manager.queued_capture = Some(PendingCaptureAction::CaptureOneWindow {
                 workspace_id: workspace_id.to_string(),
             });
             self.multi_manager
@@ -367,6 +367,7 @@ impl LauncherApp {
     pub fn multi_manager_cancel_capture(&mut self) {
         self.multi_manager.capture_session = None;
         self.multi_manager.pending_capture = None;
+        self.multi_manager.queued_capture = None;
         self.multi_manager.recapture_active = false;
         self.multi_manager.recapture_queue.clear();
         self.multi_manager
@@ -383,6 +384,8 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_poll_capture(&mut self, ctx: &eframe::egui::Context) {
+        self.multi_manager_process_queued_capture(ctx);
+
         if self.multi_manager.pending_capture.is_none() && self.multi_manager.recapture_active {
             if let Some(item) = self.multi_manager.recapture_queue.pop_front() {
                 self.multi_manager_start_recapture_window(
@@ -414,6 +417,45 @@ impl LauncherApp {
 
         for event in events {
             self.handle_capture_event(ctx, event);
+        }
+    }
+
+    fn multi_manager_process_queued_capture(&mut self, ctx: &egui::Context) {
+        let Some(action) = self.multi_manager.queued_capture.take() else {
+            return;
+        };
+
+        if !self.multi_manager_capture_action_workspace_exists(&action) {
+            self.multi_manager
+                .runtime
+                .control
+                .capture_pending
+                .store(false, Ordering::Relaxed);
+            self.report_error_message(
+                "multi_manager.capture",
+                "Failed to start MultiManager capture: workspace not found",
+            );
+            ctx.request_repaint();
+            return;
+        }
+
+        self.multi_manager.pending_capture = Some(action);
+        self.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+        self.multi_manager_start_capture_session(ctx);
+        ctx.request_repaint();
+    }
+
+    fn multi_manager_capture_action_workspace_exists(&self, action: &PendingCaptureAction) -> bool {
+        match action {
+            PendingCaptureAction::CaptureOneWindow { workspace_id }
+            | PendingCaptureAction::CaptureMultipleWindows { workspace_id }
+            | PendingCaptureAction::RecaptureWindow { workspace_id, .. } => {
+                self.multi_manager_workspace_exists(workspace_id)
+            }
         }
     }
 
@@ -958,6 +1000,102 @@ mod tests {
         assert!(app.multi_manager.recapture_active);
         assert_eq!(app.multi_manager.recapture_queue.len(), 2);
         assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn action_path_capture_queues_listener_without_pending_capture() {
+        let mut app = test_app();
+        set_workspaces(
+            &mut app,
+            vec![MmWorkspace {
+                id: "w".into(),
+                ..Default::default()
+            }],
+        );
+
+        app.multi_manager_start_capture("w");
+
+        assert_eq!(
+            app.multi_manager.queued_capture,
+            Some(PendingCaptureAction::CaptureOneWindow {
+                workspace_id: "w".into()
+            })
+        );
+        assert_eq!(app.multi_manager.pending_capture, None);
+        assert!(app.multi_manager.capture_session.is_none());
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn queued_capture_starts_when_context_becomes_available() {
+        let ctx = eframe::egui::Context::default();
+        let mut app = test_app();
+        set_workspaces(
+            &mut app,
+            vec![MmWorkspace {
+                id: "w".into(),
+                ..Default::default()
+            }],
+        );
+        app.multi_manager.queued_capture = Some(PendingCaptureAction::CaptureOneWindow {
+            workspace_id: "w".into(),
+        });
+        app.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+
+        app.multi_manager_poll_capture(&ctx);
+
+        assert_eq!(app.multi_manager.queued_capture, None);
+        assert_eq!(
+            app.multi_manager.pending_capture,
+            Some(PendingCaptureAction::CaptureOneWindow {
+                workspace_id: "w".into()
+            })
+        );
+        assert!(app.multi_manager.capture_session.is_some());
+        assert!(app
+            .multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .load(Ordering::Relaxed));
+
+        app.multi_manager.capture_session = None;
+    }
+
+    #[test]
+    fn invalid_queued_capture_workspace_is_cleared_safely() {
+        let ctx = eframe::egui::Context::default();
+        let mut app = test_app();
+        set_workspaces(&mut app, Vec::new());
+        app.multi_manager.queued_capture = Some(PendingCaptureAction::CaptureOneWindow {
+            workspace_id: "missing".into(),
+        });
+        app.multi_manager
+            .runtime
+            .control
+            .capture_pending
+            .store(true, Ordering::Relaxed);
+
+        app.multi_manager_poll_capture(&ctx);
+
+        assert_eq!(app.multi_manager.queued_capture, None);
+        assert_eq!(app.multi_manager.pending_capture, None);
+        assert!(app.multi_manager.capture_session.is_none());
+        assert!(!app
             .multi_manager
             .runtime
             .control

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -13,6 +13,7 @@ const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 pub struct MultiManagerState {
     pub dirty: bool,
     pub pending_capture: Option<PendingCaptureAction>,
+    pub queued_capture: Option<PendingCaptureAction>,
     pub recapture_queue: VecDeque<RecaptureQueueItem>,
     pub recapture_active: bool,
     pub capture_session: Option<crate::multi_manager::capture::CaptureSession>,
@@ -52,6 +53,7 @@ impl MultiManagerState {
         Self {
             dirty: false,
             pending_capture: None,
+            queued_capture: None,
             recapture_queue: VecDeque::new(),
             recapture_active: false,
             capture_session: None,
@@ -131,6 +133,8 @@ impl MultiManagerState {
 
     pub fn shutdown(&mut self) {
         self.capture_session = None;
+        self.pending_capture = None;
+        self.queued_capture = None;
         self.runtime.shutdown();
     }
 


### PR DESCRIPTION
### Motivation
- Avoid creating a half-started `pending_capture` and `CaptureSession` when capture is requested from a non-GUI action path by queuing the request until an `egui::Context` is available.
- Keep the runtime listener informed (`capture_pending`) while preventing capture state from being partially initialized without an active listener.

### Description
- Added `queued_capture: Option<PendingCaptureAction>` to `MultiManagerState` and initialized it to `None` in `load_or_default` in `src/multi_manager/state.rs`.
- Cleared queued and pending capture state during cleanup by updating `shutdown` and `multi_manager_cancel_capture` to clear `queued_capture` (and `pending_capture`) in `src/multi_manager/state.rs` and `src/gui/multi_manager_actions.rs`.
- Changed `multi_manager_start_capture` (action-path) to validate the workspace, store the action in `queued_capture`, set `runtime.control.capture_pending` to `true`, and show the existing success toast without setting `pending_capture` until a listener is active in `src/gui/multi_manager_actions.rs`.
- Added `multi_manager_process_queued_capture(&mut self, ctx: &egui::Context)` and a helper `multi_manager_capture_action_workspace_exists` in `src/gui/multi_manager_actions.rs`, invoked early from `multi_manager_poll_capture`, which moves a valid queued action into `pending_capture`, starts a real `CaptureSession` with `multi_manager_start_capture_session`, keeps `capture_pending` true, and requests a repaint, while invalid queued workspaces are cleared and produce an error toast.
- Added unit tests covering the new behavior: `action_path_capture_queues_listener_without_pending_capture`, `queued_capture_starts_when_context_becomes_available`, and `invalid_queued_capture_workspace_is_cleared_safely` in `src/gui/multi_manager_actions.rs`.

### Testing
- Ran `git diff --check` and `rustfmt src/gui/multi_manager_actions.rs src/multi_manager/state.rs` successfully to ensure formatting and no whitespace errors.
- Added unit tests and attempted `cargo test multi_manager_actions --lib`, but test execution failed in this Linux environment due to platform-specific build issues (missing system X11/ALSA libs initially, which were installed, and ultimately the crate fails to compile because the project imports Windows-only `windows::Win32`/`windows::core` APIs and other target-specific APIs that cannot be resolved on this host).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3709426b908332a522aef218b6c97d)