### PR TITLE
Add file search test coverage

### DIFF
--- a/src/file_search/preview.rs
+++ b/src/file_search/preview.rs
@@ -1228,6 +1228,26 @@ three
     }
 
     #[test]
+    fn beginning_preview_byte_limit_affects_cache_identity() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("cache-beginning-limit.txt");
+        write_file(&path, b"abcdef\n");
+        let mut cache = PreviewCache::new(2);
+        let mut short = PreviewRequest::new(&path);
+        short.max_bytes_full_file_preview = 3;
+        short.oversized_beginning_preview_bytes = 3;
+        let mut longer = PreviewRequest::new(&path);
+        longer.max_bytes_full_file_preview = 3;
+        longer.oversized_beginning_preview_bytes = 5;
+
+        assert_eq!(cache.preview(&short).lines[0].text, "abc");
+        let preview = cache.preview(&longer);
+
+        assert!(!preview.cache_hit);
+        assert_eq!(preview.lines[0].text, "abcde");
+    }
+
+    #[test]
     fn small_complete_file_preview_reuses_cache_for_different_selected_match() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("cache-small-selected.txt");

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -2384,13 +2384,15 @@ mod tests {
     }
 
     #[test]
-    fn switching_mode_clears_selection() {
+    fn switching_filename_content_mode_clears_selection() {
         let mut state = state_with_selected_filename("/tmp/a.txt");
         let previous_mode = state.selected_mode;
 
         state.selected_mode = FileSearchMode::Content;
         state.clear_selection_if_mode_changed(previous_mode);
 
+        assert_eq!(previous_mode, FileSearchMode::Filename);
+        assert_eq!(state.selected_mode, FileSearchMode::Content);
         assert!(state.selected_result().is_none());
     }
 


### PR DESCRIPTION
### Motivation
- Improve test coverage for file-search preview caching and selection behavior to prevent regressions around preview-size context and mode-switch selection clearing.
- Clarify the existing Filename→Content mode transition test to explicitly assert the mode change as part of verifying that selection is cleared.

### Description
- Added `beginning_preview_byte_limit_affects_cache_identity` in `src/file_search/preview.rs` to assert that `oversized_beginning_preview_bytes` participates in cache identity and that a request with a larger beginning-byte limit is not served from the prior cached preview.
- Renamed and strengthened the mode-switch test in `src/gui/file_search_dialog.rs` to `switching_filename_content_mode_clears_selection` and added assertions verifying the previous mode was `Filename` and the new mode is `Content` before checking selection is cleared.

### Testing
- Ran `git diff --check` which succeeded with no issues reported.
- Attempted `cargo test file_search --lib` but the run failed due to a missing system dependency (`alsa.pc` / ALSA development package) required by a crate build script, preventing the test suite from completing in this environment.
- `cargo test --lib file_search --no-default-features` was also attempted and likewise blocked by the same system ALSA dependency; tests should pass in CI or a local environment with system dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54276f08bc8332b202d64dc0967a84)