### PR TITLE
Unify ripgrep executable resolution

### DIFF
--- a/src/file_search/error.rs
+++ b/src/file_search/error.rs
@@ -19,6 +19,10 @@ pub enum FileSearchError {
         executable: PathBuf,
         message: String,
     },
+    ProcessFatalStatus {
+        executable: PathBuf,
+        message: String,
+    },
     ProcessOutputParseFailure {
         backend: String,
         message: String,
@@ -49,6 +53,16 @@ impl fmt::Display for FileSearchError {
                 message,
             } => {
                 write!(f, "Failed to launch '{}': {message}", executable.display())
+            }
+            Self::ProcessFatalStatus {
+                executable,
+                message,
+            } => {
+                write!(
+                    f,
+                    "Search process '{}' returned a fatal status: {message}",
+                    executable.display()
+                )
             }
             Self::ProcessOutputParseFailure { backend, message } => {
                 write!(f, "Failed to parse output from '{backend}': {message}")

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -102,7 +102,8 @@ pub fn search_content_with_ripgrep(
         });
     }
 
-    let executable = detect_ripgrep_executable(&settings.ripgrep_executable_path)?;
+    let executable = resolve_ripgrep_executable(&settings.ripgrep_executable_path)?;
+    tracing::debug!(executable = %executable.display(), "starting ripgrep content search");
     let roots = search_roots(&request, settings)?;
     let mut command = build_ripgrep_command(&executable, &request, settings, &roots);
     let mut child = command
@@ -148,7 +149,7 @@ pub fn search_content_with_ripgrep(
         summary.stderr = stderr;
         return Ok(summary);
     }
-    handle_exit_status(status, &stderr)?;
+    handle_exit_status(status, &executable, &stderr)?;
     let mut summary =
         parse_ripgrep_json_limited(&stdout, per_file_match_limit, request.max_results)?;
     summary.stderr = stderr;
@@ -162,40 +163,58 @@ fn per_file_match_limit(request: &SearchRequest, settings: &FileSearchSettings) 
     }
 }
 
-pub fn detect_ripgrep_executable(configured: &Path) -> Result<PathBuf, FileSearchError> {
-    if !configured.as_os_str().is_empty() && configured.components().count() > 1 {
+pub fn resolve_ripgrep_executable(configured: &Path) -> Result<PathBuf, FileSearchError> {
+    let configured = if configured.as_os_str().is_empty() {
+        Path::new("rg")
+    } else {
+        configured
+    };
+
+    if path_contains_directory_components(configured) {
         if configured.is_file() {
             return Ok(configured.to_path_buf());
         }
         return Err(FileSearchError::BackendUnavailable {
             backend: "ripgrep".to_owned(),
             message: format!(
-                "configured executable '{}' was not found",
+                "configured ripgrep executable '{}' does not exist or is not a file",
                 configured.display()
             ),
         });
     }
-    let name = if configured.as_os_str().is_empty() {
-        "rg".into()
-    } else {
-        configured.to_path_buf()
-    };
-    find_on_path(&name).ok_or_else(|| FileSearchError::BackendUnavailable {
+
+    find_on_process_path(configured).ok_or_else(|| FileSearchError::BackendUnavailable {
         backend: "ripgrep".to_owned(),
-        message: "ripgrep executable was not found in PATH".to_owned(),
+        message: format!(
+            "ripgrep executable '{}' was not found on PATH",
+            configured.display()
+        ),
     })
 }
 
-fn find_on_path(name: &Path) -> Option<PathBuf> {
+#[allow(dead_code)]
+pub fn detect_ripgrep_executable(configured: &Path) -> Result<PathBuf, FileSearchError> {
+    resolve_ripgrep_executable(configured)
+}
+
+fn path_contains_directory_components(path: &Path) -> bool {
+    path.components().count() > 1
+}
+
+fn find_on_process_path(name: &Path) -> Option<PathBuf> {
     let paths = env::var_os("PATH")?;
-    for dir in env::split_paths(&paths) {
+    find_on_path(name, env::split_paths(&paths))
+}
+
+fn find_on_path(name: &Path, paths: impl IntoIterator<Item = PathBuf>) -> Option<PathBuf> {
+    for dir in paths {
         let candidate = dir.join(name);
         if candidate.is_file() {
             return Some(candidate);
         }
         #[cfg(windows)]
-        {
-            let exe = candidate.with_extension("exe");
+        if name.extension().is_none() {
+            let exe = dir.join(format!("{}.exe", name.as_os_str().to_string_lossy()));
             if exe.is_file() {
                 return Some(exe);
             }
@@ -282,12 +301,16 @@ fn read_to_string(reader: impl Read) -> String {
     output
 }
 
-fn handle_exit_status(status: ExitStatus, stderr: &str) -> Result<(), FileSearchError> {
+fn handle_exit_status(
+    status: ExitStatus,
+    executable: &Path,
+    stderr: &str,
+) -> Result<(), FileSearchError> {
     match status.code() {
         Some(0) | Some(1) => Ok(()),
         Some(2) if is_non_fatal_ripgrep_stderr(stderr) => Ok(()),
-        _ => Err(FileSearchError::ProcessLaunchFailure {
-            executable: PathBuf::from("rg"),
+        _ => Err(FileSearchError::ProcessFatalStatus {
+            executable: executable.to_path_buf(),
             message: if stderr.trim().is_empty() {
                 format!("ripgrep exited with status {status}")
             } else {
@@ -397,7 +420,6 @@ fn parse_match_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc;
 
     fn req(root: PathBuf) -> SearchRequest {
         SearchRequest {
@@ -468,9 +490,9 @@ mod tests {
 
     #[test]
     fn backend_errors_are_distinct_from_no_matches() {
-        assert!(handle_exit_status(fake_status(1), "").is_ok());
-        assert!(handle_exit_status(fake_status(2), "unrecognized flag").is_err());
-        assert!(handle_exit_status(fake_status(2), "Permission denied").is_ok());
+        assert!(handle_exit_status(fake_status(1), Path::new("rg"), "").is_ok());
+        assert!(handle_exit_status(fake_status(2), Path::new("rg"), "unrecognized flag").is_err());
+        assert!(handle_exit_status(fake_status(2), Path::new("rg"), "Permission denied").is_ok());
     }
 
     #[cfg(unix)]
@@ -529,6 +551,77 @@ mod tests {
     }
 
     #[test]
+    fn resolves_bare_rg_from_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("rg");
+        std::fs::write(&executable, "").unwrap();
+
+        assert_eq!(
+            find_on_path(Path::new("rg"), [temp.path().to_path_buf()]),
+            Some(executable)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolves_bare_rg_exe_from_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("rg.exe");
+        std::fs::write(&executable, "").unwrap();
+
+        assert_eq!(
+            find_on_path(Path::new("rg.exe"), [temp.path().to_path_buf()]),
+            Some(executable)
+        );
+    }
+
+    #[test]
+    fn nonexistent_absolute_path_error_contains_configured_path() {
+        let configured = if cfg!(windows) {
+            PathBuf::from(r"C:\definitely\missing\rg.exe")
+        } else {
+            PathBuf::from("/definitely/missing/rg")
+        };
+        let error = resolve_ripgrep_executable(&configured)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(&configured.display().to_string()), "{error}");
+    }
+
+    #[test]
+    fn relative_path_with_directory_components_must_exist() {
+        let configured = PathBuf::from("missing-dir/rg");
+        let error = resolve_ripgrep_executable(&configured)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(&configured.display().to_string()), "{error}");
+
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("rg");
+        std::fs::write(&file, "").unwrap();
+        assert_eq!(resolve_ripgrep_executable(&file).unwrap(), file);
+    }
+
+    #[test]
+    fn settings_diagnostics_and_runtime_use_same_resolver_output() {
+        let Ok(resolved) = resolve_ripgrep_executable(Path::new("rg")) else {
+            return;
+        };
+        let settings = FileSearchSettings {
+            ripgrep_executable_path: PathBuf::from("rg"),
+            ..FileSearchSettings::default()
+        };
+        assert_eq!(
+            crate::file_search::settings::detect_ripgrep_executable(&settings),
+            Some(resolved.clone())
+        );
+        assert_eq!(
+            resolve_ripgrep_executable(&settings.ripgrep_executable_path).unwrap(),
+            resolved
+        );
+    }
+
+    #[test]
     fn query_starting_with_dash_is_after_separator() {
         let temp = tempfile::tempdir().unwrap();
         let request = SearchRequest {
@@ -551,22 +644,47 @@ mod tests {
 
     #[test]
     fn optional_integration_runs_when_rg_is_detected() {
-        let Ok(executable) = detect_ripgrep_executable(Path::new("rg")) else {
+        let Ok(executable) = resolve_ripgrep_executable(Path::new("rg")) else {
             return;
         };
         let temp = tempfile::tempdir().unwrap();
-        std::fs::write(temp.path().join("file.txt"), "hello Needle\n").unwrap();
+        let file = temp.path().join("file.txt");
+        std::fs::write(&file, "hello needle\n").unwrap();
         let settings = FileSearchSettings {
             ripgrep_executable_path: executable,
             ..FileSearchSettings::default()
         };
-        let (_tx, _rx) = mpsc::channel::<SearchEvent>();
-        let summary = search_content_with_ripgrep(
-            req(temp.path().to_path_buf()),
-            &settings,
-            &CancellationToken::new(),
-        )
-        .unwrap();
-        assert_eq!(summary.results.len(), 1);
+        let mut coordinator =
+            crate::file_search::coordinator::SearchCoordinator::from_settings(settings);
+        coordinator.start_search(req(temp.path().to_path_buf()));
+        let mut events = Vec::new();
+        for _ in 0..200 {
+            events.extend(coordinator.drain_current_events());
+            if events.iter().any(|event| {
+                matches!(
+                    event,
+                    SearchEvent::Completed { .. } | SearchEvent::Failed { .. }
+                )
+            }) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, SearchEvent::Completed { .. })),
+            "events: {events:?}"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                SearchEvent::Result {
+                    result: SearchResult::ContentFile(result),
+                    ..
+                } if result.path == file
+            )),
+            "events: {events:?}"
+        );
     }
 }

--- a/src/file_search/settings.rs
+++ b/src/file_search/settings.rs
@@ -136,20 +136,7 @@ impl fmt::Display for FileSearchDiagnosticsState {
 }
 
 pub fn detect_ripgrep_executable(settings: &FileSearchSettings) -> Option<PathBuf> {
-    let configured = &settings.ripgrep_executable_path;
-    if executable_path_is_configured_file(configured) == Some(true) {
-        return Some(configured.clone());
-    }
-    find_on_path(configured)
-}
-
-fn find_on_path(path: &PathBuf) -> Option<PathBuf> {
-    let name = path.file_name()?;
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths)
-            .map(|dir| dir.join(name))
-            .find(|candidate| candidate.is_file())
-    })
+    crate::file_search::ripgrep::resolve_ripgrep_executable(&settings.ripgrep_executable_path).ok()
 }
 
 impl Default for FileSearchSettings {
@@ -223,7 +210,9 @@ impl FileSearchSettings {
             });
         }
 
-        if executable_path_is_configured_file(&self.ripgrep_executable_path) == Some(false) {
+        if crate::file_search::ripgrep::resolve_ripgrep_executable(&self.ripgrep_executable_path)
+            .is_err()
+        {
             diagnostics.push(FileSearchSettingsDiagnostic::MissingExecutable {
                 name: "ripgrep",
                 path: self.ripgrep_executable_path.clone(),


### PR DESCRIPTION
### Motivation
- Centralize ripgrep executable detection so runtime execution and settings diagnostics use the same deterministic resolver and error messages.
- Make resolver behavior explicit for bare names, Windows `.exe` handling, and configured paths that include directory components.
- Improve backend error granularity so callers can distinguish launch failures, fatal exit statuses, and parse errors.

### Description
- Added a canonical resolver `resolve_ripgrep_executable` in `src/file_search/ripgrep.rs` that handles bare `rg`, bare `rg.exe`, absolute and relative paths containing directory components, and deterministic PATH scanning (Windows: try exact name and add `.exe` when no extension). 
- Updated runtime search to call the canonical resolver and log the resolved executable at debug level before launching ripgrep, while continuing to spawn via `std::process::Command` and preserving safe `Command::arg()` usage. 
- Replaced in-module PATH helpers with `find_on_process_path` / `find_on_path` helpers to support deterministic path iteration for diagnostics.
- Delegated settings diagnostics to the canonical resolver by making `detect_ripgrep_executable` in `src/file_search/settings.rs` call the resolver, and updated validation to rely on the resolver result.
- Added a new `ProcessFatalStatus` error variant in `src/file_search/error.rs` and updated `handle_exit_status` to return that variant when ripgrep exits with a fatal status, keeping `ProcessLaunchFailure` and `ProcessOutputParseFailure` separate.
- Expanded and added unit tests in `src/file_search/ripgrep.rs` to cover: bare `rg` resolution, bare `rg.exe` (Windows), nonexistent absolute path error containing the configured path, relative path with directory components must exist, settings diagnostics and runtime using the same resolver, and extended the optional integration test to exercise the full `SearchCoordinator` → dispatcher → ripgrep path.

### Testing
- Ran code formatting (`cargo fmt`) and lint/check (`git diff --check`) successfully.
- Attempted `cargo test file_search::ripgrep --lib`; the test invocation was executed but overall compilation/test run was blocked by unrelated platform-specific build issues in this Linux environment (missing system libraries / cross-platform `windows` crate usage and other unrelated compile errors), so the full test suite could not complete here. The new ripgrep unit tests were added and are expected to run in CI or a suitable build environment where platform dependencies are satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a5bfff048332b17b0f510ca2a59a)