### PR TITLE
Always render outline sidebar when open; show empty-state messages and add test tracking

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -468,6 +468,7 @@ struct NotePanelUiSections {
     links_visible: bool,
     backlinks_visible: bool,
     content_visible: bool,
+    outline_visible: bool,
 }
 
 #[derive(Default, Clone)]
@@ -1418,8 +1419,9 @@ impl NotePanel {
             app.note_settings.collapsible_sections_enabled,
             &self.outline_filter,
         );
-        if rows.is_empty() && self.outline_filter.is_empty() {
-            return;
+        #[cfg(test)]
+        {
+            self.last_ui_sections.outline_visible = true;
         }
 
         self.outline_width = self.outline_width.clamp(120.0, 360.0);
@@ -1445,6 +1447,13 @@ impl NotePanel {
                     });
                     self.outline_width = self.outline_width.clamp(120.0, 360.0);
                     ui.text_edit_singleline(&mut self.outline_filter);
+                    if rows.is_empty() {
+                        if self.outline_filter.is_empty() {
+                            ui.label("No headings in this note.");
+                        } else {
+                            ui.label("No headings match the filter.");
+                        }
+                    }
                     for row in rows {
                         ui.horizontal(|ui| {
                             ui.add_space((row.level.saturating_sub(1) as f32) * 12.0);
@@ -3575,6 +3584,34 @@ mod tests {
         assert!(panel.outline_filter.is_empty());
         assert!(panel.selected_outline_heading.is_none());
         assert!(panel.pending_scroll_target.is_none());
+        assert!(!panel.last_ui_sections.outline_visible);
+    }
+
+    #[test]
+    fn outline_sidebar_renders_empty_state_when_note_has_no_headings() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        let mut panel = NotePanel::from_note(empty_note("Body without headings"));
+        panel.outline_open = true;
+
+        render_panel_once(&ctx, &mut panel, &mut app);
+
+        assert!(panel.last_ui_sections.outline_visible);
+        assert!(panel.last_ui_sections.content_visible);
+    }
+
+    #[test]
+    fn outline_sidebar_renders_filtered_empty_state_when_no_headings_match() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        let mut panel = NotePanel::from_note(empty_note("# One\n\n## Two"));
+        panel.outline_open = true;
+        panel.outline_filter = "missing".into();
+
+        render_panel_once(&ctx, &mut panel, &mut app);
+
+        assert!(panel.last_ui_sections.outline_visible);
+        assert!(panel.last_ui_sections.content_visible);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure the outline sidebar container is rendered whenever the outline is open so the UI shows consistent controls even when there are no rows. 
- Provide clear empty-state text when a note has no headings or when a filter yields no matches so users understand why the outline is empty. 
- Expose test-only visibility tracking so automated tests can assert whether the outline was actually rendered.

### Description

- Added `outline_visible: bool` to the `NotePanelUiSections` test-only struct to track outline rendering visibility. 
- Mark `self.last_ui_sections.outline_visible = true` inside `render_outline_sidebar()` (test-only) and removed the early return that hid the sidebar when there were no rows. 
- Kept the existing header, width control, and filter input and added empty-state labels that render `"No headings in this note."` when there are no rows and the filter is empty and `"No headings match the filter."` when there are no rows and the filter is non-empty. 
- Added tests to assert outline visibility behavior: a negative case when the sidebar is disabled and two positive cases to ensure the sidebar renders its empty states and `content_visible` is still set.

### Testing

- Ran `cargo fmt` which completed successfully. 
- Attempted `cargo test outline_sidebar --lib`; this test run could not complete in this environment because initial builds failed due to missing Linux pkg-config libraries and subsequent attempts still failed due to Windows-specific symbols in the full library build, so the test execution could not be fully validated here. 
- The file changed is `src/gui/note_panel.rs` and the changes have been committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5255616c83328e3901994e806f0f)