### PR TITLE
Update capture banner instructions

### DIFF
--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -452,13 +452,13 @@ impl MultiManagerDialog {
 fn capture_banner_text(action: &PendingCaptureAction) -> &'static str {
     match action {
         PendingCaptureAction::CaptureOneWindow { .. } => {
-            "Capture mode: focus a window, then press Enter. Escape cancels."
+            "Capture mode active: focus the target window, then press Enter. Escape cancels."
         }
         PendingCaptureAction::CaptureMultipleWindows { .. } => {
-            "Multi-capture mode: focus a window and press Enter to add it. Escape finishes."
+            "Multi-capture active: focus a target window and press Enter. Repeat for each window. Escape finishes/cancels."
         }
         PendingCaptureAction::RecaptureWindow { .. } => {
-            "Recapture mode: focus the replacement window, press Enter. S skips. Escape cancels queue."
+            "Recapture active: focus the replacement window and press Enter. Press S to skip this item. Escape cancels the queue."
         }
     }
 }
@@ -901,7 +901,7 @@ mod tests {
 
         assert_eq!(
             capture_banner_text(&action),
-            "Capture mode: focus a window, then press Enter. Escape cancels."
+            "Capture mode active: focus the target window, then press Enter. Escape cancels."
         );
     }
 
@@ -913,7 +913,7 @@ mod tests {
 
         assert_eq!(
             capture_banner_text(&action),
-            "Multi-capture mode: focus a window and press Enter to add it. Escape finishes."
+            "Multi-capture active: focus a target window and press Enter. Repeat for each window. Escape finishes/cancels."
         );
     }
 
@@ -926,7 +926,7 @@ mod tests {
 
         assert_eq!(
             capture_banner_text(&action),
-            "Recapture mode: focus the replacement window, press Enter. S skips. Escape cancels queue."
+            "Recapture active: focus the replacement window and press Enter. Press S to skip this item. Escape cancels the queue."
         );
     }
 


### PR DESCRIPTION
### Motivation
- Make the capture-mode banner instructions clearer and match revised UX phrasing for single, multi, and recapture flows.

### Description
- Updated `capture_banner_text` in `src/multi_manager/ui.rs` to new messages for `PendingCaptureAction::CaptureOneWindow`, `PendingCaptureAction::CaptureMultipleWindows`, and `PendingCaptureAction::RecaptureWindow`.
- Updated the corresponding unit tests `capture_banner_text_explains_single_capture_controls`, `capture_banner_text_explains_multi_capture_controls`, and `capture_banner_text_explains_recapture_controls` in `src/multi_manager/ui.rs` to assert the new strings.
- Left the surrounding `capture_banner` UI logic intact so workspace-specific context lines (e.g. `Capturing one window for workspace {workspace_id}` / `Recapturing workspace {workspace_label}, window {}`) continue to render below the primary instruction.

### Testing
- Updated unit tests in `src/multi_manager/ui.rs` that assert `capture_banner_text` now compare against the new instruction strings; these source changes are present in the repo.
- Attempted to run `cargo test capture_banner_text_explains -- --nocapture`, but the test run failed in this environment due to a missing system dependency for `alsa-sys` (`alsa.pc` / `alsa` library not found), so full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a372e746d008332864c6e6edcc2b4a5)