### PR TITLE
Allow vertical auto-shrink in note preview scroll areas

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2663,7 +2663,7 @@ impl NotePanel {
             let render_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 egui::ScrollArea::horizontal()
                     .max_width(fragment_width)
-                    .auto_shrink([false, false])
+                    .auto_shrink([false, true])
                     .show(ui, |ui| {
                         ui.set_min_width(fragment_width);
                         ui.set_max_width(fragment_width);
@@ -2700,7 +2700,7 @@ impl NotePanel {
         ui.set_max_width(fallback_width);
         let response = egui::ScrollArea::horizontal()
             .max_width(fallback_width)
-            .auto_shrink([false, false])
+            .auto_shrink([false, true])
             .show(ui, |ui| {
                 ui.add_sized(
                     egui::vec2(fallback_width, 0.0),


### PR DESCRIPTION
### Motivation
- Keep long links and unbroken markdown content horizontally contained while allowing the preview area to shrink vertically when content is short by enabling vertical auto-shrink on the horizontal `ScrollArea`.

### Description
- Updated two `ScrollArea::horizontal()` calls in `src/gui/note_panel.rs` to use `.auto_shrink([false, true])` instead of `.auto_shrink([false, false])` in `NotePanel::show_markdown_fragment` and `NotePanel::render_preview_fallback`.

### Testing
- Ran `cargo check`, which failed due to a missing system `alsa` library required by `alsa-sys` (environment issue), so full build verification could not complete. 
- Ran `cargo fmt --check`, which reported repository formatting differences unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4012f41d1883328a4721b7ecaccc83)