### PR TITLE
Strengthen note outline/details independence tests

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3989,9 +3989,9 @@ mod tests {
         render_panel_once(&ctx, &mut panel, &mut app);
 
         assert!(panel.last_ui_sections.outline_visible);
+        assert!(panel.last_ui_sections.content_visible);
         assert!(!panel.last_ui_sections.tags_visible);
         assert!(!panel.last_ui_sections.links_visible);
-        assert!(panel.last_ui_sections.content_visible);
 
         let outline_rect = panel
             .last_outline_rect
@@ -4000,18 +4000,44 @@ mod tests {
             .last_content_rect
             .expect("content pane should be allocated while outline is open");
         assert!(
-            outline_rect.width() > 1.0 && outline_rect.height() > 1.0,
+            outline_rect.is_positive() && outline_rect.width() > 1.0 && outline_rect.height() > 1.0,
             "outline pane should have meaningful size, got {outline_rect:?}"
         );
         assert!(
-            content_rect.width() > 1.0 && content_rect.height() > 1.0,
+            content_rect.is_positive() && content_rect.width() > 1.0 && content_rect.height() > 1.0,
             "content pane should have meaningful size, got {content_rect:?}"
         );
+    }
+
+    #[test]
+    fn details_and_outline_can_render_together() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.note_settings.outline_sidebar_enabled = true;
+        let mut panel = NotePanel::from_note(empty_note(
+            "# One\n\n#tag [[linked-note]] https://example.com\n\n## Two",
+        ));
+        panel.show_metadata = true;
+        panel.outline_open = true;
+
+        render_panel_once(&ctx, &mut panel, &mut app);
+
+        assert!(panel.last_ui_sections.tags_visible);
+        assert!(panel.last_ui_sections.links_visible);
+        assert!(panel.last_ui_sections.backlinks_visible);
+        assert!(panel.last_ui_sections.outline_visible);
+        assert!(panel.last_ui_sections.content_visible);
         assert!(
-            content_rect.is_positive()
-                && content_rect.width() > 1.0
-                && content_rect.height() > 1.0,
-            "content pane should remain visible while outline is open and details are hidden, got {content_rect:?}"
+            panel
+                .last_outline_rect
+                .expect("outline pane should be allocated while open")
+                .is_positive()
+        );
+        assert!(
+            panel
+                .last_content_rect
+                .expect("content pane should be allocated while outline is open")
+                .is_positive()
         );
     }
 


### PR DESCRIPTION
### Motivation
- Ensure outline rendering is independent from metadata/details visibility so `Show Outline` continues to work while `Show Details` is off.
- Prevent regressions where hiding details could accidentally hide the outline (or vice-versa) by adding explicit assertions and coverage.
- Keep the existing outline-disabled cleanup logic intact to avoid stale state when the outline feature is turned off.

### Description
- Kept the outline-disabled cleanup in `NotePanel::ui` (`self.outline_open = false`, `self.outline_filter.clear()`, `self.selected_outline_heading = None`, `self.pending_scroll_target = None`).
- Strengthened `outline_can_render_while_details_are_hidden` to assert `last_ui_sections.outline_visible`, `last_ui_sections.content_visible`, `!last_ui_sections.tags_visible`, `!last_ui_sections.links_visible`, and that `last_outline_rect` and `last_content_rect` have positive sizes.
- Added a new test `details_and_outline_can_render_together` that opens details and the outline simultaneously and asserts tags/links/backlinks, outline, and content markers and positive rects.
- Ensured `render_note_body_row(...)` remains called after optional metadata/details rendering so details render above the body row (preserved call ordering in `NotePanel::ui`).

### Testing
- Ran `git diff --check`, which passed.
- Attempted `cargo test -q outline` but the build failed in this Linux environment due to native system crate dependencies and Windows-only `windows` crate symbol resolution errors, so the unit tests could not be executed here.
- The tests and code changes were committed locally with message `test: strengthen note outline independence coverage`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3efcfbdc308332840c178b4db400b6)