### PR TITLE
Implement ATX heading parsing, slug anchors, section ownership, and outline depth

### DIFF
--- a/src/notes_markdown/headings.rs
+++ b/src/notes_markdown/headings.rs
@@ -1,11 +1,20 @@
-use super::{MarkdownHeading, parse::LineSpan};
+use std::collections::HashMap;
+
+use super::{parse::LineSpan, MarkdownHeading};
 
 pub fn parse_headings(lines: &[LineSpan<'_>], code_lines: &[bool]) -> Vec<MarkdownHeading> {
+    let mut seen_anchors = HashMap::new();
+
     lines
         .iter()
         .enumerate()
         .filter(|(idx, _)| !code_lines.get(*idx).copied().unwrap_or(false))
         .filter_map(|(idx, line)| parse_heading(idx, line))
+        .map(|mut heading| {
+            heading.normalized_anchor =
+                unique_anchor(&heading.normalized_anchor, &mut seen_anchors);
+            heading
+        })
         .collect()
 }
 
@@ -31,8 +40,8 @@ fn parse_heading(line_index: usize, line: &LineSpan<'_>) -> Option<MarkdownHeadi
     {
         return None;
     }
-    let raw = rest[level..].trim();
-    let title = raw.trim_end_matches('#').trim_end().to_string();
+
+    let title = strip_closing_sequence(rest[level..].trim()).to_string();
     if title.is_empty() {
         return None;
     }
@@ -45,10 +54,33 @@ fn parse_heading(line_index: usize, line: &LineSpan<'_>) -> Option<MarkdownHeadi
     })
 }
 
+fn strip_closing_sequence(raw: &str) -> &str {
+    let trimmed = raw.trim_end();
+    let Some(hash_start) = trimmed.rfind(|ch| ch != '#') else {
+        return "";
+    };
+    let closing_start = hash_start + trimmed[hash_start..].chars().next().unwrap().len_utf8();
+    let closing = &trimmed[closing_start..];
+    if closing.is_empty() {
+        return trimmed;
+    }
+    let before_closing = &trimmed[..closing_start];
+    if before_closing.ends_with(char::is_whitespace) {
+        before_closing.trim_end()
+    } else {
+        trimmed
+    }
+}
+
+/// Normalizes a heading title into a deterministic, slug-like anchor.
+///
+/// The normalization lowercases Unicode, trims/collapses whitespace and dashes into single `-`
+/// separators, removes punctuation/symbols, and keeps Unicode letters and numbers intact.
 pub fn normalize_anchor(title: &str) -> String {
     let mut out = String::new();
     let mut last_dash = false;
-    for ch in title.chars().flat_map(char::to_lowercase) {
+
+    for ch in title.trim().chars().flat_map(char::to_lowercase) {
         if ch.is_alphanumeric() {
             out.push(ch);
             last_dash = false;
@@ -57,8 +89,24 @@ pub fn normalize_anchor(title: &str) -> String {
             last_dash = true;
         }
     }
+
     if last_dash {
         out.pop();
     }
-    out
+    if out.is_empty() {
+        "section".to_string()
+    } else {
+        out
+    }
+}
+
+fn unique_anchor(anchor: &str, seen_anchors: &mut HashMap<String, usize>) -> String {
+    let count = seen_anchors.entry(anchor.to_string()).or_insert(0);
+    let unique = if *count == 0 {
+        anchor.to_string()
+    } else {
+        format!("{anchor}-{count}")
+    };
+    *count += 1;
+    unique
 }

--- a/src/notes_markdown/mod.rs
+++ b/src/notes_markdown/mod.rs
@@ -4,7 +4,7 @@ pub mod parse;
 pub mod sections;
 pub mod task_list;
 
-pub use parse::analyze_markdown;
+pub use parse::{analyze_markdown, analyze_markdown_with_max_outline_depth};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MarkdownAnalysis {

--- a/src/notes_markdown/parse.rs
+++ b/src/notes_markdown/parse.rs
@@ -1,4 +1,4 @@
-use super::{MarkdownAnalysis, OutlineRow, callouts, headings, sections, task_list};
+use super::{callouts, headings, sections, task_list, MarkdownAnalysis, OutlineRow};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LineSpan<'a> {
@@ -8,14 +8,23 @@ pub(crate) struct LineSpan<'a> {
 }
 
 pub fn analyze_markdown(content: &str) -> MarkdownAnalysis {
+    analyze_markdown_with_max_outline_depth(content, 6)
+}
+
+pub fn analyze_markdown_with_max_outline_depth(
+    content: &str,
+    max_outline_depth: usize,
+) -> MarkdownAnalysis {
     let lines = line_spans(content);
     let code_lines = code_line_mask(&lines);
     let headings = headings::parse_headings(&lines, &code_lines);
-    let sections = sections::parse_sections(&lines, &headings);
+    let sections = sections::parse_sections(&headings, content);
     let task_items = task_list::parse_task_items(content);
     let callouts = callouts::parse_callouts(&lines, &code_lines);
+    let max_outline_depth = max_outline_depth.clamp(1, 6) as u8;
     let outline = headings
         .iter()
+        .filter(|heading| heading.level <= max_outline_depth)
         .map(|heading| OutlineRow {
             level: heading.level,
             title: heading.title.clone(),
@@ -103,7 +112,114 @@ fn fence_info(trimmed: &str) -> Option<(u8, usize)> {
 
 #[cfg(test)]
 mod tests {
-    use super::analyze_markdown;
+    use super::{analyze_markdown, analyze_markdown_with_max_outline_depth};
+
+    #[test]
+    fn extracts_atx_headings_and_ignores_non_headings() {
+        let content = "# One\n####### Not heading\n### Three ###\n    # Code block\n###### Six\n";
+        let analysis = analyze_markdown(content);
+        let headings: Vec<_> = analysis
+            .headings
+            .iter()
+            .map(|heading| (heading.level, heading.title.as_str(), heading.line_index))
+            .collect();
+
+        assert_eq!(
+            headings,
+            vec![(1, "One", 0), (3, "Three", 2), (6, "Six", 4)]
+        );
+        assert_eq!(analysis.headings[1].normalized_anchor, "three");
+    }
+
+    #[test]
+    fn duplicate_heading_anchors_get_stable_suffixes() {
+        let content = "# Repeat!\n## repeat\n# Repeat -- repeat?\n# Repeat\n";
+        let analysis = analyze_markdown(content);
+        let anchors: Vec<_> = analysis
+            .headings
+            .iter()
+            .map(|heading| heading.normalized_anchor.as_str())
+            .collect();
+
+        assert_eq!(
+            anchors,
+            vec!["repeat", "repeat-1", "repeat-repeat", "repeat-2"]
+        );
+        assert_eq!(
+            analysis
+                .outline
+                .iter()
+                .map(|row| row.normalized_anchor.as_str())
+                .collect::<Vec<_>>(),
+            anchors
+        );
+    }
+
+    #[test]
+    fn nested_sections_are_owned_until_same_or_higher_heading() {
+        let content = "# A\na body\n## B\nb body\n### C\nc body\n## D\nd body\n# E\ne body\n";
+        let analysis = analyze_markdown(content);
+
+        assert_eq!(analysis.sections[0].heading.title, "A");
+        assert_eq!(analysis.sections[0].body_line_range, 1..8);
+        assert_eq!(analysis.sections[0].nested_heading_count, 3);
+        assert_eq!(
+            &content[analysis.sections[0].body_byte_range.clone()],
+            "a body\n## B\nb body\n### C\nc body\n## D\nd body\n"
+        );
+
+        assert_eq!(analysis.sections[1].heading.title, "B");
+        assert_eq!(analysis.sections[1].body_line_range, 3..6);
+        assert_eq!(analysis.sections[1].nested_heading_count, 1);
+
+        assert_eq!(analysis.sections[2].heading.title, "C");
+        assert_eq!(analysis.sections[2].body_line_range, 5..6);
+        assert_eq!(analysis.sections[2].nested_heading_count, 0);
+    }
+
+    #[test]
+    fn fenced_code_headings_are_ignored() {
+        let content = "# Real\n~~~md\n## Ignored\n~~~\n```\n### Also ignored\n```\n## Visible\n";
+        let analysis = analyze_markdown(content);
+        assert_eq!(
+            analysis
+                .headings
+                .iter()
+                .map(|heading| heading.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Real", "Visible"]
+        );
+    }
+
+    #[test]
+    fn unicode_heading_anchors_keep_letters_and_numbers() {
+        let content = "# Café—日記  Привет №1!\n# 🌱\n";
+        let analysis = analyze_markdown(content);
+        assert_eq!(analysis.headings[0].normalized_anchor, "café日記-привет-1");
+        assert_eq!(analysis.headings[1].normalized_anchor, "section");
+    }
+
+    #[test]
+    fn notes_without_headings_have_no_sections_or_outline() {
+        let analysis = analyze_markdown("plain text\n- [ ] task\n");
+        assert!(analysis.headings.is_empty());
+        assert!(analysis.sections.is_empty());
+        assert!(analysis.outline.is_empty());
+    }
+
+    #[test]
+    fn outline_respects_max_depth_filter() {
+        let analysis = analyze_markdown_with_max_outline_depth("# One\n## Two\n### Three\n", 2);
+        assert_eq!(
+            analysis
+                .outline
+                .iter()
+                .map(|row| (row.level, row.title.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(1, "One"), (2, "Two")]
+        );
+        assert_eq!(analysis.headings.len(), 3);
+    }
 
     #[test]
     fn empty_notes_have_no_markdown_items() {

--- a/src/notes_markdown/sections.rs
+++ b/src/notes_markdown/sections.rs
@@ -1,6 +1,14 @@
-use super::{MarkdownHeading, MarkdownSection, parse::LineSpan};
+use super::{
+    parse::{line_spans, LineSpan},
+    MarkdownHeading, MarkdownSection,
+};
 
-pub fn parse_sections(
+pub fn parse_sections(headings: &[MarkdownHeading], content: &str) -> Vec<MarkdownSection> {
+    let lines = line_spans(content);
+    parse_sections_from_lines(&lines, headings)
+}
+
+fn parse_sections_from_lines(
     lines: &[LineSpan<'_>],
     headings: &[MarkdownHeading],
 ) -> Vec<MarkdownSection> {


### PR DESCRIPTION
### Motivation
- Add full ATX heading support (levels `#`–`######`) and make note analysis produce deterministic anchors and section data for use in outlines and UI features.
- Avoid treating headings that appear inside fenced code blocks as real headings to prevent noise in analysis.
- Provide a stable, Unicode-friendly anchor normalization and stable suffixing for duplicate anchors so outline links remain deterministic.
- Allow outline generation to be filtered by `max_outline_depth` so UI can limit depth without changing analysis results.

### Description
- Implemented ATX heading parsing in `src/notes_markdown/headings.rs` including trimming of optional trailing `#` sequences, indentation validation, and skipping lines flagged as code; added `normalize_anchor`, `strip_closing_sequence`, and `unique_anchor` helpers.
- Implemented `parse_sections(headings, content)` in `src/notes_markdown/sections.rs` to assign each heading a `body_line_range`, `body_byte_range`, and `nested_heading_count` that cover content until the next same-or-higher-level heading.
- Added `analyze_markdown_with_max_outline_depth` in `src/notes_markdown/parse.rs` and updated `analyze_markdown` to call it with default depth `6`, and changed outline construction to respect a clamped `max_outline_depth` filter while leaving `headings`/`sections` intact.
- Added unit tests in `src/notes_markdown/parse.rs` that cover ATX heading extraction, duplicate anchor suffixing, nested section ownership, ignoring headings in fenced code, Unicode heading normalization, behavior with no headings, and `max_outline_depth` filtering.

### Testing
- Ran `rustfmt --check` on modified files (`src/notes_markdown/headings.rs`, `src/notes_markdown/sections.rs`, `src/notes_markdown/parse.rs`) and it passed.
- Ran `git diff --check` to ensure no trivial diffs/whitespace issues and it passed.
- Added unit tests for the headings/sections behavior and attempted to run `cargo test notes_markdown`, but full test execution in this environment was blocked by unrelated platform-specific build failures (Windows-specific `windows::Win32` imports and other system-dependent crates), so the new module-level tests are present but the crate-level test run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388ea021148332b894c0a34374e197)