### PR TITLE
NotePanel: early no-outline rendering and top-aligned outline layout

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1578,15 +1578,46 @@ impl NotePanel {
     ) {
         let body_width = ui.available_width().max(0.0);
         let body_height = ui.available_height();
-        ui.horizontal(|ui| {
-            let has_outline = app.note_settings.outline_sidebar_enabled && self.outline_open;
-            let outline_separator_width = if has_outline {
-                6.0 + ui.spacing().item_spacing.x * 2.0
-            } else {
-                0.0
-            };
+        let has_outline = app.note_settings.outline_sidebar_enabled && self.outline_open;
+
+        if !has_outline {
+            let body_size = egui::vec2(body_width, body_height);
+            let content = ui.allocate_ui_with_layout(
+                body_size,
+                egui::Layout::top_down(egui::Align::Min),
+                |ui| {
+                    ui.set_width(body_width);
+                    self.render_note_content_area(
+                        ui,
+                        app,
+                        ctx,
+                        scroll_id_source,
+                        text_id_source,
+                        body_size,
+                    );
+                },
+            );
+
+            #[cfg(test)]
+            {
+                self.last_content_rect = Some(egui::Rect::from_min_size(
+                    content.response.rect.min,
+                    body_size,
+                ));
+            }
+
+            #[cfg(not(test))]
+            {
+                let _ = &content;
+            }
+
+            return;
+        }
+
+        ui.horizontal_top(|ui| {
+            let outline_separator_width = 6.0 + ui.spacing().item_spacing.x * 2.0;
             let mut content_width = body_width;
-            if has_outline {
+            {
                 self.outline_width = self.outline_width.clamp(120.0, 360.0);
                 let outline_budget = (body_width - outline_separator_width).max(0.0);
                 let outline_width = self.outline_width.min(outline_budget).min(body_width);


### PR DESCRIPTION
### Motivation
- Ensure the note content occupies the full body area when the outline sidebar is closed and avoid unnecessary layout nesting.
- Keep the outline-visible layout top-aligned while preserving existing width budgeting and testable rect bookkeeping.

### Description
- Compute `body_width`, `body_height`, and `has_outline` up-front in `NotePanel::render_note_body_row` and add an early no-outline path that allocates the full body and calls `render_note_content_area` directly.
- In the no-outline path allocate the UI with `egui::vec2(body_width, body_height)`, update `self.last_content_rect` under `#[cfg(test)]`, and return early.
- For the outline-visible path replace `ui.horizontal(|ui| { ... })` with `ui.horizontal_top(|ui| { ... })` while keeping `self.outline_width` clamped to `120.0..=360.0`, using the outline budget to compute `outline_width`, and reducing `content_width` by the outline and separator widths.
- Preserve test-updated fields: `last_content_rect`, `last_outline_rect`, `last_split_editor_rect`, and `last_split_preview_rect`.

### Testing
- Ran `cargo fmt` and `rustfmt` formatting checks which completed.
- Ran `git diff --check` which reported no issues.
- Attempted `cargo test note_panel --lib` but the build failed in this environment due to a missing system dependency (`alsa.pc` pkg-config) unrelated to the code changes, so the note-panel tests could not be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4041ae3eb88332bcc1a61873fe4c1e)