### PR TITLE
Bound split note pane layout to available size

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2325,28 +2325,29 @@ impl NotePanel {
     }
 
     fn render_split(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp, ctx: &egui::Context) {
+        let available_size = ui.available_size();
         let slug = self.note.slug.clone();
         let editor_id_source = ("note_split_text", slug.clone());
         let editor_scroll_id = ("note_split_editor_scroll", slug.clone());
         let preview_scroll_id = ("note_split_preview_scroll", slug);
-        let total_width = ui.available_width().max(0.0);
-        let total_height = ui.available_height().max(0.0);
+        let total_width = available_size.x.max(0.0);
+        let total_height = available_size.y.max(0.0);
         let separator_width = 6.0 + ui.spacing().item_spacing.x * 2.0;
         let usable_width = (total_width - separator_width).max(0.0);
         let editor_width = usable_width * 0.5;
         let preview_width = usable_width - editor_width;
-        let height = total_height;
 
         ui.horizontal(|ui| {
             let editor_pane = ui.allocate_ui_with_layout(
-                egui::vec2(editor_width, height),
+                egui::vec2(editor_width, total_height),
                 egui::Layout::top_down(egui::Align::Min),
                 |ui| {
                     ui.set_width(editor_width);
-                    let editor_size = egui::vec2(editor_width, height);
+                    let editor_size = egui::vec2(editor_width, total_height);
                     egui::ScrollArea::vertical()
                         .id_source(editor_scroll_id)
-                        .max_height(height)
+                        .max_width(editor_width)
+                        .max_height(total_height)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
                             self.render_editor(ui, app, editor_id_source, Some(editor_size))
@@ -2364,17 +2365,18 @@ impl NotePanel {
             ui.separator();
 
             let preview_pane = ui.allocate_ui_with_layout(
-                egui::vec2(preview_width, height),
+                egui::vec2(preview_width, total_height),
                 egui::Layout::top_down(egui::Align::Min),
                 |ui| {
                     ui.set_width(preview_width);
                     egui::ScrollArea::vertical()
                         .id_source(preview_scroll_id)
-                        .max_height(height)
+                        .max_width(preview_width)
+                        .max_height(total_height)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
                             ui.allocate_ui_with_layout(
-                                egui::vec2(preview_width, height),
+                                egui::vec2(preview_width, total_height),
                                 egui::Layout::top_down(egui::Align::Min),
                                 |ui| {
                                     let _ = self.markdown_analysis();


### PR DESCRIPTION
### Motivation

- Prevent split editor/preview panes from expanding unconstrained by treating the current parent content area as a maximum layout budget. 
- Ensure the editor and preview scroll areas are bounded to the pane dimensions so their allocated rects match the content body height for stable layout and tests. 
- Avoid deriving child widths from screen size or an unconstrained parent so split-layout behaves consistently in different UI contexts.

### Description

- Capture the parent content budget with `let available_size = ui.available_size()` and derive `total_width`/`total_height` from it instead of calling `ui.available_width()`/`ui.available_height()`. 
- Allocate editor and preview panes with `egui::vec2(editor_width, total_height)` and `egui::vec2(preview_width, total_height)` so each pane uses the bounded pane height. 
- Bound scroll areas with `.max_width(editor_width).max_height(total_height)` and `.max_width(preview_width).max_height(total_height)`, and only call `ui.set_width` with the already bounded pane widths. 
- Preserve test instrumentation by setting `self.last_split_editor_rect = Some(editor_pane.response.rect)` and `self.last_split_preview_rect = Some(preview_pane.response.rect)` after allocations.

### Testing

- Ran `cargo fmt --check`, which failed due to unrelated formatting differences in benchmark files. 
- Ran `cargo test split_panes -- --nocapture`, which failed to build in this environment because the system `alsa` library (`alsa.pc`) required by a dependency was not found, preventing test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fabb075148332a6d0ce7b074dd80f)