### PR TITLE
Unify bounded note editor rendering

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1704,8 +1704,12 @@ impl NotePanel {
         }
         match self.view_mode {
             NoteViewMode::Edit => {
-                let resp =
-                    self.render_editor(ui, app, text_id_source.clone(), Some(available_size));
+                let resp = self.render_bounded_editor(
+                    ui,
+                    app,
+                    text_id_source.clone(),
+                    available_size,
+                );
                 self.handle_editor_response(resp, ctx, app, true);
             }
             NoteViewMode::Preview => {
@@ -2012,11 +2016,36 @@ impl NotePanel {
         ui.separator();
     }
 
+    fn render_bounded_editor(
+        &mut self,
+        ui: &mut egui::Ui,
+        app: &mut LauncherApp,
+        id_source: impl std::hash::Hash + Clone,
+        available_size: egui::Vec2,
+    ) -> egui::Response {
+        let available_size = egui::vec2(
+            available_size.x.max(0.0),
+            available_size.y.max(0.0),
+        );
+
+        egui::ScrollArea::vertical()
+            .max_width(available_size.x)
+            .max_height(available_size.y)
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.set_width(available_size.x);
+                ui.set_min_width(available_size.x);
+                ui.set_max_width(available_size.x);
+                self.render_editor(ui, app, id_source.clone(), Some(available_size))
+            })
+            .inner
+    }
+
     fn render_editor(
         &mut self,
         ui: &mut egui::Ui,
         app: &LauncherApp,
-        text_id_source: (&'static str, String),
+        text_id_source: impl std::hash::Hash,
         desired_size: Option<egui::Vec2>,
     ) -> egui::Response {
         let desired_width = desired_size.map_or(f32::INFINITY, |size| size.x);
@@ -2418,7 +2447,6 @@ impl NotePanel {
     ) {
         let slug = self.note.slug.clone();
         let editor_id_source = ("note_split_text", slug.clone());
-        let editor_scroll_id = ("note_split_editor_scroll", slug.clone());
         let preview_scroll_id = ("note_split_preview_scroll", slug);
         let total_width = available_size.x.max(0.0);
         let total_height = available_size.y.max(0.0);
@@ -2438,15 +2466,7 @@ impl NotePanel {
                 |ui| {
                     ui.set_width(editor_width);
                     let editor_size = egui::vec2(editor_width, total_height);
-                    egui::ScrollArea::vertical()
-                        .id_source(editor_scroll_id)
-                        .max_width(editor_width)
-                        .max_height(total_height)
-                        .auto_shrink([false, false])
-                        .show(ui, |ui| {
-                            self.render_editor(ui, app, editor_id_source, Some(editor_size))
-                        })
-                        .inner
+                    self.render_bounded_editor(ui, app, editor_id_source, editor_size)
                 },
             );
             #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Ensure the note editor uses a single, consistent sizing policy when rendered in Edit and Split modes so the editor layout and interaction behave identically across views.
- Avoid duplicated bounded scroll / sizing code paths and make it easier to apply future editor layout fixes in one place.

### Description
- Added `fn render_bounded_editor(...) -> egui::Response` which clamps the available size, enforces the UI width, wraps the editor in a bounded vertical `ScrollArea`, and returns the underlying `TextEdit` response.
- Updated `render_note_content_area` so Edit mode uses `render_bounded_editor` and then calls `handle_editor_response` with the returned response to preserve all interaction behavior (`request_focus`, context menu, pending selection, vim handling, Enter consumption, etc.).
- Updated `render_split` to reuse `render_bounded_editor` for the editor pane instead of duplicating the bounded scroll/editor setup, and removed the now-unused `editor_scroll_id` binding.
- Kept `render_editor` as the low-level function that constructs the `TextEdit` and returns its `egui::Response`, adjusting the parameter type to accept a generic `impl std::hash::Hash` id source.

### Testing
- Ran `git diff --check`, which succeeded locally.
- Attempted `cargo check`; the build ultimately failed in this environment due to unrelated platform-specific issues (unresolved `windows::Win32` imports and other pre-existing dependency/platform errors), not changes introduced by this PR.
- Ran formatting/format-check attempts; `rustfmt`/`cargo fmt --check` flagged unrelated formatting/edition issues present elsewhere in the tree (e.g., let-chains and benchmark import ordering) and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4045011f4883328e6523c6054e6346)