### PR TITLE
Improve file preview handling for oversized files

### DIFF
--- a/src/file_search/preview.rs
+++ b/src/file_search/preview.rs
@@ -1,13 +1,15 @@
 use crate::common::lru::LruCache;
 
 use std::collections::hash_map::DefaultHasher;
+use std::collections::VecDeque;
 use std::fs::{self, File};
 use std::hash::{Hash, Hasher};
-use std::io::{self, Read};
+use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-pub const DEFAULT_MAX_BYTES_PER_PREVIEW: usize = 64 * 1024;
+pub const DEFAULT_MAX_BYTES_FULL_FILE_PREVIEW: usize = 5 * 1024 * 1024;
+pub const DEFAULT_OVERSIZED_BEGINNING_PREVIEW_BYTES: usize = 64 * 1024;
 pub const DEFAULT_MAX_LINES_AROUND_MATCH: usize = 3;
 pub const DEFAULT_BINARY_SAMPLE_BYTES: usize = 8192;
 pub const DEFAULT_CACHE_CAPACITY: usize = 64;
@@ -17,8 +19,9 @@ pub struct PreviewRequest {
     pub path: PathBuf,
     pub line_range: Option<PreviewLineRange>,
     pub selected_match: Option<PreviewMatchSelection>,
-    pub max_bytes_per_preview: usize,
+    pub max_bytes_full_file_preview: usize,
     pub max_lines_around_match: usize,
+    pub oversized_beginning_preview_bytes: usize,
 }
 
 impl PreviewRequest {
@@ -27,21 +30,28 @@ impl PreviewRequest {
             path: path.into(),
             line_range: None,
             selected_match: None,
-            max_bytes_per_preview: DEFAULT_MAX_BYTES_PER_PREVIEW,
+            max_bytes_full_file_preview: DEFAULT_MAX_BYTES_FULL_FILE_PREVIEW,
             max_lines_around_match: DEFAULT_MAX_LINES_AROUND_MATCH,
+            oversized_beginning_preview_bytes: DEFAULT_OVERSIZED_BEGINNING_PREVIEW_BYTES,
         }
     }
 
     pub fn for_match(path: impl Into<PathBuf>, line: usize, column: usize) -> Self {
         Self {
-            selected_match: Some(PreviewMatchSelection { line, column }),
+            selected_match: Some(PreviewMatchSelection {
+                line,
+                source_line: None,
+                start_column: column,
+                end_column: Some(column.saturating_add(1)),
+                match_length: None,
+            }),
             ..Self::new(path)
         }
     }
 
     fn effective_line_range(&self) -> Option<PreviewLineRange> {
         self.line_range.or_else(|| {
-            self.selected_match.map(|selected| {
+            self.selected_match.as_ref().map(|selected| {
                 let start = selected
                     .line
                     .saturating_sub(self.max_lines_around_match)
@@ -59,10 +69,24 @@ pub struct PreviewLineRange {
     pub end: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PreviewMatchSelection {
     pub line: usize,
-    pub column: usize,
+    pub source_line: Option<String>,
+    pub start_column: usize,
+    pub end_column: Option<usize>,
+    pub match_length: Option<usize>,
+}
+
+impl PreviewMatchSelection {
+    fn end_column(&self) -> usize {
+        self.end_column
+            .or_else(|| {
+                self.match_length
+                    .map(|length| self.start_column.saturating_add(length))
+            })
+            .unwrap_or_else(|| self.start_column.saturating_add(1))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,6 +147,10 @@ struct PreviewCacheKey {
     path: PathBuf,
     modified_hash: u64,
     line_range: Option<PreviewLineRange>,
+    selected_match: Option<PreviewMatchSelection>,
+    max_bytes_full_file_preview: usize,
+    max_lines_around_match: usize,
+    oversized_beginning_preview_bytes: usize,
 }
 
 pub struct PreviewCache {
@@ -177,7 +205,11 @@ fn cache_key(request: &PreviewRequest, modified: Option<SystemTime>) -> PreviewC
     PreviewCacheKey {
         path: request.path.clone(),
         modified_hash: hasher.finish(),
-        line_range: request.effective_line_range(),
+        line_range: request.line_range,
+        selected_match: request.selected_match.clone(),
+        max_bytes_full_file_preview: request.max_bytes_full_file_preview,
+        max_lines_around_match: request.max_lines_around_match,
+        oversized_beginning_preview_bytes: request.oversized_beginning_preview_bytes,
     }
 }
 
@@ -189,7 +221,9 @@ fn build_preview(request: &PreviewRequest, metadata: fs::Metadata) -> FilePrevie
             kind: PreviewKind::Directory,
             lines: Vec::new(),
             metadata: preview_metadata,
-            binary_or_unsupported: None,
+            binary_or_unsupported: Some(UnsupportedPreview {
+                reason: "Directories cannot be previewed as text".to_string(),
+            }),
             error: None,
             truncated: false,
             cache_hit: false,
@@ -204,26 +238,41 @@ fn build_preview(request: &PreviewRequest, metadata: fs::Metadata) -> FilePrevie
         );
     }
 
-    match read_bounded(&request.path, request.max_bytes_per_preview) {
-        Ok((bytes, truncated)) => {
-            let sampled = bytes.len().min(DEFAULT_BINARY_SAMPLE_BYTES);
-            let metadata = to_preview_metadata(&metadata, sampled);
-            if is_likely_binary(&bytes[..sampled]) {
-                return FilePreview {
-                    path: request.path.clone(),
-                    kind: PreviewKind::Binary,
-                    lines: Vec::new(),
-                    metadata,
-                    binary_or_unsupported: Some(UnsupportedPreview {
-                        reason: "File appears to be binary".to_string(),
-                    }),
-                    error: None,
-                    truncated,
-                    cache_hit: false,
-                };
-            }
-            text_preview(request, metadata, &bytes, truncated)
-        }
+    let sample_limit = DEFAULT_BINARY_SAMPLE_BYTES.min(metadata.len() as usize);
+    let (sample, _) = match read_bounded(&request.path, sample_limit) {
+        Ok(sample) => sample,
+        Err(error) => return error_preview(&request.path, error),
+    };
+    let sampled = sample.len();
+    let preview_metadata = to_preview_metadata(&metadata, sampled);
+    if is_likely_binary(&sample) {
+        return FilePreview {
+            path: request.path.clone(),
+            kind: PreviewKind::Binary,
+            lines: Vec::new(),
+            metadata: preview_metadata,
+            binary_or_unsupported: Some(UnsupportedPreview {
+                reason: "File appears to be binary".to_string(),
+            }),
+            error: None,
+            truncated: false,
+            cache_hit: false,
+        };
+    }
+
+    if metadata.len() <= request.max_bytes_full_file_preview as u64 {
+        return match fs::read(&request.path) {
+            Ok(bytes) => text_preview(request, preview_metadata, &bytes, false, false),
+            Err(error) => error_preview(&request.path, error),
+        };
+    }
+
+    if request.selected_match.is_some() && request.line_range.is_none() {
+        return oversized_match_preview(request, preview_metadata);
+    }
+
+    match read_bounded(&request.path, request.oversized_beginning_preview_bytes) {
+        Ok((bytes, _)) => text_preview(request, preview_metadata, &bytes, true, true),
         Err(error) => error_preview(&request.path, error),
     }
 }
@@ -233,11 +282,12 @@ fn text_preview(
     metadata: PreviewMetadata,
     bytes: &[u8],
     truncated: bool,
+    beginning_only: bool,
 ) -> FilePreview {
     let text = String::from_utf8_lossy(bytes);
     let lossy = matches!(text, std::borrow::Cow::Owned(_));
     let range = request.effective_line_range();
-    let selected = request.selected_match;
+    let selected = request.selected_match.as_ref();
     let mut lines = Vec::new();
 
     for (idx, line) in text.lines().enumerate() {
@@ -250,23 +300,19 @@ fn text_preview(
                 break;
             }
         }
-        let mut match_ranges = Vec::new();
-        if let Some(selected) = selected {
-            if selected.line == line_number {
-                let start = selected.column.saturating_sub(1).min(line.chars().count());
-                let end = (start + 1).min(line.chars().count());
-                match_ranges.push(PreviewMatchRange {
-                    start_column: start + 1,
-                    end_column: end + 1,
-                });
-            }
-        }
-        lines.push(PreviewLine {
-            line_number,
-            text: line.to_string(),
-            match_ranges,
-        });
+        lines.push(preview_line(line_number, line.to_string(), selected));
     }
+
+    let reason = if lossy {
+        Some("File contains invalid UTF-8; preview uses replacement characters".to_string())
+    } else if beginning_only {
+        Some(
+            "File is larger than the full-file preview limit; showing the beginning only"
+                .to_string(),
+        )
+    } else {
+        None
+    };
 
     FilePreview {
         path: request.path.clone(),
@@ -277,12 +323,122 @@ fn text_preview(
         },
         lines,
         metadata,
-        binary_or_unsupported: lossy.then(|| UnsupportedPreview {
-            reason: "File contains invalid UTF-8; preview uses replacement characters".to_string(),
-        }),
+        binary_or_unsupported: reason.map(|reason| UnsupportedPreview { reason }),
         error: None,
         truncated,
         cache_hit: false,
+    }
+}
+
+fn oversized_match_preview(request: &PreviewRequest, metadata: PreviewMetadata) -> FilePreview {
+    let selected = request.selected_match.as_ref().expect("checked above");
+    let end = selected.line.saturating_add(request.max_lines_around_match);
+    let file = match File::open(&request.path) {
+        Ok(file) => file,
+        Err(error) => return error_preview(&request.path, error),
+    };
+    let mut reader = BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut before: VecDeque<PreviewLine> = VecDeque::with_capacity(request.max_lines_around_match);
+    let mut lines = Vec::new();
+    let mut line_number = 0usize;
+    let mut found = false;
+
+    loop {
+        buf.clear();
+        let read = match reader.read_until(b'\n', &mut buf) {
+            Ok(read) => read,
+            Err(error) => return error_preview(&request.path, error),
+        };
+        if read == 0 {
+            break;
+        }
+        line_number += 1;
+        while matches!(buf.last(), Some(b'\n' | b'\r')) {
+            buf.pop();
+        }
+        let text = String::from_utf8_lossy(&buf).into_owned();
+        let preview = preview_line(line_number, text, Some(selected));
+
+        if !found {
+            if line_number == selected.line {
+                found = true;
+                lines.extend(before.drain(..));
+                lines.push(preview);
+                if request.max_lines_around_match == 0 {
+                    break;
+                }
+            } else {
+                if before.len() == request.max_lines_around_match {
+                    before.pop_front();
+                }
+                before.push_back(preview);
+            }
+            continue;
+        }
+
+        lines.push(preview);
+        if line_number >= end {
+            break;
+        }
+    }
+
+    if !found {
+        return FilePreview {
+            path: request.path.clone(),
+            kind: PreviewKind::Unsupported,
+            lines: Vec::new(),
+            metadata,
+            binary_or_unsupported: Some(UnsupportedPreview {
+                reason: "Selected match line no longer exists; the file may have changed"
+                    .to_string(),
+            }),
+            error: None,
+            truncated: true,
+            cache_hit: false,
+        };
+    }
+
+    FilePreview {
+        path: request.path.clone(),
+        kind: PreviewKind::Text,
+        lines,
+        metadata,
+        binary_or_unsupported: Some(UnsupportedPreview {
+            reason: "File is larger than the full-file preview limit; showing context around the selected match".to_string(),
+        }),
+        error: None,
+        truncated: true,
+        cache_hit: false,
+    }
+}
+
+fn preview_line(
+    line_number: usize,
+    text: String,
+    selected: Option<&PreviewMatchSelection>,
+) -> PreviewLine {
+    let mut match_ranges = Vec::new();
+    if let Some(selected) = selected {
+        if selected.line == line_number {
+            let chars = text.chars().count();
+            let start = selected.start_column.saturating_sub(1).min(chars);
+            let end = selected
+                .end_column()
+                .saturating_sub(1)
+                .min(chars)
+                .max(start + 1)
+                .min(chars);
+            match_ranges.push(PreviewMatchRange {
+                start_column: start + 1,
+                end_column: end + 1,
+            });
+        }
+    }
+    PreviewLine {
+        line_number,
+        text,
+        match_ranges,
     }
 }
 
@@ -373,7 +529,8 @@ mod tests {
         let path = dir.path().join("large.txt");
         write_file(&path, b"abcdef");
         let mut request = PreviewRequest::new(&path);
-        request.max_bytes_per_preview = 3;
+        request.max_bytes_full_file_preview = 3;
+        request.oversized_beginning_preview_bytes = 3;
         let preview = preview_file(&request);
         assert!(preview.truncated);
         assert_eq!(preview.lines[0].text, "abc");
@@ -386,7 +543,8 @@ mod tests {
         let path = dir.path().join("large.txt");
         write_file(&path, &vec![b'a'; 1024 * 1024]);
         let mut request = PreviewRequest::new(&path);
-        request.max_bytes_per_preview = 128;
+        request.max_bytes_full_file_preview = 128;
+        request.oversized_beginning_preview_bytes = 128;
         let preview = preview_file(&request);
         assert!(preview.truncated);
         assert_eq!(preview.lines[0].text.len(), 128);
@@ -400,13 +558,11 @@ mod tests {
         write_file(&path, b"abc\0def");
         let preview = preview_file(&PreviewRequest::new(&path));
         assert_eq!(preview.kind, PreviewKind::Binary);
-        assert!(
-            preview
-                .binary_or_unsupported
-                .unwrap()
-                .reason
-                .contains("binary")
-        );
+        assert!(preview
+            .binary_or_unsupported
+            .unwrap()
+            .reason
+            .contains("binary"));
     }
 
     #[test]
@@ -417,13 +573,11 @@ mod tests {
         let preview = preview_file(&PreviewRequest::new(&path));
         assert_eq!(preview.kind, PreviewKind::Unsupported);
         assert_eq!(preview.lines[0].text, "ok�bad");
-        assert!(
-            preview
-                .binary_or_unsupported
-                .unwrap()
-                .reason
-                .contains("invalid UTF-8")
-        );
+        assert!(preview
+            .binary_or_unsupported
+            .unwrap()
+            .reason
+            .contains("invalid UTF-8"));
     }
 
     #[test]
@@ -467,6 +621,177 @@ mod tests {
                 end_column: 3
             }]
         );
+    }
+
+    #[test]
+    fn small_file_below_5_mib_loads_completely_even_with_selected_match() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("small.txt");
+        write_file(
+            &path,
+            b"one
+two match
+three
+",
+        );
+        let preview = preview_file(&PreviewRequest::for_match(&path, 2, 5));
+        assert!(!preview.truncated);
+        assert_eq!(preview.lines.len(), 3);
+        assert_eq!(preview.lines[1].text, "two match");
+    }
+
+    #[test]
+    fn selected_match_in_middle_of_small_file_is_included() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("small-middle.txt");
+        write_file(
+            &path,
+            b"one
+two
+needle here
+four
+five
+",
+        );
+        let preview = preview_file(&PreviewRequest::for_match(&path, 3, 1));
+        assert_eq!(
+            preview
+                .lines
+                .iter()
+                .map(|line| line.line_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5]
+        );
+        assert_eq!(
+            preview.lines[2].match_ranges[0],
+            PreviewMatchRange {
+                start_column: 1,
+                end_column: 2
+            }
+        );
+    }
+
+    #[test]
+    fn oversized_file_returns_context_around_late_match() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("late.txt");
+        let mut contents = String::new();
+        for line in 1..=10_000 {
+            contents.push_str(&format!(
+                "line {line}
+"
+            ));
+        }
+        write_file(&path, contents.as_bytes());
+        let mut request = PreviewRequest::for_match(&path, 9_000, 6);
+        request.max_bytes_full_file_preview = 128;
+        request.max_lines_around_match = 2;
+        let preview = preview_file(&request);
+        assert!(preview.truncated);
+        assert_eq!(
+            preview
+                .lines
+                .iter()
+                .map(|line| line.line_number)
+                .collect::<Vec<_>>(),
+            vec![8998, 8999, 9000, 9001, 9002]
+        );
+        assert_eq!(preview.lines[2].text, "line 9000");
+    }
+
+    #[test]
+    fn oversized_context_extraction_does_not_retain_whole_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bounded-context.txt");
+        let mut contents = String::new();
+        for line in 1..=20_000 {
+            contents.push_str(&format!(
+                "line {line}
+"
+            ));
+        }
+        write_file(&path, contents.as_bytes());
+        let mut request = PreviewRequest::for_match(&path, 15_000, 6);
+        request.max_bytes_full_file_preview = 256;
+        request.max_lines_around_match = 3;
+        let preview = preview_file(&request);
+        assert_eq!(preview.lines.len(), 7);
+        assert!(preview
+            .lines
+            .iter()
+            .all(|line| line.line_number >= 14_997 && line.line_number <= 15_003));
+    }
+
+    #[test]
+    fn oversized_source_line_numbers_are_preserved() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("numbers.txt");
+        let mut contents = String::new();
+        for line in 1..=300 {
+            contents.push_str(&format!(
+                "line {line}
+"
+            ));
+        }
+        write_file(&path, contents.as_bytes());
+        let mut request = PreviewRequest::for_match(&path, 250, 1);
+        request.max_bytes_full_file_preview = 32;
+        request.max_lines_around_match = 1;
+        let preview = preview_file(&request);
+        assert_eq!(
+            preview
+                .lines
+                .iter()
+                .map(|line| line.line_number)
+                .collect::<Vec<_>>(),
+            vec![249, 250, 251]
+        );
+    }
+
+    #[test]
+    fn oversized_preview_without_match_returns_bounded_beginning_plus_warning() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("beginning.txt");
+        write_file(
+            &path,
+            b"abcdef
+ghijkl
+",
+        );
+        let mut request = PreviewRequest::new(&path);
+        request.max_bytes_full_file_preview = 4;
+        request.oversized_beginning_preview_bytes = 4;
+        let preview = preview_file(&request);
+        assert!(preview.truncated);
+        assert_eq!(preview.lines[0].text, "abcd");
+        assert!(preview
+            .binary_or_unsupported
+            .unwrap()
+            .reason
+            .contains("beginning only"));
+    }
+
+    #[test]
+    fn selected_line_beyond_eof_reports_missing_line_state() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("changed.txt");
+        write_file(
+            &path,
+            b"one
+two
+three
+",
+        );
+        let mut request = PreviewRequest::for_match(&path, 10, 1);
+        request.max_bytes_full_file_preview = 1;
+        let preview = preview_file(&request);
+        assert_eq!(preview.kind, PreviewKind::Unsupported);
+        assert!(preview.lines.is_empty());
+        assert!(preview
+            .binary_or_unsupported
+            .unwrap()
+            .reason
+            .contains("no longer exists"));
     }
 
     #[test]

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -886,14 +886,29 @@ impl FileSearchDialogState {
     ) -> PreviewRequest {
         let request = first_match
             .map(|content_match| {
-                PreviewRequest::for_match(
+                let mut request = PreviewRequest::for_match(
                     path,
                     content_match.line_number,
                     content_match
                         .column
                         .map(|column| column.saturating_add(1))
                         .unwrap_or(1),
-                )
+                );
+                if let Some(selection) = request.selected_match.as_mut() {
+                    selection.source_line = Some(content_match.line.clone());
+                    selection.match_length = Some(
+                        content_match
+                            .byte_end
+                            .saturating_sub(content_match.byte_start)
+                            .max(1),
+                    );
+                    selection.end_column = Some(
+                        selection
+                            .start_column
+                            .saturating_add(selection.match_length.unwrap_or(1)),
+                    );
+                }
+                request
             })
             .unwrap_or_else(|| PreviewRequest::new(path));
         self.last_preview_request = Some(request.clone());
@@ -1753,8 +1768,12 @@ mod tests {
         let request = state.request_preview(&path, Some(&content_match));
 
         assert_eq!(request.path, path);
-        assert_eq!(request.selected_match.unwrap().line, 12);
-        assert_eq!(request.selected_match.unwrap().column, 7);
+        let selected_match = request.selected_match.as_ref().unwrap();
+        assert_eq!(selected_match.line, 12);
+        assert_eq!(selected_match.start_column, 7);
+        assert_eq!(selected_match.source_line.as_deref(), Some("hello needle"));
+        assert_eq!(selected_match.match_length, Some(6));
+        assert_eq!(selected_match.end_column, Some(13));
         assert_eq!(state.last_preview_request, Some(request));
     }
 
@@ -2102,12 +2121,10 @@ mod tests {
 
         assert!(action.is_none());
         assert_eq!(state.selected_result().cloned(), selected_before);
-        assert!(
-            state
-                .warning_error_message
-                .as_deref()
-                .is_some_and(|message| message.contains("missing or inaccessible"))
-        );
+        assert!(state
+            .warning_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("missing or inaccessible")));
     }
 
     #[test]
@@ -2120,7 +2137,7 @@ mod tests {
         match action {
             Some(OpenSelectedFileSearchResultAction::PreviewContent { request }) => {
                 assert_eq!(request.path, PathBuf::from(path));
-                assert_eq!(request.selected_match.unwrap().line, 1);
+                assert_eq!(request.selected_match.as_ref().unwrap().line, 1);
                 assert_eq!(state.last_preview_request, Some(request));
             }
             other => panic!("expected preview action, got {other:?}"),


### PR DESCRIPTION
### Motivation
- Replace the old fixed per-preview byte behavior with a request-configurable full-file preview limit (default 5 MiB) and a separate bounded beginning-preview size to support large files without loading them into memory.
- Carry richer match selection data so previews can highlight matches accurately and avoid relying on callers to provide byte/column-only hints.
- Avoid reading entire oversized files to extract context around late matches by streaming line-oriented data and keeping only a bounded rolling buffer.

### Description
- Replaced `DEFAULT_MAX_BYTES_PER_PREVIEW` with `DEFAULT_MAX_BYTES_FULL_FILE_PREVIEW = 5 MiB` and added `DEFAULT_OVERSIZED_BEGINNING_PREVIEW_BYTES` for bounded beginning previews.
- Updated `PreviewRequest` to include `path`, optional `line_range`, optional `selected_match`, `max_bytes_full_file_preview`, `max_lines_around_match`, and `oversized_beginning_preview_bytes`.
- Expanded `PreviewMatchSelection` to carry `source_line`, `start_column`, optional `end_column`, and optional `match_length`, and added an `end_column()` helper for consistent end calculation.
- Reworked preview generation (`build_preview` / `text_preview`) to: read metadata first; return user-visible previews for directories/unsupported entries; sample a small prefix to detect binaries; fully read files under the full-file limit; stream oversized files to extract match context with a bounded `VecDeque` for preceding lines; return a bounded beginning preview with a warning when no match is selected.
- Implemented `oversized_match_preview` with buffered, line-oriented reading that preserves original source line numbers, uses lossy UTF-8 per captured line, stops once trailing context is complete, and reports a user-facing error if the selected line no longer exists.
- Added `preview_line` helper to centralize match-range calculation and highlighting logic.
- Updated GUI `request_preview` to populate `selected_match.source_line`, `match_length`, and `end_column` from `ContentMatch` so callers provide richer selection metadata.
- Added unit tests in `src/file_search/preview.rs` covering full-file loading for small files, selected-match inclusion, oversized late-match context extraction, bounded context retention (does not retain whole file), preserved source line numbers, beginning-only oversized previews with a warning, and selected-line-beyond-EOF handling.

### Testing
- Ran `rustfmt` on modified files and `git diff --check` successfully.
- Added multiple unit tests under `src/file_search/preview.rs` (see file) exercising small-file full reads, match context extraction, oversized streaming behavior, and edge cases.
- Attempted `cargo test preview --lib`, but test execution was blocked by unrelated platform/system dependencies during the build (missing system libraries and Windows-specific `windows::Win32`/`windows::core` symbols) so the new preview tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53eae462c4833280c8ac6f3962d1c9)