### PR TITLE
Fix note preview scroll sizing

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1683,14 +1683,12 @@ impl NotePanel {
                     .max_height(available_size.y)
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        ui.allocate_ui_with_layout(
-                            available_size,
-                            egui::Layout::top_down(egui::Align::Min),
-                            |ui| {
-                                let _ = self.markdown_analysis();
-                                self.render_preview(ui, app, ctx);
-                            },
-                        );
+                        ui.set_width(available_size.x);
+                        ui.set_min_width(available_size.x);
+                        ui.set_max_width(available_size.x);
+
+                        let _ = self.markdown_analysis();
+                        self.render_preview(ui, app, ctx);
                     });
             }
             NoteViewMode::Split => {


### PR DESCRIPTION
### Motivation
- Ensure the preview-mode scroll area remains height-bounded while allowing the preview body to render at its natural height and a fixed width, avoiding the inner fixed-size layout that forced a full-height allocation.

### Description
- In `src/gui/note_panel.rs` inside `NotePanel::render_note_content_area` for `NoteViewMode::Preview`, keep the outer `egui::ScrollArea::vertical()` with `.max_height(available_size.y)` and `.auto_shrink([false, false])` and remove the inner `ui.allocate_ui_with_layout(...)` wrapper.
- Constrain the preview body width by calling `ui.set_width(available_size.x)`, `ui.set_min_width(available_size.x)`, and `ui.set_max_width(available_size.x)` before calling `self.render_preview(ui, app, ctx);` so the content can determine its height naturally.
- Preserve the test-only instrumentation `self.last_ui_sections.content_visible = true;` in `render_note_content_area`.

### Testing
- Ran `git diff --check`, which succeeded.
- Ran `cargo fmt --check`, which reported pre-existing formatting differences outside this change (did not pass in this environment).
- Ran `cargo test render_note_content_area --lib`, which failed to build due to a missing system dependency for `alsa-sys` (`alsa` / `alsa.pc`) in the environment and not due to the code changes made here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a401d78b3f08332b62bd9113b43ad88)