### PR TITLE
Add one-time File Search focus handling

### DIFF
--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -847,7 +847,7 @@ impl LauncherApp {
         };
 
         if action == OPEN_ACTION {
-            self.file_search_dialog.open = true;
+            self.file_search_dialog.open();
             return true;
         }
         if action == CANCEL_ACTION {
@@ -856,7 +856,7 @@ impl LauncherApp {
             return true;
         }
         if let Some(encoded) = action.strip_prefix(MODE_PREFIX) {
-            self.file_search_dialog.open = true;
+            self.file_search_dialog.open();
             match decode_action_payload::<FileSearchModePayload>(encoded).and_then(|payload| {
                 payload.validate()?;
                 Ok(payload)
@@ -877,13 +877,13 @@ impl LauncherApp {
             return true;
         }
         if let Some(encoded) = action.strip_prefix(START_PREFIX) {
-            self.file_search_dialog.open = true;
+            self.file_search_dialog.open();
             match decode_action_payload::<FileSearchStartPayload>(encoded).and_then(|payload| {
                 payload.validate()?;
                 Ok(payload)
             }) {
                 Ok(payload) => {
-                    self.file_search_dialog.selected_mode = match payload.search_kind() {
+                    let mode = match payload.search_kind() {
                         crate::file_search::model::SearchKind::Filename => {
                             crate::gui::FileSearchMode::Filename
                         }
@@ -891,14 +891,13 @@ impl LauncherApp {
                             crate::gui::FileSearchMode::Content
                         }
                     };
-                    if let Some(root) = payload.root_path() {
-                        self.file_search_dialog.selected_scope =
-                            crate::gui::FileSearchScopeMode::Directory;
-                        self.file_search_dialog.root_directory = root.display().to_string();
-                    }
-                    self.file_search_dialog.search_text = payload.text;
-                    self.file_search_dialog
-                        .start_search(&mut self.file_search_coordinator);
+                    let root = payload.root_path();
+                    self.file_search_dialog.open_and_start(
+                        mode,
+                        root,
+                        payload.text,
+                        &mut self.file_search_coordinator,
+                    );
                 }
                 Err(err) => self.report_file_search_action_error(err),
             }

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -17,6 +17,9 @@ use std::path::PathBuf;
 
 const DEFAULT_WINDOW_SIZE: egui::Vec2 = egui::vec2(760.0, 560.0);
 
+pub const FILE_SEARCH_SEARCH_FIELD_ID_SOURCE: &str = "file_search_search_text";
+pub const FILE_SEARCH_ROOT_FIELD_ID_SOURCE: &str = "file_search_root_directory";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileSearchMode {
     Filename,
@@ -66,6 +69,7 @@ pub struct FileSearchDialogState {
     pub last_preview_request: Option<PreviewRequest>,
     pub persisted_window_size: egui::Vec2,
     pub settings: FileSearchSettings,
+    pub request_search_focus: bool,
 }
 
 impl Default for FileSearchDialogState {
@@ -88,14 +92,54 @@ impl Default for FileSearchDialogState {
             last_preview_request: None,
             persisted_window_size: DEFAULT_WINDOW_SIZE,
             settings: FileSearchSettings::default(),
+            request_search_focus: false,
         }
     }
 }
 
 impl FileSearchDialogState {
+    pub fn search_field_id() -> egui::Id {
+        egui::Id::new(FILE_SEARCH_SEARCH_FIELD_ID_SOURCE)
+    }
+
+    pub fn root_field_id() -> egui::Id {
+        egui::Id::new(FILE_SEARCH_ROOT_FIELD_ID_SOURCE)
+    }
+
+    pub fn open(&mut self) {
+        self.open = true;
+        self.request_search_focus = true;
+    }
+
     pub fn open_with_mode(&mut self, mode: FileSearchMode) {
         self.selected_mode = mode;
-        self.open = true;
+        self.open();
+    }
+
+    pub fn open_and_start(
+        &mut self,
+        mode: FileSearchMode,
+        root: Option<PathBuf>,
+        text: String,
+        coordinator: &mut SearchCoordinator,
+    ) -> Option<SearchId> {
+        self.selected_mode = mode;
+        if let Some(root) = root {
+            self.selected_scope = FileSearchScopeMode::Directory;
+            self.root_directory = root.display().to_string();
+        }
+        self.search_text = text;
+        self.open();
+        self.start_search(coordinator)
+    }
+
+    pub fn consume_search_focus_request(&mut self) -> bool {
+        if self.request_search_focus {
+            self.request_search_focus = false;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn start_search(&mut self, coordinator: &mut SearchCoordinator) -> Option<SearchId> {
@@ -246,7 +290,13 @@ impl FileSearchDialogState {
         });
         ui.horizontal(|ui| {
             ui.label("Search");
-            let search_response = ui.text_edit_singleline(&mut self.search_text);
+            let search_response = ui.add(
+                egui::TextEdit::singleline(&mut self.search_text)
+                    .id_source(Self::search_field_id()),
+            );
+            if self.consume_search_focus_request() {
+                search_response.request_focus();
+            }
             if search_response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                 self.start_search(coordinator);
                 ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
@@ -254,7 +304,10 @@ impl FileSearchDialogState {
         });
         ui.horizontal(|ui| {
             ui.label("Root");
-            let root_response = ui.text_edit_singleline(&mut self.root_directory);
+            let root_response = ui.add(
+                egui::TextEdit::singleline(&mut self.root_directory)
+                    .id_source(Self::root_field_id()),
+            );
             if root_response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                 self.start_search(coordinator);
                 ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
@@ -564,6 +617,67 @@ mod tests {
         state.open_with_mode(FileSearchMode::Content);
         assert!(state.open);
         assert_eq!(state.selected_mode, FileSearchMode::Content);
+    }
+
+    #[test]
+    fn opening_file_search_requests_search_focus_once() {
+        let mut state = FileSearchDialogState::default();
+
+        state.open();
+
+        assert!(state.open);
+        assert!(state.request_search_focus);
+    }
+
+    #[test]
+    fn consuming_search_focus_request_clears_flag_after_one_use() {
+        let mut state = FileSearchDialogState::default();
+        state.open();
+
+        assert!(state.consume_search_focus_request());
+        assert!(!state.request_search_focus);
+        assert!(!state.consume_search_focus_request());
+    }
+
+    #[test]
+    fn reopening_file_search_requests_search_focus_again() {
+        let mut state = FileSearchDialogState::default();
+        state.open();
+        assert!(state.consume_search_focus_request());
+
+        state.open_with_mode(FileSearchMode::Content);
+
+        assert!(state.request_search_focus);
+        assert_eq!(state.selected_mode, FileSearchMode::Content);
+    }
+
+    #[test]
+    fn root_field_has_stable_distinct_id_and_does_not_rearm_search_focus() {
+        let mut state = FileSearchDialogState::default();
+        state.open();
+        assert!(state.consume_search_focus_request());
+
+        let root_id = FileSearchDialogState::root_field_id();
+        let search_id = FileSearchDialogState::search_field_id();
+
+        assert_ne!(root_id, search_id);
+        assert!(!state.request_search_focus);
+        assert!(!state.consume_search_focus_request());
+    }
+
+    #[test]
+    fn opening_file_search_does_not_depend_on_launcher_query_text() {
+        let launcher_query = String::from("fs");
+        let mut state = FileSearchDialogState::default();
+
+        state.open();
+
+        assert_eq!(launcher_query, "fs");
+        assert!(state.request_search_focus);
+        assert_ne!(
+            FileSearchDialogState::search_field_id(),
+            egui::Id::new("query_input")
+        );
     }
 
     #[test]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2231,7 +2231,7 @@ impl LauncherApp {
             Panel::MouseGestureSettingsDialog => self.mouse_gesture_settings_dialog.open(),
             Panel::ThemeSettingsDialog => self.open_theme_settings_dialog(),
             Panel::FavDialog => self.fav_dialog.open = true,
-            Panel::FileSearchDialog => self.file_search_dialog.open = true,
+            Panel::FileSearchDialog => self.file_search_dialog.open(),
             Panel::NotesDialog => self.notes_dialog.open = true,
             Panel::NoteGraphDialog => self.note_graph_dialog.open = true,
             Panel::UnusedAssetsDialog => self.unused_assets_dialog.open = true,


### PR DESCRIPTION
### Motivation
- Implement explicit one-time focus behavior for the File Search dialog so the Search field gets focused exactly once when the dialog is opened, without stealing focus later or when root is clicked.
- Provide stable `egui::Id` sources for Search and Root fields to maintain ownership across frames and ensure root field clicks do not rearm search focus.

### Description
- Added stable ID sources `FILE_SEARCH_SEARCH_FIELD_ID_SOURCE` and `FILE_SEARCH_ROOT_FIELD_ID_SOURCE` and accessors `search_field_id()` and `root_field_id()` in `src/gui/file_search_dialog.rs`.
- Added `request_search_focus: bool` to `FileSearchDialogState` and helper methods `open()`, `open_with_mode()`, `open_and_start(...)`, and `consume_search_focus_request()` to centralize open/focus behavior and preserve existing mode/query/root setup.
- Updated dialog UI to use `.id_source(...)` for both Search and Root `TextEdit`s and to call `response.request_focus()` only when the one-time request flag is set and then immediately consume it; Root uses its own ID and does not rearm search focus when focused/clicked.
- Replaced direct `file_search_dialog.open = true` assignments with `file_search_dialog.open()` (and `open_with_mode` / `open_and_start` where appropriate) in action handling and panel-opening flows (`src/gui/actions.rs`, `src/gui/mod.rs`).
- Added unit tests in `src/gui/file_search_dialog.rs` covering opening focus request, one-time consumption, reopen behavior, distinct IDs for Root/Search, and launcher query separation.

### Testing
- Ran `git diff --check` successfully after changes.
- Attempted `cargo test file_search_dialog --lib`; the test target compilation initially failed due to missing native packages (`alsa`, X11) which were installed during the session, but the full test run ultimately could not complete in this environment because other platform-specific (Windows) APIs are compiled unconditionally on this target and cause build failures; as a result the new unit tests were added but the test run did not finish successfully in this Linux CI environment.
- The following unit tests were added: `opening_file_search_requests_search_focus_once`, `consuming_search_focus_request_clears_flag_after_one_use`, `reopening_file_search_requests_search_focus_again`, `root_field_has_stable_distinct_id_and_does_not_rearm_search_focus`, and `opening_file_search_does_not_depend_on_launcher_query_text`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b733897483329b8e7a779e12438d)