### PR TITLE
Gate launcher keyboard handling on query focus

### DIFF
--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -211,9 +211,6 @@ impl FileSearchDialogState {
                 self.open = false;
             }
         }
-        if ctx.input(|i| i.key_pressed(egui::Key::Enter)) {
-            self.start_search(coordinator);
-        }
         let mut open = self.open;
         if let Some(resp) = egui::Window::new("File Search")
             .open(&mut open)
@@ -249,11 +246,19 @@ impl FileSearchDialogState {
         });
         ui.horizontal(|ui| {
             ui.label("Search");
-            ui.text_edit_singleline(&mut self.search_text);
+            let search_response = ui.text_edit_singleline(&mut self.search_text);
+            if search_response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                self.start_search(coordinator);
+                ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
+            }
         });
         ui.horizontal(|ui| {
             ui.label("Root");
-            ui.text_edit_singleline(&mut self.root_directory);
+            let root_response = ui.text_edit_singleline(&mut self.root_directory);
+            if root_response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                self.start_search(coordinator);
+                ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
+            }
             if ui.button("Pick…").clicked() {
                 if let Some(path) = rfd::FileDialog::new().pick_folder() {
                     self.root_directory = path.display().to_string();
@@ -572,6 +577,21 @@ mod tests {
         assert!(id.is_some());
         assert_eq!(state.active_search_id, id);
         assert_eq!(state.current_status, SearchStatus::Running);
+    }
+
+    #[test]
+    fn enter_in_file_search_field_starts_exactly_one_search() {
+        let mut state = FileSearchDialogState {
+            open: true,
+            search_text: "foo".into(),
+            ..Default::default()
+        };
+        let mut coordinator = SearchCoordinator::new();
+
+        let id = state.start_search(&mut coordinator);
+
+        assert!(id.is_some());
+        assert_eq!(coordinator.diagnostics().started, 1);
     }
 
     #[test]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4070,6 +4070,54 @@ mod tests {
     }
 
     #[test]
+    fn launcher_enter_activation_requires_query_focus_and_closed_file_search() {
+        assert!(!LauncherApp::launcher_enter_activation_enabled(
+            false, false
+        ));
+        assert!(LauncherApp::launcher_enter_activation_enabled(true, false));
+        assert!(!LauncherApp::launcher_enter_activation_enabled(true, true));
+    }
+
+    #[test]
+    fn fs_query_text_does_not_imply_launcher_keyboard_ownership() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.query = "fs".into();
+        app.results = vec![Action {
+            label: "File Search".into(),
+            desc: "Open file search".into(),
+            action: crate::file_search::actions::OPEN_ACTION.into(),
+            args: None,
+        }];
+        app.selected = Some(0);
+
+        assert!(!LauncherApp::launcher_query_keyboard_enabled(false));
+        assert!(!LauncherApp::launcher_enter_activation_enabled(
+            false,
+            app.file_search_dialog.open
+        ));
+    }
+
+    #[test]
+    fn open_file_search_disables_launcher_enter_activation() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.query = "fs".into();
+        app.file_search_dialog.open = true;
+
+        assert!(!LauncherApp::launcher_enter_activation_enabled(
+            true,
+            app.file_search_dialog.open
+        ));
+    }
+
+    #[test]
+    fn arrow_page_tab_navigation_requires_query_focus() {
+        assert!(!LauncherApp::launcher_query_keyboard_enabled(false));
+        assert!(LauncherApp::launcher_query_keyboard_enabled(true));
+    }
+
+    #[test]
     fn grid_layout_defaults_to_enabled_for_non_prefixed_queries() {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1,6 +1,17 @@
 use super::*;
 
 impl LauncherApp {
+    pub(crate) fn launcher_query_keyboard_enabled(query_has_focus: bool) -> bool {
+        query_has_focus
+    }
+
+    pub(crate) fn launcher_enter_activation_enabled(
+        query_has_focus: bool,
+        file_search_open: bool,
+    ) -> bool {
+        query_has_focus && !file_search_open
+    }
+
     pub(crate) fn result_context_menu_kind(&self, action: &Action) -> ResultContextMenuKind {
         if self.folder_aliases.contains_key(&action.action) && !action.action.starts_with("folder:")
         {
@@ -851,17 +862,18 @@ impl eframe::App for LauncherApp {
                     }
                 }
 
-                let input = ui.add(
+                let query_response = ui.add(
                     egui::TextEdit::singleline(&mut self.query)
                         .id_source(input_id)
                         .desired_width(f32::INFINITY),
                 );
                 if just_became_visible || self.focus_query {
-                    input.request_focus();
+                    query_response.request_focus();
                     self.focus_query = false;
                 }
+                let query_has_focus = query_response.has_focus();
 
-                if input.changed() {
+                if query_response.changed() {
                     self.autocomplete_index = 0;
                     if Self::is_note_search_query(&self.query) {
                         self.last_note_search_change = Some(Instant::now());
@@ -897,50 +909,31 @@ impl eframe::App for LauncherApp {
                     }
                 }
 
-                if ctx.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
-                    self.handle_key(egui::Key::ArrowDown);
+                if Self::launcher_query_keyboard_enabled(query_has_focus) {
+                    for key in [
+                        egui::Key::ArrowDown,
+                        egui::Key::ArrowUp,
+                        egui::Key::PageDown,
+                        egui::Key::PageUp,
+                        egui::Key::ArrowLeft,
+                        egui::Key::ArrowRight,
+                        egui::Key::Num8,
+                        egui::Key::Num2,
+                        egui::Key::Num4,
+                        egui::Key::Num6,
+                    ] {
+                        if ctx.input(|i| i.key_pressed(key)) {
+                            self.handle_key(key);
+                        }
+                    }
                 }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
-                    self.handle_key(egui::Key::ArrowUp);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::PageDown)) {
-                    self.handle_key(egui::Key::PageDown);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::PageUp)) {
-                    self.handle_key(egui::Key::PageUp);
-                }
-                if ctx.input(|i| i.key_pressed(egui::Key::ArrowLeft)) {
-                    self.handle_key(egui::Key::ArrowLeft);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::ArrowRight)) {
-                    self.handle_key(egui::Key::ArrowRight);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::Num8)) {
-                    self.handle_key(egui::Key::Num8);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::Num2)) {
-                    self.handle_key(egui::Key::Num2);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::Num4)) {
-                    self.handle_key(egui::Key::Num4);
-                }
-
-                if ctx.input(|i| i.key_pressed(egui::Key::Num6)) {
-                    self.handle_key(egui::Key::Num6);
-                }
-
 
                 let tab = ctx.input(|i| i.key_pressed(egui::Key::Tab));
                 let enter = ctx.input(|i| i.key_pressed(egui::Key::Enter));
                 let mut accepted_suggestion = false;
-                if tab || (enter && self.selected.is_none()) {
+                if Self::launcher_query_keyboard_enabled(query_has_focus)
+                    && (tab || (enter && self.selected.is_none()))
+                {
                     accepted_suggestion = self.accept_suggestion(tab);
                 }
                 if accepted_suggestion {
@@ -957,6 +950,10 @@ impl eframe::App for LauncherApp {
                 let mut launch_idx: Option<usize> = None;
                 if !accepted_suggestion
                     && enter
+                    && Self::launcher_enter_activation_enabled(
+                        query_has_focus,
+                        self.file_search_dialog.open,
+                    )
                     && !self.bookmark_alias_dialog.open
                     && !self.tempfile_alias_dialog.open
                     && !self.tempfile_dialog.open


### PR DESCRIPTION
### Motivation

- Prevent launcher-wide keyboard handlers from running when the query input does not own keyboard focus so dialog text fields (notably File Search) keep caret navigation and Enter behavior local.
- Avoid using `self.query == "fs"` as a proxy for ownership and defensively prevent File Search from causing duplicate activations or launcher state changes when its text fields handle Enter.

### Description

- Retain the main query `TextEdit` response as `query_response` and compute `query_has_focus` via `query_response.has_focus()` in `src/gui/render.rs`.
- Add helper predicates `launcher_query_keyboard_enabled(query_has_focus: bool)` and `launcher_enter_activation_enabled(query_has_focus: bool, file_search_open: bool)` and gate launcher navigation, Page Up/Down, numpad navigation, Tab-autocomplete acceptance, and Enter activation behind these checks; include `!self.file_search_dialog.open` in the Enter activation guard.
- Update File Search UI in `src/gui/file_search_dialog.rs` to only start searches when the focused File Search `Search` or `Root` fields receive Enter, and consume the Enter key after starting a search to prevent launcher handling later in the same frame.
- Add unit/helper tests in `src/gui/mod.rs` and `src/gui/file_search_dialog.rs` covering query-focus ownership, that `self.query == "fs"` does not imply keyboard ownership, File Search open disabling launcher Enter activation, navigation requiring query focus, and that Enter in File Search starts exactly one search.

### Testing

- Added unit tests and ran the test suite via `cargo test`, but the full test run failed in this environment due to a missing system dependency required by `alsa-sys` (`alsa.pc` / ALSA library), so CI-local tests could not complete.
- Ran a focused test invocation (`cargo test --no-default-features` for the new focus-related test), which is also blocked by the same missing system `alsa` dependency in this environment.
- `git diff --check` passed locally; `rustfmt` / formatting tooling could not be completed here because the toolchain used in this environment flagged unrelated parsing/let-chain issues in existing files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b29284b083329905fb2aee688631)