### PR TITLE
Add notes_markdown module tests and alias rename mutation

### DIFF
--- a/src/notes_markdown/headings.rs
+++ b/src/notes_markdown/headings.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::{parse::LineSpan, MarkdownHeading};
+use super::{MarkdownHeading, parse::LineSpan};
 
 pub fn parse_headings(lines: &[LineSpan<'_>], code_lines: &[bool]) -> Vec<MarkdownHeading> {
     let mut seen_anchors = HashMap::new();
@@ -109,4 +109,118 @@ fn unique_anchor(anchor: &str, seen_anchors: &mut HashMap<String, usize>) -> Str
     };
     *count += 1;
     unique
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::notes_markdown::{parse::line_spans, sections::parse_sections};
+
+    fn parse(content: &str) -> Vec<MarkdownHeading> {
+        let lines = line_spans(content);
+        let code_lines = vec![false; lines.len()];
+        parse_headings(&lines, &code_lines)
+    }
+
+    fn parse_with_code_mask(content: &str, code_lines: &[bool]) -> Vec<MarkdownHeading> {
+        let lines = line_spans(content);
+        parse_headings(&lines, code_lines)
+    }
+
+    #[test]
+    fn extracts_atx_headings() {
+        let content = "# One\nText\n### Three ###\n####### Nope\n  ## Indented\n";
+        let headings = parse(content);
+
+        assert_eq!(
+            headings
+                .iter()
+                .map(|heading| (heading.level, heading.title.as_str(), heading.line_index))
+                .collect::<Vec<_>>(),
+            vec![(1, "One", 0), (3, "Three", 2), (2, "Indented", 4)]
+        );
+        assert_eq!(&content[headings[0].byte_range.clone()], "# One\n");
+    }
+
+    #[test]
+    fn duplicate_anchors_get_incrementing_suffixes() {
+        let headings = parse("# Repeat!\n## repeat\n# Repeat -- repeat?\n# Repeat\n");
+
+        assert_eq!(
+            headings
+                .iter()
+                .map(|heading| heading.normalized_anchor.as_str())
+                .collect::<Vec<_>>(),
+            vec!["repeat", "repeat-1", "repeat-repeat", "repeat-2"]
+        );
+    }
+
+    #[test]
+    fn sections_own_nested_content_until_same_or_higher_heading() {
+        let content = "# A\na body\n## B\nb body\n### C\nc body\n## D\nd body\n# E\ne body\n";
+        let headings = parse(content);
+        let sections = parse_sections(&headings, content);
+
+        assert_eq!(sections[0].heading.title, "A");
+        assert_eq!(sections[0].body_line_range, 1..8);
+        assert_eq!(sections[0].nested_heading_count, 3);
+        assert_eq!(
+            &content[sections[0].body_byte_range.clone()],
+            "a body\n## B\nb body\n### C\nc body\n## D\nd body\n"
+        );
+        assert_eq!(sections[1].heading.title, "B");
+        assert_eq!(sections[1].body_line_range, 3..6);
+        assert_eq!(sections[1].nested_heading_count, 1);
+        assert_eq!(sections[2].heading.title, "C");
+        assert_eq!(sections[2].body_line_range, 5..6);
+    }
+
+    #[test]
+    fn caller_can_filter_to_max_outline_depth() {
+        let headings = parse("# One\n## Two\n### Three\n#### Four\n");
+        let max_depth = 2;
+        let outline = headings
+            .iter()
+            .filter(|heading| heading.level <= max_depth)
+            .map(|heading| heading.title.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(outline, vec!["One", "Two"]);
+        assert_eq!(headings.len(), 4);
+    }
+
+    #[test]
+    fn fenced_code_lines_are_ignored_when_masked() {
+        let content = "# Real\n```\n## Ignored\n```\n## Visible\n";
+        let headings = parse_with_code_mask(content, &[false, true, true, true, false]);
+
+        assert_eq!(
+            headings
+                .iter()
+                .map(|heading| heading.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Real", "Visible"]
+        );
+    }
+
+    #[test]
+    fn unicode_headings_keep_unicode_anchor_text_and_byte_ranges() {
+        let content = "# Café—日記  Привет №1!\n# 🌱\n";
+        let headings = parse(content);
+
+        assert_eq!(headings[0].title, "Café—日記  Привет №1!");
+        assert_eq!(headings[0].normalized_anchor, "café日記-привет-1");
+        assert_eq!(
+            &content[headings[0].byte_range.clone()],
+            "# Café—日記  Привет №1!\n"
+        );
+        assert_eq!(headings[1].normalized_anchor, "section");
+    }
+
+    #[test]
+    fn notes_without_headings_return_empty_heading_list() {
+        let headings = parse("plain text\n- [ ] task\n####### too many\n#\n");
+
+        assert!(headings.is_empty());
+    }
 }

--- a/src/notes_markdown/mutations.rs
+++ b/src/notes_markdown/mutations.rs
@@ -143,6 +143,20 @@ pub fn remove_alias_metadata(content: &str, alias: &str) -> Result<String, Mutat
     Ok(updated)
 }
 
+pub fn rename_alias_metadata(
+    content: &str,
+    old_alias: &str,
+    new_alias: &str,
+) -> Result<String, MutationError> {
+    let new_alias = new_alias.trim();
+    let without_old = remove_alias_metadata(content, old_alias)?;
+    if new_alias.is_empty() {
+        Ok(without_old)
+    } else {
+        add_alias_metadata(&without_old, new_alias)
+    }
+}
+
 pub fn insert_callout(
     content: &str,
     byte_index: usize,
@@ -411,14 +425,19 @@ mod tests {
     }
 
     #[test]
-    fn unicode_aliases_add_and_remove_preserve_body() {
+    fn unicode_aliases_add_remove_and_rename_preserve_body() {
         let content = "# タイトル\nBody 🌱\n";
         let added = add_alias_metadata(content, "Café 日記").unwrap();
         assert_eq!(
             added,
             "---\naliases:\n  - Café 日記\n---\n# タイトル\nBody 🌱\n"
         );
-        let removed = remove_alias_metadata(&added, "Café 日記").unwrap();
+        let renamed = rename_alias_metadata(&added, "Café 日記", "京都 🦀").unwrap();
+        assert_eq!(
+            renamed,
+            "---\naliases:\n  - \"京都 🦀\"\n---\n# タイトル\nBody 🌱\n"
+        );
+        let removed = remove_alias_metadata(&renamed, "京都 🦀").unwrap();
         assert_eq!(removed, content);
     }
 


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the notes Markdown handling (headings and mutations) and verify Unicode and boundary behaviors.
- Provide a small mutation helper for renaming aliases so add/remove/rename flows can be exercised in tests.

### Description
- Added a test module to `src/notes_markdown/headings.rs` (under `#[cfg(test)]`) that exercises `parse_headings` and `sections::parse_sections` for ATX extraction, duplicate-anchor suffixing, section ownership/nesting, max outline-depth filtering, fenced-code masking, Unicode anchors/byte-range behavior, and documents without headings.
- Implemented `rename_alias_metadata` in `src/notes_markdown/mutations.rs` which performs rename by calling `remove_alias_metadata` followed by `add_alias_metadata` when appropriate.
- Extended the mutation tests in `src/notes_markdown/mutations.rs` to cover alias add/remove/rename with Unicode aliases and to assert preserved note body and proper quoting.
- Ran code formatting before committing the changes (used `cargo fmt`).

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Attempted `cargo test notes_markdown`, but the test run could not complete in this environment because a system dependency required by `alsa-sys` (`alsa.pc`) was missing, causing the build to fail before the test suite could execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8129e6f88332ab8a32c6ed169702)