### PR TITLE
Group content file search matches by file

### DIFF
--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -3,7 +3,7 @@ use crate::file_search::model::{
     SearchStatus,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 use std::thread;
 
 #[derive(Debug, Clone, Default)]
@@ -173,6 +173,7 @@ impl SearchCoordinator {
         match (&request.kind, &request.scope) {
             (SearchKind::Filename, SearchScope::Directory { .. }) => SearchBackend::WalkDir,
             (SearchKind::Filename, SearchScope::Global) => SearchBackend::Everything,
+            (SearchKind::Filename, SearchScope::File { .. }) => SearchBackend::WalkDir,
             (SearchKind::Content, _) => SearchBackend::Ripgrep,
         }
     }

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -13,6 +13,7 @@ pub enum SearchKind {
 pub enum SearchScope {
     Global,
     Directory { root: PathBuf },
+    File { path: PathBuf },
 }
 
 /// Backend-ready request with all user and settings-derived search options resolved.
@@ -103,15 +104,74 @@ pub struct FilenameResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentFileResult {
     pub path: PathBuf,
+    pub total_matches: usize,
     pub matches: Vec<ContentMatch>,
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentMatch {
     pub line_number: usize,
+    pub column: Option<usize>,
     pub line: String,
     pub byte_start: usize,
     pub byte_end: usize,
+    pub ranges: Vec<ContentMatchRange>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContentMatchRange {
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+impl ContentMatch {
+    pub fn new(line_number: usize, line: String, byte_start: usize, byte_end: usize) -> Self {
+        Self {
+            line_number,
+            column: Some(byte_start),
+            line,
+            byte_start,
+            byte_end,
+            ranges: vec![ContentMatchRange {
+                byte_start,
+                byte_end,
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentFileResultBuilder {
+    result: ContentFileResult,
+    display_limit: usize,
+}
+
+impl ContentFileResultBuilder {
+    pub fn new(path: PathBuf, display_limit: usize) -> Self {
+        Self {
+            result: ContentFileResult {
+                path,
+                total_matches: 0,
+                matches: Vec::new(),
+                truncated: false,
+            },
+            display_limit,
+        }
+    }
+
+    pub fn push_match(&mut self, content_match: ContentMatch) {
+        self.result.total_matches = self.result.total_matches.saturating_add(1);
+        if self.result.matches.len() < self.display_limit {
+            self.result.matches.push(content_match);
+        } else {
+            self.result.truncated = true;
+        }
+    }
+
+    pub fn finish(self) -> ContentFileResult {
+        self.result
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,4 +204,59 @@ pub enum SearchEvent {
         id: SearchId,
         error: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_match(line_number: usize) -> ContentMatch {
+        ContentMatch::new(line_number, format!("line {line_number} needle"), 5, 11)
+    }
+
+    #[test]
+    fn content_builder_groups_by_path() {
+        let mut builder = ContentFileResultBuilder::new("src/lib.rs".into(), 10);
+        builder.push_match(sample_match(1));
+        builder.push_match(sample_match(2));
+        let result = builder.finish();
+        assert_eq!(result.path, PathBuf::from("src/lib.rs"));
+        assert_eq!(result.matches.len(), 2);
+    }
+
+    #[test]
+    fn content_builder_total_count_increments_past_display_limit() {
+        let mut builder = ContentFileResultBuilder::new("src/lib.rs".into(), 1);
+        builder.push_match(sample_match(1));
+        builder.push_match(sample_match(2));
+        let result = builder.finish();
+        assert_eq!(result.total_matches, 2);
+    }
+
+    #[test]
+    fn content_builder_enforces_per_file_display_limit() {
+        let mut builder = ContentFileResultBuilder::new("src/lib.rs".into(), 1);
+        builder.push_match(sample_match(1));
+        builder.push_match(sample_match(2));
+        let result = builder.finish();
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].line_number, 1);
+    }
+
+    #[test]
+    fn content_builder_sets_truncation_flag() {
+        let mut builder = ContentFileResultBuilder::new("src/lib.rs".into(), 1);
+        builder.push_match(sample_match(1));
+        builder.push_match(sample_match(2));
+        assert!(builder.finish().truncated);
+    }
+
+    #[test]
+    fn content_match_preserves_display_data() {
+        let content_match = ContentMatch::new(12, "abc needle".into(), 4, 10);
+        assert_eq!(content_match.line_number, 12);
+        assert_eq!(content_match.column, Some(4));
+        assert_eq!(content_match.line, "abc needle");
+        assert_eq!(content_match.ranges.len(), 1);
+    }
 }

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -1,8 +1,8 @@
 use crate::file_search::coordinator::{CancellationToken, SearchExecutor};
 use crate::file_search::error::FileSearchError;
 use crate::file_search::model::{
-    ContentFileResult, ContentMatch, SearchEvent, SearchId, SearchKind, SearchProgress,
-    SearchRequest, SearchResult, SearchScope, SearchStatus,
+    ContentFileResult, ContentFileResultBuilder, ContentMatch, SearchEvent, SearchId, SearchKind,
+    SearchProgress, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::settings::FileSearchSettings;
 use serde_json::Value;
@@ -140,24 +140,26 @@ pub fn search_content_with_ripgrep(
 
     let stdout = stdout_handle.join().unwrap_or_default();
     let stderr = stderr_handle.join().unwrap_or_default();
+    let per_file_match_limit = per_file_match_limit(&request, settings);
     if cancelled {
-        let mut summary = parse_ripgrep_json_limited(
-            &stdout,
-            settings.max_matches_per_content_file,
-            request.max_results,
-        )?;
+        let mut summary =
+            parse_ripgrep_json_limited(&stdout, per_file_match_limit, request.max_results)?;
         summary.cancelled = true;
         summary.stderr = stderr;
         return Ok(summary);
     }
     handle_exit_status(status, &stderr)?;
-    let mut summary = parse_ripgrep_json_limited(
-        &stdout,
-        settings.max_matches_per_content_file,
-        request.max_results,
-    )?;
+    let mut summary =
+        parse_ripgrep_json_limited(&stdout, per_file_match_limit, request.max_results)?;
     summary.stderr = stderr;
     Ok(summary)
+}
+
+fn per_file_match_limit(request: &SearchRequest, settings: &FileSearchSettings) -> usize {
+    match &request.scope {
+        SearchScope::File { .. } => usize::MAX,
+        _ => settings.max_matches_per_content_file,
+    }
 }
 
 pub fn detect_ripgrep_executable(configured: &Path) -> Result<PathBuf, FileSearchError> {
@@ -259,13 +261,14 @@ fn search_roots(
 ) -> Result<Vec<PathBuf>, FileSearchError> {
     let roots = match &request.scope {
         SearchScope::Directory { root } => vec![root.clone()],
+        SearchScope::File { path } => vec![path.clone()],
         SearchScope::Global => settings.global_content_search_roots.clone(),
     };
     for root in &roots {
-        if !root.is_dir() {
+        if !(root.is_dir() || root.is_file()) {
             return Err(FileSearchError::InvalidDirectory {
                 path: root.clone(),
-                message: "path is not a directory".to_owned(),
+                message: "path is not a directory or file".to_owned(),
             });
         }
     }
@@ -314,7 +317,7 @@ fn parse_ripgrep_json_limited(
     max_matches_per_file: usize,
     max_result_files: usize,
 ) -> Result<RipgrepSearchSummary, FileSearchError> {
-    let mut files: BTreeMap<PathBuf, Vec<ContentMatch>> = BTreeMap::new();
+    let mut files: BTreeMap<PathBuf, ContentFileResultBuilder> = BTreeMap::new();
     let mut files_scanned = 0_u64;
     for line in output.lines() {
         if line.trim().is_empty() {
@@ -343,7 +346,7 @@ fn parse_ripgrep_json_limited(
     let results: Vec<_> = files
         .into_iter()
         .take(max_result_files)
-        .map(|(path, matches)| ContentFileResult { path, matches })
+        .map(|(_path, builder)| builder.finish())
         .collect();
     Ok(RipgrepSearchSummary {
         results_found: results.len(),
@@ -356,7 +359,7 @@ fn parse_ripgrep_json_limited(
 
 fn parse_match_event(
     value: &Value,
-    files: &mut BTreeMap<PathBuf, Vec<ContentMatch>>,
+    files: &mut BTreeMap<PathBuf, ContentFileResultBuilder>,
     max_matches_per_file: usize,
 ) -> Result<(), FileSearchError> {
     let data = &value["data"];
@@ -372,21 +375,20 @@ fn parse_match_event(
         .and_then(Value::as_str)
         .unwrap_or("");
     let line_number = data.get("line_number").and_then(Value::as_u64).unwrap_or(0) as usize;
-    let entry = files.entry(PathBuf::from(path)).or_default();
-    if entry.len() >= max_matches_per_file {
-        return Ok(());
-    }
+    let normalized_line = line.trim_end_matches(['\r', '\n']).to_owned();
+    let entry = files.entry(PathBuf::from(path)).or_insert_with(|| {
+        ContentFileResultBuilder::new(PathBuf::from(path), max_matches_per_file)
+    });
     if let Some(submatches) = data.get("submatches").and_then(Value::as_array) {
         for submatch in submatches {
-            if entry.len() >= max_matches_per_file {
-                break;
-            }
-            entry.push(ContentMatch {
+            let byte_start = submatch.get("start").and_then(Value::as_u64).unwrap_or(0) as usize;
+            let byte_end = submatch.get("end").and_then(Value::as_u64).unwrap_or(0) as usize;
+            entry.push_match(ContentMatch::new(
                 line_number,
-                line: line.trim_end_matches(['\r', '\n']).to_owned(),
-                byte_start: submatch.get("start").and_then(Value::as_u64).unwrap_or(0) as usize,
-                byte_end: submatch.get("end").and_then(Value::as_u64).unwrap_or(0) as usize,
-            });
+                normalized_line.clone(),
+                byte_start,
+                byte_end,
+            ));
         }
     }
     Ok(())
@@ -491,6 +493,38 @@ mod tests {
                 .matches
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn grouped_results_count_total_matches_past_limit_and_truncate() {
+        let json = r#"{"type":"match","data":{"path":{"text":"a.txt"},"lines":{"text":"needle needle\n"},"line_number":1,"submatches":[{"start":0,"end":6},{"start":7,"end":13}]}}"#;
+        let result = parse_ripgrep_json(json, 1).unwrap().results.remove(0);
+        assert_eq!(result.total_matches, 2);
+        assert_eq!(result.matches.len(), 1);
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn grouped_results_keep_same_filename_in_different_directories_separate() {
+        let json = concat!(
+            r#"{"type":"match","data":{"path":{"text":"one/a.txt"},"lines":{"text":"needle\n"},"line_number":1,"submatches":[{"start":0,"end":6}]}}"#,
+            "\n",
+            r#"{"type":"match","data":{"path":{"text":"two/a.txt"},"lines":{"text":"needle\n"},"line_number":2,"submatches":[{"start":0,"end":6}]}}"#
+        );
+        let summary = parse_ripgrep_json(json, 25).unwrap();
+        assert_eq!(summary.results.len(), 2);
+        assert!(
+            summary
+                .results
+                .iter()
+                .any(|r| r.path == PathBuf::from("one/a.txt"))
+        );
+        assert!(
+            summary
+                .results
+                .iter()
+                .any(|r| r.path == PathBuf::from("two/a.txt"))
         );
     }
 

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -3,10 +3,10 @@ use crate::file_search::actions::{
     containing_directory, copied_filename, nested_search_root, open_path,
     open_terminal_in_directory, reveal_path,
 };
-use crate::file_search::coordinator::{event_id, SearchCoordinator};
+use crate::file_search::coordinator::{SearchCoordinator, event_id};
 use crate::file_search::model::{
-    ContentFileResult, SearchBackend, SearchEvent, SearchId, SearchKind, SearchRequest,
-    SearchResult, SearchScope, SearchStatus,
+    ContentFileResult, ContentMatch, SearchBackend, SearchEvent, SearchId, SearchKind,
+    SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use eframe::egui;
 use std::collections::BTreeMap;
@@ -42,7 +42,7 @@ pub struct ContentResultGroup {
     pub path: PathBuf,
     pub total_matches: usize,
     pub first_line: Option<String>,
-    pub lines: Vec<(usize, String)>,
+    pub matches: Vec<ContentMatch>,
     pub truncated: bool,
 }
 
@@ -182,20 +182,14 @@ impl FileSearchDialogState {
     }
 
     fn upsert_content_group(&mut self, content: &ContentFileResult) {
-        let lines: Vec<_> = content
-            .matches
-            .iter()
-            .take(20)
-            .map(|m| (m.line_number, m.line.clone()))
-            .collect();
         self.content_result_groups.insert(
             content.path.clone(),
             ContentResultGroup {
                 path: content.path.clone(),
-                total_matches: content.matches.len(),
+                total_matches: content.total_matches,
                 first_line: content.matches.first().map(|m| m.line.clone()),
-                lines,
-                truncated: content.matches.len() > 20,
+                matches: content.matches.clone(),
+                truncated: content.truncated,
             },
         );
     }
@@ -338,14 +332,73 @@ impl FileSearchDialogState {
                 }
             ))
             .show(ui, |ui| {
-                for (line_no, line) in &group.lines {
-                    ui.label(format!("{line_no}: {line}"));
+                for content_match in &group.matches {
+                    let column = content_match
+                        .column
+                        .map(|column| format!(":{}", column.saturating_add(1)))
+                        .unwrap_or_default();
+                    ui.label(format!(
+                        "{}{}: {}",
+                        content_match.line_number, column, content_match.line
+                    ));
+                }
+                if group.truncated {
+                    ui.weak("Additional matches omitted. Use the context menu to search only this file.");
                 }
             })
             .header_response;
             response
-                .context_menu(|ui| self.result_context_menu(ui, &group.path, false, coordinator));
+                .context_menu(|ui| self.content_result_context_menu(ui, &group.path, coordinator));
         }
+    }
+
+    fn content_result_context_menu(
+        &mut self,
+        ui: &mut egui::Ui,
+        path: &std::path::Path,
+        coordinator: &mut SearchCoordinator,
+    ) {
+        if ui.button("Show all matches in this file").clicked() {
+            self.start_file_content_search(path, coordinator);
+            ui.close_menu();
+        }
+        self.result_context_menu(ui, path, false, coordinator);
+    }
+
+    fn start_file_content_search(
+        &mut self,
+        path: &std::path::Path,
+        coordinator: &mut SearchCoordinator,
+    ) {
+        let text = self.search_text.trim();
+        if text.is_empty() {
+            self.warning_error_message =
+                Some("Enter search text before searching this file.".to_string());
+            return;
+        }
+        let request = SearchRequest {
+            kind: SearchKind::Content,
+            scope: SearchScope::File {
+                path: path.to_path_buf(),
+            },
+            text: text.to_string(),
+            case_sensitive: self.case_sensitive,
+            include_hidden_files: self.include_hidden,
+            max_results: 1,
+            max_file_size_bytes: MAX_FILE_SIZE_BYTES,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: Vec::new(),
+        };
+        self.selected_mode = FileSearchMode::Content;
+        self.results.clear();
+        self.content_result_groups.clear();
+        self.warning_error_message = None;
+        self.inaccessible_path_warnings = 0;
+        self.current_status = SearchStatus::Running;
+        self.backend = Some(SearchCoordinator::select_backend(&request));
+        let id = coordinator.start_search(request);
+        self.active_search_id = Some(id);
     }
 
     fn result_context_menu(
@@ -545,12 +598,9 @@ mod tests {
             id: SearchId(1),
             result: SearchResult::ContentFile(ContentFileResult {
                 path: "src/lib.rs".into(),
-                matches: vec![ContentMatch {
-                    line_number: 4,
-                    line: "needle".into(),
-                    byte_start: 0,
-                    byte_end: 6,
-                }],
+                total_matches: 1,
+                matches: vec![ContentMatch::new(4, "needle".into(), 0, 6)],
+                truncated: false,
             }),
         });
         assert_eq!(state.content_result_groups.len(), 1);


### PR DESCRIPTION
### Motivation

- Ensure content search results are grouped by file path so the UI shows one entry per file while still reporting the true total number of matches per file. 
- Preserve enough match detail (line, column, ranges) for display while enforcing a per-file display limit to avoid storing unlimited matches.
- Provide a UI action to show all matches for a single file by running a constrained file-only search rather than storing everything up front.

### Description

- Added `SearchScope::File` and per-file search support so single-file constrained searches can be started (`SearchScope::File { path }`).
- Introduced richer content result types: `ContentFileResult` now carries `total_matches` and `truncated`, `ContentMatch` includes `column` and `ranges`, and a `ContentFileResultBuilder` enforces a configurable `display_limit` while incrementing the total count.
- Updated ripgrep backend parsing to aggregate matches into a `BTreeMap<PathBuf, ContentFileResultBuilder>`, append matches using the builder (preserving line/column/range data), and use `per_file_match_limit` so file-scoped searches can return unlimited matches while normal searches are display-limited.
- Updated GUI `FileSearchDialogState` to use grouped `ContentResultGroup` entries (showing file path, `total_matches`, stored lines, and truncation indicator), render stored matches with line and column, and added a context menu action `Show all matches in this file` that builds a `SearchRequest` with `SearchScope::File` and starts a new constrained search via the `SearchCoordinator`.
- Minor coordinator change to select the appropriate backend for the new file scope.
- Added unit tests covering grouping by path, total count incrementing past display limits, per-file display limits, truncation flag, preservation of match data, multiple matches in a file, and separate files with the same filename in different directories.

### Testing

- Added unit tests in `src/file_search/model.rs` and `src/file_search/ripgrep.rs` exercising the grouping and truncation behavior (`content_builder_*` and `grouped_results_*` tests).
- Ran formatting and checks with `cargo fmt` and `cargo check`; these completed locally in the workspace.
- Attempted `cargo test file_search --lib` but the full lib test run failed in this Linux environment due to unrelated platform-specific build issues (unresolved Windows `windows::Win32` / `windows::core` imports and system deps), so the file-search unit tests could not be executed end-to-end here. `git diff --check` completed without problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522731e0388332be4d4c3c2310821b)