### PR TITLE
Refresh NoteSettings when applying settings

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -99,7 +99,7 @@ use crate::plugin::{PluginManager, CAP_FORCE_LIST_RESULTS, CAP_GRID_RESULTS_COMP
 use crate::plugin_editor::PluginEditor;
 use crate::plugins::note::{NoteExternalOpen, NotePluginSettings};
 use crate::plugins::snippets::{remove_snippet, SNIPPETS_FILE};
-use crate::settings::{MultiManagerSettings, QueryResultsLayoutSettings, Settings};
+use crate::settings::{MultiManagerSettings, NoteSettings, QueryResultsLayoutSettings, Settings};
 use crate::settings_editor::SettingsEditor;
 use crate::toast_log::{append_toast_log, TOAST_LOG_FILE};
 use crate::usage::{self, USAGE_FILE};
@@ -446,6 +446,7 @@ pub struct LauncherApp {
     pub page_jump: usize,
     pub query_results_layout: QueryResultsLayoutSettings,
     resolved_grid_layout: bool,
+    pub note_settings: NoteSettings,
     pub note_panel_default_size: (f32, f32),
     pub note_save_on_close: bool,
     pub note_always_overwrite: bool,
@@ -637,6 +638,7 @@ impl LauncherApp {
         screenshot_auto_save: Option<bool>,
         always_on_top: Option<bool>,
         page_jump: Option<usize>,
+        note_settings: Option<NoteSettings>,
         note_panel_default_size: Option<(f32, f32)>,
         note_save_on_close: Option<bool>,
         note_always_overwrite: Option<bool>,
@@ -742,6 +744,9 @@ impl LauncherApp {
         }
         if let Some(v) = page_jump {
             self.page_jump = v;
+        }
+        if let Some(v) = note_settings {
+            self.note_settings = v;
         }
         if let Some(v) = note_panel_default_size {
             self.note_panel_default_size = v;
@@ -1169,6 +1174,7 @@ impl LauncherApp {
             page_jump: settings.page_jump,
             query_results_layout: settings.query_results_layout.clone(),
             resolved_grid_layout: false,
+            note_settings: settings.note.clone(),
             note_panel_default_size: settings.note_panel_default_size,
             note_save_on_close: settings.note_save_on_close,
             note_always_overwrite: settings.note_always_overwrite,
@@ -3095,6 +3101,7 @@ mod tests {
             None, // screenshot_auto_save
             None, // always_on_top
             None, // page_jump
+            None, // note_settings
             None, // note_panel_default_size
             None, // note_save_on_close
             None, // note_always_overwrite
@@ -3109,6 +3116,60 @@ mod tests {
         assert_eq!(app.command_search_cache[0].label_lc, "plugin command");
         assert_eq!(app.command_search_cache[0].desc_lc, "plugin desc");
         assert_eq!(app.command_search_cache[0].action_lc, "plugin:command");
+    }
+
+    #[test]
+    fn update_paths_refreshes_note_settings() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        assert!(app.note_settings.split_view_enabled);
+
+        let mut note_settings = app.note_settings.clone();
+        note_settings.split_view_enabled = false;
+
+        app.update_paths(
+            None, // plugin_dirs
+            None, // index_paths
+            None, // enabled_plugins
+            None, // enabled_capabilities
+            None, // offscreen_pos
+            None, // enable_toasts
+            None, // show_inline_errors
+            None, // show_error_toasts
+            None, // toast_duration
+            None, // fuzzy_weight
+            None, // usage_weight
+            None, // match_exact
+            None, // follow_mouse
+            None, // static_enabled
+            None, // static_pos
+            None, // static_size
+            None, // hide_after_run
+            None, // clear_query_after_run
+            None, // require_confirm_destructive
+            None, // timer_refresh
+            None, // disable_timer_updates
+            None, // preserve_command
+            None, // query_autocomplete
+            None, // net_refresh
+            None, // net_unit
+            None, // screenshot_dir
+            None, // screenshot_save_file
+            None, // screenshot_use_editor
+            None, // screenshot_auto_save
+            None, // always_on_top
+            None, // page_jump
+            Some(note_settings), // note_settings
+            None, // note_panel_default_size
+            None, // note_save_on_close
+            None, // note_always_overwrite
+            None, // note_images_as_links
+            None, // note_show_details
+            None, // note_more_limit
+            None, // show_dashboard_diagnostics
+        );
+
+        assert!(!app.note_settings.split_view_enabled);
     }
 
     #[test]

--- a/src/plugin_editor.rs
+++ b/src/plugin_editor.rs
@@ -133,6 +133,7 @@ impl PluginEditor {
                         Some(s.screenshot_auto_save),
                         Some(s.always_on_top),
                         Some(s.page_jump),
+                        Some(s.note.clone()),
                         Some(s.note_panel_default_size),
                         Some(s.note_save_on_close),
                         Some(s.note_always_overwrite),

--- a/src/settings_editor/save.rs
+++ b/src/settings_editor/save.rs
@@ -72,6 +72,7 @@ impl SettingsEditor {
             Some(new_settings.screenshot_auto_save),
             Some(new_settings.always_on_top),
             Some(new_settings.page_jump),
+            Some(new_settings.note.clone()),
             Some(new_settings.note_panel_default_size),
             Some(new_settings.note_save_on_close),
             Some(new_settings.note_always_overwrite),

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -47,45 +47,45 @@ fn run_action(action: &str) -> bool {
     }];
     let (mut app, flag) = new_app_with_settings(&ctx, actions, Settings::default());
     app.update_paths(
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(true),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+        None, // plugin_dirs
+        None, // index_paths
+        None, // enabled_plugins
+        None, // enabled_capabilities
+        None, // offscreen_pos
+        None, // enable_toasts
+        None, // show_inline_errors
+        None, // show_error_toasts
+        None, // toast_duration
+        None, // fuzzy_weight
+        None, // usage_weight
+        None, // match_exact
+        None, // follow_mouse
+        None, // static_enabled
+        None, // static_pos
+        None, // static_size
+        Some(true), // hide_after_run
+        None, // clear_query_after_run
+        None, // require_confirm_destructive
+        None, // timer_refresh
+        None, // disable_timer_updates
+        None, // preserve_command
+        None, // query_autocomplete
+        None, // net_refresh
+        None, // net_unit
+        None, // screenshot_dir
+        None, // screenshot_save_file
+        None, // screenshot_use_editor
+        None, // screenshot_auto_save
+        None, // always_on_top
+        None, // page_jump
+        None, // note_settings
+        None, // note_panel_default_size
+        None, // note_save_on_close
+        None, // note_always_overwrite
+        None, // note_images_as_links
+        None, // note_show_details
+        None, // note_more_limit
+        None, // show_dashboard_diagnostics
     );
     flag.store(true, Ordering::SeqCst);
     let a = app.results[0].clone();

--- a/tests/hide_after_run.rs
+++ b/tests/hide_after_run.rs
@@ -63,6 +63,7 @@ fn run_action(action: &str) -> bool {
         None,
         None,
         None,
+        None,
         Some(true),
         None,
         None,


### PR DESCRIPTION
### Motivation

- The GUI needs to track full note-related preferences, not just a set of legacy note fields, so applied/saved settings should update an in-memory `NoteSettings` struct on the running app.

### Description

- Added `pub note_settings: NoteSettings` to `LauncherApp` and imported `NoteSettings` from the settings module via `use crate::settings::{..., NoteSettings, ...};`.
- Initialized `note_settings` from `settings.note.clone()` when `LauncherApp` is constructed and added an optional `note_settings` parameter to the `update_paths`/apply flow so saved settings propagate into the running app via `if let Some(v) = note_settings { self.note_settings = v; }`.
- Preserved existing legacy assignments for `note_panel_default_size`, `note_save_on_close`, `note_images_as_links`, `note_show_details`, and `note_more_limit` so older code paths remain unaffected while `note_settings` is added.
- Wired the new `note_settings` argument through the settings-apply path by passing `Some(new_settings.note.clone())` from `SettingsEditor::apply_saved_settings` and from `PluginEditor` where settings are applied.
- Added a unit test `update_paths_refreshes_note_settings` that verifies updating `settings.note.split_view_enabled` via `update_paths` updates `app.note_settings.split_view_enabled`.

### Testing

- Ran `git diff --check` and `cargo fmt` as part of validation (no diff warnings).
- Added unit test `update_paths_refreshes_note_settings` under the existing GUI tests.
- Attempted to run `cargo test update_paths_refreshes_note_settings` and `cargo check` in this environment, but builds were blocked by unrelated platform-specific native dependency and build issues (missing system pkg-config / native libs for some crates and Windows-specific API compilation errors) so the test could not complete here. The change is limited to settings plumbing and a unit test; the test should pass in a normal development environment where the repo fully compiles for the target platform.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38781230b8833294385c5e3fb34fe8)