### PR TITLE
Add file-search action payload helpers and launcher handling

### DIFF
--- a/src/file_search.rs
+++ b/src/file_search.rs
@@ -1,3 +1,4 @@
+pub mod actions;
 pub mod error;
 pub mod model;
 pub mod query;

--- a/src/file_search/actions.rs
+++ b/src/file_search/actions.rs
@@ -1,0 +1,163 @@
+use std::path::PathBuf;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::file_search::model::SearchKind;
+
+pub const OPEN_ACTION: &str = "file_search:open";
+pub const MODE_PREFIX: &str = "file_search:mode:";
+pub const START_PREFIX: &str = "file_search:start:";
+pub const CANCEL_ACTION: &str = "file_search:cancel";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileSearchModePayload {
+    pub kind: FileSearchKindPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileSearchStartPayload {
+    pub kind: FileSearchKindPayload,
+    pub root: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileSearchKindPayload {
+    File,
+    Content,
+}
+
+impl From<SearchKind> for FileSearchKindPayload {
+    fn from(kind: SearchKind) -> Self {
+        match kind {
+            SearchKind::Filename => Self::File,
+            SearchKind::Content => Self::Content,
+        }
+    }
+}
+
+impl From<FileSearchKindPayload> for SearchKind {
+    fn from(kind: FileSearchKindPayload) -> Self {
+        match kind {
+            FileSearchKindPayload::File => Self::Filename,
+            FileSearchKindPayload::Content => Self::Content,
+        }
+    }
+}
+
+pub fn mode_action_payload(kind: SearchKind) -> FileSearchModePayload {
+    FileSearchModePayload { kind: kind.into() }
+}
+
+pub fn start_action_payload(
+    kind: SearchKind,
+    root: Option<String>,
+    text: String,
+) -> FileSearchStartPayload {
+    FileSearchStartPayload {
+        kind: kind.into(),
+        root,
+        text,
+    }
+}
+
+pub fn encode_action_payload<T: Serialize>(payload: &T) -> Result<String, String> {
+    let json = serde_json::to_vec(payload).map_err(|err| format!("serialize payload: {err}"))?;
+    Ok(URL_SAFE_NO_PAD.encode(json))
+}
+
+pub fn decode_action_payload<T: DeserializeOwned>(encoded: &str) -> Result<T, String> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|err| format!("invalid base64 payload: {err}"))?;
+    serde_json::from_slice(&bytes).map_err(|err| format!("invalid JSON payload: {err}"))
+}
+
+impl FileSearchModePayload {
+    pub fn validate(&self) -> Result<(), String> {
+        Ok(())
+    }
+    pub fn search_kind(&self) -> SearchKind {
+        self.kind.into()
+    }
+}
+
+impl FileSearchStartPayload {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.text.trim().is_empty() {
+            return Err("File search text cannot be empty".to_string());
+        }
+        if self
+            .root
+            .as_deref()
+            .is_some_and(|root| root.trim().is_empty())
+        {
+            return Err("File search root cannot be empty".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn search_kind(&self) -> SearchKind {
+        self.kind.into()
+    }
+
+    pub fn root_path(&self) -> Option<PathBuf> {
+        self.root.as_ref().map(PathBuf::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_request_payload_round_trips() {
+        let request = start_action_payload(
+            SearchKind::Content,
+            Some("/tmp/project".to_string()),
+            "needle".to_string(),
+        );
+        let encoded = encode_action_payload(&request).unwrap();
+        let decoded: FileSearchStartPayload = decode_action_payload(&encoded).unwrap();
+        decoded.validate().unwrap();
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn windows_paths_are_preserved() {
+        let request = start_action_payload(
+            SearchKind::Filename,
+            Some(r"C:\Users\alice\Project".to_string()),
+            "main.rs".to_string(),
+        );
+        let encoded = encode_action_payload(&request).unwrap();
+        let decoded: FileSearchStartPayload = decode_action_payload(&encoded).unwrap();
+        assert_eq!(decoded.root.as_deref(), Some(r"C:\Users\alice\Project"));
+    }
+
+    #[test]
+    fn malformed_base64_is_rejected() {
+        let err =
+            decode_action_payload::<FileSearchStartPayload>("not valid base64!!!").unwrap_err();
+        assert!(err.contains("base64"));
+    }
+
+    #[test]
+    fn malformed_json_is_rejected() {
+        let encoded = URL_SAFE_NO_PAD.encode(b"{not-json");
+        let err = decode_action_payload::<FileSearchStartPayload>(&encoded).unwrap_err();
+        assert!(err.contains("JSON"));
+    }
+
+    #[test]
+    fn decoded_request_validation_errors_are_surfaced() {
+        let request =
+            start_action_payload(SearchKind::Content, Some("".to_string()), "".to_string());
+        let encoded = encode_action_payload(&request).unwrap();
+        let decoded: FileSearchStartPayload = decode_action_payload(&encoded).unwrap();
+        let err = decoded.validate().unwrap_err();
+        assert!(err.contains("text"));
+    }
+}

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -50,6 +50,9 @@ impl LauncherApp {
         query_override: Option<String>,
         source: ActivationSource,
     ) {
+        if self.handle_file_search_action(&a.action) {
+            return;
+        }
         if let Some(new_query) = query_override {
             self.query = new_query;
             self.last_timer_query =
@@ -835,6 +838,59 @@ impl LauncherApp {
         } else if self.visible_flag.load(Ordering::SeqCst) && !self.any_panel_open() {
             self.focus_input();
         }
+    }
+
+    fn handle_file_search_action(&mut self, action: &str) -> bool {
+        use crate::file_search::actions::{
+            decode_action_payload, FileSearchModePayload, FileSearchStartPayload, CANCEL_ACTION,
+            MODE_PREFIX, OPEN_ACTION, START_PREFIX,
+        };
+
+        if action == OPEN_ACTION {
+            self.file_search_window_open = true;
+            return true;
+        }
+        if action == CANCEL_ACTION {
+            self.file_search_active = false;
+            return true;
+        }
+        if let Some(encoded) = action.strip_prefix(MODE_PREFIX) {
+            self.file_search_window_open = true;
+            match decode_action_payload::<FileSearchModePayload>(encoded).and_then(|payload| {
+                payload.validate()?;
+                Ok(payload)
+            }) {
+                Ok(payload) => {
+                    self.file_search_selected_kind = payload.search_kind();
+                }
+                Err(err) => self.report_file_search_action_error(err),
+            }
+            return true;
+        }
+        if let Some(encoded) = action.strip_prefix(START_PREFIX) {
+            self.file_search_window_open = true;
+            match decode_action_payload::<FileSearchStartPayload>(encoded).and_then(|payload| {
+                payload.validate()?;
+                Ok(payload)
+            }) {
+                Ok(payload) => {
+                    self.file_search_active = false;
+                    self.file_search_selected_kind = payload.search_kind();
+                    self.file_search_root = payload.root_path();
+                    self.file_search_text = payload.text;
+                    self.file_search_active = true;
+                }
+                Err(err) => self.report_file_search_action_error(err),
+            }
+            return true;
+        }
+        false
+    }
+
+    fn report_file_search_action_error(&mut self, err: String) {
+        let msg = format!("Invalid file search action: {err}");
+        self.set_inline_error(msg.clone());
+        self.add_error_toast(msg);
     }
 
     fn record_history_usage(&mut self, action: &Action, query: &str, source: ActivationSource) {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -490,6 +490,11 @@ pub struct LauncherApp {
     confirm_modal: ConfirmationModal,
     pending_confirm: Option<PendingConfirmAction>,
     pub vim_mode: bool,
+    pub file_search_window_open: bool,
+    pub file_search_selected_kind: crate::file_search::model::SearchKind,
+    pub file_search_root: Option<std::path::PathBuf>,
+    pub file_search_text: String,
+    pub file_search_active: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -1229,6 +1234,11 @@ impl LauncherApp {
             suggestions: Vec::new(),
             autocomplete_index: 0,
             vim_mode: false,
+            file_search_window_open: false,
+            file_search_selected_kind: crate::file_search::model::SearchKind::Filename,
+            file_search_root: None,
+            file_search_text: String::new(),
+            file_search_active: false,
         };
 
         tracing::debug!("initial viewport visible: {}", initial_visible);

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -1,24 +1,13 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use serde::Serialize;
-
 use crate::actions::Action;
+use crate::file_search::actions::{
+    encode_action_payload, mode_action_payload, start_action_payload, MODE_PREFIX, OPEN_ACTION,
+    START_PREFIX,
+};
 use crate::file_search::model::SearchKind;
 use crate::file_search::query::{FileSearchCommand, SearchRequestDraft};
 use crate::plugin::Plugin;
 
 pub struct FileSearchPlugin;
-
-#[derive(Debug, Serialize)]
-struct ModePayload {
-    kind: &'static str,
-}
-
-#[derive(Debug, Serialize)]
-struct StartPayload {
-    kind: &'static str,
-    root: Option<String>,
-    text: String,
-}
 
 impl Plugin for FileSearchPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
@@ -65,7 +54,7 @@ fn open_action() -> Action {
     Action {
         label: "Open file search".into(),
         desc: "Open local filename/content search".into(),
-        action: "file_search:open".into(),
+        action: OPEN_ACTION.into(),
         args: None,
     }
 }
@@ -75,10 +64,10 @@ fn mode_action(kind: SearchKind) -> Action {
         label: format!("Open file search ({})", kind_label(kind)),
         desc: format!("Open local search with {} mode selected", kind_label(kind)),
         action: format!(
-            "file_search:mode:{}",
-            encode_payload(&ModePayload {
-                kind: kind_payload(kind)
-            })
+            "{}{}",
+            MODE_PREFIX,
+            encode_action_payload(&mode_action_payload(kind))
+                .expect("file search action payload should serialize")
         ),
         args: None,
     }
@@ -89,29 +78,29 @@ fn start_action(request: SearchRequestDraft) -> Action {
         .root
         .as_ref()
         .map(|path| path.to_string_lossy().into_owned());
-    let payload = StartPayload {
-        kind: kind_payload(request.kind),
-        root,
-        text: request.search_text.clone(),
-    };
+    let payload = start_action_payload(request.kind, root, request.search_text.clone());
     Action {
         label: format!("Start {} search", kind_label(request.kind)),
         desc: request.search_text,
-        action: format!("file_search:start:{}", encode_payload(&payload)),
+        action: format!(
+            "{}{}",
+            START_PREFIX,
+            encode_action_payload(&payload).expect("file search action payload should serialize")
+        ),
         args: None,
     }
 }
 
 fn request_directory_action(kind: SearchKind, search_text: String) -> Action {
-    let payload = StartPayload {
-        kind: kind_payload(kind),
-        root: None,
-        text: search_text.clone(),
-    };
+    let payload = start_action_payload(kind, None, search_text.clone());
     Action {
         label: format!("Choose folder for {} search", kind_label(kind)),
         desc: search_text,
-        action: format!("file_search:mode:{}", encode_payload(&payload)),
+        action: format!(
+            "{}{}",
+            MODE_PREFIX,
+            encode_action_payload(&payload).expect("file search action payload should serialize")
+        ),
         args: None,
     }
 }
@@ -120,7 +109,7 @@ fn error_action(message: String) -> Action {
     Action {
         label: "Invalid file search query".into(),
         desc: message,
-        action: "file_search:open".into(),
+        action: OPEN_ACTION.into(),
         args: None,
     }
 }
@@ -134,23 +123,11 @@ fn command_action(query: &str, desc: &str) -> Action {
     }
 }
 
-fn kind_payload(kind: SearchKind) -> &'static str {
-    match kind {
-        SearchKind::Filename => "file",
-        SearchKind::Content => "content",
-    }
-}
-
 fn kind_label(kind: SearchKind) -> &'static str {
     match kind {
         SearchKind::Filename => "filename",
         SearchKind::Content => "content",
     }
-}
-
-fn encode_payload<T: Serialize>(payload: &T) -> String {
-    let json = serde_json::to_vec(payload).expect("file search action payload should serialize");
-    URL_SAFE_NO_PAD.encode(json)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Provide a single, typed representation and safe encode/decode helpers for file-search action payloads so plugins and the launcher share the same contract. 
- Intercept file-search action strings in the launcher to implement window/mode/start/cancel behavior and surface invalid payloads as user-facing errors instead of panics.

### Description
- Added a new module `src/file_search/actions.rs` that exposes constants (`file_search:open`, `file_search:mode:<b64>`, `file_search:start:<b64>`, `file_search:cancel`), typed payload structs (`FileSearchModePayload`, `FileSearchStartPayload`, `FileSearchKindPayload`), conversion to/from `SearchKind`, validation helpers, and URL-safe Base64 JSON `encode_action_payload` / `decode_action_payload` helpers. (See `src/file_search/actions.rs`.)
- Re-exported the new module from `src/file_search.rs` so other code can import the helpers. (See `src/file_search.rs`.)
- Updated the File Search plugin (`src/plugins/file_search.rs`) to use the shared constants and helper functions when emitting `open`, `mode`, and `start` actions instead of ad-hoc encoding logic.
- Extended `LauncherApp` state in `src/gui/mod.rs` with fields to control the file-search window and current request controls (`file_search_window_open`, `file_search_selected_kind`, `file_search_root`, `file_search_text`, `file_search_active`).
- Intercepted file-search actions in `src/gui/actions.rs` by adding `handle_file_search_action` and `report_file_search_action_error`, which decode and validate payloads, update UI state, start/cancel searches, and report invalid payloads via inline error/toast without panicking.
- Added unit tests in `src/file_search/actions.rs` to cover payload round-trip, preservation of Windows-style paths, malformed Base64 rejection, malformed JSON rejection, and decoded validation errors.

### Testing
- Ran `cargo test file_search --lib` in this environment; the run initially failed due to missing native system packages for some native crates, so `libasound2-dev`, `libxi-dev`, and `libxtst-dev` were installed to progress past those checks. The full test run did not complete on this Linux host because the workspace contains `windows`-crate usages that are compiled on non-Windows targets and produced unresolved Windows-specific imports, causing the build to fail before the entire test suite could finish. 
- The PR adds focused unit tests for the new action helpers (round-trip, Windows-path preservation, malformed base64/json, and validation errors) in `src/file_search/actions.rs` to verify encoding/decoding and validation behavior. These tests are present in the repository and exercise the new helpers, but the cross-target build issues prevented the unified `cargo test` run from completing in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5147ad5b90833281d6fbc331449d63)