### PR TITLE
Add long link preview heading layout test

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -4651,6 +4651,56 @@ Some text.
     }
 
     #[test]
+    fn horizontal_markdown_fragments_shrink_vertically_with_long_links() {
+        const LONG_LINK_MARKDOWN: &str = r#"# First
+
+https://www.google.com/maps/place/very-long-unbroken-url-or-query-string-that-keeps-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going-and-going...
+
+# Second
+
+More text.
+"#;
+
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.note_settings.rich_markdown_enabled = true;
+        app.note_settings.collapsible_sections_enabled = true;
+
+        let mut note = empty_note(LONG_LINK_MARKDOWN);
+        note.title = "Long link preview".into();
+        note.slug = "long-link-preview".into();
+        let mut panel = NotePanel::from_note(note);
+        panel.view_mode = NoteViewMode::Preview;
+        panel.show_metadata = false;
+        panel.outline_open = false;
+        panel.last_preview_heading_rects.clear();
+
+        let note_body_size = egui::vec2(500.0, 700.0);
+        render_note_body_once(&ctx, &mut panel, &mut app, note_body_size);
+
+        let content_rect = panel
+            .last_content_rect
+            .expect("preview content body pane should be allocated");
+        assert!(
+            content_rect.width() <= note_body_size.x + 1.0,
+            "long unbroken URL should not expand the bounded note body width, body_size={note_body_size:?}, content={content_rect:?}"
+        );
+        assert!(
+            panel.last_preview_heading_rects.len() >= 2,
+            "expected at least two recorded preview heading rects, got {:?}",
+            panel.last_preview_heading_rects
+        );
+
+        let first = panel.last_preview_heading_rects[0];
+        let second = panel.last_preview_heading_rects[1];
+        let gap = second.min.y - first.max.y;
+        assert!(
+            gap < 160.0,
+            "long-link markdown fragment should not consume the vertical viewport; gap was {gap}"
+        );
+    }
+
+    #[test]
     fn preview_headings_stack_vertically_with_outline_body_row() {
         const FPV_MARKDOWN_SAMPLE: &str = r#"# fpv
 #fpv #drone


### PR DESCRIPTION
### Motivation

- Prevent regressions where long unbroken URLs in preview-mode collapsible markdown consume the vertical viewport or expand the bounded note/dialog width.

### Description

- Add a new test `horizontal_markdown_fragments_shrink_vertically_with_long_links` to `src/gui/note_panel.rs` that renders preview content containing a very long Google Maps URL and two headings. 
- The test configures `rich_markdown_enabled = true`, `collapsible_sections_enabled = true`, `panel.view_mode = NoteViewMode::Preview`, `panel.show_metadata = false`, and `panel.outline_open = false`, renders the note body into a bounded size of `500.0 x 700.0`, then inspects `last_preview_heading_rects`.
- The test asserts that at least two heading rects were recorded, the content width was not expanded by the long unbroken URL, and the vertical gap between the first two headings is bounded (asserts `gap < 160.0`).

### Testing

- Ran `cargo test horizontal_markdown_fragments_shrink_vertically_with_long_links`, but the run was blocked by a build failure in `alsa-sys` due to a missing system `alsa` library / `alsa.pc` required by the environment, so the test could not complete in this environment.
- Ran `cargo fmt --check`, which reported repository-wide formatting diffs before this change could be validated by the formatter in this CI environment.
- Attempted to run `rustfmt` on the file, but the available `rustfmt` rejected some Rust 2024 constructs (let-chains) present in the codebase, preventing an automatic format pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4059951390833288ebbd914e347b60)