### PR TITLE
Clamp note panel width/height in UI and mapping (with test)

### DIFF
--- a/src/settings_editor/mapping.rs
+++ b/src/settings_editor/mapping.rs
@@ -234,7 +234,10 @@ impl SettingsEditor {
             toast_duration: self.toast_duration,
             offscreen_pos: Some((self.offscreen_x, self.offscreen_y)),
             window_size: Some((self.window_w, self.window_h)),
-            note_panel_default_size: (self.note_panel_w, self.note_panel_h),
+            note_panel_default_size: (
+                self.note_panel_w.clamp(200.0, 2000.0),
+                self.note_panel_h.clamp(150.0, 1600.0),
+            ),
             note_save_on_close: self.note_save_on_close,
             note_always_overwrite: self.note_always_overwrite,
             note_images_as_links: self.note_images_as_links,
@@ -421,6 +424,22 @@ mod tests {
         let saved = editor.to_settings(&initial);
         assert_eq!(saved.query_results_layout.rows, 1);
         assert_eq!(saved.query_results_layout.cols, 1);
+    }
+
+    #[test]
+    fn note_panel_default_size_clamps_to_allowed_bounds() {
+        let initial = Settings::default();
+        let mut editor = SettingsEditor::new(&initial);
+
+        editor.note_panel_w = 199.0;
+        editor.note_panel_h = 149.0;
+        let saved_min = editor.to_settings(&initial);
+        assert_eq!(saved_min.note_panel_default_size, (200.0, 150.0));
+
+        editor.note_panel_w = 2001.0;
+        editor.note_panel_h = 1601.0;
+        let saved_max = editor.to_settings(&initial);
+        assert_eq!(saved_max.note_panel_default_size, (2000.0, 1600.0));
     }
 
     #[test]

--- a/src/settings_editor/render.rs
+++ b/src/settings_editor/render.rs
@@ -444,9 +444,13 @@ impl SettingsEditor {
                 });
                 ui.horizontal(|ui| {
                     ui.label("Note panel W");
-                    ui.add(egui::DragValue::new(&mut self.note_panel_w));
+                    ui.add(
+                        egui::DragValue::new(&mut self.note_panel_w).clamp_range(200.0..=2000.0),
+                    );
                     ui.label("H");
-                    ui.add(egui::DragValue::new(&mut self.note_panel_h));
+                    ui.add(
+                        egui::DragValue::new(&mut self.note_panel_h).clamp_range(150.0..=1600.0),
+                    );
                 });
                 let mut cfg = self
                     .plugin_settings


### PR DESCRIPTION
### Motivation
- Prevent users or configs from setting extreme note panel sizes by enforcing sane bounds in the UI and during settings mapping.
- Ensure programmatic/config edits cannot bypass the same validation enforced by the UI.

### Description
- Clamp the note panel width DragValue in the settings UI to `200.0..=2000.0` in `src/settings_editor/render.rs`.
- Clamp the note panel height DragValue in the settings UI to `150.0..=1600.0` in `src/settings_editor/render.rs`.
- Clamp the saved `note_panel_default_size` values in `src/settings_editor/mapping.rs` using `self.note_panel_w.clamp(200.0, 2000.0)` and `self.note_panel_h.clamp(150.0, 1600.0)` so config changes cannot bypass validation.
- Add a unit test `note_panel_default_size_clamps_to_allowed_bounds` to `src/settings_editor/mapping.rs` that verifies below-min and above-max width/height are saved as clamped values.

### Testing
- Ran `git diff --check`, which passed.
- Committed the changes with `git commit -m "Clamp note panel settings"` successfully.
- Attempted to run `cargo test settings_editor::mapping::tests::note_panel_default_size_clamps_to_allowed_bounds`, but the test run failed in this environment due to a system build dependency error (`alsa` / `pkg-config` missing) during `cargo build`, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a404e24d3448332a98b138a3747224c)