### PR TITLE
Constrain note panel to available screen

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1120,8 +1120,9 @@ impl NotePanel {
         let mut open = self.open;
         let mut save_now = false;
         let screen_rect = ctx.available_rect();
-        let max_width = screen_rect.width().min(800.0);
-        let max_height = screen_rect.height().min(600.0);
+        let margin = 24.0;
+        let max_width = (screen_rect.width() - margin).max(200.0);
+        let max_height = (screen_rect.height() - margin).max(150.0);
         // NOTE: `egui::TextEditState` cursor indices are char-based and we also mutate `self` inside the
         // window closure (save, open externally, etc.). Don't capture borrows of `self.note.slug` in
         // the closure environment - keep IDs based on an owned clone instead.

--- a/tests/note_panel_scroll.rs
+++ b/tests/note_panel_scroll.rs
@@ -1,7 +1,7 @@
 use eframe::egui;
 use multi_launcher::gui::{LauncherApp, NotePanel};
 use multi_launcher::plugin::PluginManager;
-use multi_launcher::plugins::note::{save_notes, Note};
+use multi_launcher::plugins::note::{Note, save_notes};
 use multi_launcher::settings::Settings;
 use once_cell::sync::Lazy;
 use std::sync::atomic::AtomicBool;
@@ -41,11 +41,12 @@ fn new_app(ctx: &egui::Context) -> LauncherApp {
 }
 
 #[test]
-fn long_note_panel_respects_max_height() {
+fn note_panel_max_height_tracks_available_screen_height() {
     let _lock = TEST_MUTEX.lock().unwrap();
     let _tmp = setup();
     let ctx = egui::Context::default();
     let mut app = new_app(&ctx);
+    app.note_panel_default_size = (700.0, 900.0);
 
     let long_content = (0..5000).map(|i| format!("line {i}\n")).collect::<String>();
     let note = Note {
@@ -74,5 +75,12 @@ fn long_note_panel_respects_max_height() {
     let rect = ctx
         .memory(|m| m.area_rect(egui::Id::new("Long note")))
         .expect("window rect");
-    assert!(rect.height() <= 600.0);
+    assert!(
+        rect.height() > 600.0,
+        "note panel should be able to exceed the old 600 px cap on tall screens, got {rect:?}"
+    );
+    assert!(
+        rect.height() <= 976.0,
+        "note panel should still fit within the available screen height minus margin, got {rect:?}"
+    );
 }


### PR DESCRIPTION
### Motivation
- Replace the arbitrary `800x600` maximum caps for the note dialog with a screen-aware cap so the dialog can expand on tall/wide displays while still fitting the available screen area.
- Preserve minimum usable dimensions so the dialog remains functional on small screens.

### Description
- Compute sizing from `ctx.available_rect()` with a `margin = 24.0` and set `max_width = (screen_rect.width() - margin).max(200.0)` and `max_height = (screen_rect.height() - margin).max(150.0)` in `NotePanel::ui` (keeps `.resizable(true)`, `.default_size(...)`, `.min_width(200.0)`, `.min_height(150.0)`, `.max_width(max_width)`, and `.max_height(max_height)`).
- Update the note panel unit test to `note_panel_max_height_tracks_available_screen_height`, configure a tall default size and available rect, and assert the panel can exceed the old 600 px cap while still fitting within the new screen-height-minus-margin bound (`tests/note_panel_scroll.rs`).
- Files changed: `src/gui/note_panel.rs` and `tests/note_panel_scroll.rs`.

### Testing
- Ran `git diff --check` which produced no local diff-check errors.
- Ran `rustfmt --edition 2024 tests/note_panel_scroll.rs` which succeeded for the modified test file.
- Attempted `cargo test note_panel_max_height_tracks_available_screen_height` but the build failed due to a missing system dependency when compiling `alsa-sys` (pkg-config / `alsa.pc` not available), so the unit test could not be executed to completion in this environment.
- Ran `cargo fmt --check` which flagged unrelated repository-wide formatting diffs outside of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee5f623f48332a3602c79e2570997)