### PR TITLE
Preserve outline row click behavior

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1481,23 +1481,7 @@ impl NotePanel {
                             let selected = self.selected_outline_heading.as_deref()
                                 == Some(row.normalized_anchor.as_str());
                             if ui.selectable_label(selected, &row.title).clicked() {
-                                self.selected_outline_heading = Some(row.normalized_anchor.clone());
-                                self.pending_scroll_target = Some(row.normalized_anchor.clone());
-                                match self.view_mode {
-                                    NoteViewMode::Edit => {
-                                        self.move_editor_cursor_to(row.char_index, ui.ctx());
-                                    }
-                                    NoteViewMode::Split => {
-                                        let editor_focused = self
-                                            .last_textedit_id
-                                            .map(|id| ui.ctx().memory(|m| m.has_focus(id)))
-                                            .unwrap_or(false);
-                                        if editor_focused {
-                                            self.move_editor_cursor_to(row.char_index, ui.ctx());
-                                        }
-                                    }
-                                    NoteViewMode::Preview => {}
-                                }
+                                self.handle_outline_row_click(&row, ui.ctx());
                             }
                         });
                     }
@@ -1539,6 +1523,27 @@ impl NotePanel {
             }
             NoteViewMode::Split => {
                 self.render_split(ui, app, ctx);
+            }
+        }
+    }
+
+    fn handle_outline_row_click(&mut self, row: &NoteOutlineRow, ctx: &egui::Context) {
+        self.selected_outline_heading = Some(row.normalized_anchor.clone());
+        self.pending_scroll_target = Some(row.normalized_anchor.clone());
+
+        match self.view_mode {
+            NoteViewMode::Edit => {
+                self.move_editor_cursor_to(row.char_index, ctx);
+            }
+            NoteViewMode::Preview => {}
+            NoteViewMode::Split => {
+                let editor_focused = self
+                    .last_textedit_id
+                    .map(|id| ctx.memory(|m| m.has_focus(id)))
+                    .unwrap_or(false);
+                if editor_focused {
+                    self.move_editor_cursor_to(row.char_index, ctx);
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Keep the existing outline row click semantics while refactoring `render_outline_sidebar()` to route clicks through a dedicated handler. 
- Ensure clicking an outline row still selects the heading, schedules preview scrolls, and preserves the editor-focus / cursor-move behavior per view mode (`Edit`/`Split`/`Preview`).

### Description
- Replaced the inline click handler in `render_outline_sidebar()` with a call to a new helper `handle_outline_row_click(&row, ui.ctx())` in `src/gui/note_panel.rs`.
- Added `fn handle_outline_row_click(&mut self, row: &NoteOutlineRow, ctx: &egui::Context)` which always sets `self.selected_outline_heading` and `self.pending_scroll_target` to `row.normalized_anchor.clone()`.
- Implemented mode-specific behavior inside the handler: in `NoteViewMode::Edit` call `self.move_editor_cursor_to(row.char_index, ctx)` (which preserves the `focus_textedit_next_frame` path), in `NoteViewMode::Split` only call `move_editor_cursor_to(...)` when the editor currently has focus, and in `NoteViewMode::Preview` do not move the editor cursor and rely on `pending_scroll_target` for preview scrolling.
- Preserved selected-row highlighting using `self.selected_outline_heading.as_deref() == Some(row.normalized_anchor.as_str())`.

### Testing
- Ran `git diff --check` which succeeded with no issues.
- Ran `cargo test` which failed in this environment due to a missing system library required by `alsa-sys` (`alsa.pc` not found), so tests could not complete.
- Ran `cargo fmt -- --check` which reported repository-wide formatting differences unrelated to the focused change.
- Ran `rustfmt --check src/gui/note_panel.rs` which failed due to existing crate edition/let-chain syntax constraints in the repo preventing standalone `rustfmt` from passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e76f07c788332a2a6d1d8f58df34d)