### PR TITLE
Share FileSearchSettings between dialog and backend; add production constructor and reconfigure support

### DIFF
--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -61,6 +61,7 @@ pub struct SearchCoordinator {
     last_backend: Option<SearchBackend>,
     diagnostics: SearchDiagnostics,
     executor: Arc<dyn SearchExecutor>,
+    production_settings: Option<FileSearchSettings>,
 }
 
 impl Default for SearchCoordinator {
@@ -71,14 +72,26 @@ impl Default for SearchCoordinator {
 
 impl SearchCoordinator {
     pub fn new() -> Self {
-        Self::with_settings(FileSearchSettings::default())
+        Self::from_settings(FileSearchSettings::default())
+    }
+
+    pub fn from_settings(settings: FileSearchSettings) -> Self {
+        let executor = Arc::new(FileSearchExecutor::new(settings.clone()));
+        Self::with_executor_and_settings(executor, Some(settings))
     }
 
     pub fn with_settings(settings: FileSearchSettings) -> Self {
-        Self::with_executor(Arc::new(FileSearchExecutor::new(settings)))
+        Self::from_settings(settings)
     }
 
     pub fn with_executor(executor: Arc<dyn SearchExecutor>) -> Self {
+        Self::with_executor_and_settings(executor, None)
+    }
+
+    fn with_executor_and_settings(
+        executor: Arc<dyn SearchExecutor>,
+        production_settings: Option<FileSearchSettings>,
+    ) -> Self {
         let (event_sender, event_receiver) = mpsc::channel();
         Self {
             next_id: 1,
@@ -90,7 +103,18 @@ impl SearchCoordinator {
             last_backend: None,
             diagnostics: SearchDiagnostics::default(),
             executor,
+            production_settings,
         }
+    }
+
+    pub fn reconfigure_from_settings(&mut self, settings: FileSearchSettings) {
+        self.cancel_active();
+        self.executor = Arc::new(FileSearchExecutor::new(settings.clone()));
+        self.production_settings = Some(settings);
+    }
+
+    pub fn production_settings(&self) -> Option<&FileSearchSettings> {
+        self.production_settings.as_ref()
     }
 
     pub fn start_search(&mut self, request: SearchRequest) -> SearchId {
@@ -495,6 +519,48 @@ mod tests {
             }
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[test]
+    fn from_settings_installs_production_dispatcher() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let expected = "configured-dispatcher-filename.txt";
+        std::fs::write(temp.path().join(expected), "contents").expect("write file");
+        let settings = FileSearchSettings {
+            max_search_results: 3,
+            ..FileSearchSettings::default()
+        };
+        let mut coordinator = SearchCoordinator::from_settings(settings.clone());
+
+        assert_eq!(coordinator.production_settings(), Some(&settings));
+        coordinator.start_search(SearchRequest {
+            kind: SearchKind::Filename,
+            scope: SearchScope::Directory {
+                root: temp.path().to_path_buf(),
+            },
+            text: expected.to_owned(),
+            case_sensitive: settings.case_sensitive,
+            include_hidden_files: settings.include_hidden_files,
+            max_results: settings.max_search_results,
+            max_file_size_bytes: settings.max_content_search_file_size_bytes,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: settings.excluded_directory_names.clone(),
+        });
+
+        let events = drain_until_terminal(&mut coordinator);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Result {
+                result: SearchResult::Filename(result),
+                ..
+            } if result.file_name == expected
+        )));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Failed { error, .. } if error.contains("not wired yet")
+                || error.contains("Search backend execution is not wired yet")
+        )));
     }
 
     #[test]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -604,6 +604,19 @@ impl LauncherApp {
         self.mouse_gesture_settings_dialog.open();
     }
 
+    pub fn apply_file_search_settings(
+        &mut self,
+        settings: crate::file_search::settings::FileSearchSettings,
+    ) {
+        self.file_search_dialog
+            .cancel_search(&mut self.file_search_coordinator);
+        self.file_search_coordinator
+            .reconfigure_from_settings(settings.clone());
+        self.file_search_dialog.case_sensitive = settings.case_sensitive;
+        self.file_search_dialog.include_hidden = settings.include_hidden_files;
+        self.file_search_dialog.settings = settings;
+    }
+
     pub fn open_theme_settings_dialog(&mut self) {
         self.theme_settings_dialog_open = true;
         self.theme_settings_dialog.request_reload();
@@ -1168,7 +1181,7 @@ impl LauncherApp {
                 include_hidden: file_search_settings.include_hidden_files,
                 ..FileSearchDialogState::default()
             },
-            file_search_coordinator: SearchCoordinator::new(),
+            file_search_coordinator: SearchCoordinator::from_settings(file_search_settings),
             notes_dialog: NotesDialog::default(),
             note_graph_dialog: NoteGraphDialog::default(),
             unused_assets_dialog: UnusedAssetsDialog::default(),
@@ -3858,6 +3871,60 @@ mod tests {
             NOTE_SEARCH_DEBOUNCE,
         ));
     }
+    #[test]
+    fn launcher_new_shares_file_search_settings_with_dialog_and_coordinator() {
+        let ctx = egui::Context::default();
+        let mut settings = Settings::default();
+        let file_search_settings = crate::file_search::settings::FileSearchSettings {
+            global_content_search_roots: vec![std::path::PathBuf::from("/tmp/search-root")],
+            excluded_directory_names: vec!["skip-me".to_owned()],
+            max_search_results: 123,
+            max_matches_per_content_file: 7,
+            max_content_search_file_size_bytes: 456_789,
+            include_hidden_files: true,
+            case_sensitive: true,
+            everything_executable_path: std::path::PathBuf::from("custom-everything.exe"),
+            ripgrep_executable_path: std::path::PathBuf::from("custom-rg"),
+            everything_enabled: false,
+            ..crate::file_search::settings::FileSearchSettings::default()
+        };
+        settings.plugin_settings.insert(
+            "file_search".to_owned(),
+            serde_json::to_value(file_search_settings.clone()).expect("serialize settings"),
+        );
+
+        let app = LauncherApp::new(
+            &ctx,
+            Arc::new(Vec::new()),
+            0,
+            PluginManager::new(),
+            "actions.json".into(),
+            "settings.json".into(),
+            settings,
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        assert_eq!(app.file_search_dialog.settings, file_search_settings);
+        assert_eq!(
+            app.file_search_dialog.case_sensitive,
+            file_search_settings.case_sensitive
+        );
+        assert_eq!(
+            app.file_search_dialog.include_hidden,
+            file_search_settings.include_hidden_files
+        );
+        assert_eq!(
+            app.file_search_coordinator.production_settings(),
+            Some(&file_search_settings)
+        );
+    }
+
     #[test]
     fn launcher_new_normalizes_conflicting_follow_mouse_static_config() {
         let ctx = egui::Context::default();

--- a/src/settings_editor/save.rs
+++ b/src/settings_editor/save.rs
@@ -147,6 +147,14 @@ impl SettingsEditor {
             &plugin_settings,
             actions_arc,
         );
+        if let Some(val) = new_settings.plugin_settings.get("file_search") {
+            if let Ok(cfg) = serde_json::from_value::<
+                crate::file_search::settings::FileSearchSettings,
+            >(val.clone())
+            {
+                app.apply_file_search_settings(cfg);
+            }
+        }
         if let Some(val) = new_settings.plugin_settings.get("note") {
             if let Ok(cfg) = serde_json::from_value::<NotePluginSettings>(val.clone()) {
                 app.note_external_open = cfg.external_open;


### PR DESCRIPTION
### Motivation
- Ensure the File Search GUI and backend use the exact same resolved `FileSearchSettings` so configured paths, roots and UI defaults stay in sync. 
- Replace placeholder executor wiring with the real production dispatcher when constructing the coordinator in production paths. 
- Provide a way to apply file-search settings at runtime that safely cancels active searches and swaps the dispatcher.

### Description
- Added `SearchCoordinator::from_settings(settings: FileSearchSettings)` and a `production_settings: Option<FileSearchSettings>` field so production construction installs the `FileSearchExecutor` dispatcher. 
- Kept `SearchCoordinator::with_executor(executor)` for tests and added an internal `with_executor_and_settings` helper. 
- Added `SearchCoordinator::reconfigure_from_settings(&mut self, settings)` to cancel active work and replace the production dispatcher at runtime, and `production_settings()` accessor for tests. 
- Changed `SearchCoordinator::new()` / `Default` to build via `from_settings(FileSearchSettings::default())` so default construction uses the production dispatcher. 
- Updated `LauncherApp::new` to resolve `file_search_settings` once and pass the same value into both `file_search_dialog.settings` and `file_search_coordinator` construction. 
- Added `LauncherApp::apply_file_search_settings(&mut self, settings)` which cancels active search, reconfigures the coordinator, and updates dialog flags (`case_sensitive`, `include_hidden`) and `file_search_dialog.settings`. 
- Hooked the settings save path to call `apply_file_search_settings` when `file_search` plugin settings are present. 
- Added unit tests: one coordinator test verifying `SearchCoordinator::from_settings()` installs the production dispatcher, and one GUI test verifying `LauncherApp::new` shares the same `FileSearchSettings` between dialog and coordinator.

### Testing
- Added unit tests `from_settings_installs_production_dispatcher` and `launcher_new_shares_file_search_settings_with_dialog_and_coordinator` in the repository. 
- Ran repository checks and attempted `cargo test` for the new tests but full test execution did not complete in this environment because unrelated platform-specific build failures occurred (initial native deps such as `alsa`/`x11` required system packages which were installed, and subsequent compilation failed while compiling Windows-specific modules that reference the `windows` crate). 
- `git diff --check` passed; `rustfmt` reported a repository-wide parse issue unrelated to these changes (existing `let`-chain usage under a different Rust edition).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a048a4e08332869e007d87371744)