### PR TITLE
Render note task text inline

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -13,7 +13,7 @@ use crate::plugins::note::{
 };
 use crate::plugins::todo::{TODO_FILE, load_todos, todo_version};
 use crate::settings::{NoteSettings, NoteViewMode};
-use eframe::egui::{self, Color32, FontId, Key, popup};
+use eframe::egui::{self, Color32, FontId, Key, RichText, popup};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 use egui_toast::{Toast, ToastKind, ToastOptions};
 use fuzzy_matcher::FuzzyMatcher;
@@ -93,6 +93,10 @@ struct LinkMenuResult {
 
 static IMAGE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"!\[([^\]]*)\]\(([^)]+)\)").unwrap());
 static TODO_TOKEN_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"@todo:([A-Za-z0-9_-]+)").unwrap());
+
+fn task_display_text(task_item: &MarkdownTaskItem) -> &str {
+    task_item.text.as_str()
+}
 
 fn clamp_char_index(s: &str, char_index: usize) -> usize {
     char_index.min(s.chars().count())
@@ -2451,15 +2455,11 @@ impl NotePanel {
             if interactive && resp.changed() {
                 modified = self.toggle_rendered_checkbox_marker(task_item, ctx.input(|i| i.time));
             }
-            ui.vertical(|ui| {
-                ui.set_width(ui.available_width());
-                self.show_markdown_fragment(
-                    ui,
-                    app,
-                    &task_item.text,
-                    format!("task_{}", task_item.marker_byte_range.start),
-                );
-            });
+            ui.add_space(4.0);
+            ui.label(
+                RichText::new(task_display_text(task_item))
+                    .font(FontId::proportional(app.note_font_size)),
+            );
         });
         modified
     }
@@ -3499,6 +3499,19 @@ mod tests {
             aliases: Vec::new(),
             entity_refs: Vec::new(),
         }
+    }
+
+    #[test]
+    fn task_display_text_uses_normalized_task_text_without_marker_or_bullet() {
+        let content = "  - [ ]   item text";
+        let task_item = analyze_markdown(content).task_items.remove(0);
+
+        assert_eq!(task_item.bullet_marker, "-");
+        assert_eq!(&content[task_item.marker_byte_range.clone()], "[ ]");
+        assert_eq!(task_item.text, "item text");
+        assert_eq!(task_display_text(&task_item), "item text");
+        assert!(!task_display_text(&task_item).contains("[ ]"));
+        assert!(!task_display_text(&task_item).starts_with('-'));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Render task item text inline in the existing horizontal checkbox row so task lines are not rebuilt from rendered markdown and checkbox toggles keep the exact mutation path. 

### Description

- Replace the `ui.vertical(...)` call in `render_task_item()` with inline rendering using `ui.add_space(4.0)` and a `ui.label(RichText::new(...).font(...))` so task text is displayed directly in the checkbox row. 
- Add a helper `fn task_display_text(task_item: &MarkdownTaskItem) -> &str` that returns the already-normalized `task_item.text` for display. 
- Import `RichText` from `eframe::egui` and remove calling `self.show_markdown_fragment()` from `render_task_item()`. 
- Add a unit test `task_display_text_uses_normalized_task_text_without_marker_or_bullet` to assert the display text excludes the bullet and checkbox marker.

### Testing

- Ran `cargo fmt` successfully.
- Ran `cargo test task_display_text_uses_normalized_task_text_without_marker_or_bullet` (and attempted related checkbox tests), but the test run was blocked and the build failed due to a missing system dependency (`alsa.pc`) required by `alsa-sys`, so the test suite could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5e3388f483329ca851648b44bd48)