### PR TITLE
Add notes_markdown analysis module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod mouse_gestures;
 pub mod multi_manager;
 pub mod note_todo_sync;
+pub mod notes_markdown;
 pub mod platform;
 pub mod plugin;
 pub mod plugin_editor;

--- a/src/notes_markdown/callouts.rs
+++ b/src/notes_markdown/callouts.rs
@@ -1,0 +1,60 @@
+use super::{
+    MarkdownCallout,
+    parse::{LineSpan, leading_spaces},
+};
+
+pub fn parse_callouts(lines: &[LineSpan<'_>], code_lines: &[bool]) -> Vec<MarkdownCallout> {
+    let mut out = Vec::new();
+    let mut idx = 0;
+    while idx < lines.len() {
+        if code_lines.get(idx).copied().unwrap_or(false) {
+            idx += 1;
+            continue;
+        }
+        if let Some((kind, title)) = callout_header(lines[idx].text) {
+            let start = idx;
+            idx += 1;
+            let mut body = Vec::new();
+            while idx < lines.len() && !code_lines.get(idx).copied().unwrap_or(false) {
+                if let Some(stripped) = blockquote_text(lines[idx].text) {
+                    body.push(stripped.to_string());
+                    idx += 1;
+                } else {
+                    break;
+                }
+            }
+            let end = idx;
+            out.push(MarkdownCallout {
+                kind,
+                title,
+                line_range: start..end,
+                byte_range: lines[start].start..lines[end.saturating_sub(1)].end,
+                body: body.join("\n"),
+            });
+        } else {
+            idx += 1;
+        }
+    }
+    out
+}
+
+fn callout_header(line: &str) -> Option<(String, String)> {
+    let text = blockquote_text(line)?;
+    let rest = text.strip_prefix("[!")?;
+    let close = rest.find(']')?;
+    let kind = rest[..close].trim().to_ascii_lowercase();
+    if kind.is_empty() {
+        return None;
+    }
+    Some((kind, rest[close + 1..].trim().to_string()))
+}
+
+fn blockquote_text(line: &str) -> Option<&str> {
+    let indent = leading_spaces(line);
+    if indent > 3 {
+        return None;
+    }
+    let rest = &line[indent..];
+    let rest = rest.strip_prefix('>')?;
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
+}

--- a/src/notes_markdown/headings.rs
+++ b/src/notes_markdown/headings.rs
@@ -1,0 +1,64 @@
+use super::{MarkdownHeading, parse::LineSpan};
+
+pub fn parse_headings(lines: &[LineSpan<'_>], code_lines: &[bool]) -> Vec<MarkdownHeading> {
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !code_lines.get(*idx).copied().unwrap_or(false))
+        .filter_map(|(idx, line)| parse_heading(idx, line))
+        .collect()
+}
+
+fn parse_heading(line_index: usize, line: &LineSpan<'_>) -> Option<MarkdownHeading> {
+    let indent = line
+        .text
+        .as_bytes()
+        .iter()
+        .take_while(|&&b| b == b' ')
+        .count();
+    if indent > 3 {
+        return None;
+    }
+    let rest = &line.text[indent..];
+    let level = rest.as_bytes().iter().take_while(|&&b| b == b'#').count();
+    if !(1..=6).contains(&level) {
+        return None;
+    }
+    if rest
+        .as_bytes()
+        .get(level)
+        .is_some_and(|b| *b != b' ' && *b != b'\t')
+    {
+        return None;
+    }
+    let raw = rest[level..].trim();
+    let title = raw.trim_end_matches('#').trim_end().to_string();
+    if title.is_empty() {
+        return None;
+    }
+    Some(MarkdownHeading {
+        level: level as u8,
+        normalized_anchor: normalize_anchor(&title),
+        title,
+        line_index,
+        byte_range: line.start..line.end,
+    })
+}
+
+pub fn normalize_anchor(title: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in title.chars().flat_map(char::to_lowercase) {
+        if ch.is_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if (ch.is_whitespace() || ch == '-') && !out.is_empty() && !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    if last_dash {
+        out.pop();
+    }
+    out
+}

--- a/src/notes_markdown/mod.rs
+++ b/src/notes_markdown/mod.rs
@@ -1,0 +1,61 @@
+pub mod callouts;
+pub mod headings;
+pub mod parse;
+pub mod sections;
+pub mod task_list;
+
+pub use parse::analyze_markdown;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MarkdownAnalysis {
+    pub headings: Vec<MarkdownHeading>,
+    pub sections: Vec<MarkdownSection>,
+    pub task_items: Vec<MarkdownTaskItem>,
+    pub callouts: Vec<MarkdownCallout>,
+    pub outline: Vec<OutlineRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownHeading {
+    pub level: u8,
+    pub title: String,
+    pub normalized_anchor: String,
+    pub line_index: usize,
+    pub byte_range: std::ops::Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownSection {
+    pub heading: MarkdownHeading,
+    pub body_line_range: std::ops::Range<usize>,
+    pub body_byte_range: std::ops::Range<usize>,
+    pub nested_heading_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownTaskItem {
+    pub line_index: usize,
+    pub line_byte_range: std::ops::Range<usize>,
+    pub marker_byte_range: std::ops::Range<usize>,
+    pub checked: bool,
+    pub indent: usize,
+    pub bullet_marker: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownCallout {
+    pub kind: String,
+    pub title: String,
+    pub line_range: std::ops::Range<usize>,
+    pub byte_range: std::ops::Range<usize>,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutlineRow {
+    pub level: u8,
+    pub title: String,
+    pub normalized_anchor: String,
+    pub line_index: usize,
+}

--- a/src/notes_markdown/parse.rs
+++ b/src/notes_markdown/parse.rs
@@ -1,0 +1,157 @@
+use super::{MarkdownAnalysis, OutlineRow, callouts, headings, sections, task_list};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LineSpan<'a> {
+    pub text: &'a str,
+    pub start: usize,
+    pub end: usize,
+}
+
+pub fn analyze_markdown(content: &str) -> MarkdownAnalysis {
+    let lines = line_spans(content);
+    let code_lines = code_line_mask(&lines);
+    let headings = headings::parse_headings(&lines, &code_lines);
+    let sections = sections::parse_sections(&lines, &headings);
+    let task_items = task_list::parse_task_items(&lines, &code_lines);
+    let callouts = callouts::parse_callouts(&lines, &code_lines);
+    let outline = headings
+        .iter()
+        .map(|heading| OutlineRow {
+            level: heading.level,
+            title: heading.title.clone(),
+            normalized_anchor: heading.normalized_anchor.clone(),
+            line_index: heading.line_index,
+        })
+        .collect();
+
+    MarkdownAnalysis {
+        headings,
+        sections,
+        task_items,
+        callouts,
+        outline,
+    }
+}
+
+pub(crate) fn line_spans(content: &str) -> Vec<LineSpan<'_>> {
+    let mut spans = Vec::new();
+    let mut start = 0;
+    for line in content.split_inclusive('\n') {
+        let end = start + line.len();
+        let text = line.trim_end_matches(['\r', '\n']);
+        spans.push(LineSpan { text, start, end });
+        start = end;
+    }
+    if start < content.len() || content.is_empty() {
+        if !content.is_empty() {
+            spans.push(LineSpan {
+                text: &content[start..],
+                start,
+                end: content.len(),
+            });
+        }
+    }
+    spans
+}
+
+pub(crate) fn leading_spaces(line: &str) -> usize {
+    line.as_bytes().iter().take_while(|&&b| b == b' ').count()
+}
+
+fn code_line_mask(lines: &[LineSpan<'_>]) -> Vec<bool> {
+    let mut mask = vec![false; lines.len()];
+    let mut in_fence = false;
+    let mut fence_marker = b'`';
+    let mut fence_len = 0usize;
+
+    for (idx, line) in lines.iter().enumerate() {
+        let indent = leading_spaces(line.text);
+        let trimmed = &line.text[indent..];
+        let fence = fence_info(trimmed);
+        if in_fence {
+            mask[idx] = true;
+            if let Some((marker, len)) = fence {
+                if marker == fence_marker && len >= fence_len {
+                    in_fence = false;
+                }
+            }
+            continue;
+        }
+
+        if let Some((marker, len)) = fence.filter(|_| indent <= 3) {
+            mask[idx] = true;
+            in_fence = true;
+            fence_marker = marker;
+            fence_len = len;
+        } else if indent >= 4 && !trimmed.is_empty() {
+            mask[idx] = true;
+        }
+    }
+
+    mask
+}
+
+fn fence_info(trimmed: &str) -> Option<(u8, usize)> {
+    let bytes = trimmed.as_bytes();
+    let marker = *bytes.first()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let len = bytes.iter().take_while(|&&b| b == marker).count();
+    (len >= 3).then_some((marker, len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::analyze_markdown;
+
+    #[test]
+    fn empty_notes_have_no_markdown_items() {
+        let analysis = analyze_markdown("");
+        assert!(analysis.headings.is_empty());
+        assert!(analysis.sections.is_empty());
+        assert!(analysis.task_items.is_empty());
+        assert!(analysis.callouts.is_empty());
+        assert!(analysis.outline.is_empty());
+    }
+
+    #[test]
+    fn unicode_content_keeps_byte_ranges_and_normalizes_anchors() {
+        let content = "# Café 日記\n- [x] Привет мир\n> [!note] Täitle\n> body 🌱\n";
+        let analysis = analyze_markdown(content);
+        assert_eq!(analysis.headings[0].title, "Café 日記");
+        assert_eq!(analysis.headings[0].normalized_anchor, "café-日記");
+        assert_eq!(
+            &content[analysis.headings[0].byte_range.clone()],
+            "# Café 日記\n"
+        );
+        assert_eq!(analysis.task_items[0].text, "Привет мир");
+        assert!(analysis.task_items[0].checked);
+        assert_eq!(analysis.callouts[0].kind, "note");
+        assert_eq!(analysis.callouts[0].body, "body 🌱");
+    }
+
+    #[test]
+    fn mixed_line_endings_are_supported() {
+        let content = "# One\r\ntext\n## Two\r\n- [ ] task\r\n";
+        let analysis = analyze_markdown(content);
+        assert_eq!(analysis.headings.len(), 2);
+        assert_eq!(analysis.sections[0].body_line_range, 1..4);
+        assert_eq!(analysis.task_items[0].line_index, 3);
+        assert_eq!(
+            &content[analysis.task_items[0].marker_byte_range.clone()],
+            "[ ]"
+        );
+    }
+
+    #[test]
+    fn fenced_code_blocks_are_ignored() {
+        let content =
+            "# Real\n```\n# Not heading\n- [x] no task\n> [!warning] nope\n```\n- [ ] yes\n";
+        let analysis = analyze_markdown(content);
+        assert_eq!(analysis.headings.len(), 1);
+        assert_eq!(analysis.task_items.len(), 1);
+        assert_eq!(analysis.task_items[0].text, "yes");
+        assert!(analysis.callouts.is_empty());
+    }
+}

--- a/src/notes_markdown/sections.rs
+++ b/src/notes_markdown/sections.rs
@@ -1,0 +1,39 @@
+use super::{MarkdownHeading, MarkdownSection, parse::LineSpan};
+
+pub fn parse_sections(
+    lines: &[LineSpan<'_>],
+    headings: &[MarkdownHeading],
+) -> Vec<MarkdownSection> {
+    headings
+        .iter()
+        .enumerate()
+        .map(|(idx, heading)| {
+            let end_heading_idx = headings
+                .iter()
+                .enumerate()
+                .skip(idx + 1)
+                .find(|(_, candidate)| candidate.level <= heading.level)
+                .map(|(next_idx, _)| next_idx)
+                .unwrap_or(headings.len());
+            let end_line = headings
+                .get(end_heading_idx)
+                .map(|h| h.line_index)
+                .unwrap_or(lines.len());
+            let body_start_line = heading.line_index + 1;
+            let body_start_byte = lines
+                .get(body_start_line)
+                .map(|l| l.start)
+                .unwrap_or(heading.byte_range.end);
+            let body_end_byte = lines
+                .get(end_line)
+                .map(|l| l.start)
+                .unwrap_or_else(|| lines.last().map(|l| l.end).unwrap_or(0));
+            MarkdownSection {
+                heading: heading.clone(),
+                body_line_range: body_start_line..end_line,
+                body_byte_range: body_start_byte..body_end_byte,
+                nested_heading_count: end_heading_idx.saturating_sub(idx + 1),
+            }
+        })
+        .collect()
+}

--- a/src/notes_markdown/task_list.rs
+++ b/src/notes_markdown/task_list.rs
@@ -1,0 +1,55 @@
+use super::{
+    MarkdownTaskItem,
+    parse::{LineSpan, leading_spaces},
+};
+
+pub fn parse_task_items(lines: &[LineSpan<'_>], code_lines: &[bool]) -> Vec<MarkdownTaskItem> {
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !code_lines.get(*idx).copied().unwrap_or(false))
+        .filter_map(|(idx, line)| parse_task_item(idx, line))
+        .collect()
+}
+
+fn parse_task_item(line_index: usize, line: &LineSpan<'_>) -> Option<MarkdownTaskItem> {
+    let indent = leading_spaces(line.text);
+    let rest = &line.text[indent..];
+    let (bullet_len, bullet_marker) =
+        if rest.starts_with("- ") || rest.starts_with("* ") || rest.starts_with("+ ") {
+            (1, rest[..1].to_string())
+        } else {
+            let dot = rest.find(['.', ')'])?;
+            if dot == 0
+                || !rest[..dot].chars().all(|c| c.is_ascii_digit())
+                || rest.as_bytes().get(dot + 1) != Some(&b' ')
+            {
+                return None;
+            }
+            (dot + 1, rest[..=dot].to_string())
+        };
+    let after_bullet = &rest[bullet_len + 1..];
+    let marker = after_bullet.get(..3)?;
+    let checked = match marker.as_bytes() {
+        [b'[', b' ', b']'] => false,
+        [b'[', b'x' | b'X', b']'] => true,
+        _ => return None,
+    };
+    if after_bullet
+        .as_bytes()
+        .get(3)
+        .is_some_and(|b| *b != b' ' && *b != b'\t')
+    {
+        return None;
+    }
+    let marker_start = line.start + indent + bullet_len + 1;
+    Some(MarkdownTaskItem {
+        line_index,
+        line_byte_range: line.start..line.end,
+        marker_byte_range: marker_start..marker_start + 3,
+        checked,
+        indent,
+        bullet_marker,
+        text: after_bullet[3..].trim_start().to_string(),
+    })
+}


### PR DESCRIPTION
### Motivation
- Add a small, pure Rust markdown analysis subsystem for notes to extract headings, sections, task list items, callouts and an outline useful for note UI and indexing. 
- Ensure parsers correctly handle Unicode and mixed line endings and ignore fenced and indented code blocks so analysis doesn't pick up code content.

### Description
- Register the module by adding `pub mod notes_markdown;` to `src/lib.rs` and add the new module files under `src/notes_markdown/` (`mod.rs`, `parse.rs`, `headings.rs`, `sections.rs`, `task_list.rs`, `callouts.rs`).
- Define pure data structs `MarkdownAnalysis`, `MarkdownHeading`, `MarkdownSection`, `MarkdownTaskItem`, `MarkdownCallout`, and `OutlineRow` in `src/notes_markdown/mod.rs` with the requested fields and ranges.
- Implement `analyze_markdown(content: &str) -> MarkdownAnalysis` in `src/notes_markdown/parse.rs` with `line_spans`, `code_line_mask` (fenced and indented code skipping), and helpers, and wire the specific parsers to produce the aggregated `MarkdownAnalysis`.
- Add focused parsers: ATX heading parsing and anchor normalization in `headings.rs`, section splitting in `sections.rs`, GitHub-style task list parsing in `task_list.rs`, and blockquote callout parsing in `callouts.rs`.

### Testing
- Ran the module unit tests with a local test harness via `rustc --edition=2024 --test /tmp/notes_markdown_harness.rs -o /tmp/notes_markdown_tests && /tmp/notes_markdown_tests`, and all tests passed (4 passed, 0 failed).
- Attempted `cargo test notes_markdown`, which could not complete in this environment due to an unrelated system dependency error for `alsa-sys` (missing `alsa.pc`), so full workspace `cargo test` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3880f61f788332b86b6970fa84c128)