### PR TITLE
Preserve note split pane height sizing

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -38,6 +38,28 @@ const BACKLINK_PAGE_SIZE: usize = 12;
 const HEAVY_RECOMPUTE_IDLE_DEBOUNCE: Duration = Duration::from_millis(250);
 const NOTE_LINK_CONTEXT_MENU_RESULT_LIMIT: usize = 50;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct SplitPaneWidths {
+    editor: f32,
+    preview: f32,
+    separator: f32,
+}
+
+fn split_pane_widths(
+    total_width: f32,
+    split_ratio: f32,
+    separator_width: f32,
+) -> SplitPaneWidths {
+    let separator = separator_width.max(0.0);
+    let usable_width = (total_width.max(0.0) - separator).max(0.0);
+    let editor = usable_width * split_ratio.clamp(0.2, 0.8);
+    SplitPaneWidths {
+        editor,
+        preview: usable_width - editor,
+        separator,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BacklinkTab {
     LinkedTodos,
@@ -2371,11 +2393,14 @@ impl NotePanel {
         let preview_scroll_id = ("note_split_preview_scroll", slug);
         let total_width = available_size.x.max(0.0);
         let total_height = available_size.y.max(0.0);
-        let separator_width = 6.0 + ui.spacing().item_spacing.x * 2.0;
-        let usable_width = (total_width - separator_width).max(0.0);
+        let widths = split_pane_widths(
+            total_width,
+            self.split_ratio,
+            6.0 + ui.spacing().item_spacing.x * 2.0,
+        );
         self.split_ratio = self.split_ratio.clamp(0.2, 0.8);
-        let editor_width = usable_width * self.split_ratio;
-        let preview_width = usable_width - editor_width;
+        let editor_width = widths.editor;
+        let preview_width = widths.preview;
 
         ui.horizontal(|ui| {
             let editor_pane = ui.allocate_ui_with_layout(
@@ -2438,7 +2463,7 @@ impl NotePanel {
                 let preview_min = self
                     .last_split_editor_rect
                     .map_or(preview_pane.response.rect.min, |rect| {
-                        egui::pos2(rect.min.x + rect.width() + separator_width, rect.min.y)
+                        egui::pos2(rect.min.x + rect.width() + widths.separator, rect.min.y)
                     });
                 self.last_split_preview_rect = Some(egui::Rect::from_min_size(
                     preview_min,

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2458,6 +2458,10 @@ impl NotePanel {
                         });
                 },
             );
+            #[cfg(not(test))]
+            {
+                let _ = &preview_pane;
+            }
             #[cfg(test)]
             {
                 let preview_min = self
@@ -2707,6 +2711,10 @@ impl NotePanel {
                 )
             })
             .inner;
+        #[cfg(not(test))]
+        {
+            let _ = &response;
+        }
         #[cfg(test)]
         {
             self.last_preview_fallback_rect = Some(response.rect);


### PR DESCRIPTION
### Motivation
- While extracting split-width math into a helper, avoid regressing vertical sizing so edit and split panes continue to fill the allocated body height and existing layout tests remain valid.

### Description
- Add a horizontal-only helper `split_pane_widths` and `SplitPaneWidths` to compute `editor`, `preview`, and `separator` widths without touching heights in `src/gui/note_panel.rs`.
- Update `render_split` to use `widths.editor`/`widths.preview` and `widths.separator` for horizontal allocation while keeping `total_height` for editor and preview pane sizing.
- Preserve existing behavior in `render_note_content_area` by continuing to pass the full `available_size` into edit and split rendering instead of falling back to `desired_rows(10)`.

### Testing
- Ran `git diff --check` which reported no problems with the change.
- Attempted `cargo test edit_mode_editor_height_tracks_tall_content_pane` but the Linux CI environment failed to build unrelated platform-native crates (Windows/X11/ALSA) causing the test run to abort. 
- Ran `cargo fmt --check` which highlighted pre-existing repository formatting differences unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fedaf3c148332a01eae93f3bc1818)