### PR TITLE
Persist file search UI preferences and add Serde alias for global roots

### DIFF
--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -5,7 +5,7 @@ use crate::file_search::model::{
 };
 use crate::file_search::settings::FileSearchSettings;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 use std::thread;
 
 #[derive(Debug, Clone, Default)]
@@ -261,7 +261,7 @@ fn roots_match_global_search_roots(
     if roots.is_empty() {
         return true;
     }
-    if roots.len() != settings.global_content_search_roots.len() {
+    if roots.len() != settings.global_search_roots.len() {
         return false;
     }
     let mut request_roots: Vec<_> = roots
@@ -269,7 +269,7 @@ fn roots_match_global_search_roots(
         .map(|path| crate::file_search::model::normalize_path_for_identity(path))
         .collect();
     let mut global_roots: Vec<_> = settings
-        .global_content_search_roots
+        .global_search_roots
         .iter()
         .map(|path| crate::file_search::model::normalize_path_for_identity(path))
         .collect();
@@ -740,9 +740,11 @@ mod tests {
                 ..
             } if result.file_name == expected
         )));
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, SearchEvent::Completed { .. })));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, SearchEvent::Completed { .. }))
+        );
         assert_no_unwired_placeholder(&events);
     }
 
@@ -865,7 +867,7 @@ mod tests {
         let expected = "global-ripgrep-hit.txt";
         std::fs::write(temp.path().join(expected), "contents").expect("write file");
         let settings = FileSearchSettings {
-            global_content_search_roots: vec![temp.path().to_path_buf()],
+            global_search_roots: vec![temp.path().to_path_buf()],
             everything_enabled: false,
             ripgrep_executable_path: ripgrep,
             ..FileSearchSettings::default()
@@ -911,7 +913,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let missing_rg = temp.path().join("missing").join("rg");
         let settings = FileSearchSettings {
-            global_content_search_roots: vec![temp.path().to_path_buf()],
+            global_search_roots: vec![temp.path().to_path_buf()],
             everything_enabled: false,
             ripgrep_executable_path: missing_rg.clone(),
             ..FileSearchSettings::default()

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -15,19 +16,22 @@ pub enum SearchScope {
     Files { files: Vec<PathBuf> },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FilenameMatchMode {
     RankedSubstring,
     Fuzzy,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ContentMatchMode {
     ExactPhrase,
     AnyTerm,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FileTypeFilter {
     FilesOnly,
     DirectoriesOnly,

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -403,9 +403,7 @@ fn search_roots(
     settings: &FileSearchSettings,
 ) -> Result<Vec<PathBuf>, FileSearchError> {
     let roots = match &request.scope {
-        SearchScope::Roots { roots } if roots.is_empty() => {
-            settings.global_content_search_roots.clone()
-        }
+        SearchScope::Roots { roots } if roots.is_empty() => settings.global_search_roots.clone(),
         SearchScope::Roots { roots } => roots.clone(),
         SearchScope::Files { files } => files.clone(),
     };
@@ -674,14 +672,18 @@ mod tests {
         );
         let summary = parse_ripgrep_json(json, 25).unwrap();
         assert_eq!(summary.results.len(), 2);
-        assert!(summary
-            .results
-            .iter()
-            .any(|r| r.path == PathBuf::from("one/a.txt")));
-        assert!(summary
-            .results
-            .iter()
-            .any(|r| r.path == PathBuf::from("two/a.txt")));
+        assert!(
+            summary
+                .results
+                .iter()
+                .any(|r| r.path == PathBuf::from("one/a.txt"))
+        );
+        assert!(
+            summary
+                .results
+                .iter()
+                .any(|r| r.path == PathBuf::from("two/a.txt"))
+        );
     }
 
     #[test]

--- a/src/file_search/settings.rs
+++ b/src/file_search/settings.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -8,7 +9,8 @@ pub const DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FileSearchSettings {
-    pub global_content_search_roots: Vec<PathBuf>,
+    #[serde(alias = "global_content_search_roots")]
+    pub global_search_roots: Vec<PathBuf>,
     pub excluded_directory_names: Vec<String>,
     pub max_search_results: usize,
     pub max_matches_per_content_file: usize,
@@ -23,6 +25,73 @@ pub struct FileSearchSettings {
     pub preferred_editor_args: Vec<String>,
     pub preferred_terminal_command: String,
     pub preferred_terminal_args: Vec<String>,
+    #[serde(default)]
+    pub ui_preferences: FileSearchUiPreferences,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileSearchFilenameSort {
+    Relevance,
+    Name,
+    Path,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileSearchContentSort {
+    PathThenLine,
+    LineThenPath,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileSearchColumn {
+    Name,
+    Directory,
+    Kind,
+    MatchQuality,
+    Path,
+    Line,
+    MatchText,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FileSearchUiPreferences {
+    pub filename_sort: FileSearchFilenameSort,
+    pub content_sort: FileSearchContentSort,
+    pub filename_match_mode: crate::file_search::model::FilenameMatchMode,
+    pub content_match_mode: crate::file_search::model::ContentMatchMode,
+    pub whole_word: bool,
+    pub file_type_filter: crate::file_search::model::FileTypeFilter,
+    pub included_extensions: Vec<String>,
+    pub excluded_extensions: Vec<String>,
+    pub excluded_directory_names: Vec<String>,
+    pub visible_columns: Vec<FileSearchColumn>,
+    pub column_widths: BTreeMap<FileSearchColumn, u32>,
+}
+
+impl Default for FileSearchUiPreferences {
+    fn default() -> Self {
+        Self {
+            filename_sort: FileSearchFilenameSort::Relevance,
+            content_sort: FileSearchContentSort::PathThenLine,
+            filename_match_mode: crate::file_search::model::FilenameMatchMode::RankedSubstring,
+            content_match_mode: crate::file_search::model::ContentMatchMode::ExactPhrase,
+            whole_word: false,
+            file_type_filter: crate::file_search::model::FileTypeFilter::FilesAndDirectories,
+            included_extensions: Vec::new(),
+            excluded_extensions: Vec::new(),
+            excluded_directory_names: Vec::new(),
+            visible_columns: vec![
+                FileSearchColumn::Name,
+                FileSearchColumn::Directory,
+                FileSearchColumn::MatchQuality,
+            ],
+            column_widths: BTreeMap::new(),
+        }
+    }
 }
 
 /// Non-panicking validation diagnostics for user-editable file-search settings.
@@ -84,7 +153,7 @@ impl FileSearchDiagnosticsState {
     pub fn from_settings(settings: &FileSearchSettings) -> Self {
         let mut valid_roots = Vec::new();
         let mut invalid_roots = Vec::new();
-        for root in &settings.global_content_search_roots {
+        for root in &settings.global_search_roots {
             if root.is_dir() {
                 valid_roots.push(root.clone());
             } else {
@@ -148,7 +217,7 @@ pub fn detect_ripgrep_executable(settings: &FileSearchSettings) -> Option<PathBu
 impl Default for FileSearchSettings {
     fn default() -> Self {
         Self {
-            global_content_search_roots: default_global_content_search_roots(),
+            global_search_roots: default_global_search_roots(),
             excluded_directory_names: [
                 ".git",
                 "target",
@@ -174,6 +243,7 @@ impl Default for FileSearchSettings {
             preferred_editor_args: Vec::new(),
             preferred_terminal_command: String::new(),
             preferred_terminal_args: Vec::new(),
+            ui_preferences: FileSearchUiPreferences::default(),
         }
     }
 }
@@ -189,7 +259,7 @@ impl FileSearchSettings {
     }
 
     pub fn validate_root_paths(&self) -> Vec<FileSearchSettingsDiagnostic> {
-        self.global_content_search_roots
+        self.global_search_roots
             .iter()
             .filter_map(|path| match path.metadata() {
                 Ok(metadata) if metadata.is_dir() => None,
@@ -290,7 +360,7 @@ impl FileSearchSettings {
     }
 }
 
-fn default_global_content_search_roots() -> Vec<PathBuf> {
+fn default_global_search_roots() -> Vec<PathBuf> {
     dirs_next::home_dir().into_iter().collect()
 }
 
@@ -347,7 +417,7 @@ mod tests {
         std::fs::write(&file_path, "content").expect("write temp file");
 
         let settings = FileSearchSettings {
-            global_content_search_roots: vec![file_path.clone(), temp_dir.path().join("missing")],
+            global_search_roots: vec![file_path.clone(), temp_dir.path().join("missing")],
             max_search_results: 0,
             max_matches_per_content_file: 0,
             max_content_search_file_size_bytes: 0,
@@ -485,10 +555,62 @@ mod diagnostics_state_tests {
     }
 
     #[test]
+    fn old_global_content_search_roots_alias_deserializes() {
+        let parsed: FileSearchSettings =
+            serde_json::from_str(r#"{"global_content_search_roots":["/tmp/legacy-root"]}"#)
+                .expect("legacy root key should deserialize");
+
+        assert_eq!(
+            parsed.global_search_roots,
+            vec![PathBuf::from("/tmp/legacy-root")]
+        );
+    }
+
+    #[test]
+    fn default_ui_preferences_match_expected_file_search_defaults() {
+        let prefs = FileSearchUiPreferences::default();
+
+        assert_eq!(prefs.filename_sort, FileSearchFilenameSort::Relevance);
+        assert_eq!(prefs.content_sort, FileSearchContentSort::PathThenLine);
+        assert_eq!(
+            prefs.filename_match_mode,
+            crate::file_search::model::FilenameMatchMode::RankedSubstring
+        );
+        assert_eq!(
+            prefs.content_match_mode,
+            crate::file_search::model::ContentMatchMode::ExactPhrase
+        );
+        assert!(!prefs.whole_word);
+        assert_eq!(
+            prefs.file_type_filter,
+            crate::file_search::model::FileTypeFilter::FilesAndDirectories
+        );
+        assert_eq!(
+            prefs.visible_columns,
+            vec![
+                FileSearchColumn::Name,
+                FileSearchColumn::Directory,
+                FileSearchColumn::MatchQuality
+            ]
+        );
+    }
+
+    #[test]
+    fn ui_preferences_serialization_excludes_search_session_state() {
+        let serialized =
+            serde_json::to_string(&FileSearchUiPreferences::default()).expect("serialize prefs");
+
+        assert!(!serialized.contains("query"));
+        assert!(!serialized.contains("selected"));
+        assert!(!serialized.contains("timestamp"));
+        assert!(!serialized.contains("history"));
+    }
+
+    #[test]
     fn existing_settings_json_without_preview_limit_remains_deserializable() {
         let parsed: FileSearchSettings = serde_json::from_str(
             r#"{
-                "global_content_search_roots": [],
+                "global_search_roots": [],
                 "excluded_directory_names": [".git", "target"],
                 "max_search_results": 123,
                 "max_matches_per_content_file": 10,
@@ -516,7 +638,7 @@ mod diagnostics_state_tests {
     #[test]
     fn invalid_settings_do_not_panic() {
         let settings = FileSearchSettings {
-            global_content_search_roots: vec![PathBuf::from("/definitely/missing/root")],
+            global_search_roots: vec![PathBuf::from("/definitely/missing/root")],
             everything_enabled: true,
             everything_executable_path: PathBuf::from("/definitely/missing/es.exe"),
             ripgrep_executable_path: PathBuf::from("/definitely/missing/rg"),

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -10,12 +10,11 @@ use crate::file_search::actions::{
 };
 use crate::file_search::coordinator::{SearchCoordinator, event_id};
 use crate::file_search::model::{
-    ContentMatch, ContentMatchMode, FileKind, FileSearchResultKey, FileTypeFilter,
-    FilenameMatchMode, PathIdentity, SearchBackend, SearchEvent, SearchId, SearchKind,
-    SearchRequest, SearchResult, SearchScope, SearchStatus,
+    ContentMatch, FileKind, FileSearchResultKey, FileTypeFilter, PathIdentity, SearchBackend,
+    SearchEvent, SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::preview::PreviewRequest;
-use crate::file_search::settings::FileSearchSettings;
+use crate::file_search::settings::{FileSearchSettings, FileSearchUiPreferences};
 use crate::gui::file_search_preview_dialog::FileSearchPreviewDialogState;
 use eframe::egui;
 use std::path::PathBuf;
@@ -133,18 +132,6 @@ pub struct FileSearchResultRow {
     pub payload: FileSearchRowPayload,
 }
 
-fn default_filename_match_mode() -> FilenameMatchMode {
-    FilenameMatchMode::RankedSubstring
-}
-
-fn default_content_match_mode() -> ContentMatchMode {
-    ContentMatchMode::ExactPhrase
-}
-
-fn default_file_type_filter() -> FileTypeFilter {
-    FileTypeFilter::FilesAndDirectories
-}
-
 pub fn dedup_search_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
     let mut seen = std::collections::HashSet::new();
     let mut deduped = Vec::new();
@@ -226,6 +213,8 @@ pub struct FileSearchDialogState {
     pub preview_dialog: FileSearchPreviewDialogState,
     pub persisted_window_size: egui::Vec2,
     pub settings: FileSearchSettings,
+    pub ui_preferences: FileSearchUiPreferences,
+    pub ui_preferences_dirty: bool,
     pub request_search_focus: bool,
     pub request_immediate_repaint: bool,
 }
@@ -251,6 +240,8 @@ impl Default for FileSearchDialogState {
             preview_dialog: FileSearchPreviewDialogState::default(),
             persisted_window_size: DEFAULT_WINDOW_SIZE,
             settings: FileSearchSettings::default(),
+            ui_preferences: FileSearchUiPreferences::default(),
+            ui_preferences_dirty: false,
             request_search_focus: false,
             request_immediate_repaint: false,
         }
@@ -327,7 +318,7 @@ impl FileSearchDialogState {
         }
         let scope = match self.selected_scope {
             FileSearchScopeMode::Global => {
-                let roots = dedup_search_paths(self.settings.global_content_search_roots.clone());
+                let roots = dedup_search_paths(self.settings.global_search_roots.clone());
                 if roots.is_empty() {
                     self.warning_error_message =
                         Some("Global file search has no configured roots.".to_string());
@@ -354,13 +345,20 @@ impl FileSearchDialogState {
             include_hidden_files: self.include_hidden,
             max_results: self.settings.max_search_results.max(1),
             max_file_size_bytes: self.settings.max_content_search_file_size_bytes.max(1),
-            included_extensions: Vec::new(),
-            excluded_extensions: Vec::new(),
-            excluded_directory_names: self.settings.excluded_directory_names.clone(),
-            filename_match_mode: default_filename_match_mode(),
-            content_match_mode: default_content_match_mode(),
-            whole_word: false,
-            file_type_filter: default_file_type_filter(),
+            included_extensions: self.ui_preferences.included_extensions.clone(),
+            excluded_extensions: self.ui_preferences.excluded_extensions.clone(),
+            excluded_directory_names: if self.ui_preferences.excluded_directory_names.is_empty() {
+                self.settings.excluded_directory_names.clone()
+            } else {
+                self.ui_preferences.excluded_directory_names.clone()
+            },
+            filename_match_mode: self.ui_preferences.filename_match_mode,
+            content_match_mode: self.ui_preferences.content_match_mode,
+            whole_word: self.ui_preferences.whole_word,
+            file_type_filter: match self.selected_mode {
+                FileSearchMode::Filename => self.ui_preferences.file_type_filter,
+                FileSearchMode::Content => FileTypeFilter::FilesOnly,
+            },
         };
         self.clear_results_and_selection();
         self.warning_error_message = None;
@@ -644,6 +642,37 @@ impl FileSearchDialogState {
             self.persisted_window_size = resp.response.rect.size();
         }
         self.open = open;
+    }
+
+    pub fn set_ui_preferences(&mut self, preferences: FileSearchUiPreferences) {
+        self.ui_preferences = preferences;
+        self.ui_preferences_dirty = false;
+    }
+
+    pub fn mark_ui_preferences_dirty(&mut self) {
+        self.ui_preferences_dirty = true;
+    }
+
+    pub fn update_ui_preferences(
+        &mut self,
+        update: impl FnOnce(&mut FileSearchUiPreferences),
+    ) -> bool {
+        let before = self.ui_preferences.clone();
+        update(&mut self.ui_preferences);
+        if self.ui_preferences != before {
+            self.mark_ui_preferences_dirty();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn save_dirty_ui_preferences(&mut self) {
+        if !self.ui_preferences_dirty {
+            return;
+        }
+        self.settings.ui_preferences = self.ui_preferences.clone();
+        self.ui_preferences_dirty = false;
     }
 
     fn contents(&mut self, ui: &mut egui::Ui, coordinator: &mut SearchCoordinator) {
@@ -1107,13 +1136,17 @@ impl FileSearchDialogState {
             include_hidden_files: self.include_hidden,
             max_results: 1,
             max_file_size_bytes: self.settings.max_content_search_file_size_bytes.max(1),
-            included_extensions: Vec::new(),
-            excluded_extensions: Vec::new(),
-            excluded_directory_names: Vec::new(),
-            filename_match_mode: default_filename_match_mode(),
-            content_match_mode: default_content_match_mode(),
-            whole_word: false,
-            file_type_filter: default_file_type_filter(),
+            included_extensions: self.ui_preferences.included_extensions.clone(),
+            excluded_extensions: self.ui_preferences.excluded_extensions.clone(),
+            excluded_directory_names: if self.ui_preferences.excluded_directory_names.is_empty() {
+                self.settings.excluded_directory_names.clone()
+            } else {
+                self.ui_preferences.excluded_directory_names.clone()
+            },
+            filename_match_mode: self.ui_preferences.filename_match_mode,
+            content_match_mode: self.ui_preferences.content_match_mode,
+            whole_word: self.ui_preferences.whole_word,
+            file_type_filter: FileTypeFilter::FilesOnly,
         };
         self.selected_mode = FileSearchMode::Content;
         self.clear_results_and_selection();
@@ -1315,12 +1348,35 @@ mod tests {
     }
 
     #[test]
+    fn dirty_state_changes_only_for_preferences() {
+        let mut state = FileSearchDialogState::default();
+
+        state.search_text = "needle".into();
+        state.selected_result = None;
+        assert!(!state.ui_preferences_dirty);
+
+        let changed = state.update_ui_preferences(|prefs| {
+            prefs.whole_word = true;
+        });
+        assert!(changed);
+        assert!(state.ui_preferences_dirty);
+
+        state.save_dirty_ui_preferences();
+        assert!(!state.ui_preferences_dirty);
+        let unchanged = state.update_ui_preferences(|prefs| {
+            prefs.whole_word = true;
+        });
+        assert!(!unchanged);
+        assert!(!state.ui_preferences_dirty);
+    }
+
+    #[test]
     fn global_roots_resolve_into_roots_scope() {
         let executor = RecordingExecutor::new();
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             settings: FileSearchSettings {
-                global_content_search_roots: vec![PathBuf::from("/tmp/root-a")],
+                global_search_roots: vec![PathBuf::from("/tmp/root-a")],
                 ..FileSearchSettings::default()
             },
             ..Default::default()
@@ -1341,7 +1397,7 @@ mod tests {
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             settings: FileSearchSettings {
-                global_content_search_roots: vec![],
+                global_search_roots: vec![],
                 ..FileSearchSettings::default()
             },
             ..Default::default()
@@ -1361,10 +1417,7 @@ mod tests {
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             settings: FileSearchSettings {
-                global_content_search_roots: vec![
-                    PathBuf::from("/tmp/root"),
-                    PathBuf::from("/tmp/root"),
-                ],
+                global_search_roots: vec![PathBuf::from("/tmp/root"), PathBuf::from("/tmp/root")],
                 ..FileSearchSettings::default()
             },
             ..Default::default()

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -616,7 +616,36 @@ impl LauncherApp {
             .reconfigure_from_settings(settings.clone());
         self.file_search_dialog.case_sensitive = settings.case_sensitive;
         self.file_search_dialog.include_hidden = settings.include_hidden_files;
+        self.file_search_dialog
+            .set_ui_preferences(settings.ui_preferences.clone());
         self.file_search_dialog.settings = settings;
+    }
+
+    pub(crate) fn save_file_search_ui_preferences_if_dirty(&mut self) {
+        if !self.file_search_dialog.ui_preferences_dirty {
+            return;
+        }
+        self.file_search_dialog.save_dirty_ui_preferences();
+        if let Ok(mut settings) = crate::settings::Settings::load(&self.settings_path) {
+            if let Ok(value) = serde_json::to_value(&self.file_search_dialog.settings) {
+                settings
+                    .plugin_settings
+                    .insert("file_search".to_owned(), value);
+                let _ = settings.save(&self.settings_path);
+            }
+        }
+    }
+
+    pub(crate) fn merge_file_search_ui_preferences_into_settings(
+        &mut self,
+        settings: &mut crate::settings::Settings,
+    ) {
+        self.file_search_dialog.save_dirty_ui_preferences();
+        if let Ok(value) = serde_json::to_value(&self.file_search_dialog.settings) {
+            settings
+                .plugin_settings
+                .insert("file_search".to_owned(), value);
+        }
     }
 
     pub fn open_theme_settings_dialog(&mut self) {
@@ -1179,6 +1208,7 @@ impl LauncherApp {
             fav_dialog: FavDialog::default(),
             file_search_dialog: FileSearchDialogState {
                 settings: file_search_settings.clone(),
+                ui_preferences: file_search_settings.ui_preferences.clone(),
                 case_sensitive: file_search_settings.case_sensitive,
                 include_hidden: file_search_settings.include_hidden_files,
                 ..FileSearchDialogState::default()
@@ -3867,7 +3897,7 @@ mod tests {
         let ctx = egui::Context::default();
         let mut settings = Settings::default();
         let file_search_settings = crate::file_search::settings::FileSearchSettings {
-            global_content_search_roots: vec![std::path::PathBuf::from("/tmp/search-root")],
+            global_search_roots: vec![std::path::PathBuf::from("/tmp/search-root")],
             excluded_directory_names: vec!["skip-me".to_owned()],
             max_search_results: 123,
             max_matches_per_content_file: 7,

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1247,8 +1247,12 @@ impl eframe::App for LauncherApp {
         let mut fav_dlg = std::mem::take(&mut self.fav_dialog);
         fav_dlg.ui(ctx, self);
         self.fav_dialog = fav_dlg;
+        let file_search_was_open = self.file_search_dialog.open;
         self.file_search_dialog
             .ui(ctx, &mut self.file_search_coordinator);
+        if file_search_was_open && !self.file_search_dialog.open {
+            self.save_file_search_ui_preferences_if_dirty();
+        }
         self.file_search_dialog
             .preview_dialog
             .ui(ctx, &self.file_search_dialog.settings);
@@ -1358,6 +1362,7 @@ impl eframe::App for LauncherApp {
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;
+        self.save_file_search_ui_preferences_if_dirty();
         if let Ok(mut settings) = crate::settings::Settings::load(&self.settings_path) {
             settings.window_size = Some(self.window_size);
             settings.pinned_panels = self.pinned_panels.clone();

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -1,12 +1,12 @@
 use crate::actions::Action;
 use crate::file_search::actions::{
-    encode_action_payload, mode_action_payload, start_action_payload, MODE_PREFIX, OPEN_ACTION,
-    START_PREFIX,
+    MODE_PREFIX, OPEN_ACTION, START_PREFIX, encode_action_payload, mode_action_payload,
+    start_action_payload,
 };
 use crate::file_search::model::SearchKind;
 use crate::file_search::query::{FileSearchCommand, SearchRequestDraft};
 use crate::file_search::settings::{
-    FileSearchDiagnosticsState, FileSearchSettings, DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES,
+    DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES, FileSearchDiagnosticsState, FileSearchSettings,
 };
 use crate::plugin::Plugin;
 use eframe::egui;
@@ -82,11 +82,7 @@ impl Plugin for FileSearchPlugin {
     fn settings_ui(&mut self, ui: &mut egui::Ui, value: &mut serde_json::Value) {
         let mut cfg: FileSearchSettings = serde_json::from_value(value.clone()).unwrap_or_default();
         ui.heading("File Search");
-        path_list_editor(
-            ui,
-            "Global ripgrep search roots",
-            &mut cfg.global_content_search_roots,
-        );
+        path_list_editor(ui, "Global search roots", &mut cfg.global_search_roots);
         string_list_editor(
             ui,
             "Excluded directory names",

--- a/src/settings_editor/save.rs
+++ b/src/settings_editor/save.rs
@@ -17,7 +17,8 @@ impl SettingsEditor {
         self.sync_from_plugin_settings();
         match Settings::load(&app.settings_path) {
             Ok(current) => {
-                let new_settings = self.to_settings(&current);
+                let mut new_settings = self.to_settings(&current);
+                app.merge_file_search_ui_preferences_into_settings(&mut new_settings);
                 if let Err(e) = new_settings.save(&app.settings_path) {
                     app.report_ui_error(UiErrorEvent::new(
                         "settings_editor.save",

--- a/tests/plugin_routing.rs
+++ b/tests/plugin_routing.rs
@@ -260,7 +260,7 @@ fn constructing_manager_with_file_search_settings_preserves_omni_and_indexer_beh
     plugin_settings.insert(
         "file_search".to_string(),
         serde_json::to_value(FileSearchSettings {
-            global_content_search_roots: vec![dir.path().to_path_buf()],
+            global_search_roots: vec![dir.path().to_path_buf()],
             max_search_results: 7,
             everything_enabled: false,
             ..FileSearchSettings::default()


### PR DESCRIPTION
### Motivation
- Generalize the configured global search roots name and preserve compatibility with existing settings files by accepting the old key without requiring manual migration. 
- Add a serializable, persistent UI preferences model for file search so user filters/sorting/column layout survive restarts. 
- Keep search session data (last query, selection, timestamps, history) out of persisted preferences. 
- Persist preferences only when needed (on dialog close, app exit, or main settings save) to avoid excessive writes.

### Description
- Renamed `global_content_search_roots` to `global_search_roots` and added Serde compatibility with `#[serde(alias = "global_content_search_roots")]` so old settings still deserialize into the new field (`src/file_search/settings.rs`).
- Introduced `FileSearchUiPreferences` and supporting enums (`FileSearchFilenameSort`, `FileSearchContentSort`, `FileSearchColumn`) with defaults matching the requested behavior, and stored it on `FileSearchSettings` (`src/file_search/settings.rs`).
- Made `FilenameMatchMode`, `ContentMatchMode`, and `FileTypeFilter` serializable so preferences round-trip via settings (`src/file_search/model.rs`).
- Plumbed preferences into the UI/dialog: `LauncherApp` loads preferences on init and when applying file-search settings; `FileSearchDialogState` now stores `ui_preferences` and a `ui_preferences_dirty` flag and exposes helpers to update/mark/save preferences (`src/gui/mod.rs`, `src/gui/file_search_dialog.rs`).
- Applied UI preferences when building `SearchRequest` (filename requests use configured file-type filter; content searches remain files-only) and ensured dialog-only per-session state (queries, selection, timestamps, history) is not serialized (`src/gui/file_search_dialog.rs`).
- Persisted dirty preferences by merging them into the main `Settings.plugin_settings` on three events: file-search window close, `LauncherApp::on_exit`, and when the Settings editor saves; added targeted save helpers to avoid writing `settings.json` every frame or on every column drag (`src/gui/render.rs`, `src/gui/mod.rs`, `src/settings_editor/save.rs`).
- Added unit tests covering legacy alias deserialization, default UI preferences, exclusion of session/search state from serialization, and dirty-state behavior (`src/file_search/settings.rs`, `src/gui/file_search_dialog.rs`).

### Testing
- Ran formatting and static checks with `cargo fmt --edition 2024` and `git diff --check`, which completed successfully.
- Attempted to run the crate-level file-search tests via `cargo test -q file_search`, but the test run failed in this Linux environment due to unrelated platform-specific build failures (missing system dependencies and Windows/X11-specific crate build issues), so the new tests could not be executed here.
- The patch includes the new unit tests: `old_global_content_search_roots_alias_deserializes`, `default_ui_preferences_match_expected_file_search_defaults`, `ui_preferences_serialization_excludes_search_session_state`, and `dirty_state_changes_only_for_preferences` which are present and intended to be run in CI or developer environments where platform dependencies are satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54c2f38fa8833284afad55f438b4eb)