### PR TITLE
Add note panel default size regression checks

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -4020,6 +4020,7 @@ mod tests {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);
         app.note_panel_default_size = (760.0, 540.0);
+        let original_default_size = app.note_panel_default_size;
         app.note_settings.rich_markdown_enabled = true;
         app.note_settings.split_view_enabled = true;
         app.note_settings.outline_sidebar_enabled = true;
@@ -4063,6 +4064,35 @@ mod tests {
         assert!(
             (content_rect.height() - preview_rect.height()).abs() < 8.0,
             "split preview pane should closely match content body height, content={content_rect:?}, preview={preview_rect:?}"
+        );
+        assert_eq!(
+            app.note_panel_default_size, original_default_size,
+            "split rendering must use bounded layout and must not write the measured window size back to the global note panel default"
+        );
+    }
+
+    #[test]
+    fn note_panel_default_size_is_only_runtime_window_default() {
+        let source = include_str!("note_panel.rs");
+        let production_source = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("note_panel.rs should contain production source before tests");
+
+        assert_eq!(
+            production_source
+                .matches("app.note_panel_default_size")
+                .count(),
+            1,
+            "production note panel code should only read app.note_panel_default_size for Window::default_size"
+        );
+        assert!(
+            production_source.contains(".default_size(app.note_panel_default_size)"),
+            "production note panel code should pass app.note_panel_default_size to egui::Window::default_size"
+        );
+        assert!(
+            !production_source.contains("app.note_panel_default_size ="),
+            "ordinary note panel rendering must not write measured sizes back to app.note_panel_default_size"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental mutations of the global `note_panel_default_size` during ordinary rendering and ensure the split-view layout fix relies on bounded layout rather than writing settings.
- Make the intended usage explicit: `app.note_panel_default_size` should only be used as the `egui::Window::default_size(...)` runtime default.
- Add automated regressions to catch future changes that would write measured sizes back to the global default.

### Description
- Added an assertion to `split_panes_fill_allocated_body_height` that captures `original_default_size` and verifies `app.note_panel_default_size` is unchanged after split rendering. (`src/gui/note_panel.rs`).
- Added a static-style unit test `note_panel_default_size_is_only_runtime_window_default` that `include_str!`s the file and asserts production code only reads `app.note_panel_default_size` (once, via `.default_size(...)`) and does not assign to it. (`src/gui/note_panel.rs`).
- No behavioral runtime code changes to note rendering were made; the PR only adds tests and assertions inside the test module.

### Testing
- Ran `git diff --check` which passed.
- Attempted `cargo test note_panel -- --nocapture`, but the build/test run was blocked by a missing system dependency (`alsa.pc`) required by `alsa-sys`, so tests could not be fully executed in this environment.
- The tests and assertions have been committed so they will run in CI or on developer machines with the required system libraries installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fce82269c833280697ef4b07f3dc2)