### PR TITLE
Support multiple note aliases

### DIFF
--- a/src/dashboard/widgets/notes_graph.rs
+++ b/src/dashboard/widgets/notes_graph.rs
@@ -199,6 +199,7 @@ mod tests {
             links: links.iter().map(|v| v.to_string()).collect(),
             slug: slug.to_string(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }
     }

--- a/src/graph/note_graph.rs
+++ b/src/graph/note_graph.rs
@@ -593,6 +593,7 @@ mod tests {
             links: links.iter().map(|l| l.to_string()).collect(),
             slug: slug.to_string(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2342,7 +2342,7 @@ impl LauncherApp {
 
     /// Open a note panel for the given slug, optionally using a template for new notes.
     pub fn open_note_panel(&mut self, slug: &str, template: Option<&str>) {
-        use crate::plugins::note::{extract_alias, get_template, load_notes, Note};
+        use crate::plugins::note::{extract_aliases, get_template, load_notes, Note};
         let note = load_notes()
             .unwrap_or_default()
             .into_iter()
@@ -2369,7 +2369,8 @@ impl LauncherApp {
                 } else {
                     format!("# {}\n\n", title)
                 };
-                let alias = extract_alias(&content);
+                let aliases = extract_aliases(&content);
+                let alias = aliases.first().cloned();
                 Note {
                     title,
                     path: std::path::PathBuf::new(),
@@ -2378,6 +2379,7 @@ impl LauncherApp {
                     links: Vec::new(),
                     slug: String::new(),
                     alias,
+                    aliases,
                     entity_refs: Vec::new(),
                 }
             });
@@ -3610,6 +3612,7 @@ mod tests {
                     links: Vec::new(),
                     slug: "alpha".into(),
                     alias: None,
+                    aliases: Vec::new(),
                     entity_refs: Vec::new(),
                 }])
             },

--- a/src/gui/note_graph_dialog.rs
+++ b/src/gui/note_graph_dialog.rs
@@ -867,6 +867,7 @@ mod tests {
             links: Vec::new(),
             slug: slug.to_string(),
             alias: alias.map(str::to_string),
+            aliases: alias.map(|a| vec![a.to_string()]).unwrap_or_default(),
             entity_refs: Vec::new(),
         }
     }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3151,6 +3151,7 @@ mod tests {
             links: Vec::new(),
             slug: String::new(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }
     }
@@ -3237,6 +3238,7 @@ mod tests {
             links: Vec::new(),
             slug: slug.into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }
     }
@@ -3697,6 +3699,7 @@ mod tests {
             links: Vec::new(),
             slug: String::new(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let mut panel = NotePanel::from_note(note);
@@ -3824,6 +3827,7 @@ mod tests {
             links: Vec::new(),
             slug: "central".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let notes = vec![
@@ -3835,6 +3839,7 @@ mod tests {
                 links: vec!["central".into()],
                 slug: "related".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -3845,6 +3850,7 @@ mod tests {
                 links: Vec::new(),
                 slug: "mention".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ];
@@ -3924,6 +3930,7 @@ Body visible always",
             links: Vec::new(),
             slug: "central-note".into(),
             alias: Some("Hub".into()),
+            aliases: vec!["Hub".into()],
             entity_refs: Vec::new(),
         };
         let coded = Note {
@@ -3941,6 +3948,7 @@ link://note/central-note
             links: Vec::new(),
             slug: "coded".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let linked = Note {
@@ -3951,6 +3959,7 @@ link://note/central-note
             links: Vec::new(),
             slug: "linked".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let notes = vec![current, coded, linked];
@@ -4140,6 +4149,7 @@ Body with [[Other]]"
             links: Vec::new(),
             slug: "title".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let mut panel = NotePanel::from_note(note);
@@ -4165,6 +4175,7 @@ Body with [[Other]]"
             links: Vec::new(),
             slug: "title".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let mut panel = NotePanel::from_note(note);
@@ -4302,6 +4313,7 @@ Body with [[Other]]"
             links: Vec::new(),
             slug: String::new(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let mut panel = NotePanel::from_note(note);
@@ -4444,6 +4456,7 @@ body"
             links: Vec::new(),
             slug: String::new(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
         let mut panel = NotePanel::from_note(note);

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -148,6 +148,7 @@ impl NotesDialog {
                                         links: Vec::new(),
                                         slug: String::new(),
                                         alias: None,
+                                        aliases: Vec::new(),
                                         entity_refs: Vec::new(),
                                     });
                                 } else if let Some(e) = self.entries.get_mut(idx) {

--- a/src/linking/mod.rs
+++ b/src/linking/mod.rs
@@ -228,6 +228,7 @@ mod tests {
             links: vec!["beta".into()],
             slug: "alpha".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: vec![EntityRef::new(EntityKind::Todo, "todo-1", None)],
         }];
         let todos = vec![TodoEntry {

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -3,14 +3,14 @@ use crate::common::entity_ref::{EntityKind, EntityRef};
 use crate::common::query::parse_query_filters;
 use crate::common::slug::{register_slug, reset_slug_lookup, slugify, unique_slug};
 use crate::linking::{
-    EntityKey, LinkRef, LinkTarget, build_index_from_notes_and_todos, format_link_id,
+    build_index_from_notes_and_todos, format_link_id, EntityKey, LinkRef, LinkTarget,
 };
 use crate::plugin::Plugin;
 use crate::plugins::todo::TODO_DATA;
 use chrono::Local;
 use eframe::egui;
-use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{
-    Arc, Mutex,
     atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -76,6 +76,7 @@ pub struct Note {
     pub links: Vec<String>,
     pub slug: String,
     pub alias: Option<String>,
+    pub aliases: Vec<String>,
     pub entity_refs: Vec<EntityRef>,
 }
 
@@ -84,6 +85,7 @@ pub struct NoteLinkMenuTarget {
     pub slug: String,
     pub title: String,
     pub alias: Option<String>,
+    pub aliases: Vec<String>,
 }
 
 impl NoteLinkMenuTarget {
@@ -94,6 +96,10 @@ impl NoteLinkMenuTarget {
     pub fn search_text(&self) -> String {
         let mut text = self.title.clone();
         if let Some(alias) = &self.alias {
+            text.push('\n');
+            text.push_str(alias);
+        }
+        for alias in &self.aliases {
             text.push('\n');
             text.push_str(alias);
         }
@@ -127,8 +133,8 @@ pub struct NoteCache {
     pub links: HashMap<String, Vec<String>>,
     /// Lowercased contents for simple full-text search.
     pub index: Vec<String>,
-    /// Map of note alias -> note slug for quick lookup.
-    pub aliases: HashMap<String, String>,
+    /// Map of lowercased note alias -> candidate note slugs for quick lookup.
+    pub aliases: HashMap<String, Vec<String>>,
     /// Set of canonical note slugs for exact-existence checks.
     pub slug_set: HashSet<String>,
     /// Map of lowercased slug -> canonical slug.
@@ -142,7 +148,7 @@ impl NoteCache {
         let mut notes = notes;
         let mut tag_set: HashSet<String> = HashSet::new();
         let mut link_map: HashMap<String, Vec<String>> = HashMap::new();
-        let mut alias_map: HashMap<String, String> = HashMap::new();
+        let mut alias_map: HashMap<String, Vec<String>> = HashMap::new();
         let mut slug_set: HashSet<String> = HashSet::new();
         let mut slug_map: HashMap<String, String> = HashMap::new();
         let mut title_map: HashMap<String, Vec<String>> = HashMap::new();
@@ -153,8 +159,12 @@ impl NoteCache {
             } else {
                 n.tags = n.tags.iter().map(|t| t.to_lowercase()).collect();
             }
-            if let Some(a) = &n.alias {
-                alias_map.insert(a.to_lowercase(), n.slug.clone());
+            normalize_note_aliases(n);
+            for a in &n.aliases {
+                let entry = alias_map.entry(a.to_lowercase()).or_default();
+                if !entry.contains(&n.slug) {
+                    entry.push(n.slug.clone());
+                }
             }
             slug_set.insert(n.slug.clone());
             slug_map.insert(n.slug.to_lowercase(), n.slug.clone());
@@ -206,11 +216,17 @@ impl NoteCache {
             .map(|n| {
                 let mut txt = n.title.to_lowercase();
                 txt.push('\n');
-                txt.push_str(&n.content.to_lowercase());
+                txt.push_str(&n.slug.to_lowercase());
                 if let Some(a) = &n.alias {
                     txt.push('\n');
                     txt.push_str(&a.to_lowercase());
                 }
+                for a in &n.aliases {
+                    txt.push('\n');
+                    txt.push_str(&a.to_lowercase());
+                }
+                txt.push('\n');
+                txt.push_str(&n.content.to_lowercase());
                 txt
             })
             .collect();
@@ -360,8 +376,12 @@ fn resolve_target(cache: &NoteCache, query: &str) -> NoteTarget {
         return NoteTarget::Broken;
     }
     let query_lower = query.to_lowercase();
-    if let Some(slug) = cache.aliases.get(&query_lower) {
-        return NoteTarget::Resolved(slug.clone());
+    if let Some(slugs) = cache.aliases.get(&query_lower) {
+        return match slugs.as_slice() {
+            [slug] => NoteTarget::Resolved(slug.clone()),
+            [] => NoteTarget::Broken,
+            _ => NoteTarget::Ambiguous(slugs.clone()),
+        };
     }
     if let Some(slug) = query_lower.strip_prefix("slug:") {
         let slug = slug.trim();
@@ -523,11 +543,54 @@ pub fn note_relationship_edges() -> Vec<(String, String)> {
 }
 
 pub fn extract_alias(content: &str) -> Option<String> {
-    content
-        .lines()
-        .skip(1)
-        .take_while(|l| !l.trim().is_empty())
-        .find_map(|l| l.strip_prefix("Alias:").map(|a| a.trim().to_string()))
+    extract_aliases(content).into_iter().next()
+}
+
+pub fn extract_aliases(content: &str) -> Vec<String> {
+    let mut aliases = Vec::new();
+    for line in content.lines().skip(1).take_while(|l| !l.trim().is_empty()) {
+        let trimmed = line.trim_start();
+        if let Some(alias) = trimmed.strip_prefix("Alias:") {
+            aliases.push(alias.trim().to_string());
+        } else if let Some(alias_list) = trimmed.strip_prefix("Aliases:") {
+            aliases.extend(
+                alias_list
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|alias| !alias.is_empty())
+                    .map(str::to_string),
+            );
+        }
+    }
+    dedup_aliases(aliases)
+}
+
+fn dedup_aliases(aliases: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for alias in aliases {
+        let alias = alias.trim();
+        if alias.is_empty() {
+            continue;
+        }
+        if seen.insert(alias.to_lowercase()) {
+            deduped.push(alias.to_string());
+        }
+    }
+    deduped
+}
+
+fn normalize_note_aliases(note: &mut Note) {
+    let mut aliases = Vec::new();
+    if let Some(alias) = &note.alias {
+        aliases.push(alias.clone());
+    }
+    aliases.extend(note.aliases.clone());
+    if !note.content.is_empty() {
+        aliases.extend(extract_aliases(&note.content));
+    }
+    note.aliases = dedup_aliases(aliases);
+    note.alias = note.aliases.first().cloned();
 }
 
 fn templates_dir() -> PathBuf {
@@ -669,7 +732,8 @@ pub fn load_notes() -> anyhow::Result<Vec<Note>> {
             .to_string();
         register_slug(&slug);
         let content = std::fs::read_to_string(&path)?;
-        let alias = extract_alias(&content);
+        let aliases = extract_aliases(&content);
+        let alias = aliases.first().cloned();
         let title = content
             .lines()
             .next()
@@ -687,6 +751,7 @@ pub fn load_notes() -> anyhow::Result<Vec<Note>> {
             links,
             slug,
             alias,
+            aliases,
             entity_refs,
         });
     }
@@ -727,6 +792,7 @@ pub fn note_link_menu_targets_snapshot() -> Vec<NoteLinkMenuTarget> {
                     slug: note.slug.clone(),
                     title: note.title.clone(),
                     alias: note.alias.clone(),
+                    aliases: note.aliases.clone(),
                 })
                 .collect()
         })
@@ -791,7 +857,14 @@ pub fn save_note(note: &mut Note, overwrite: bool) -> anyhow::Result<bool> {
             content = format!("{first}\nAlias: {a}\n{rest}");
         }
     }
-    note.alias = extract_alias(&content);
+    note.aliases = extract_aliases(&content);
+    if let Some(alias) = &note.alias {
+        if !note.aliases.iter().any(|a| a.eq_ignore_ascii_case(alias)) {
+            note.aliases.insert(0, alias.clone());
+        }
+    }
+    note.aliases = dedup_aliases(note.aliases.clone());
+    note.alias = note.aliases.first().cloned();
     note.tags = extract_tags(&content);
     note.entity_refs = extract_entity_refs(&content);
     std::fs::write(&path, content)?;
@@ -856,6 +929,7 @@ pub fn append_note(title: &str, content: &str) -> anyhow::Result<()> {
         links: extract_links(content),
         slug: String::new(),
         alias: None,
+        aliases: Vec::new(),
         entity_refs: extract_entity_refs(content),
     };
     save_note(&mut note, true).map(|_| ())
@@ -976,6 +1050,20 @@ impl NoteRelationshipCommand {
 
 fn note_display_title(note: &Note) -> &str {
     note.alias.as_ref().unwrap_or(&note.title)
+}
+
+fn note_matches_title_or_alias(matcher: &SkimMatcherV2, note: &Note, filter: &str) -> bool {
+    matcher.fuzzy_match(&note.title, filter).is_some()
+        || matcher.fuzzy_match(&note.slug, filter).is_some()
+        || note
+            .alias
+            .as_ref()
+            .and_then(|a| matcher.fuzzy_match(a, filter))
+            .is_some()
+        || note
+            .aliases
+            .iter()
+            .any(|a| matcher.fuzzy_match(a, filter).is_some())
 }
 
 fn note_query_action(command: NoteRelationshipCommand, query: &str) -> Action {
@@ -1320,13 +1408,7 @@ impl Plugin for NotePlugin {
                     return guard
                         .notes
                         .iter()
-                        .filter(|n| {
-                            self.matcher.fuzzy_match(&n.title, filter).is_some()
-                                || n.alias
-                                    .as_ref()
-                                    .and_then(|a| self.matcher.fuzzy_match(a, filter))
-                                    .is_some()
-                        })
+                        .filter(|n| note_matches_title_or_alias(&self.matcher, n, filter))
                         .map(|n| Action {
                             label: n.alias.as_ref().unwrap_or(&n.title).clone(),
                             desc: "Note".into(),
@@ -1368,11 +1450,7 @@ impl Plugin for NotePlugin {
                                 true
                             } else {
                                 let matches =
-                                    self.matcher.fuzzy_match(&n.title, &text_filter).is_some()
-                                        || n.alias
-                                            .as_ref()
-                                            .and_then(|a| self.matcher.fuzzy_match(a, &text_filter))
-                                            .is_some();
+                                    note_matches_title_or_alias(&self.matcher, n, &text_filter);
                                 if filters.negate_text {
                                     !matches
                                 } else {
@@ -1530,13 +1608,7 @@ impl Plugin for NotePlugin {
                     return guard
                         .notes
                         .iter()
-                        .filter(|n| {
-                            self.matcher.fuzzy_match(&n.title, filter).is_some()
-                                || n.alias
-                                    .as_ref()
-                                    .and_then(|a| self.matcher.fuzzy_match(a, filter))
-                                    .is_some()
-                        })
+                        .filter(|n| note_matches_title_or_alias(&self.matcher, n, filter))
                         .map(|n| Action {
                             label: format!("Remove {}", n.alias.as_ref().unwrap_or(&n.title)),
                             desc: "Note".into(),
@@ -1762,6 +1834,130 @@ mod tests {
         *guard = original;
     }
 
+    fn test_note(title: &str, slug: &str, content: &str) -> Note {
+        let aliases = extract_aliases(content);
+        Note {
+            title: title.into(),
+            path: PathBuf::new(),
+            content: content.into(),
+            tags: Vec::new(),
+            links: Vec::new(),
+            slug: slug.into(),
+            alias: aliases.first().cloned(),
+            aliases,
+            entity_refs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn extract_alias_parses_single_alias() {
+        let content = "# Alpha\nAlias: Display Name\n\nBody";
+        assert_eq!(extract_alias(content), Some("Display Name".into()));
+        assert_eq!(extract_aliases(content), vec!["Display Name"]);
+    }
+
+    #[test]
+    fn extract_aliases_parses_comma_separated_aliases() {
+        let content = "# Alpha\nAliases: foo, bar, baz\n\nBody";
+        assert_eq!(extract_aliases(content), vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn extract_aliases_includes_old_single_alias_and_dedups_case_insensitively() {
+        let content = "# Alpha\nAlias: Foo\nAliases: foo, Bar, FOO\n\nBody";
+        assert_eq!(extract_aliases(content), vec!["Foo", "Bar"]);
+    }
+
+    #[test]
+    fn note_alias_resolution_is_case_insensitive_and_supports_all_aliases() {
+        let original = set_notes(vec![test_note(
+            "Alpha",
+            "alpha",
+            "# Alpha\nAlias: Primary\nAliases: Second, Third\n\nBody",
+        )]);
+
+        assert_eq!(
+            resolve_note_query("primary"),
+            NoteTarget::Resolved("alpha".into())
+        );
+        assert_eq!(
+            resolve_note_query("SECOND"),
+            NoteTarget::Resolved("alpha".into())
+        );
+        assert_eq!(
+            resolve_note_query("third"),
+            NoteTarget::Resolved("alpha".into())
+        );
+
+        restore_cache(original);
+    }
+
+    #[test]
+    fn duplicate_alias_resolution_is_ambiguous() {
+        let original = set_notes(vec![
+            test_note("Alpha", "alpha", "# Alpha\nAlias: Shared\n\nBody"),
+            test_note("Beta", "beta", "# Beta\nAliases: shared, Other\n\nBody"),
+        ]);
+
+        assert_eq!(
+            resolve_note_query("SHARED"),
+            NoteTarget::Ambiguous(vec!["alpha".into(), "beta".into()])
+        );
+
+        let plugin = NotePlugin {
+            matcher: SkimMatcherV2::default(),
+            data: CACHE.clone(),
+            templates: TEMPLATE_CACHE.clone(),
+            external_open: NoteExternalOpen::Wezterm,
+            backlinks_enabled: true,
+            watcher: None,
+        };
+        let open_actions = plugin.search("note open Shared");
+        let open_slugs: Vec<&str> = open_actions
+            .iter()
+            .map(|action| action.action.as_str())
+            .collect();
+        assert_eq!(open_slugs, vec!["note:open:alpha", "note:open:beta"]);
+
+        restore_cache(original);
+    }
+
+    #[test]
+    fn note_search_and_open_include_all_aliases() {
+        let original = set_notes(vec![
+            test_note(
+                "Alpha",
+                "alpha",
+                "# Alpha\nAlias: Primary\nAliases: Second, Third\n\nBody",
+            ),
+            test_note("Beta", "beta", "# Beta\n\nBody"),
+        ]);
+        let plugin = NotePlugin {
+            matcher: SkimMatcherV2::default(),
+            data: CACHE.clone(),
+            templates: TEMPLATE_CACHE.clone(),
+            external_open: NoteExternalOpen::Wezterm,
+            backlinks_enabled: true,
+            watcher: None,
+        };
+
+        let search_labels: Vec<String> = plugin
+            .search("note search third")
+            .into_iter()
+            .map(|a| a.label)
+            .collect();
+        assert_eq!(search_labels, vec!["Primary"]);
+
+        let open_labels: Vec<String> = plugin
+            .search("note open Second")
+            .into_iter()
+            .map(|a| a.label)
+            .collect();
+        assert_eq!(open_labels, vec!["Primary"]);
+
+        restore_cache(original);
+    }
+
     #[test]
     fn note_cache_snapshot_is_read_only_copy() {
         let original = set_notes(vec![Note {
@@ -1772,6 +1968,7 @@ mod tests {
             links: Vec::new(),
             slug: "alpha".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }]);
 
@@ -1841,6 +2038,7 @@ Body",
                 links: Vec::new(),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1851,6 +2049,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1861,6 +2060,7 @@ Body",
                 links: Vec::new(),
                 slug: "gamma".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -1905,6 +2105,7 @@ Body",
                 links: Vec::new(),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1915,6 +2116,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1925,6 +2127,7 @@ Body",
                 links: Vec::new(),
                 slug: "gamma".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -1964,6 +2167,7 @@ Body",
                 links: Vec::new(),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1974,6 +2178,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -1984,6 +2189,7 @@ Body",
                 links: Vec::new(),
                 slug: "gamma".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2039,6 +2245,7 @@ Body",
                 links: Vec::new(),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2049,6 +2256,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2085,6 +2293,7 @@ Body",
                 links: Vec::new(),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2095,6 +2304,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2128,6 +2338,7 @@ Body",
                 links: extract_links(alpha_content),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2138,6 +2349,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta-note".into(),
                 alias: Some("Second".into()),
+                aliases: vec!["Second".into()],
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2148,6 +2360,7 @@ Body",
                 links: extract_links(delta_content),
                 slug: "delta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2158,6 +2371,7 @@ Body",
                 links: Vec::new(),
                 slug: "gamma-note".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2172,11 +2386,9 @@ Body",
         };
 
         let links = plugin.search("note links Second");
-        assert!(
-            links
-                .iter()
-                .any(|a| a.label.contains("[backlink]") && a.label.contains("type=note"))
-        );
+        assert!(links
+            .iter()
+            .any(|a| a.label.contains("[backlink]") && a.label.contains("type=note")));
         assert!(links.iter().any(|a| a.action.starts_with("note:open:")));
 
         restore_cache(original);
@@ -2193,6 +2405,7 @@ Body",
                 links: Vec::new(),
                 slug: "roadmap-a".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2203,6 +2416,7 @@ Body",
                 links: Vec::new(),
                 slug: "roadmap-b".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2215,11 +2429,9 @@ Body",
             watcher: None,
         };
         let links = plugin.search("note links Roadmap");
-        assert!(
-            links
-                .iter()
-                .any(|a| a.label.starts_with("Ambiguous note query"))
-        );
+        assert!(links
+            .iter()
+            .any(|a| a.label.starts_with("Ambiguous note query")));
         assert!(links.iter().any(|a| {
             a.action == "query:note links"
                 && a.args
@@ -2248,6 +2460,7 @@ Body",
                 links: extract_links(alpha_content),
                 slug: "alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2258,6 +2471,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta-note".into(),
                 alias: Some("Second".into()),
+                aliases: vec!["Second".into()],
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2268,6 +2482,7 @@ Body",
                 links: extract_links(delta_content),
                 slug: "delta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2308,6 +2523,7 @@ Body",
             links: Vec::new(),
             slug: "target".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         }]);
         let plugin = NotePlugin {
@@ -2340,6 +2556,7 @@ Body",
                 links: Vec::new(),
                 slug: "roadmap-alpha".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2350,6 +2567,7 @@ Body",
                 links: Vec::new(),
                 slug: "roadmap-beta".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2360,6 +2578,7 @@ Body",
                 links: Vec::new(),
                 slug: "beta-roadmap-copy".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2400,6 +2619,7 @@ Body",
                 links: Vec::new(),
                 slug: "main".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
             Note {
@@ -2410,6 +2630,7 @@ Body",
                 links: Vec::new(),
                 slug: "target".into(),
                 alias: None,
+                aliases: Vec::new(),
                 entity_refs: Vec::new(),
             },
         ]);
@@ -2442,6 +2663,7 @@ Body",
             links: Vec::new(),
             slug: "alpha".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
 
@@ -2475,6 +2697,7 @@ Body",
             links: Vec::new(),
             slug: String::new(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
 
@@ -2510,6 +2733,7 @@ Body",
             links: Vec::new(),
             slug: "alpha-renamed".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
 

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -1048,18 +1048,24 @@ impl NoteRelationshipCommand {
     }
 }
 
+fn note_fuzzy_match_ci(matcher: &SkimMatcherV2, haystack: &str, needle: &str) -> bool {
+    matcher.fuzzy_match(haystack, needle).is_some()
+        || matcher
+            .fuzzy_match(&haystack.to_lowercase(), &needle.to_lowercase())
+            .is_some()
+}
+
 fn note_matches_title_or_alias(matcher: &SkimMatcherV2, note: &Note, filter: &str) -> bool {
-    matcher.fuzzy_match(&note.title, filter).is_some()
-        || matcher.fuzzy_match(&note.slug, filter).is_some()
+    note_fuzzy_match_ci(matcher, &note.title, filter)
+        || note_fuzzy_match_ci(matcher, &note.slug, filter)
         || note
             .alias
             .as_ref()
-            .and_then(|a| matcher.fuzzy_match(a, filter))
-            .is_some()
+            .is_some_and(|a| note_fuzzy_match_ci(matcher, a, filter))
         || note
             .aliases
             .iter()
-            .any(|a| matcher.fuzzy_match(a, filter).is_some())
+            .any(|a| note_fuzzy_match_ci(matcher, a, filter))
 }
 
 fn note_query_action(command: NoteRelationshipCommand, query: &str) -> Action {
@@ -1900,17 +1906,23 @@ mod tests {
         ]);
 
         let cache = data.lock().expect("note cache lock poisoned");
+        let mut resolved_slugs = match resolve_target(&cache, "SHARED") {
+            NoteTarget::Ambiguous(slugs) => slugs,
+            other => panic!("expected ambiguous alias resolution, got {other:?}"),
+        };
+        resolved_slugs.sort();
         assert_eq!(
-            resolve_target(&cache, "SHARED"),
-            NoteTarget::Ambiguous(vec!["alpha".into(), "beta".into()])
+            resolved_slugs,
+            vec!["alpha".to_string(), "beta".to_string()]
         );
         drop(cache);
 
         let open_actions = plugin.search("note open Shared");
-        let open_slugs: Vec<&str> = open_actions
+        let mut open_slugs: Vec<&str> = open_actions
             .iter()
             .map(|action| action.action.as_str())
             .collect();
+        open_slugs.sort_unstable();
         assert_eq!(open_slugs, vec!["note:open:alpha", "note:open:beta"]);
     }
 

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -1048,10 +1048,6 @@ impl NoteRelationshipCommand {
     }
 }
 
-fn note_display_title(note: &Note) -> &str {
-    note.alias.as_ref().unwrap_or(&note.title)
-}
-
 fn note_matches_title_or_alias(matcher: &SkimMatcherV2, note: &Note, filter: &str) -> bool {
     matcher.fuzzy_match(&note.title, filter).is_some()
         || matcher.fuzzy_match(&note.slug, filter).is_some()
@@ -1072,15 +1068,6 @@ fn note_query_action(command: NoteRelationshipCommand, query: &str) -> Action {
         desc: "Note".into(),
         action: format!("query:note {}", command.query_name()),
         args: Some(serde_json::json!({ "query": query }).to_string()),
-    }
-}
-
-fn relationship_note_action(command: NoteRelationshipCommand, note: &Note) -> Action {
-    Action {
-        label: format!("{} {}", command.label_badge(), note_display_title(note)),
-        desc: "Note".into(),
-        action: format!("note:open:{}", note.slug),
-        args: None,
     }
 }
 

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -1836,6 +1836,21 @@ mod tests {
         }
     }
 
+    fn test_plugin_with_notes(notes: Vec<Note>) -> (NotePlugin, Arc<Mutex<NoteCache>>) {
+        let data = Arc::new(Mutex::new(NoteCache::from_notes(notes)));
+        (
+            NotePlugin {
+                matcher: SkimMatcherV2::default(),
+                data: data.clone(),
+                templates: TEMPLATE_CACHE.clone(),
+                external_open: NoteExternalOpen::Wezterm,
+                backlinks_enabled: true,
+                watcher: None,
+            },
+            data,
+        )
+    }
+
     #[test]
     fn extract_alias_parses_single_alias() {
         let content = "# Alpha\nAlias: Display Name\n\nBody";
@@ -1857,61 +1872,51 @@ mod tests {
 
     #[test]
     fn note_alias_resolution_is_case_insensitive_and_supports_all_aliases() {
-        let original = set_notes(vec![test_note(
+        let cache = NoteCache::from_notes(vec![test_note(
             "Alpha",
             "alpha",
             "# Alpha\nAlias: Primary\nAliases: Second, Third\n\nBody",
         )]);
 
         assert_eq!(
-            resolve_note_query("primary"),
+            resolve_target(&cache, "primary"),
             NoteTarget::Resolved("alpha".into())
         );
         assert_eq!(
-            resolve_note_query("SECOND"),
+            resolve_target(&cache, "SECOND"),
             NoteTarget::Resolved("alpha".into())
         );
         assert_eq!(
-            resolve_note_query("third"),
+            resolve_target(&cache, "third"),
             NoteTarget::Resolved("alpha".into())
         );
-
-        restore_cache(original);
     }
 
     #[test]
     fn duplicate_alias_resolution_is_ambiguous() {
-        let original = set_notes(vec![
+        let (plugin, data) = test_plugin_with_notes(vec![
             test_note("Alpha", "alpha", "# Alpha\nAlias: Shared\n\nBody"),
             test_note("Beta", "beta", "# Beta\nAliases: shared, Other\n\nBody"),
         ]);
 
+        let cache = data.lock().expect("note cache lock poisoned");
         assert_eq!(
-            resolve_note_query("SHARED"),
+            resolve_target(&cache, "SHARED"),
             NoteTarget::Ambiguous(vec!["alpha".into(), "beta".into()])
         );
+        drop(cache);
 
-        let plugin = NotePlugin {
-            matcher: SkimMatcherV2::default(),
-            data: CACHE.clone(),
-            templates: TEMPLATE_CACHE.clone(),
-            external_open: NoteExternalOpen::Wezterm,
-            backlinks_enabled: true,
-            watcher: None,
-        };
         let open_actions = plugin.search("note open Shared");
         let open_slugs: Vec<&str> = open_actions
             .iter()
             .map(|action| action.action.as_str())
             .collect();
         assert_eq!(open_slugs, vec!["note:open:alpha", "note:open:beta"]);
-
-        restore_cache(original);
     }
 
     #[test]
     fn note_search_and_open_include_all_aliases() {
-        let original = set_notes(vec![
+        let (plugin, _) = test_plugin_with_notes(vec![
             test_note(
                 "Alpha",
                 "alpha",
@@ -1919,14 +1924,6 @@ mod tests {
             ),
             test_note("Beta", "beta", "# Beta\n\nBody"),
         ]);
-        let plugin = NotePlugin {
-            matcher: SkimMatcherV2::default(),
-            data: CACHE.clone(),
-            templates: TEMPLATE_CACHE.clone(),
-            external_open: NoteExternalOpen::Wezterm,
-            backlinks_enabled: true,
-            watcher: None,
-        };
 
         let search_labels: Vec<String> = plugin
             .search("note search third")
@@ -1941,8 +1938,6 @@ mod tests {
             .map(|a| a.label)
             .collect();
         assert_eq!(open_labels, vec!["Primary"]);
-
-        restore_cache(original);
     }
 
     #[test]

--- a/tests/note_panel_scroll.rs
+++ b/tests/note_panel_scroll.rs
@@ -56,6 +56,7 @@ fn long_note_panel_respects_max_height() {
         links: Vec::new(),
         slug: String::new(),
         alias: None,
+        aliases: Vec::new(),
         entity_refs: Vec::new(),
     };
     let mut panel = NotePanel::from_note(note);

--- a/tests/notes_plugin.rs
+++ b/tests/notes_plugin.rs
@@ -232,6 +232,7 @@ fn link_new_creates_only_when_missing_and_inserts_exact_wiki_syntax() {
             links: Vec::new(),
             slug: "current".into(),
             alias: None,
+            aliases: Vec::new(),
             entity_refs: Vec::new(),
         });
     let id = egui::Id::new("note_content");

--- a/tests/omni_search_plugin.rs
+++ b/tests/omni_search_plugin.rs
@@ -44,6 +44,7 @@ fn setup_fixture() -> (tempfile::TempDir, EnvGuard) {
         &[BookmarkEntry {
             url: "https://plan.example.com".into(),
             alias: Some("Plan Bookmark".into()),
+            aliases: vec!["Plan Bookmark".into()],
         }],
     )
     .unwrap();
@@ -65,6 +66,7 @@ fn setup_fixture() -> (tempfile::TempDir, EnvGuard) {
         links: Vec::new(),
         slug: "project-plan".into(),
         alias: None,
+        aliases: Vec::new(),
         entity_refs: Vec::new(),
     }])
     .unwrap();
@@ -277,6 +279,7 @@ fn o_list_dedups_duplicate_rows_across_sources() {
         links: Vec::new(),
         slug: "shared-item".into(),
         alias: None,
+        aliases: Vec::new(),
         entity_refs: Vec::new(),
     }])
     .unwrap();

--- a/tests/omni_search_plugin.rs
+++ b/tests/omni_search_plugin.rs
@@ -44,7 +44,6 @@ fn setup_fixture() -> (tempfile::TempDir, EnvGuard) {
         &[BookmarkEntry {
             url: "https://plan.example.com".into(),
             alias: Some("Plan Bookmark".into()),
-            aliases: vec!["Plan Bookmark".into()],
         }],
     )
     .unwrap();


### PR DESCRIPTION
### Motivation

- Allow notes to declare multiple human-friendly aliases while preserving the existing single `alias: Option<String>` field for backward compatibility.
- Accept both `Alias: foo` and comma-separated `Aliases: a, b, c` near the top of a note and include the old `Alias:` value in the aliases list.
- Represent alias->note lookup as a candidate list so duplicate aliases can be detected and treated as ambiguous.

### Description

- Add `pub aliases: Vec<String>` to `Note` and `NoteLinkMenuTarget`, and include aliases in link menu search text and display logic.
- Implement `extract_aliases(content: &str) -> Vec<String>`, `dedup_aliases`, and `normalize_note_aliases` to parse `Alias:`/`Aliases:`, include legacy `alias`, and deduplicate case-insensitively while preserving display text.
- Change `NoteCache.aliases` to `HashMap<String, Vec<String>>`, populate it with normalized aliases for each note, and update `resolve_target` to return `NoteTarget::Ambiguous` when multiple slugs map to the same alias.
- Update `load_notes`, `save_note`, indexing (`index`), and search matching to include title, slug, primary alias, and all aliases, and add `note_matches_title_or_alias` to centralize fuzzy-match logic.
- Add unit tests covering `Alias:` parsing, `Aliases:` parsing, legacy single-alias notes, case-insensitive resolution, duplicate-alias ambiguity, and search including all aliases.

### Testing

- Ran `git diff --check` and `cargo fmt` to ensure diffs and formatting are clean.
- Attempted `cargo check`; alias-related code changes were exercised, but a full project build on this Linux environment is blocked by unrelated platform-native dependencies (Windows/X11 native crates) causing top-level compilation errors, so `cargo test` was not executed end-to-end here. 
- Added unit tests in `src/plugins/note.rs` for alias parsing/resolution (these tests should run in CI or on a platform where the full project builds successfully).
- Verified captured compile logs contain no note-alias-specific errors such as missing/duplicate `aliases` fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0087abc48332a6ba18097432aa6f)