### PR TITLE
Expand note template variables

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2342,7 +2342,9 @@ impl LauncherApp {
 
     /// Open a note panel for the given slug, optionally using a template for new notes.
     pub fn open_note_panel(&mut self, slug: &str, template: Option<&str>) {
-        use crate::plugins::note::{extract_aliases, get_template, load_notes, Note};
+        use crate::plugins::note::{
+            expand_template_variables, extract_aliases, get_template, load_notes, Note,
+        };
         let note = load_notes()
             .unwrap_or_default()
             .into_iter()
@@ -2357,7 +2359,8 @@ impl LauncherApp {
                 let title = slug.replace('-', " ");
                 let content = if let Some(tpl_name) = template {
                     if let Some(tpl) = get_template(tpl_name) {
-                        let filled = tpl.replace("{{title}}", &title).replace("{{date}}", slug);
+                        let filled =
+                            expand_template_variables(&tpl, &title, slug, chrono::Local::now());
                         if filled.starts_with("# ") {
                             filled
                         } else {

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -677,7 +677,10 @@ pub fn expand_template_variables<Tz: chrono::TimeZone>(
     title: &str,
     slug: &str,
     now: chrono::DateTime<Tz>,
-) -> String {
+) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
     template
         .replace("{{title}}", title)
         .replace("{{slug}}", slug)

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -672,6 +672,23 @@ pub fn get_template(name: &str) -> Option<String> {
         .and_then(|m| m.get(name).cloned())
 }
 
+pub fn expand_template_variables<Tz: chrono::TimeZone>(
+    template: &str,
+    title: &str,
+    slug: &str,
+    now: chrono::DateTime<Tz>,
+) -> String {
+    template
+        .replace("{{title}}", title)
+        .replace("{{slug}}", slug)
+        .replace("{{date}}", slug)
+        .replace("{{datetime}}", &now.format("%Y-%m-%d %H:%M:%S").to_string())
+        .replace("{{year}}", &now.format("%Y").to_string())
+        .replace("{{month}}", &now.format("%m").to_string())
+        .replace("{{day}}", &now.format("%d").to_string())
+        .replace("{{time}}", &now.format("%H:%M:%S").to_string())
+}
+
 pub fn save_template(name: &str, content: &str) -> anyhow::Result<()> {
     let path = template_path(name)?;
     if let Some(parent) = path.parent() {
@@ -1872,6 +1889,7 @@ impl Plugin for NotePlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::path::PathBuf;
 
     fn set_notes(notes: Vec<Note>) -> NoteCache {
@@ -2017,6 +2035,38 @@ mod tests {
                 "query:note new --template daily ",
                 "query:note new --template meeting "
             ]
+        );
+    }
+
+    #[test]
+    fn expand_template_variables_replaces_all_supported_variables() {
+        let now = chrono::FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(2026, 6, 24, 7, 8, 9)
+            .unwrap();
+        let expanded = expand_template_variables(
+            "{{title}}|{{slug}}|{{date}}|{{datetime}}|{{year}}|{{month}}|{{day}}|{{time}}",
+            "Daily Notes",
+            "daily-notes",
+            now,
+        );
+
+        assert_eq!(
+            expanded,
+            "Daily Notes|daily-notes|daily-notes|2026-06-24 07:08:09|2026|06|24|07:08:09"
+        );
+    }
+
+    #[test]
+    fn expand_template_variables_preserves_title_and_date_compatibility() {
+        let now = chrono::FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(1999, 1, 2, 3, 4, 5)
+            .unwrap();
+
+        assert_eq!(
+            expand_template_variables("# {{title}}\nDate: {{date}}", "My Note", "my-note", now),
+            "# My Note\nDate: my-note"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Provide a single helper to expand variables inside note templates so templates can reference title, slug and date/time parts consistently.
- Preserve existing behavior where `{{title}}` and `{{date}}` previously produced the same outputs to avoid breaking users relying on the current output.

### Description
- Add `expand_template_variables(template: &str, title: &str, slug: &str, now: DateTime)` in `src/plugins/note.rs` that supports `{{title}}`, `{{slug}}`, `{{date}}`, `{{datetime}}`, `{{year}}`, `{{month}}`, `{{day}}`, and `{{time}}` and keeps `{{date}}` as the slug for backward compatibility.
- Use the helper from `LauncherApp::open_note_panel` when filling templates for new notes so all creation paths use the same expansion logic.
- Add deterministic unit tests in `src/plugins/note.rs` that use a fixed `chrono::FixedOffset` time to validate full variable expansion and to check existing `{{title}}`/`{{date}}` compatibility.

### Testing
- Ran `git diff --check` and `cargo fmt --check` to validate formatting and diffs, which passed checks for the edited files.
- Added tests `expand_template_variables_replaces_all_supported_variables` and `expand_template_variables_preserves_title_and_date_compatibility` that use `chrono::FixedOffset` for deterministic assertions.
- Attempted `cargo test expand_template_variables` in this environment but the build could not complete due to platform-native dependency issues (system X11/ALSA and Windows `windows` crate APIs) unrelated to the template logic, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b31dc5a6c8332b63c1e4d1c43d170)