### PR TITLE
Add note panel size regression test

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -4197,6 +4197,46 @@ mod tests {
     }
 
     #[test]
+    fn short_and_long_notes_use_similar_outer_window_size() {
+        fn rendered_note_panel_rect(content: &str, slug: &str) -> egui::Rect {
+            let ctx = egui::Context::default();
+            let mut app = new_app(&ctx);
+            app.note_panel_default_size = (500.0, 360.0);
+
+            let mut note = empty_note(content);
+            note.slug = slug.into();
+            let mut panel = NotePanel::from_note(note);
+            panel.show_metadata = false;
+            panel.view_mode = NoteViewMode::Edit;
+
+            let window_id = egui::Id::new(("note_panel_window", panel.note.slug.clone()));
+            let raw_input = egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::Pos2::ZERO,
+                    egui::vec2(1200.0, 900.0),
+                )),
+                ..Default::default()
+            };
+            let _ = ctx.run(raw_input, |ctx| {
+                panel.ui(ctx, &mut app);
+            });
+
+            ctx.memory(|memory| memory.area_rect(window_id))
+                .expect("note panel window rect should be remembered after rendering")
+        }
+
+        let short_rect = rendered_note_panel_rect("short note", "short-note");
+        let long_content = (0..300)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let long_rect = rendered_note_panel_rect(&long_content, "long-note");
+
+        assert!((short_rect.width() - long_rect.width()).abs() <= 40.0);
+        assert!((short_rect.height() - long_rect.height()).abs() <= 60.0);
+    }
+
+    #[test]
     fn split_panes_fill_allocated_body_height() {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);


### PR DESCRIPTION
### Motivation

- Ensure the note panel outer window does not grow unexpectedly for long edit-mode notes by validating that short and long notes produce similar remembered window sizes.

### Description

- Added a new test `short_and_long_notes_use_similar_outer_window_size` inside the `#[cfg(test)]` module in `src/gui/note_panel.rs` that renders two `NotePanel`s with the same app/default settings and asserts their remembered outer window rects are similar.
- Each panel is rendered with `app.note_panel_default_size = (500.0, 360.0)`, the same screen size via `egui::RawInput` (1200×900), `NoteViewMode::Edit`, and `show_metadata = false`, and uses distinct note slugs to avoid egui ID conflicts.
- The test reads each window rect with `ctx.memory(|memory| memory.area_rect(window_id))` and asserts width difference ≤ `40.0` and height difference ≤ `60.0`.

### Testing

- Ran `git diff --check` which reported no immediate diff issues.
- Attempted `cargo test short_and_long_notes_use_similar_outer_window_size`, but the build failed due to a missing system library required by `alsa-sys` (`alsa.pc` not found), so the test could not be executed in this environment.
- Formatted the updated file with `rustfmt` and committed the change to the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40671280648332bc895551c4830e50)