### PR TITLE
Add test to ensure long edit-mode notes do not expand outer window

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -4153,6 +4153,50 @@ mod tests {
     }
 
     #[test]
+    fn edit_mode_long_note_does_not_expand_outer_window() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.note_panel_default_size = (500.0, 360.0);
+
+        let content = (0..300)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut panel = NotePanel::from_note(empty_note(&content));
+        panel.show_metadata = false;
+        panel.view_mode = NoteViewMode::Edit;
+
+        let window_id = egui::Id::new(("note_panel_window", panel.note.slug.clone()));
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1200.0, 900.0),
+            )),
+            ..Default::default()
+        };
+        let _ = ctx.run(raw_input, |ctx| {
+            panel.ui(ctx, &mut app);
+        });
+
+        let rect = ctx
+            .memory(|memory| memory.area_rect(window_id))
+            .expect("note panel window rect should be remembered after rendering");
+
+        assert!(
+            rect.height() <= app.note_panel_default_size.1 + 120.0,
+            "long edit content should not expand the outer window from content height, rect={rect:?}"
+        );
+        assert!(
+            rect.height() < 700.0,
+            "long edit content should not expand the outer window near the screen height, rect={rect:?}"
+        );
+        assert!(
+            rect.width() <= app.note_panel_default_size.0 + 80.0,
+            "long edit content or lines should not expand the outer window width, rect={rect:?}"
+        );
+    }
+
+    #[test]
     fn split_panes_fill_allocated_body_height() {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);


### PR DESCRIPTION
### Motivation
- Prevent a regression where very long edit-mode note content expands the outer note window beyond the configured/default dialog size.
- Add a reproducible egui unit test that renders the full note panel window and inspects the production window id in egui memory to assert window bounds remain reasonable.

### Description
- Added a test named `edit_mode_long_note_does_not_expand_outer_window` in the `#[cfg(test)]` module of `src/gui/note_panel.rs` that constructs a 300-line note with `let content = (0..300).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");`.
- The test configures `app.note_panel_default_size = (500.0, 360.0)`, sets a screen rect around `egui::vec2(1200.0, 900.0)`, sets `panel.view_mode = NoteViewMode::Edit`, and `panel.show_metadata = false` before rendering the full panel via `panel.ui(...)`.
- It locates the production window id with `egui::Id::new(("note_panel_window", panel.note.slug.clone()))`, reads the remembered rect with `ctx.memory(|memory| memory.area_rect(window_id))`, and asserts height/width tolerances so long content or long lines do not expand the outer window.
- Assertions use tolerant bounds similar to existing tests (for example `rect.height() <= app.note_panel_default_size.1 + 120.0`, `rect.height() < 700.0`, `rect.width() <= app.note_panel_default_size.0 + 80.0`).

### Testing
- Ran `cargo test edit_mode_long_note_does_not_expand_outer_window`, which initially error-ed on missing system pkg-config libraries; `libasound2-dev`, `libxi-dev`, and `libxtst-dev` were subsequently installed but the build then failed with many unrelated compilation errors arising from platform-specific Windows bindings (unresolved `windows::Win32` / `windows::core` imports) on this Linux environment, so the test could not complete successfully here.
- Ran `cargo test --lib edit_mode_long_note_does_not_expand_outer_window` with the same Windows-target build failures preventing completion.
- Ran `cargo fmt --check` and `rustfmt` checks which did not pass due to pre-existing repository formatting diffs and tooling differences (including a `let`-chain usage that requires Rust 2024 edition context).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a405d23b2608332bcb19960a5d19a4e)