### PR TITLE
Load file previews asynchronously with request-state machine

### DIFF
--- a/src/file_search/preview.rs
+++ b/src/file_search/preview.rs
@@ -12,6 +12,78 @@ pub const DEFAULT_MAX_LINES_AROUND_MATCH: usize = 3;
 pub const DEFAULT_BINARY_SAMPLE_BYTES: usize = 8192;
 pub const DEFAULT_CACHE_CAPACITY: usize = 64;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreviewLoadingState {
+    Idle,
+    Loading {
+        request_id: u64,
+    },
+    Loaded {
+        request_id: u64,
+        preview: FilePreview,
+    },
+    Failed {
+        request_id: u64,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreviewLoadOutcome {
+    Loaded(FilePreview),
+    Failed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewLoadStateMachine {
+    next_request_id: u64,
+    pub current_request_id: Option<u64>,
+    pub state: PreviewLoadingState,
+}
+
+impl Default for PreviewLoadStateMachine {
+    fn default() -> Self {
+        Self {
+            next_request_id: 0,
+            current_request_id: None,
+            state: PreviewLoadingState::Idle,
+        }
+    }
+}
+
+impl PreviewLoadStateMachine {
+    pub fn begin_request(&mut self) -> u64 {
+        self.next_request_id = self.next_request_id.saturating_add(1);
+        let request_id = self.next_request_id;
+        self.current_request_id = Some(request_id);
+        self.state = PreviewLoadingState::Loading { request_id };
+        request_id
+    }
+
+    pub fn complete_request(&mut self, request_id: u64, outcome: PreviewLoadOutcome) -> bool {
+        if self.current_request_id != Some(request_id) {
+            return false;
+        }
+        self.state = match outcome {
+            PreviewLoadOutcome::Loaded(preview) => PreviewLoadingState::Loaded {
+                request_id,
+                preview,
+            },
+            PreviewLoadOutcome::Failed(error) => PreviewLoadingState::Failed { request_id, error },
+        };
+        true
+    }
+
+    pub fn clear(&mut self) {
+        self.current_request_id = None;
+        self.state = PreviewLoadingState::Idle;
+    }
+
+    pub fn is_loading(&self) -> bool {
+        matches!(self.state, PreviewLoadingState::Loading { .. })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PreviewRequest {
     pub path: PathBuf,
@@ -645,6 +717,96 @@ mod tests {
         file.sync_all().unwrap();
     }
 
+    fn preview_for_state_machine(path: &str, text: &str) -> FilePreview {
+        FilePreview {
+            path: PathBuf::from(path),
+            kind: PreviewKind::Text,
+            lines: vec![PreviewLine {
+                line_number: 1,
+                text: text.to_string(),
+                match_ranges: Vec::new(),
+            }],
+            metadata: PreviewMetadata {
+                is_directory: false,
+                len_bytes: text.len() as u64,
+                modified: None,
+                readonly: false,
+                sampled_bytes: text.len(),
+            },
+            binary_or_unsupported: None,
+            error: None,
+            coverage: PreviewCoverage::Complete,
+            displayed_start_line: Some(1),
+            displayed_end_line: Some(1),
+            warnings: Vec::new(),
+            lossy_utf8: false,
+            cache_hit: false,
+        }
+    }
+
+    #[test]
+    fn preview_state_machine_new_request_increments_request_id() {
+        let mut state = PreviewLoadStateMachine::default();
+        let first = state.begin_request();
+        let second = state.begin_request();
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+        assert_eq!(state.current_request_id, Some(second));
+        assert_eq!(
+            state.state,
+            PreviewLoadingState::Loading { request_id: second }
+        );
+    }
+
+    #[test]
+    fn preview_state_machine_ignores_stale_response() {
+        let mut state = PreviewLoadStateMachine::default();
+        let stale = state.begin_request();
+        let current = state.begin_request();
+        let accepted = state.complete_request(
+            stale,
+            PreviewLoadOutcome::Loaded(preview_for_state_machine("stale.txt", "stale")),
+        );
+        assert!(!accepted);
+        assert_eq!(
+            state.state,
+            PreviewLoadingState::Loading {
+                request_id: current
+            }
+        );
+    }
+
+    #[test]
+    fn preview_state_machine_accepts_current_response() {
+        let mut state = PreviewLoadStateMachine::default();
+        let current = state.begin_request();
+        let preview = preview_for_state_machine("current.txt", "current");
+        let accepted = state.complete_request(current, PreviewLoadOutcome::Loaded(preview.clone()));
+        assert!(accepted);
+        assert_eq!(
+            state.state,
+            PreviewLoadingState::Loaded {
+                request_id: current,
+                preview
+            }
+        );
+    }
+
+    #[test]
+    fn preview_state_machine_new_request_clears_loaded_result_until_response_arrives() {
+        let mut state = PreviewLoadStateMachine::default();
+        let first = state.begin_request();
+        assert!(state.complete_request(
+            first,
+            PreviewLoadOutcome::Loaded(preview_for_state_machine("first.txt", "first")),
+        ));
+        let second = state.begin_request();
+        assert_eq!(
+            state.state,
+            PreviewLoadingState::Loading { request_id: second }
+        );
+    }
+
     #[test]
     fn bounded_reads_mark_beginning_only_coverage() {
         let dir = tempdir().unwrap();
@@ -684,11 +846,13 @@ mod tests {
         assert_eq!(preview.kind, PreviewKind::Binary);
         assert_eq!(preview.coverage, PreviewCoverage::BinaryUnsupported);
         assert!(preview.lines.is_empty());
-        assert!(preview
-            .binary_or_unsupported
-            .unwrap()
-            .reason
-            .contains("binary"));
+        assert!(
+            preview
+                .binary_or_unsupported
+                .unwrap()
+                .reason
+                .contains("binary")
+        );
     }
 
     #[test]
@@ -701,10 +865,12 @@ mod tests {
         assert_eq!(preview.coverage, PreviewCoverage::Complete);
         assert!(preview.lossy_utf8);
         assert_eq!(preview.lines[0].text, "ok�bad");
-        assert!(preview
-            .warnings
-            .iter()
-            .any(|warning| warning.contains("replacement characters")));
+        assert!(
+            preview
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("replacement characters"))
+        );
     }
 
     #[test]
@@ -843,10 +1009,12 @@ five
         request.max_lines_around_match = 3;
         let preview = preview_file(&request);
         assert_eq!(preview.lines.len(), 7);
-        assert!(preview
-            .lines
-            .iter()
-            .all(|line| line.line_number >= 14_997 && line.line_number <= 15_003));
+        assert!(
+            preview
+                .lines
+                .iter()
+                .all(|line| line.line_number >= 14_997 && line.line_number <= 15_003)
+        );
     }
 
     #[test]
@@ -891,11 +1059,13 @@ ghijkl
         let preview = preview_file(&request);
         assert_eq!(preview.coverage, PreviewCoverage::BeginningOnly);
         assert_eq!(preview.lines[0].text, "abcd");
-        assert!(preview
-            .binary_or_unsupported
-            .unwrap()
-            .reason
-            .contains("beginning only"));
+        assert!(
+            preview
+                .binary_or_unsupported
+                .unwrap()
+                .reason
+                .contains("beginning only")
+        );
     }
 
     #[test]
@@ -915,11 +1085,13 @@ three
         assert_eq!(preview.kind, PreviewKind::Unsupported);
         assert_eq!(preview.coverage, PreviewCoverage::Unsupported);
         assert!(preview.lines.is_empty());
-        assert!(preview
-            .binary_or_unsupported
-            .unwrap()
-            .reason
-            .contains("no longer exists"));
+        assert!(
+            preview
+                .binary_or_unsupported
+                .unwrap()
+                .reason
+                .contains("no longer exists")
+        );
     }
 
     #[test]
@@ -930,10 +1102,12 @@ three
         assert_eq!(preview.kind, PreviewKind::Error);
         assert_eq!(preview.coverage, PreviewCoverage::ReadError);
         assert!(preview.error.is_some());
-        assert!(preview
-            .warnings
-            .iter()
-            .any(|warning| warning.contains("Unable to read preview")));
+        assert!(
+            preview
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Unable to read preview"))
+        );
     }
 
     #[test]

--- a/src/gui/file_search_preview_dialog.rs
+++ b/src/gui/file_search_preview_dialog.rs
@@ -1,9 +1,14 @@
 use crate::file_search::actions::{InvocationTarget, open_in_configured_editor};
 use crate::file_search::model::ContentMatch;
-use crate::file_search::preview::{FilePreview, PreviewCache, PreviewKind, PreviewRequest};
+use crate::file_search::preview::{
+    FilePreview, PreviewKind, PreviewLoadOutcome, PreviewLoadStateMachine, PreviewLoadingState,
+    PreviewRequest, preview_file,
+};
 use crate::file_search::settings::FileSearchSettings;
 use eframe::egui;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 const DEFAULT_PREVIEW_WINDOW_SIZE: egui::Vec2 = egui::vec2(860.0, 620.0);
 
@@ -33,7 +38,8 @@ pub struct FileSearchPreviewDialogState {
     pub pending_auto_scroll: bool,
     pub persisted_window_size: egui::Vec2,
     pub reset_horizontal_scroll: bool,
-    preview_cache: PreviewCache,
+    load_state: PreviewLoadStateMachine,
+    preview_result_rx: Option<Receiver<(u64, PreviewLoadOutcome)>>,
 }
 
 impl std::fmt::Debug for FileSearchPreviewDialogState {
@@ -66,7 +72,8 @@ impl Clone for FileSearchPreviewDialogState {
             pending_auto_scroll: self.pending_auto_scroll,
             persisted_window_size: self.persisted_window_size,
             reset_horizontal_scroll: self.reset_horizontal_scroll,
-            preview_cache: PreviewCache::default(),
+            load_state: self.load_state.clone(),
+            preview_result_rx: None,
         }
     }
 }
@@ -99,7 +106,8 @@ impl Default for FileSearchPreviewDialogState {
             pending_auto_scroll: false,
             persisted_window_size: DEFAULT_PREVIEW_WINDOW_SIZE,
             reset_horizontal_scroll: false,
-            preview_cache: PreviewCache::default(),
+            load_state: PreviewLoadStateMachine::default(),
+            preview_result_rx: None,
         }
     }
 }
@@ -143,24 +151,75 @@ impl FileSearchPreviewDialogState {
         self.action_error_message = None;
         self.reset_horizontal_scroll = true;
         self.pending_auto_scroll = true;
-        self.load_current_preview();
+        self.start_loading_current_preview();
     }
 
     pub fn load_current_preview(&mut self) {
+        self.start_loading_current_preview();
+    }
+
+    pub fn start_loading_current_preview(&mut self) {
         let Some(request) = self.current_request.clone() else {
             self.loaded_preview = None;
             self.loading = false;
+            self.load_state.clear();
+            self.preview_result_rx = None;
             return;
         };
-        let preview = self.preview_cache.preview(&request);
-        self.load_error_message = preview.error.as_ref().map(|error| error.message.clone());
-        self.loaded_preview = Some(preview);
-        self.loading = false;
+
+        self.loaded_preview = None;
+        self.loading = true;
+        self.load_error_message = None;
+        let request_id = self.load_state.begin_request();
+        let (tx, rx) = mpsc::channel();
+        self.preview_result_rx = Some(rx);
+        thread::spawn(move || {
+            let preview = preview_file(&request);
+            let outcome = preview
+                .error
+                .as_ref()
+                .map(|error| PreviewLoadOutcome::Failed(error.message.clone()))
+                .unwrap_or_else(|| PreviewLoadOutcome::Loaded(preview));
+            let _ = tx.send((request_id, outcome));
+        });
+    }
+
+    fn poll_preview_result(&mut self) {
+        let Some(rx) = self.preview_result_rx.take() else {
+            return;
+        };
+        let mut keep_rx = true;
+        while let Ok((request_id, outcome)) = rx.try_recv() {
+            let accepted = self.load_state.complete_request(request_id, outcome);
+            if accepted {
+                match &self.load_state.state {
+                    PreviewLoadingState::Loaded { preview, .. } => {
+                        self.load_error_message = None;
+                        self.loaded_preview = Some(preview.clone());
+                        self.loading = false;
+                    }
+                    PreviewLoadingState::Failed { error, .. } => {
+                        self.load_error_message = Some(error.clone());
+                        self.loaded_preview = None;
+                        self.loading = false;
+                    }
+                    _ => {}
+                }
+                keep_rx = false;
+            }
+        }
+        if keep_rx {
+            self.preview_result_rx = Some(rx);
+        }
     }
 
     pub fn ui(&mut self, ctx: &egui::Context, settings: &FileSearchSettings) {
         if !self.open {
             return;
+        }
+        self.poll_preview_result();
+        if self.load_state.is_loading() {
+            ctx.request_repaint();
         }
         let mut open = self.open;
         let mut size_to_persist = None;
@@ -205,7 +264,10 @@ impl FileSearchPreviewDialogState {
             ui.colored_label(egui::Color32::YELLOW, error);
         }
         if self.loading {
-            ui.spinner();
+            ui.horizontal(|ui| {
+                ui.spinner();
+                ui.label("Loading…");
+            });
             return;
         }
         let Some(preview) = &self.loaded_preview else {


### PR DESCRIPTION
### Motivation
- Avoid running `preview_file` synchronously from GUI render paths to prevent expensive work every frame and to provide clear loading/failure semantics.
- Introduce an explicit loading state so the preview UI can show a lightweight `Loading…` indicator and ignore stale results.

### Description
- Add `PreviewLoadingState`, `PreviewLoadOutcome`, and `PreviewLoadStateMachine` to `src/file_search/preview.rs` to track `Idle`, `Loading { request_id }`, `Loaded { request_id, preview }`, and `Failed { request_id, error }` states with a monotonically increasing request id.
- Update `src/gui/file_search_preview_dialog.rs` to start preview loads only on explicit requests, spawn a worker thread to call `preview_file`, send results back over an `mpsc` channel, poll for responses in `ui()`, request repaints while loading, and ignore stale responses by matching request IDs.
- Replace synchronous cache-based loading in the dialog with the new asynchronous flow and show a compact `Loading…` UI while a worker is active.
- Add focused unit tests exercising the pure state-machine behavior in `src/file_search/preview.rs` that verify request-id incrementing, stale-response rejection, acceptance of current responses, and clearing of loaded results when a new request starts.

### Testing
- Ran `cargo fmt` successfully on the modified sources.
- Attempted `cargo test preview_state_machine --lib`; the new tests are present, but the test run could not complete due to unrelated platform-specific native dependency and Windows-target build steps in the workspace (the run encountered native package checks and unresolved `windows::Win32` imports while compiling the full crate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54145f25848332b2f6def2c29153eb)