### PR TITLE
Adjust note editor desired width

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1942,9 +1942,10 @@ impl NotePanel {
         text_id_source: (&'static str, String),
         desired_size: Option<egui::Vec2>,
     ) -> egui::Response {
+        let desired_width = desired_size.map_or(f32::INFINITY, |size| size.x);
         let text_edit = egui::TextEdit::multiline(&mut self.note.content)
             .id_source(text_id_source)
-            .desired_width(f32::INFINITY)
+            .desired_width(desired_width)
             .font(FontId::monospace(app.note_font_size))
             .frame(true)
             .lock_focus(true);


### PR DESCRIPTION
### Motivation
- Ensure the multiline note editor respects an explicitly provided size by using the supplied width when available while retaining the previous full-width/rows fallback behavior.

### Description
- In `NotePanel::render_editor` compute `desired_width` from `desired_size` and pass it to `egui::TextEdit::multiline`, use `ui.add_sized(size, text_edit)` when `desired_size` is `Some(size)` and fall back to `ui.add(text_edit.desired_rows(10))` when `None`, while preserving `id_source`, monospace font, `frame(true)`, `lock_focus(true)`, and the `last_editor_rect` test instrumentation.

### Testing
- Ran `cargo test` which failed in this environment due to missing system `alsa` pkg-config (failure in `alsa-sys`), and ran `cargo fmt -- --check` which reported existing formatting diffs in the repo; neither failure is caused by this change to `render_editor`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fafbacd7c8332bdb520b058112520)