### PR TITLE
Render collapsible headings from parsed titles

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2095,26 +2095,12 @@ impl NotePanel {
                     &hidden,
                 );
             }
-            let key = self.section_key(section);
-            let collapsed = self.collapsed_sections.contains(&key);
-            let resp = ui.horizontal_top(|ui| {
-                ui.add_space((section.heading.level.saturating_sub(1) as f32) * 10.0);
-                let label = if collapsed { "▶" } else { "▼" };
-                if ui.small_button(label).clicked() {
-                    if collapsed {
-                        self.collapsed_sections.remove(&key);
-                    } else {
-                        self.collapsed_sections.insert(key.clone());
-                    }
-                    self.persist_collapsed_sections_state(app);
-                }
-                let heading = self.note.content[heading_range.clone()].to_string();
-                self.show_markdown_fragment(ui, app, &heading, heading_range.start);
-            });
+            let collapsed = self.collapsed_sections.contains(&self.section_key(section));
+            let resp = self.render_collapsible_heading_row(ui, app, section, collapsed);
             if self.pending_scroll_target.as_deref()
                 == Some(section.heading.normalized_anchor.as_str())
             {
-                ui.scroll_to_rect(resp.response.rect, Some(egui::Align::Center));
+                ui.scroll_to_rect(resp.rect, Some(egui::Align::Center));
                 self.pending_scroll_target = None;
             }
             cursor = heading_range.end;
@@ -2128,6 +2114,41 @@ impl NotePanel {
                 &hidden,
             );
         }
+    }
+
+    fn render_collapsible_heading_row(
+        &mut self,
+        ui: &mut egui::Ui,
+        app: &mut LauncherApp,
+        section: &MarkdownSection,
+        collapsed: bool,
+    ) -> egui::Response {
+        let key = self.section_key(section);
+        ui.horizontal_top(|ui| {
+            ui.add_space((section.heading.level.saturating_sub(1) as f32) * 10.0);
+            let label = if collapsed { "▶" } else { "▼" };
+            if ui.small_button(label).clicked() {
+                if collapsed {
+                    self.collapsed_sections.remove(&key);
+                } else {
+                    self.collapsed_sections.insert(key.clone());
+                }
+                self.persist_collapsed_sections_state(app);
+            }
+
+            let size = match section.heading.level {
+                1 => app.note_font_size * 1.45,
+                2 => app.note_font_size * 1.30,
+                3 => app.note_font_size * 1.15,
+                _ => app.note_font_size,
+            };
+            ui.label(
+                egui::RichText::new(&section.heading.title)
+                    .size(size)
+                    .strong(),
+            );
+        })
+        .response
     }
 
     fn render_visible_preview_range(


### PR DESCRIPTION
### Motivation

- Avoid rendering raw markdown source (with `#` prefixes) inside collapsible heading rows and instead display the parsed heading text.
- Apply consistent, manual heading-level styling and sizing for collapsible preview rows so heading appearance is controlled by the UI code rather than the markdown renderer.
- Keep existing collapse/expand behavior, indentation, persisted state, and pending-scroll behavior intact while removing `show_markdown_fragment()` usage for heading rows.

### Description

- Replaced the inline heading-row code in `fn render_collapsible_preview` with a call to a new helper `render_collapsible_heading_row` that renders from `section.heading.title` instead of the raw source fragment.
- Added `fn render_collapsible_heading_row(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp, section: &MarkdownSection, collapsed: bool) -> egui::Response` which preserves indentation via `ui.add_space((section.heading.level.saturating_sub(1) as f32) * 10.0)`, shows the collapse arrow (`▶` / `▼`) and toggles `self.collapsed_sections` while calling `self.persist_collapsed_sections_state(app)`.
- Applied manual heading-level sizing and emphasis: H1 = `app.note_font_size * 1.45` strong, H2 = `* 1.30` strong, H3 = `* 1.15` strong, and H4-H6 = `app.note_font_size` strong, using `egui::RichText`.
- Preserved pending-scroll behavior by returning the helper's `egui::Response` and using its rect for `ui.scroll_to_rect`, and removed the `show_markdown_fragment()` call from collapsible heading rows.

### Testing

- Ran `git diff --check`, which passed without whitespace/merge conflicts.
- Ran `cargo check`, which failed in this environment due to a missing system library required by `alsa-sys` (`alsa.pc` / ALSA pkg-config entry missing); the compile errors are unrelated to the change in heading rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e58762bb083328fd8b457c59b2337)