### PR TITLE
Add production file search dispatcher

### DIFF
--- a/src/file_search.rs
+++ b/src/file_search.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod coordinator;
 pub mod error;
 pub mod everything;
+pub mod executor;
 pub mod model;
 pub mod preview;
 pub mod query;

--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -1,9 +1,11 @@
+use crate::file_search::executor::FileSearchExecutor;
 use crate::file_search::model::{
     SearchBackend, SearchEvent, SearchId, SearchKind, SearchRequest, SearchResult, SearchScope,
     SearchStatus,
 };
+use crate::file_search::settings::FileSearchSettings;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::{mpsc, Arc};
 use std::thread;
 
 #[derive(Debug, Clone, Default)]
@@ -49,29 +51,6 @@ pub trait SearchExecutor: Send + Sync + 'static {
     );
 }
 
-#[derive(Clone)]
-struct UnimplementedExecutor;
-
-impl SearchExecutor for UnimplementedExecutor {
-    fn execute(
-        &self,
-        id: SearchId,
-        _request: SearchRequest,
-        token: CancellationToken,
-        events: mpsc::Sender<SearchEvent>,
-    ) {
-        if token.is_cancelled() {
-            let _ = events.send(SearchEvent::Cancelled { id });
-            return;
-        }
-
-        let _ = events.send(SearchEvent::Failed {
-            id,
-            error: "Search backend execution is not wired yet".to_string(),
-        });
-    }
-}
-
 pub struct SearchCoordinator {
     next_id: u64,
     active_search_id: Option<SearchId>,
@@ -92,7 +71,11 @@ impl Default for SearchCoordinator {
 
 impl SearchCoordinator {
     pub fn new() -> Self {
-        Self::with_executor(Arc::new(UnimplementedExecutor))
+        Self::with_settings(FileSearchSettings::default())
+    }
+
+    pub fn with_settings(settings: FileSearchSettings) -> Self {
+        Self::with_executor(Arc::new(FileSearchExecutor::new(settings)))
     }
 
     pub fn with_executor(executor: Arc<dyn SearchExecutor>) -> Self {
@@ -492,5 +475,105 @@ mod tests {
             .filter(|event| matches!(event, SearchEvent::Result { .. }))
             .count();
         assert_eq!(results, 2);
+    }
+    fn drain_until_terminal(coordinator: &mut SearchCoordinator) -> Vec<SearchEvent> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut all_events = Vec::new();
+        loop {
+            let events = coordinator.drain_current_events();
+            let terminal = events.iter().any(|event| {
+                matches!(
+                    event,
+                    SearchEvent::Completed { .. }
+                        | SearchEvent::Cancelled { .. }
+                        | SearchEvent::Failed { .. }
+                )
+            });
+            all_events.extend(events);
+            if terminal || std::time::Instant::now() >= deadline {
+                return all_events;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn production_directory_filename_search_uses_walkdir_and_returns_result() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let expected = "known-production-filename.txt";
+        std::fs::write(temp.path().join(expected), "contents").expect("write file");
+        let mut coordinator = SearchCoordinator::new();
+
+        coordinator.start_search(SearchRequest {
+            kind: SearchKind::Filename,
+            scope: SearchScope::Directory {
+                root: temp.path().to_path_buf(),
+            },
+            text: expected.to_owned(),
+            case_sensitive: false,
+            include_hidden_files: false,
+            max_results: 10,
+            max_file_size_bytes: 1024,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: Vec::new(),
+        });
+
+        let events = drain_until_terminal(&mut coordinator);
+        assert_eq!(coordinator.last_backend(), Some(SearchBackend::WalkDir));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Result {
+                result: SearchResult::Filename(result),
+                ..
+            } if result.file_name == expected
+        )));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Completed { .. })));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Failed { error, .. } if error.contains("not wired yet")
+        )));
+    }
+
+    #[test]
+    fn production_content_search_with_missing_ripgrep_fails_with_configured_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("haystack.txt"), "needle").expect("write file");
+        let missing_rg = temp.path().join("missing").join("rg");
+        assert!(missing_rg.is_absolute());
+        let settings = FileSearchSettings {
+            ripgrep_executable_path: missing_rg.clone(),
+            ..FileSearchSettings::default()
+        };
+        let mut coordinator = SearchCoordinator::with_settings(settings);
+
+        coordinator.start_search(SearchRequest {
+            kind: SearchKind::Content,
+            scope: SearchScope::Directory {
+                root: temp.path().to_path_buf(),
+            },
+            text: "needle".to_owned(),
+            case_sensitive: false,
+            include_hidden_files: false,
+            max_results: 10,
+            max_file_size_bytes: 1024,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: Vec::new(),
+        });
+
+        let events = drain_until_terminal(&mut coordinator);
+        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Ripgrep));
+        let error = events
+            .iter()
+            .find_map(|event| match event {
+                SearchEvent::Failed { error, .. } => Some(error.as_str()),
+                _ => None,
+            })
+            .expect("failed event");
+        assert!(error.contains(&missing_rg.display().to_string()), "{error}");
+        assert!(!error.contains("not wired yet"), "{error}");
     }
 }

--- a/src/file_search/executor.rs
+++ b/src/file_search/executor.rs
@@ -1,0 +1,193 @@
+use crate::file_search::coordinator::{CancellationToken, SearchCoordinator, SearchExecutor};
+use crate::file_search::everything::EverythingSearchExecutor;
+use crate::file_search::model::{SearchBackend, SearchEvent, SearchId, SearchRequest};
+use crate::file_search::ripgrep::RipgrepSearchExecutor;
+use crate::file_search::settings::FileSearchSettings;
+use crate::file_search::walkdir::WalkDirSearchExecutor;
+use std::sync::{mpsc, Arc};
+
+/// Production file-search dispatcher that selects the configured backend for a
+/// request and delegates execution to the corresponding backend executor.
+#[derive(Clone)]
+pub struct FileSearchExecutor {
+    settings: FileSearchSettings,
+    ripgrep: Arc<dyn SearchExecutor>,
+    walkdir: Arc<dyn SearchExecutor>,
+    everything: Arc<dyn SearchExecutor>,
+}
+
+impl FileSearchExecutor {
+    pub fn new(settings: FileSearchSettings) -> Self {
+        Self::with_backend_executors(
+            settings.clone(),
+            Arc::new(RipgrepSearchExecutor::new(settings.clone())),
+            Arc::new(WalkDirSearchExecutor::new(settings.clone())),
+            Arc::new(EverythingSearchExecutor::new(settings.clone())),
+        )
+    }
+
+    pub fn settings(&self) -> &FileSearchSettings {
+        &self.settings
+    }
+
+    pub fn with_backend_executors(
+        settings: FileSearchSettings,
+        ripgrep: Arc<dyn SearchExecutor>,
+        walkdir: Arc<dyn SearchExecutor>,
+        everything: Arc<dyn SearchExecutor>,
+    ) -> Self {
+        Self {
+            settings,
+            ripgrep,
+            walkdir,
+            everything,
+        }
+    }
+}
+
+impl SearchExecutor for FileSearchExecutor {
+    fn execute(
+        &self,
+        id: SearchId,
+        request: SearchRequest,
+        token: CancellationToken,
+        events: mpsc::Sender<SearchEvent>,
+    ) {
+        match SearchCoordinator::select_backend(&request) {
+            SearchBackend::Ripgrep => self.ripgrep.execute(id, request, token, events),
+            SearchBackend::WalkDir => self.walkdir.execute(id, request, token, events),
+            SearchBackend::Everything => self.everything.execute(id, request, token, events),
+            SearchBackend::Native => {
+                let _ = events.send(SearchEvent::Failed {
+                    id,
+                    error: "Native file search backend is not implemented".to_owned(),
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_search::model::{SearchKind, SearchScope};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingExecutor {
+        calls: Mutex<Vec<SearchId>>,
+    }
+
+    impl RecordingExecutor {
+        fn calls(&self) -> Vec<SearchId> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl SearchExecutor for RecordingExecutor {
+        fn execute(
+            &self,
+            id: SearchId,
+            _request: SearchRequest,
+            _token: CancellationToken,
+            events: mpsc::Sender<SearchEvent>,
+        ) {
+            self.calls.lock().unwrap().push(id);
+            let _ = events.send(SearchEvent::Completed { id });
+        }
+    }
+
+    fn request(kind: SearchKind, scope: SearchScope) -> SearchRequest {
+        SearchRequest {
+            kind,
+            scope,
+            text: "needle".to_owned(),
+            case_sensitive: false,
+            include_hidden_files: false,
+            max_results: 10,
+            max_file_size_bytes: 1024,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: Vec::new(),
+        }
+    }
+
+    fn dispatcher(
+        ripgrep: Arc<RecordingExecutor>,
+        walkdir: Arc<RecordingExecutor>,
+        everything: Arc<RecordingExecutor>,
+    ) -> FileSearchExecutor {
+        FileSearchExecutor::with_backend_executors(
+            FileSearchSettings::default(),
+            ripgrep,
+            walkdir,
+            everything,
+        )
+    }
+
+    #[test]
+    fn content_request_routes_to_ripgrep() {
+        let ripgrep = Arc::new(RecordingExecutor::default());
+        let walkdir = Arc::new(RecordingExecutor::default());
+        let everything = Arc::new(RecordingExecutor::default());
+        let executor = dispatcher(ripgrep.clone(), walkdir.clone(), everything.clone());
+
+        let (tx, _rx) = mpsc::channel();
+        executor.execute(
+            SearchId(7),
+            request(
+                SearchKind::Content,
+                SearchScope::Directory { root: ".".into() },
+            ),
+            CancellationToken::new(),
+            tx,
+        );
+
+        assert_eq!(ripgrep.calls(), vec![SearchId(7)]);
+        assert!(walkdir.calls().is_empty());
+        assert!(everything.calls().is_empty());
+    }
+
+    #[test]
+    fn directory_filename_request_routes_to_walkdir() {
+        let ripgrep = Arc::new(RecordingExecutor::default());
+        let walkdir = Arc::new(RecordingExecutor::default());
+        let everything = Arc::new(RecordingExecutor::default());
+        let executor = dispatcher(ripgrep.clone(), walkdir.clone(), everything.clone());
+
+        let (tx, _rx) = mpsc::channel();
+        executor.execute(
+            SearchId(8),
+            request(
+                SearchKind::Filename,
+                SearchScope::Directory { root: ".".into() },
+            ),
+            CancellationToken::new(),
+            tx,
+        );
+
+        assert!(ripgrep.calls().is_empty());
+        assert_eq!(walkdir.calls(), vec![SearchId(8)]);
+        assert!(everything.calls().is_empty());
+    }
+
+    #[test]
+    fn global_filename_request_routes_to_everything() {
+        let ripgrep = Arc::new(RecordingExecutor::default());
+        let walkdir = Arc::new(RecordingExecutor::default());
+        let everything = Arc::new(RecordingExecutor::default());
+        let executor = dispatcher(ripgrep.clone(), walkdir.clone(), everything.clone());
+
+        let (tx, _rx) = mpsc::channel();
+        executor.execute(
+            SearchId(9),
+            request(SearchKind::Filename, SearchScope::Global),
+            CancellationToken::new(),
+            tx,
+        );
+
+        assert!(ripgrep.calls().is_empty());
+        assert!(walkdir.calls().is_empty());
+        assert_eq!(everything.calls(), vec![SearchId(9)]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a production dispatcher for file search that selects the appropriate backend and delegates execution rather than shipping an unimplemented default, enabling real searches in production.
- Ensure coordinator tests remain deterministic by preserving `SearchCoordinator::with_executor()` while wiring the production path through a configurable dispatcher holding resolved `FileSearchSettings`.

### Description
- Add `src/file_search/executor.rs` with `FileSearchExecutor` that stores `FileSearchSettings` and backend executors (`RipgrepSearchExecutor`, `WalkDirSearchExecutor`, `EverythingSearchExecutor`) and implements `SearchExecutor` by delegating based on `SearchCoordinator::select_backend` and returning a clear failure for `SearchBackend::Native`.
- Export the module from `src/file_search.rs` via `pub mod executor;` and wire `SearchCoordinator::new()` through the production dispatcher by adding `SearchCoordinator::with_settings()` while keeping `with_executor()` unchanged.
- Remove the production `UnimplementedExecutor` path and avoid duplicating backend logic in the dispatcher, leaving the dispatcher to only route to existing executors.
- Add tests: routing/unit tests for the dispatcher (using recording executors), a production directory-filename test using `WalkDir`, and a production missing-ripgrep test validating a `Failed` terminal event referencing the configured missing path.

### Testing
- Attempted `cargo test file_search --lib`, but the run failed due to a missing system dependency for `alsa-sys` (`pkg-config`/`alsa.pc`), so the full test suite could not be executed in this environment (failed).
- Attempted the focused test `cargo test file_search::coordinator::tests::production_directory_filename_search_uses_walkdir_and_returns_result --lib --no-default-features`, but it was also blocked by the same system dependency failure (failed).
- `git diff --check` was run as part of validation and produced no whitespace/errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5296b31dc483329ef962240052400f)