### PR TITLE
Add FileSearchPlugin for `fs` queries (emits encoded GUI actions)

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::plugins::convert_panel::ConvertPanelPlugin;
 use crate::plugins::dropcalc::DropCalcPlugin;
 use crate::plugins::emoji::EmojiPlugin;
 use crate::plugins::fav::FavPlugin;
+use crate::plugins::file_search::FileSearchPlugin;
 use crate::plugins::folders::FoldersPlugin;
 use crate::plugins::help::HelpPlugin;
 use crate::plugins::history::HistoryPlugin;
@@ -155,6 +156,7 @@ impl PluginManager {
         self.register_with_settings(ClipboardPlugin::new(clipboard_limit), plugin_settings);
         self.register_with_settings(BookmarksPlugin::default(), plugin_settings);
         self.register_with_settings(FoldersPlugin::default(), plugin_settings);
+        self.register_with_settings(FileSearchPlugin, plugin_settings);
         self.register_with_settings(OmniSearchPlugin::new(actions.clone()), plugin_settings);
         self.register_with_settings(SystemPlugin, plugin_settings);
         self.register_with_settings(ProcessesPlugin, plugin_settings);

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -1,0 +1,224 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::Serialize;
+
+use crate::actions::Action;
+use crate::file_search::model::SearchKind;
+use crate::file_search::query::{FileSearchCommand, SearchRequestDraft};
+use crate::plugin::Plugin;
+
+pub struct FileSearchPlugin;
+
+#[derive(Debug, Serialize)]
+struct ModePayload {
+    kind: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct StartPayload {
+    kind: &'static str,
+    root: Option<String>,
+    text: String,
+}
+
+impl Plugin for FileSearchPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        match crate::file_search::query::parse_file_search_query(query) {
+            None => Vec::new(),
+            Some(FileSearchCommand::OpenWindow) => vec![open_action()],
+            Some(FileSearchCommand::OpenWindowWithMode { kind }) => vec![mode_action(kind)],
+            Some(FileSearchCommand::StartSearch(request)) => vec![start_action(request)],
+            Some(FileSearchCommand::RequestDirectory { kind, search_text }) => {
+                vec![request_directory_action(kind, search_text)]
+            }
+            Some(FileSearchCommand::Error(error)) => vec![error_action(error.to_string())],
+        }
+    }
+
+    fn name(&self) -> &str {
+        "file_search"
+    }
+
+    fn description(&self) -> &str {
+        "Opens local filename/content search with prefix `fs`"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![
+            command_action("fs", "Open local file search"),
+            command_action("fs file", "Search local filenames"),
+            command_action("fs content", "Search local file contents"),
+            command_action("fs here file", "Search filenames in a selected folder"),
+            command_action("fs here content", "Search contents in a selected folder"),
+        ]
+    }
+
+    fn query_prefixes(&self) -> &[&str] {
+        &["fs"]
+    }
+}
+
+fn open_action() -> Action {
+    Action {
+        label: "Open file search".into(),
+        desc: "Open local filename/content search".into(),
+        action: "file_search:open".into(),
+        args: None,
+    }
+}
+
+fn mode_action(kind: SearchKind) -> Action {
+    Action {
+        label: format!("Open file search ({})", kind_label(kind)),
+        desc: format!("Open local search with {} mode selected", kind_label(kind)),
+        action: format!(
+            "file_search:mode:{}",
+            encode_payload(&ModePayload {
+                kind: kind_payload(kind)
+            })
+        ),
+        args: None,
+    }
+}
+
+fn start_action(request: SearchRequestDraft) -> Action {
+    let root = request
+        .root
+        .as_ref()
+        .map(|path| path.to_string_lossy().into_owned());
+    let payload = StartPayload {
+        kind: kind_payload(request.kind),
+        root,
+        text: request.search_text.clone(),
+    };
+    Action {
+        label: format!("Start {} search", kind_label(request.kind)),
+        desc: request.search_text,
+        action: format!("file_search:start:{}", encode_payload(&payload)),
+        args: None,
+    }
+}
+
+fn request_directory_action(kind: SearchKind, search_text: String) -> Action {
+    let payload = StartPayload {
+        kind: kind_payload(kind),
+        root: None,
+        text: search_text.clone(),
+    };
+    Action {
+        label: format!("Choose folder for {} search", kind_label(kind)),
+        desc: search_text,
+        action: format!("file_search:mode:{}", encode_payload(&payload)),
+        args: None,
+    }
+}
+
+fn error_action(message: String) -> Action {
+    Action {
+        label: "Invalid file search query".into(),
+        desc: message,
+        action: "file_search:open".into(),
+        args: None,
+    }
+}
+
+fn command_action(query: &str, desc: &str) -> Action {
+    Action {
+        label: query.into(),
+        desc: desc.into(),
+        action: format!("query:{query}"),
+        args: None,
+    }
+}
+
+fn kind_payload(kind: SearchKind) -> &'static str {
+    match kind {
+        SearchKind::Filename => "file",
+        SearchKind::Content => "content",
+    }
+}
+
+fn kind_label(kind: SearchKind) -> &'static str {
+    match kind {
+        SearchKind::Filename => "filename",
+        SearchKind::Content => "content",
+    }
+}
+
+fn encode_payload<T: Serialize>(payload: &T) -> String {
+    let json = serde_json::to_vec(payload).expect("file search action payload should serialize");
+    URL_SAFE_NO_PAD.encode(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use serde_json::Value;
+
+    fn plugin() -> FileSearchPlugin {
+        FileSearchPlugin
+    }
+
+    fn decode_payload(action: &str, prefix: &str) -> Value {
+        let encoded = action
+            .strip_prefix(prefix)
+            .expect("action should have expected prefix");
+        let bytes = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .expect("payload should be URL-safe base64");
+        serde_json::from_slice(&bytes).expect("payload should be JSON")
+    }
+
+    #[test]
+    fn non_fs_queries_return_no_results() {
+        assert!(plugin().search("note hello").is_empty());
+        assert!(plugin().search("").is_empty());
+    }
+
+    #[test]
+    fn fs_opens_search_window() {
+        let actions = plugin().search("fs");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action, "file_search:open");
+    }
+
+    #[test]
+    fn mode_commands_open_window_preselected() {
+        let file = plugin().search("fs file");
+        let file_payload = decode_payload(&file[0].action, "file_search:mode:");
+        assert_eq!(file_payload["kind"], "file");
+
+        let content = plugin().search("fs content");
+        let content_payload = decode_payload(&content[0].action, "file_search:mode:");
+        assert_eq!(content_payload["kind"], "content");
+    }
+
+    #[test]
+    fn fully_specified_searches_produce_encoded_start_actions() {
+        let temp = tempfile::tempdir().unwrap();
+        let actions = plugin().search(&format!("fs content needle {}", temp.path().display()));
+        assert_eq!(actions.len(), 1);
+        assert!(actions[0].action.starts_with("file_search:start:"));
+
+        let payload = decode_payload(&actions[0].action, "file_search:start:");
+        assert_eq!(payload["kind"], "content");
+        assert_eq!(payload["text"], "needle");
+        assert_eq!(payload["root"], temp.path().to_string_lossy());
+    }
+
+    #[test]
+    fn malformed_queries_do_not_emit_unsafe_start_actions() {
+        let unterminated = plugin().search("fs file \"unterminated");
+        assert_eq!(unterminated.len(), 1);
+        assert_eq!(unterminated[0].action, "file_search:open");
+        assert!(unterminated[0].label.contains("Invalid"));
+
+        let missing_dir = plugin().search("fs file README ./definitely-not-a-directory");
+        assert_eq!(missing_dir.len(), 1);
+        assert!(!missing_dir[0].action.starts_with("file_search:start:"));
+    }
+}

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -156,7 +156,7 @@ fn encode_payload<T: Serialize>(payload: &T) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use serde_json::Value;
 
     fn plugin() -> FileSearchPlugin {
@@ -167,8 +167,7 @@ mod tests {
         let encoded = action
             .strip_prefix(prefix)
             .expect("action should have expected prefix");
-        let bytes = URL_SAFE_NO_PAD
-            .decode(encoded)
+        let bytes = base64::Engine::decode(&URL_SAFE_NO_PAD, encoded)
             .expect("payload should be URL-safe base64");
         serde_json::from_slice(&bytes).expect("payload should be JSON")
     }
@@ -207,7 +206,10 @@ mod tests {
         let payload = decode_payload(&actions[0].action, "file_search:start:");
         assert_eq!(payload["kind"], "content");
         assert_eq!(payload["text"], "needle");
-        assert_eq!(payload["root"], temp.path().to_string_lossy());
+        assert_eq!(
+            payload["root"].as_str(),
+            Some(temp.path().to_string_lossy().as_ref())
+        );
     }
 
     #[test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,7 @@ pub mod convert_panel;
 pub mod dropcalc;
 pub mod emoji;
 pub mod fav;
+pub mod file_search;
 pub mod folders;
 pub mod help;
 pub mod history;


### PR DESCRIPTION
### Motivation
- Provide a built-in launcher plugin that routes `fs` queries to the existing file search parser and integrates with the GUI via action strings. 
- Avoid performing any filesystem traversal or invoking backends from the `search()` path; instead, surface GUI-owned actions that the UI can handle. 
- Support explicit command/help entries and safe handling of malformed queries to avoid launching unsafe searches from the search phase.

### Description
- Added `src/plugins/file_search.rs` which implements `FileSearchPlugin` and implements `Plugin` with `name()` = `file_search`, `description()` explaining the `fs` prefix, `capabilities()` = `["search"]`, and `query_prefixes()` = `["fs"]`.
- `search(&self, query)` calls `crate::file_search::query::parse_file_search_query` and maps parsed variants to GUI action strings: `file_search:open`, `file_search:mode:<base64-json>`, and `file_search:start:<base64-json>`; it returns an invalid/open action for parse errors instead of starting a search. 
- Encodes mode/start payloads as JSON then URL-safe Base64 (using the existing `base64` dependency with `URL_SAFE_NO_PAD`) so payloads are safe with Windows paths and are not split on colons. 
- Exports the new plugin via `pub mod file_search;` in `src/plugins/mod.rs` and registers `FileSearchPlugin` in `PluginManager::reload_from_dirs` in `src/plugin.rs` alongside other built-ins. 
- Adds launcher command/help entries (`fs`, `fs file`, `fs content`, `fs here file`, `fs here content`) and unit tests covering routing, open/mode/start actions, and malformed-query safety.

### Testing
- Added unit tests in the plugin file verifying: non-`fs` queries return no results, `fs` opens the window, mode commands produce `file_search:mode:` payloads, fully specified searches produce `file_search:start:` payloads, and malformed queries do not emit unsafe start actions. 
- Attempted to run `cargo test file_search --lib`, but the test run was blocked during compilation by an environment issue: `alsa-sys` failed to build because the system ALSA development package (`alsa.pc`) / `pkg-config` path is missing, so the unit tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5131e6000083329086123c2fb0dc7e)