### PR TITLE
Persist collapsed note sections

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2408,11 +2408,13 @@ impl LauncherApp {
                 },
             );
         }
-        self.note_panels.push(NotePanel::from_note_with_details_and_settings(
+        let mut panel = NotePanel::from_note_with_details_and_settings(
             note,
             self.note_show_details,
             &self.note_settings,
-        ));
+        );
+        panel.load_collapsed_sections_state(self);
+        self.note_panels.push(panel);
         // Allow keyboard shortcuts like Esc/Cmd+W to immediately close the panel
         self.update_panel_stack();
     }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -190,6 +190,7 @@ pub struct NotePanel {
     markdown_analysis: Option<MarkdownAnalysis>,
     markdown_analysis_source_hash: Option<u64>,
     collapsed_sections: HashSet<String>,
+    ui_state_error_reported: bool,
     outline_visible: bool,
     image_cache: HashMap<std::path::PathBuf, egui::TextureHandle>,
     overwrite_prompt: bool,
@@ -385,6 +386,7 @@ impl NotePanel {
             markdown_analysis: None,
             markdown_analysis_source_hash: None,
             collapsed_sections: HashSet::new(),
+            ui_state_error_reported: false,
             outline_visible: false,
             image_cache: HashMap::new(),
             overwrite_prompt: false,
@@ -420,6 +422,63 @@ impl NotePanel {
         panel.refresh_fast_derived();
         panel.refresh_heavy_derived(true);
         panel
+    }
+
+    pub(crate) fn load_collapsed_sections_state(&mut self, app: &mut LauncherApp) {
+        if !app.note_settings.collapsed_sections_persist {
+            return;
+        }
+        let path = crate::note_ui_state::path_for_settings(Path::new(&app.settings_path));
+        match crate::note_ui_state::load(&path) {
+            Ok(state) => {
+                self.collapsed_sections = state.collapsed_sections_for(&self.note.slug);
+            }
+            Err(err) => self.report_ui_state_error_once(
+                app,
+                format!(
+                    "Failed to load note UI state from {}: {err}",
+                    path.display()
+                ),
+            ),
+        }
+    }
+
+    fn persist_collapsed_sections_state(&mut self, app: &mut LauncherApp) {
+        if !app.note_settings.collapsed_sections_persist {
+            return;
+        }
+        let path = crate::note_ui_state::path_for_settings(Path::new(&app.settings_path));
+        let mut state = match crate::note_ui_state::load(&path) {
+            Ok(state) => state,
+            Err(err) => {
+                self.report_ui_state_error_once(
+                    app,
+                    format!(
+                        "Failed to load note UI state from {}: {err}",
+                        path.display()
+                    ),
+                );
+                return;
+            }
+        };
+        state.set_collapsed_sections(
+            self.note.slug.clone(),
+            self.collapsed_sections.iter().cloned(),
+        );
+        if let Err(err) = crate::note_ui_state::save(&path, &state) {
+            self.report_ui_state_error_once(
+                app,
+                format!("Failed to save note UI state to {}: {err}", path.display()),
+            );
+        }
+    }
+
+    fn report_ui_state_error_once(&mut self, app: &mut LauncherApp, message: String) {
+        if self.ui_state_error_reported {
+            return;
+        }
+        self.ui_state_error_reported = true;
+        app.report_error("note UI state", message);
     }
 
     fn backlink_rows_for_active_tab(&self) -> &[BacklinkRow] {
@@ -1346,6 +1405,7 @@ impl NotePanel {
                     } else {
                         self.collapsed_sections.insert(key.clone());
                     }
+                    self.persist_collapsed_sections_state(app);
                 }
                 let heading = self.note.content[heading_range.clone()].to_string();
                 self.show_markdown_fragment(ui, app, &heading, heading_range.start);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod mouse_gestures;
 pub mod multi_manager;
 pub mod note_todo_sync;
+pub mod note_ui_state;
 pub mod notes_markdown;
 pub mod platform;
 pub mod plugin;

--- a/src/note_ui_state.rs
+++ b/src/note_ui_state.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+const NOTE_UI_STATE_RELATIVE_PATH: &str = "note_ui_state.json";
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteUiState {
+    #[serde(default)]
+    pub notes: BTreeMap<String, NoteCollapsedState>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteCollapsedState {
+    #[serde(default)]
+    pub collapsed_sections: BTreeSet<String>,
+}
+
+impl NoteUiState {
+    pub fn collapsed_sections_for(&self, note_slug: &str) -> HashSet<String> {
+        self.notes
+            .get(note_slug)
+            .map(|note| note.collapsed_sections.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn set_collapsed_sections<I>(&mut self, note_slug: impl Into<String>, collapsed_sections: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let collapsed_sections = collapsed_sections.into_iter().collect::<BTreeSet<_>>();
+        let note_slug = note_slug.into();
+        if collapsed_sections.is_empty() {
+            self.notes.remove(&note_slug);
+        } else {
+            self.notes
+                .insert(note_slug, NoteCollapsedState { collapsed_sections });
+        }
+    }
+
+    pub fn from_json(contents: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(contents)
+    }
+
+    pub fn to_json_pretty(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self).map(|json| format!("{json}\n"))
+    }
+}
+
+pub fn path_for_settings(settings_path: &Path) -> PathBuf {
+    settings_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(NOTE_UI_STATE_RELATIVE_PATH)
+}
+
+pub fn load(path: &Path) -> anyhow::Result<NoteUiState> {
+    if !path.exists() {
+        return Ok(NoteUiState::default());
+    }
+    let contents = std::fs::read_to_string(path)?;
+    Ok(NoteUiState::from_json(&contents)?)
+}
+
+pub fn save(path: &Path, state: &NoteUiState) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, state.to_json_pretty()?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoteUiState;
+
+    #[test]
+    fn serializes_collapsed_sections_per_note_slug() {
+        let mut state = NoteUiState::default();
+        state.set_collapsed_sections(
+            "daily-note",
+            vec![
+                "daily-note::later::Later::8".to_string(),
+                "daily-note::top::Top::0".to_string(),
+            ],
+        );
+        state.set_collapsed_sections(
+            "project-note",
+            vec!["project-note::ideas::Ideas::3".to_string()],
+        );
+
+        let json = state.to_json_pretty().expect("serialize note ui state");
+
+        assert!(json.contains("daily-note"));
+        assert!(json.contains("project-note"));
+        assert!(json.contains("collapsed_sections"));
+        assert_eq!(json, state.to_json_pretty().expect("stable serialization"));
+    }
+
+    #[test]
+    fn deserializes_collapsed_sections_and_defaults_missing_notes() {
+        let state = NoteUiState::from_json(
+            r#"{
+              "notes": {
+                "daily-note": {
+                  "collapsed_sections": [
+                    "daily-note::later::Later::8",
+                    "daily-note::top::Top::0"
+                  ]
+                }
+              }
+            }"#,
+        )
+        .expect("deserialize note ui state");
+
+        let collapsed = state.collapsed_sections_for("daily-note");
+        assert!(collapsed.contains("daily-note::later::Later::8"));
+        assert!(collapsed.contains("daily-note::top::Top::0"));
+        assert!(state.collapsed_sections_for("missing-note").is_empty());
+    }
+
+    #[test]
+    fn empty_collapsed_sections_remove_note_entry() {
+        let mut state = NoteUiState::default();
+        state.set_collapsed_sections("daily-note", vec!["daily-note::top::Top::0".to_string()]);
+        state.set_collapsed_sections("daily-note", Vec::<String>::new());
+
+        assert!(state.notes.is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a small, opt-in persistence layer so note panels can remember which markdown sections were collapsed per-note across sessions.
- Use a sidecar JSON next to the app settings file rather than mutating note Markdown, and surface load/save errors non-fatally.

### Description
- Introduced a new module `src/note_ui_state.rs` that defines a `NoteUiState` model, helpers `path_for_settings`, `load`, and `save`, and pure unit tests for serialization/deserialization.
- Exposed the module in the crate root by adding `pub mod note_ui_state;` to `src/lib.rs`.
- In `NotePanel` (`src/gui/note_panel.rs`) added a `ui_state_error_reported: bool` flag plus methods `load_collapsed_sections_state`, `persist_collapsed_sections_state`, and `report_ui_state_error_once` to load/save per-note collapsed keys and to report errors once per panel.
- Wire up loading on open by calling `panel.load_collapsed_sections_state(self)` when creating a new note panel in `src/gui/mod.rs` and persist changes when a section toggle is clicked, only when `note_settings.collapsed_sections_persist` is true.
- All load/save operations use the sidecar JSON next to the app `settings.json` and treat IO/serialization errors as non-fatal by calling `app.report_error(...)` once per panel.

### Testing
- Added unit tests in `src/note_ui_state.rs` that cover serialization, deserialization, per-note collapsed sets, and cleanup when a note's collapsed set becomes empty.
- Attempted to run `cargo test note_ui_state --lib` in the CI/dev environment, but running tests could not complete because unrelated platform-specific build steps (native system libraries and Windows-target code) caused the overall build to fail before the unit tests ran.
- No other automated tests were changed; the new tests are pure and should run successfully in a typical development environment where the crate builds for the host target.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39d4794e7c833299427ff5bae7b861)