### PR TITLE
Add note outline sidebar state tests

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3733,6 +3733,23 @@ mod tests {
     }
 
     #[test]
+    fn outline_can_render_while_details_are_hidden() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.note_settings.outline_sidebar_enabled = true;
+        let mut panel = NotePanel::from_note(empty_note("# One\n\n## Two"));
+        panel.show_metadata = false;
+        panel.outline_open = true;
+
+        render_panel_once(&ctx, &mut panel, &mut app);
+
+        assert!(panel.last_ui_sections.outline_visible);
+        assert!(!panel.last_ui_sections.tags_visible);
+        assert!(!panel.last_ui_sections.links_visible);
+        assert!(panel.last_ui_sections.content_visible);
+    }
+
+    #[test]
     fn outline_sidebar_renders_empty_state_when_note_has_no_headings() {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);
@@ -4575,6 +4592,28 @@ link://note/central-note
             NotePanel::from_note_with_details_and_settings(empty_note("body"), true, &settings);
 
         assert_eq!(panel.view_mode, NoteViewMode::Edit);
+    }
+
+    #[test]
+    fn outline_opens_by_default_when_enabled_in_settings() {
+        let mut settings = NoteSettings::default();
+        settings.outline_sidebar_default_open = true;
+
+        let panel =
+            NotePanel::from_note_with_details_and_settings(empty_note("body"), true, &settings);
+
+        assert!(panel.outline_open);
+    }
+
+    #[test]
+    fn outline_stays_closed_by_default_when_disabled_in_settings() {
+        let mut settings = NoteSettings::default();
+        settings.outline_sidebar_default_open = false;
+
+        let panel =
+            NotePanel::from_note_with_details_and_settings(empty_note("body"), true, &settings);
+
+        assert!(!panel.outline_open);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure the note outline sidebar continues to render when metadata/details sections are hidden and that outline-related state honors settings and disabled behavior.
- Protect regressions around clearing outline state when the outline feature is disabled and initialize `outline_open` per note settings.

### Description
- Added a test `outline_can_render_while_details_are_hidden` that verifies the outline renders while `show_metadata == false` and that tags/links sections are not rendered but content remains visible in `src/gui/note_panel.rs`.
- Added tests `outline_opens_by_default_when_enabled_in_settings` and `outline_stays_closed_by_default_when_disabled_in_settings` that assert `NotePanel::from_note_with_details_and_settings(...)` respects `outline_sidebar_default_open`.
- Kept and exercised the existing disabled-outline test that asserts `outline_open`, `outline_filter`, `selected_outline_heading`, and `pending_scroll_target` are cleared when `outline_sidebar_enabled` is false.

### Testing
- Ran `cargo fmt` successfully to format the changes.
- Attempted to run the targeted tests with `cargo test outline_`, but the build failed in this environment because the `alsa-sys` crate failed to find the system `alsa` pkg-config metadata (`alsa.pc`), so the test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ea21b465483328b8448bded1e5e08)