### PR TITLE
File search: Add configurable full-file preview limit (5 MiB)

### DIFF
--- a/src/file_search/settings.rs
+++ b/src/file_search/settings.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::PathBuf;
 
+pub const DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+
 /// Settings used to construct and validate file-search requests/backends.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -11,6 +13,7 @@ pub struct FileSearchSettings {
     pub max_search_results: usize,
     pub max_matches_per_content_file: usize,
     pub max_content_search_file_size_bytes: u64,
+    pub max_full_preview_file_size_bytes: u64,
     pub include_hidden_files: bool,
     pub case_sensitive: bool,
     pub everything_executable_path: PathBuf,
@@ -74,6 +77,7 @@ pub struct FileSearchDiagnosticsState {
     pub last_backend_error: Option<String>,
     pub inaccessible_entry_count: usize,
     pub preview_cache_usage: String,
+    pub max_full_preview_file_size_bytes: u64,
 }
 
 impl FileSearchDiagnosticsState {
@@ -102,6 +106,7 @@ impl FileSearchDiagnosticsState {
             last_backend_error: None,
             inaccessible_entry_count: 0,
             preview_cache_usage: "0 entries".to_owned(),
+            max_full_preview_file_size_bytes: settings.max_full_preview_file_size_bytes,
         }
     }
 }
@@ -110,7 +115,7 @@ impl fmt::Display for FileSearchDiagnosticsState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Use Everything for global filename search: {}; detected es.exe: {}; detected rg: {}; valid roots: {}; invalid roots: {}; current backend: {}; active search state: {}; last search duration: {}; last result count: {}; last backend error: {}; inaccessible entries: {}; preview cache: {}",
+            "Use Everything for global filename search: {}; detected es.exe: {}; detected rg: {}; valid roots: {}; invalid roots: {}; current backend: {}; active search state: {}; last search duration: {}; last result count: {}; last backend error: {}; inaccessible entries: {}; preview cache: {}; full-file preview limit: {} bytes",
             self.everything_enabled,
             self.detected_everything
                 .as_ref()
@@ -130,7 +135,8 @@ impl fmt::Display for FileSearchDiagnosticsState {
             self.last_result_count,
             self.last_backend_error.as_deref().unwrap_or("none"),
             self.inaccessible_entry_count,
-            self.preview_cache_usage
+            self.preview_cache_usage,
+            self.max_full_preview_file_size_bytes
         )
     }
 }
@@ -158,6 +164,7 @@ impl Default for FileSearchSettings {
             max_search_results: 500,
             max_matches_per_content_file: 25,
             max_content_search_file_size_bytes: 2 * 1024 * 1024,
+            max_full_preview_file_size_bytes: DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES,
             include_hidden_files: false,
             case_sensitive: false,
             everything_executable_path: PathBuf::from("Everything.exe"),
@@ -271,6 +278,14 @@ impl FileSearchSettings {
             });
         }
 
+        if self.max_full_preview_file_size_bytes == 0 {
+            diagnostics.push(FileSearchSettingsDiagnostic::UnusableMaxValue {
+                field: "max_full_preview_file_size_bytes",
+                value: self.max_full_preview_file_size_bytes,
+                message: "must be greater than zero".to_owned(),
+            });
+        }
+
         diagnostics
     }
 }
@@ -310,6 +325,10 @@ mod tests {
         assert_eq!(settings.max_search_results, 500);
         assert_eq!(settings.max_matches_per_content_file, 25);
         assert_eq!(settings.max_content_search_file_size_bytes, 2 * 1024 * 1024);
+        assert_eq!(
+            settings.max_full_preview_file_size_bytes,
+            DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES
+        );
         assert!(!settings.include_hidden_files);
         assert!(!settings.case_sensitive);
         assert_eq!(
@@ -332,6 +351,7 @@ mod tests {
             max_search_results: 0,
             max_matches_per_content_file: 0,
             max_content_search_file_size_bytes: 0,
+            max_full_preview_file_size_bytes: 0,
             ..FileSearchSettings::default()
         };
 
@@ -359,6 +379,32 @@ mod tests {
             diagnostic,
             FileSearchSettingsDiagnostic::UnusableMaxValue {
                 field: "max_content_search_file_size_bytes",
+                ..
+            }
+        )));
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            FileSearchSettingsDiagnostic::UnusableMaxValue {
+                field: "max_full_preview_file_size_bytes",
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn zero_preview_limit_creates_validation_diagnostic() {
+        let settings = FileSearchSettings {
+            max_full_preview_file_size_bytes: 0,
+            ..FileSearchSettings::default()
+        };
+
+        let diagnostics = settings.validate_max_values();
+
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            FileSearchSettingsDiagnostic::UnusableMaxValue {
+                field: "max_full_preview_file_size_bytes",
+                value: 0,
                 ..
             }
         )));
@@ -432,6 +478,39 @@ mod diagnostics_state_tests {
             FileSearchSettings::default().max_matches_per_content_file
         );
         assert_eq!(parsed.ripgrep_executable_path, PathBuf::from("rg"));
+        assert_eq!(
+            parsed.max_full_preview_file_size_bytes,
+            DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES
+        );
+    }
+
+    #[test]
+    fn existing_settings_json_without_preview_limit_remains_deserializable() {
+        let parsed: FileSearchSettings = serde_json::from_str(
+            r#"{
+                "global_content_search_roots": [],
+                "excluded_directory_names": [".git", "target"],
+                "max_search_results": 123,
+                "max_matches_per_content_file": 10,
+                "max_content_search_file_size_bytes": 4096,
+                "include_hidden_files": true,
+                "case_sensitive": true,
+                "everything_executable_path": "Everything.exe",
+                "ripgrep_executable_path": "rg",
+                "everything_enabled": false,
+                "preferred_editor_command": "",
+                "preferred_editor_args": [],
+                "preferred_terminal_command": "",
+                "preferred_terminal_args": []
+            }"#,
+        )
+        .expect("old settings JSON should deserialize");
+
+        assert_eq!(parsed.max_search_results, 123);
+        assert_eq!(
+            parsed.max_full_preview_file_size_bytes,
+            DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES
+        );
     }
 
     #[test]
@@ -444,6 +523,7 @@ mod diagnostics_state_tests {
             max_search_results: 0,
             max_matches_per_content_file: 0,
             max_content_search_file_size_bytes: 0,
+            max_full_preview_file_size_bytes: 0,
             ..FileSearchSettings::default()
         };
         let diagnostics = settings.validate();
@@ -465,11 +545,13 @@ mod diagnostics_state_tests {
             last_backend_error: Some("boom".into()),
             inaccessible_entry_count: 3,
             preview_cache_usage: "2 entries".into(),
+            max_full_preview_file_size_bytes: DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES,
         };
         let formatted = state.to_string();
         assert!(formatted.contains("Use Everything for global filename search: true"));
         assert!(formatted.contains("current backend: ripgrep"));
         assert!(formatted.contains("preview cache: 2 entries"));
+        assert!(formatted.contains("full-file preview limit: 5242880 bytes"));
     }
 
     #[test]

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -880,12 +880,20 @@ impl FileSearchDialogState {
         self.open_selected_result()
     }
 
+    fn apply_preview_settings_to_request(&self, request: &mut PreviewRequest) {
+        request.max_bytes_full_file_preview = self
+            .settings
+            .max_full_preview_file_size_bytes
+            .try_into()
+            .unwrap_or(usize::MAX);
+    }
+
     pub fn request_preview(
         &mut self,
         path: &std::path::Path,
         first_match: Option<&ContentMatch>,
     ) -> PreviewRequest {
-        let request = first_match
+        let mut request = first_match
             .map(|content_match| {
                 let mut request = PreviewRequest::for_match(
                     path,
@@ -912,6 +920,7 @@ impl FileSearchDialogState {
                 request
             })
             .unwrap_or_else(|| PreviewRequest::new(path));
+        self.apply_preview_settings_to_request(&mut request);
         if let Some(content_match) = first_match.cloned() {
             self.preview_dialog
                 .open_content_match(path, content_match, &self.settings);
@@ -1773,7 +1782,13 @@ mod tests {
 
     #[test]
     fn requesting_preview_records_match_context() {
-        let mut state = FileSearchDialogState::default();
+        let mut state = FileSearchDialogState {
+            settings: FileSearchSettings {
+                max_full_preview_file_size_bytes: 7 * 1024 * 1024,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         let path = PathBuf::from("src/lib.rs");
         let content_match = ContentMatch::new(12, "hello needle".into(), 6, 12);
 
@@ -1786,6 +1801,7 @@ mod tests {
         assert_eq!(selected_match.source_line.as_deref(), Some("hello needle"));
         assert_eq!(selected_match.match_length, Some(6));
         assert_eq!(selected_match.end_column, Some(13));
+        assert_eq!(request.max_bytes_full_file_preview, 7 * 1024 * 1024);
         assert_eq!(state.preview_dialog.current_request, Some(request));
     }
 
@@ -2143,6 +2159,7 @@ mod tests {
     fn content_selection_resolves_to_preview_behavior() {
         let path = "src/lib.rs";
         let mut state = state_with_selected_content(path);
+        state.settings.max_full_preview_file_size_bytes = 9 * 1024 * 1024;
 
         let action = state.resolve_open_selected_result_action();
 
@@ -2150,6 +2167,7 @@ mod tests {
             Some(OpenSelectedFileSearchResultAction::PreviewContent { request }) => {
                 assert_eq!(request.path, PathBuf::from(path));
                 assert_eq!(request.selected_match.as_ref().unwrap().line, 1);
+                assert_eq!(request.max_bytes_full_file_preview, 9 * 1024 * 1024);
                 assert_eq!(state.preview_dialog.current_request, Some(request));
             }
             other => panic!("expected preview action, got {other:?}"),
@@ -2160,9 +2178,14 @@ mod tests {
     fn double_click_uses_same_dispatch_path_as_open() {
         let path = "src/lib.rs";
         let mut open_button_state = state_with_selected_content(path);
+        open_button_state.settings.max_full_preview_file_size_bytes = 11 * 1024 * 1024;
         let mut double_click_state = FileSearchDialogState {
             active_search_id: Some(SearchId(1)),
             selected_mode: FileSearchMode::Content,
+            settings: FileSearchSettings {
+                max_full_preview_file_size_bytes: 11 * 1024 * 1024,
+                ..Default::default()
+            },
             ..Default::default()
         };
         double_click_state.apply_event(SearchEvent::Result {

--- a/src/gui/file_search_preview_dialog.rs
+++ b/src/gui/file_search_preview_dialog.rs
@@ -118,7 +118,7 @@ impl FileSearchPreviewDialogState {
         &mut self,
         path: impl AsRef<Path>,
         content_match: ContentMatch,
-        _settings: &FileSearchSettings,
+        settings: &FileSearchSettings,
     ) {
         let mut request = PreviewRequest::for_match(
             path.as_ref(),
@@ -128,6 +128,10 @@ impl FileSearchPreviewDialogState {
                 .map(|column| column.saturating_add(1))
                 .unwrap_or(1),
         );
+        request.max_bytes_full_file_preview = settings
+            .max_full_preview_file_size_bytes
+            .try_into()
+            .unwrap_or(usize::MAX);
         if let Some(selection) = request.selected_match.as_mut() {
             selection.source_line = Some(content_match.line.clone());
             selection.match_length = Some(

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -1,11 +1,13 @@
 use crate::actions::Action;
 use crate::file_search::actions::{
-    MODE_PREFIX, OPEN_ACTION, START_PREFIX, encode_action_payload, mode_action_payload,
-    start_action_payload,
+    encode_action_payload, mode_action_payload, start_action_payload, MODE_PREFIX, OPEN_ACTION,
+    START_PREFIX,
 };
 use crate::file_search::model::SearchKind;
 use crate::file_search::query::{FileSearchCommand, SearchRequestDraft};
-use crate::file_search::settings::{FileSearchDiagnosticsState, FileSearchSettings};
+use crate::file_search::settings::{
+    FileSearchDiagnosticsState, FileSearchSettings, DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES,
+};
 use crate::plugin::Plugin;
 use eframe::egui;
 use std::path::PathBuf;
@@ -105,6 +107,7 @@ impl Plugin for FileSearchPlugin {
                     .clamp_range(1..=u64::MAX),
             );
         });
+        full_preview_limit_mib_editor(ui, &mut cfg.max_full_preview_file_size_bytes);
         ui.checkbox(&mut cfg.include_hidden_files, "Include hidden by default");
         ui.checkbox(&mut cfg.case_sensitive, "Case-sensitive by default");
         ui.checkbox(
@@ -146,6 +149,32 @@ impl Plugin for FileSearchPlugin {
         if let Ok(v) = serde_json::to_value(&cfg) {
             *value = v;
         }
+    }
+}
+
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+
+fn full_preview_limit_mib_editor(ui: &mut egui::Ui, bytes: &mut u64) {
+    let max_mib = u64::MAX / BYTES_PER_MIB;
+    let mut mib = (*bytes / BYTES_PER_MIB).max(1);
+    ui.horizontal(|ui| {
+        ui.label("Full-file preview limit (MiB)");
+        if ui
+            .add(
+                egui::DragValue::new(&mut mib)
+                    .speed(1.0)
+                    .clamp_range(1..=max_mib),
+            )
+            .changed()
+        {
+            *bytes = mib
+                .max(1)
+                .checked_mul(BYTES_PER_MIB)
+                .unwrap_or(DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES);
+        }
+    });
+    if *bytes == 0 {
+        *bytes = DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Allow users to configure the maximum full-file preview size used by the file-search preview system. 
- Preserve backward-compatible deserialization for existing settings files via `#[serde(default)]`. 
- Surface invalid zero values as non-panicking diagnostics so misconfiguration is visible. 
- Make the setting accessible and understandable in the plugin settings UI using MiB units.

### Description
- Add `max_full_preview_file_size_bytes: u64` to `FileSearchSettings` with the exact default `DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES = 5 * 1024 * 1024`. 
- Ensure serde-default deserialization yields the 5 MiB default when the field is missing and include tests for that case. 
- Validate the new field in `validate_max_values()` so a zero value emits a `UnusableMaxValue` diagnostic and include the value in diagnostics text shown in the UI. 
- Expose the setting in the plugin settings UI via a `Full-file preview limit (MiB)` editor that converts safely to/from bytes, prevents zero, and avoids overflow when multiplying MiB -> bytes. 
- Propagate the configured preview limit into `PreviewRequest` for top-level Open, content-row double-click, and context-menu Preview flows, and set the preview dialog to use that limit when opening content matches. 
- Add unit tests verifying the exact default (5 MiB), that missing serialized field uses the default, that zero produces a validation diagnostic, that old settings JSON deserializes, and that dialog/plugin flows propagate the preview limit into `PreviewRequest`.

### Testing
- Ran `rustfmt --check` on modified files and a code style check succeeded. 
- Ran `git diff --check` / basic repository checks which passed without new whitespace issues. 
- Added multiple unit tests under `src/file_search` and `src/gui` for defaults, deserialization, validation diagnostics, and preview-request propagation, but `cargo test` could not complete in this environment due to a missing system dependency (`alsa` / `alsa.pc`) causing `alsa-sys` build failures; the new tests are present and will run in CI or a dev environment with system deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541ff2baa88332a87f0ea2748f4fd5)