### PR TITLE
Constrain note body split widths

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1552,13 +1552,21 @@ impl NotePanel {
         scroll_id_source: (&'static str, String),
         text_id_source: (&'static str, String),
     ) {
-        let body_width = ui.available_width();
+        let body_width = ui.available_width().max(0.0);
         let body_height = ui.available_height();
         ui.horizontal(|ui| {
             let has_outline = app.note_settings.outline_sidebar_enabled && self.outline_open;
+            let outline_separator_width = if has_outline {
+                6.0 + ui.spacing().item_spacing.x * 2.0
+            } else {
+                0.0
+            };
+            let mut content_width = body_width;
             if has_outline {
                 self.outline_width = self.outline_width.clamp(120.0, 360.0);
-                let outline_width = self.outline_width.min(body_width);
+                let outline_budget = (body_width - outline_separator_width).max(0.0);
+                let outline_width = self.outline_width.min(outline_budget).min(body_width);
+                content_width = (body_width - outline_width - outline_separator_width).max(0.0);
                 let outline = ui.allocate_ui_with_layout(
                     egui::vec2(outline_width, body_height),
                     egui::Layout::top_down(egui::Align::Min),
@@ -1583,24 +1591,19 @@ impl NotePanel {
                 ui.separator();
             }
 
-            let content_width = ui.available_width().max(0.0);
             let content = ui.allocate_ui_with_layout(
-                egui::vec2(
-                    if has_outline {
-                        content_width
-                    } else {
-                        body_width
-                    },
-                    body_height,
-                ),
+                egui::vec2(content_width, body_height),
                 egui::Layout::top_down(egui::Align::Min),
                 |ui| {
-                    ui.set_width(if has_outline {
-                        content_width
-                    } else {
-                        body_width
-                    });
-                    self.render_note_content_area(ui, app, ctx, scroll_id_source, text_id_source);
+                    ui.set_width(content_width);
+                    self.render_note_content_area(
+                        ui,
+                        app,
+                        ctx,
+                        scroll_id_source,
+                        text_id_source,
+                        egui::vec2(content_width, body_height),
+                    );
                 },
             );
             #[cfg(test)]
@@ -1621,8 +1624,9 @@ impl NotePanel {
         ctx: &egui::Context,
         scroll_id_source: (&'static str, String),
         text_id_source: (&'static str, String),
+        available_size: egui::Vec2,
     ) {
-        let available_size = ui.available_size();
+        let available_size = egui::vec2(available_size.x.max(0.0), available_size.y.max(0.0));
         #[cfg(test)]
         {
             self.last_ui_sections.content_visible = true;
@@ -1650,7 +1654,7 @@ impl NotePanel {
                     });
             }
             NoteViewMode::Split => {
-                self.render_split(ui, app, ctx);
+                self.render_split(ui, app, ctx, available_size);
             }
         }
     }
@@ -2336,8 +2340,13 @@ impl NotePanel {
         }
     }
 
-    fn render_split(&mut self, ui: &mut egui::Ui, app: &mut LauncherApp, ctx: &egui::Context) {
-        let available_size = ui.available_size();
+    fn render_split(
+        &mut self,
+        ui: &mut egui::Ui,
+        app: &mut LauncherApp,
+        ctx: &egui::Context,
+        available_size: egui::Vec2,
+    ) {
         let slug = self.note.slug.clone();
         let editor_id_source = ("note_split_text", slug.clone());
         let editor_scroll_id = ("note_split_editor_scroll", slug.clone());


### PR DESCRIPTION
### Motivation
- Prevent the outline sidebar and split editor/preview from exceeding the note body horizontal budget when the outline is open by reserving separator/spacing and allocating only the remaining width to content and split panes.

### Description
- Treat the body row budget as `ui.available_width().max(0.0)` and compute an `outline_separator_width` to reserve separator/spacing when the outline is present.
- Clamp `self.outline_width` as before but bound it by an `outline_budget` derived from the body width minus the reserved separator, and subtract the outline + separator from the body before allocating the content area.
- Pass the remaining content `egui::Vec2` into `render_note_content_area` (signature updated) so edit/preview receive the post-outline width only.
- Update `render_split` (signature updated) to accept the provided remaining content size and divide that usable width between editor and preview, ensuring split separators are accounted for.
- Preserve existing outline sidebar height behavior and tests (outline rendering code and sizing logic left intact except for horizontal budget calculations).

### Testing
- Ran `git diff --check` (no leftover whitespace/format issues) and applied formatting changes where needed.
- Attempted `cargo test outline -- --nocapture`, but the build failed due to a missing system dependency (`alsa.pc`) required by `alsa-sys`, so the test suite could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc1bcd3688332a19b1fce57213844)