### PR TITLE
Constrain split note preview width

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1966,6 +1966,9 @@ impl NotePanel {
     }
 
     fn render_preview(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp, ctx: &egui::Context) {
+        let preview_width = ui.available_width().max(0.0);
+        ui.set_min_width(preview_width);
+        ui.set_max_width(preview_width);
         self.render_preview_document(ui, app, ctx);
     }
 
@@ -2119,6 +2122,10 @@ impl NotePanel {
                 let mut display = tex.size_vec2();
                 if let Some(w) = width {
                     display *= w / display.x;
+                }
+                let max_preview_width = ui.available_width().max(1.0);
+                if display.x > max_preview_width {
+                    display *= max_preview_width / display.x;
                 }
                 let response = ui.add(
                     egui::Image::new(&tex)
@@ -2380,10 +2387,14 @@ impl NotePanel {
                         .max_height(total_height)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
+                            ui.set_min_width(preview_width);
+                            ui.set_max_width(preview_width);
                             ui.allocate_ui_with_layout(
                                 egui::vec2(preview_width, total_height),
                                 egui::Layout::top_down(egui::Align::Min),
                                 |ui| {
+                                    ui.set_min_width(preview_width);
+                                    ui.set_max_width(preview_width);
                                     let _ = self.markdown_analysis();
                                     self.render_preview(ui, app, ctx);
                                 },
@@ -2571,7 +2582,10 @@ impl NotePanel {
         if fragment.is_empty() {
             return;
         }
+        let fragment_width = ui.available_width().max(0.0);
         ui.scope(|ui| {
+            ui.set_min_width(fragment_width);
+            ui.set_max_width(fragment_width);
             ui.style_mut().override_font_id = Some(FontId::proportional(app.note_font_size));
             let processed = preprocess_preview_markdown(
                 fragment,
@@ -2579,13 +2593,18 @@ impl NotePanel {
                 &self.derived.todo_label_map,
             );
             let render_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                ui.vertical(|ui| {
-                    CommonMarkViewer::new(format!("note_seg_{}", cache_id)).show(
-                        ui,
-                        &mut self.markdown_cache,
-                        &processed,
-                    );
-                });
+                egui::ScrollArea::horizontal()
+                    .max_width(fragment_width)
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        ui.set_min_width(fragment_width);
+                        ui.set_max_width(fragment_width);
+                        CommonMarkViewer::new(format!("note_seg_{}", cache_id)).show(
+                            ui,
+                            &mut self.markdown_cache,
+                            &processed,
+                        );
+                    });
             }));
             match render_result {
                 Ok(()) => handle_markdown_links(ui, app),
@@ -2609,13 +2628,21 @@ impl NotePanel {
         }
         let mut fallback = fragment.to_string();
         let fallback_width = ui.available_width().max(0.0);
-        let response = ui.add_sized(
-            egui::vec2(fallback_width, 0.0),
-            egui::TextEdit::multiline(&mut fallback)
-                .desired_width(fallback_width)
-                .font(FontId::monospace(app.note_font_size))
-                .interactive(false),
-        );
+        ui.set_min_width(fallback_width);
+        ui.set_max_width(fallback_width);
+        let response = egui::ScrollArea::horizontal()
+            .max_width(fallback_width)
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.add_sized(
+                    egui::vec2(fallback_width, 0.0),
+                    egui::TextEdit::multiline(&mut fallback)
+                        .desired_width(fallback_width)
+                        .font(FontId::monospace(app.note_font_size))
+                        .interactive(false),
+                )
+            })
+            .inner;
         #[cfg(test)]
         {
             self.last_preview_fallback_rect = Some(response.rect);


### PR DESCRIPTION
### Motivation
- Prevent preview-pane content from widening the parent note window by ensuring the preview child UI receives exactly the computed preview width. 
- Keep long/unbreakable preview content (large images, long words) clipped/wrapped or horizontally scrollable inside the pane rather than forcing the parent window to grow.

### Description
- In `render_split`, set the preview child UI `min_width`/`max_width` to `preview_width` and ensure `self.render_preview(ui, app, ctx)` is invoked only inside the `egui::vec2(preview_width, total_height)` allocation for that child UI. 
- In `render_preview`, read `ui.available_width()` into `preview_width` and apply `ui.set_min_width`/`ui.set_max_width` so the preview is constrained to the available width rather than using an infinite width. 
- In `show_markdown_fragment`, compute `fragment_width` from `ui.available_width()` and render the markdown inside a bounded horizontal `egui::ScrollArea` with the child UI constrained to `fragment_width`. 
- In `render_preview_fallback` and image rendering, clamp image display sizes to the available preview width and wrap the fallback text in a horizontal scroll area so unbreakable content remains inside the preview pane.

### Testing
- Ran `git diff --check` with no reported issues. 
- Attempted `cargo test split_` but the run failed due to a missing system dependency for `alsa-sys` (`alsa.pc` not found), which blocks executing the test suite in this environment. 
- Ran `cargo fmt --check` which reported unrelated repository-wide formatting differences that are not part of this one-file functional change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fba1f90488332bdd3a35a588a6f3a)