### PR TITLE
Use stateful label for outline toolbar button

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1392,7 +1392,13 @@ impl NotePanel {
             }
             if app.note_settings.outline_sidebar_enabled {
                 ui.separator();
-                if ui.button("Toggle outline").clicked() {
+                let outline_label = if self.outline_open {
+                    "Hide Outline"
+                } else {
+                    "Show Outline"
+                };
+
+                if ui.button(outline_label).clicked() {
                     self.outline_open = !self.outline_open;
                 }
             }


### PR DESCRIPTION
### Motivation
- Make the outline toolbar control reflect its current state by showing `Show Outline` / `Hide Outline` instead of a static `Toggle outline` label to improve clarity in the UI.

### Description
- Replace the static `ui.button("Toggle outline")` in `fn render_toolbar` (file `src/gui/note_panel.rs`) with a computed `outline_label` that is `"Hide Outline"` when `self.outline_open` and `"Show Outline"` otherwise, and keep the button gated behind `app.note_settings.outline_sidebar_enabled`.

### Testing
- Ran `cargo check`, which failed due to a missing system ALSA development package (`alsa.pc`) required by `alsa-sys`, and ran `cargo fmt --check`, which reported repository formatting differences unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e55bda2388332bcd9245575b58735)