### PR TITLE
Bound split preview scroll body

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -2441,18 +2441,12 @@ impl NotePanel {
                         .max_height(total_height)
                         .auto_shrink([false, false])
                         .show(ui, |ui| {
+                            ui.set_width(preview_width);
                             ui.set_min_width(preview_width);
                             ui.set_max_width(preview_width);
-                            ui.allocate_ui_with_layout(
-                                egui::vec2(preview_width, total_height),
-                                egui::Layout::top_down(egui::Align::Min),
-                                |ui| {
-                                    ui.set_min_width(preview_width);
-                                    ui.set_max_width(preview_width);
-                                    let _ = self.markdown_analysis();
-                                    self.render_preview(ui, app, ctx);
-                                },
-                            );
+
+                            let _ = self.markdown_analysis();
+                            self.render_preview(ui, app, ctx);
                         });
                 },
             );


### PR DESCRIPTION
### Motivation
- Constrain the preview pane inside the split view so the scroll body has a fixed width and avoid the unnecessary full-height inner allocation that could cause layout oversizing.

### Description
- In `render_split`, removed the nested `allocate_ui_with_layout` inside the preview `ScrollArea::vertical().show(...)` and instead set `ui.set_width`, `ui.set_min_width`, and `ui.set_max_width` in the scroll body before invoking `self.markdown_analysis()` and `self.render_preview(...)`, while preserving the existing scroll constraints and `last_split_preview_rect` instrumentation and the split pane width calculations from `split_pane_widths`.

### Testing
- Ran `cargo fmt --check` (reported unrelated formatting diffs) and `cargo test` (failed due to missing system `alsa` pkg-config / `alsa` library required by `alsa-sys`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4038ce5f2c83328e38e5c7f2d95c6b)