### PR TITLE
Refactor file search backend selection and add backend fallback reporting

### DIFF
--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -122,24 +122,18 @@ impl SearchCoordinator {
 
         let id = SearchId(self.next_id);
         self.next_id = self.next_id.saturating_add(1);
-        let backend =
-            Self::select_backend_with_settings(&request, self.production_settings.as_ref());
         let token = CancellationToken::new();
 
         self.active_search_id = Some(id);
         self.active_token = Some(token.clone());
         self.active_status = SearchStatus::Running;
-        self.last_backend = Some(backend);
-        self.diagnostics.started += 1;
+        self.last_backend = None;
 
         let events = self.event_sender.clone();
         let executor = Arc::clone(&self.executor);
         let worker_request = request;
         let worker_token = token;
         thread::spawn(move || {
-            if events.send(SearchEvent::Started { id, backend }).is_err() {
-                return;
-            }
             executor.execute(id, worker_request, worker_token, events);
         });
 
@@ -185,25 +179,21 @@ impl SearchCoordinator {
         request: &SearchRequest,
         settings: Option<&FileSearchSettings>,
     ) -> SearchBackend {
-        match (&request.kind, &request.scope) {
-            (SearchKind::Filename, SearchScope::Roots { roots })
-                if settings.is_some_and(|settings| {
-                    !settings.everything_enabled && roots_match_global_search_roots(roots, settings)
-                }) =>
-            {
-                SearchBackend::Ripgrep
+        if let Some(settings) = settings {
+            crate::file_search::executor::FileSearchExecutor::plan_for_request(request, settings)
+                .candidates
+                .into_iter()
+                .next()
+                .unwrap_or(SearchBackend::WalkDir)
+        } else {
+            match (&request.kind, &request.scope) {
+                (SearchKind::Filename, SearchScope::Roots { roots }) if roots.len() == 1 => {
+                    SearchBackend::WalkDir
+                }
+                (SearchKind::Filename, SearchScope::Roots { .. }) => SearchBackend::Everything,
+                (SearchKind::Filename, SearchScope::Files { .. }) => SearchBackend::WalkDir,
+                (SearchKind::Content, _) => SearchBackend::Ripgrep,
             }
-            (SearchKind::Filename, SearchScope::Roots { roots })
-                if roots.len() == 1
-                    && !settings.is_some_and(|settings| {
-                        roots_match_global_search_roots(roots, settings)
-                    }) =>
-            {
-                SearchBackend::WalkDir
-            }
-            (SearchKind::Filename, SearchScope::Roots { .. }) => SearchBackend::Everything,
-            (SearchKind::Filename, SearchScope::Files { .. }) => SearchBackend::WalkDir,
-            (SearchKind::Content, _) => SearchBackend::Ripgrep,
         }
     }
 
@@ -232,6 +222,11 @@ impl SearchCoordinator {
             SearchEvent::Started { backend, .. } => {
                 self.active_status = SearchStatus::Running;
                 self.last_backend = Some(*backend);
+                self.diagnostics.started += 1;
+            }
+            SearchEvent::BackendFallback { to, reason, .. } => {
+                self.last_backend = Some(*to);
+                self.diagnostics.last_error = Some(reason.clone());
             }
             SearchEvent::Result { .. } | SearchEvent::Progress { .. } => {}
             SearchEvent::Completed { .. } => {
@@ -281,6 +276,7 @@ fn roots_match_global_search_roots(
 pub fn event_id(event: &SearchEvent) -> SearchId {
     match event {
         SearchEvent::Started { id, .. }
+        | SearchEvent::BackendFallback { id, .. }
         | SearchEvent::Result { id, .. }
         | SearchEvent::Progress { id, .. }
         | SearchEvent::Completed { id }
@@ -467,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn everything_disabled_selects_ripgrep_for_global_filename_search() {
+    fn everything_disabled_selects_walkdir_for_global_filename_search() {
         let settings = FileSearchSettings {
             everything_enabled: false,
             ..FileSearchSettings::default()
@@ -482,7 +478,7 @@ mod tests {
                 ),
                 Some(&settings),
             ),
-            SearchBackend::Ripgrep
+            SearchBackend::WalkDir
         );
     }
 
@@ -570,16 +566,7 @@ mod tests {
             10,
         ));
         let events = drain_after(&mut coordinator);
-        assert_eq!(
-            events,
-            vec![
-                SearchEvent::Started {
-                    id,
-                    backend: SearchBackend::Everything
-                },
-                SearchEvent::Completed { id }
-            ]
-        );
+        assert_eq!(events, vec![SearchEvent::Completed { id }]);
     }
 
     #[test]
@@ -748,17 +735,11 @@ mod tests {
 
     #[test]
     fn production_content_search_uses_ripgrep_and_returns_result_when_available() {
-        let Ok(ripgrep) =
-            crate::file_search::ripgrep::resolve_ripgrep_executable(std::path::Path::new("rg"))
-        else {
-            return;
-        };
         let temp = tempfile::tempdir().expect("tempdir");
         let expected = temp.path().join("content-hit.txt");
         std::fs::write(&expected, "alpha needle omega\n").expect("write file");
         std::fs::write(temp.path().join("miss.txt"), "alpha omega\n").expect("write miss file");
         let settings = FileSearchSettings {
-            ripgrep_executable_path: ripgrep,
             max_search_results: 10,
             ..FileSearchSettings::default()
         };
@@ -806,7 +787,7 @@ mod tests {
     }
 
     #[test]
-    fn production_content_search_with_missing_ripgrep_falls_back_to_detected_ripgrep() {
+    fn production_content_search_with_missing_ripgrep_falls_back_to_native() {
         let temp = tempfile::tempdir().expect("tempdir");
         std::fs::write(temp.path().join("haystack.txt"), "needle").expect("write file");
         let missing_rg = temp.path().join("missing").join("rg");
@@ -837,52 +818,40 @@ mod tests {
         });
 
         let events = drain_until_terminal(&mut coordinator);
-        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Ripgrep));
-        if crate::file_search::ripgrep::resolve_ripgrep_executable(&missing_rg).is_err() {
-            let error = events
-                .iter()
-                .find_map(|event| match event {
-                    SearchEvent::Failed { error, .. } => Some(error.as_str()),
-                    _ => None,
-                })
-                .expect("failed event");
-            assert!(error.contains("ripgrep"), "{error}");
-        } else {
-            assert!(
-                events.iter().any(|event| matches!(
-                    event,
-                    SearchEvent::Result {
-                        result: SearchResult::ContentFile(result),
-                        ..
-                    } if result.path == temp.path().join("haystack.txt")
-                        || result.path == PathBuf::from("haystack.txt")
-                )),
-                "events: {events:?}"
-            );
-            assert!(
-                events
-                    .iter()
-                    .any(|event| matches!(event, SearchEvent::Completed { .. })),
-                "events: {events:?}"
-            );
-        }
+        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Native));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SearchEvent::BackendFallback {
+                from: SearchBackend::Ripgrep,
+                to: SearchBackend::Native,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Started {
+                backend: SearchBackend::Native,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|event| matches!(event, SearchEvent::Result { result: SearchResult::ContentFile(result), .. } if result.path == temp.path().join("haystack.txt"))));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Completed { .. })));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Failed { .. })));
         assert_no_unwired_placeholder(&events);
     }
 
     #[test]
-    fn everything_disabled_global_filename_search_returns_ripgrep_results_when_available() {
-        let Ok(ripgrep) =
-            crate::file_search::ripgrep::resolve_ripgrep_executable(std::path::Path::new("rg"))
-        else {
-            return;
-        };
+    fn everything_disabled_global_filename_search_returns_walkdir_results() {
         let temp = tempfile::tempdir().expect("tempdir");
         let expected = "global-ripgrep-hit.txt";
         std::fs::write(temp.path().join(expected), "contents").expect("write file");
         let settings = FileSearchSettings {
             global_search_roots: vec![temp.path().to_path_buf()],
             everything_enabled: false,
-            ripgrep_executable_path: ripgrep,
             ..FileSearchSettings::default()
         };
         let mut coordinator = SearchCoordinator::with_settings(settings);
@@ -907,7 +876,7 @@ mod tests {
         });
 
         let events = drain_until_terminal(&mut coordinator);
-        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Ripgrep));
+        assert_eq!(coordinator.last_backend(), Some(SearchBackend::WalkDir));
         assert!(
             events.iter().any(|event| matches!(
                 event,
@@ -922,7 +891,7 @@ mod tests {
     }
 
     #[test]
-    fn production_global_filename_search_with_everything_disabled_uses_detected_ripgrep_fallback() {
+    fn production_global_filename_search_with_everything_disabled_uses_walkdir() {
         let temp = tempfile::tempdir().expect("tempdir");
         let missing_rg = temp.path().join("missing").join("rg");
         let settings = FileSearchSettings {
@@ -951,25 +920,13 @@ mod tests {
         });
 
         let events = drain_until_terminal(&mut coordinator);
-        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Ripgrep));
-        if crate::file_search::ripgrep::resolve_ripgrep_executable(&missing_rg).is_err() {
-            let error = events
-                .iter()
-                .find_map(|event| match event {
-                    SearchEvent::Failed { error, .. } => Some(error.as_str()),
-                    _ => None,
-                })
-                .expect("failed event");
-            assert!(error.contains("ripgrep"), "{error}");
-            assert!(!error.contains("Everything filename search"), "{error}");
-        } else {
-            assert!(
-                events
-                    .iter()
-                    .any(|event| matches!(event, SearchEvent::Completed { .. })),
-                "events: {events:?}"
-            );
-        }
+        assert_eq!(coordinator.last_backend(), Some(SearchBackend::WalkDir));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Completed { .. })));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Failed { .. })));
         assert_no_unwired_placeholder(&events);
     }
 }

--- a/src/file_search/executor.rs
+++ b/src/file_search/executor.rs
@@ -79,7 +79,23 @@ impl FileSearchExecutor {
     fn availability(&self, backend: SearchBackend) -> Result<(), String> {
         match backend {
             SearchBackend::Ripgrep => {
-                resolve_ripgrep_executable(&self.settings.ripgrep_executable_path)
+                let configured = &self.settings.ripgrep_executable_path;
+                if configured.is_absolute() && !configured.is_file() {
+                    return Err(format!(
+                        "ripgrep executable was not found at configured path '{}'",
+                        configured.display()
+                    ));
+                }
+                if !configured.as_os_str().is_empty()
+                    && configured.components().count() > 1
+                    && !configured.is_absolute()
+                {
+                    return Err(format!(
+                        "ripgrep executable path '{}' must be absolute when it includes directories",
+                        configured.display()
+                    ));
+                }
+                resolve_ripgrep_executable(configured)
                     .map(|_| ())
                     .map_err(|e| e.to_string())
             }
@@ -102,6 +118,21 @@ impl FileSearchExecutor {
             SearchBackend::WalkDir => self.walkdir.clone(),
             SearchBackend::Everything => self.everything.clone(),
         }
+    }
+
+    fn prepare_request_for_backend(
+        &self,
+        mut request: SearchRequest,
+        backend: SearchBackend,
+    ) -> SearchRequest {
+        if backend == SearchBackend::WalkDir {
+            if let SearchScope::Roots { roots } = &mut request.scope {
+                if roots.is_empty() {
+                    *roots = self.settings.global_search_roots.clone();
+                }
+            }
+        }
+        request
     }
 }
 
@@ -129,6 +160,7 @@ impl SearchExecutor for FileSearchExecutor {
                     if events.send(SearchEvent::Started { id, backend }).is_err() {
                         return;
                     }
+                    let request = self.prepare_request_for_backend(request, backend);
                     self.executor_for(backend)
                         .execute(id, request, token, events);
                     return;

--- a/src/file_search/executor.rs
+++ b/src/file_search/executor.rs
@@ -1,17 +1,26 @@
-use crate::file_search::coordinator::{CancellationToken, SearchCoordinator, SearchExecutor};
-use crate::file_search::everything::EverythingSearchExecutor;
-use crate::file_search::model::{SearchBackend, SearchEvent, SearchId, SearchRequest};
-use crate::file_search::ripgrep::RipgrepSearchExecutor;
+use crate::file_search::coordinator::{CancellationToken, SearchExecutor};
+use crate::file_search::everything::{everything_diagnostic, EverythingSearchExecutor};
+use crate::file_search::model::{
+    FilenameMatchMode, SearchBackend, SearchEvent, SearchId, SearchKind, SearchRequest, SearchScope,
+};
+use crate::file_search::native::NativeSearchExecutor;
+use crate::file_search::ripgrep::{resolve_ripgrep_executable, RipgrepSearchExecutor};
 use crate::file_search::settings::FileSearchSettings;
 use crate::file_search::walkdir::WalkDirSearchExecutor;
-use std::sync::{Arc, mpsc};
+use std::sync::{mpsc, Arc};
 
-/// Production file-search dispatcher that selects the configured backend for a
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendPlan {
+    pub candidates: Vec<SearchBackend>,
+}
+
+/// Production file-search dispatcher that selects an available backend for a
 /// request and delegates execution to the corresponding backend executor.
 #[derive(Clone)]
 pub struct FileSearchExecutor {
     settings: FileSearchSettings,
     ripgrep: Arc<dyn SearchExecutor>,
+    native: Arc<dyn SearchExecutor>,
     walkdir: Arc<dyn SearchExecutor>,
     everything: Arc<dyn SearchExecutor>,
 }
@@ -21,6 +30,7 @@ impl FileSearchExecutor {
         Self::with_backend_executors(
             settings.clone(),
             Arc::new(RipgrepSearchExecutor::new(settings.clone())),
+            Arc::new(NativeSearchExecutor::new(settings.clone())),
             Arc::new(WalkDirSearchExecutor::new(settings.clone())),
             Arc::new(EverythingSearchExecutor::new(settings.clone())),
         )
@@ -33,14 +43,64 @@ impl FileSearchExecutor {
     pub fn with_backend_executors(
         settings: FileSearchSettings,
         ripgrep: Arc<dyn SearchExecutor>,
+        native: Arc<dyn SearchExecutor>,
         walkdir: Arc<dyn SearchExecutor>,
         everything: Arc<dyn SearchExecutor>,
     ) -> Self {
         Self {
             settings,
             ripgrep,
+            native,
             walkdir,
             everything,
+        }
+    }
+
+    pub fn plan_for_request(request: &SearchRequest, settings: &FileSearchSettings) -> BackendPlan {
+        let candidates = match (&request.kind, &request.scope) {
+            (SearchKind::Content, _) => vec![SearchBackend::Ripgrep, SearchBackend::Native],
+            (SearchKind::Filename, SearchScope::Roots { roots })
+                if is_custom_root(roots, settings) =>
+            {
+                vec![SearchBackend::WalkDir]
+            }
+            (SearchKind::Filename, SearchScope::Roots { .. })
+                if settings.everything_enabled
+                    && request.filename_match_mode == FilenameMatchMode::RankedSubstring =>
+            {
+                vec![SearchBackend::Everything, SearchBackend::WalkDir]
+            }
+            (SearchKind::Filename, SearchScope::Roots { .. }) => vec![SearchBackend::WalkDir],
+            (SearchKind::Filename, SearchScope::Files { .. }) => vec![SearchBackend::WalkDir],
+        };
+        BackendPlan { candidates }
+    }
+
+    fn availability(&self, backend: SearchBackend) -> Result<(), String> {
+        match backend {
+            SearchBackend::Ripgrep => {
+                resolve_ripgrep_executable(&self.settings.ripgrep_executable_path)
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            }
+            SearchBackend::Everything => {
+                let diagnostic = everything_diagnostic(&self.settings);
+                diagnostic.detected_path.map(|_| ()).ok_or_else(|| {
+                    diagnostic
+                        .unavailable_reason
+                        .unwrap_or_else(|| "Everything executable is unavailable".to_owned())
+                })
+            }
+            SearchBackend::WalkDir | SearchBackend::Native => Ok(()),
+        }
+    }
+
+    fn executor_for(&self, backend: SearchBackend) -> Arc<dyn SearchExecutor> {
+        match backend {
+            SearchBackend::Ripgrep => self.ripgrep.clone(),
+            SearchBackend::Native => self.native.clone(),
+            SearchBackend::WalkDir => self.walkdir.clone(),
+            SearchBackend::Everything => self.everything.clone(),
         }
     }
 }
@@ -53,37 +113,84 @@ impl SearchExecutor for FileSearchExecutor {
         token: CancellationToken,
         events: mpsc::Sender<SearchEvent>,
     ) {
-        match SearchCoordinator::select_backend_with_settings(&request, Some(&self.settings)) {
-            SearchBackend::Ripgrep => self.ripgrep.execute(id, request, token, events),
-            SearchBackend::WalkDir => self.walkdir.execute(id, request, token, events),
-            SearchBackend::Everything => self.everything.execute(id, request, token, events),
-            SearchBackend::Native => {
-                let _ = events.send(SearchEvent::Failed {
-                    id,
-                    error: "Native file search backend is not implemented".to_owned(),
-                });
+        let plan = Self::plan_for_request(&request, &self.settings);
+        let mut skipped: Option<(SearchBackend, String)> = None;
+        for backend in plan.candidates {
+            match self.availability(backend) {
+                Ok(()) => {
+                    if let Some((from, reason)) = skipped.take() {
+                        let _ = events.send(SearchEvent::BackendFallback {
+                            id,
+                            from,
+                            to: backend,
+                            reason,
+                        });
+                    }
+                    if events.send(SearchEvent::Started { id, backend }).is_err() {
+                        return;
+                    }
+                    self.executor_for(backend)
+                        .execute(id, request, token, events);
+                    return;
+                }
+                Err(reason) => {
+                    if skipped.is_none() {
+                        skipped = Some((backend, reason));
+                    }
+                }
             }
         }
+        let error = skipped
+            .map(|(_, r)| r)
+            .unwrap_or_else(|| "No search backend is available".to_owned());
+        let _ = events.send(SearchEvent::Failed { id, error });
     }
+}
+
+fn is_custom_root(roots: &[std::path::PathBuf], settings: &FileSearchSettings) -> bool {
+    !roots_match_global_search_roots(roots, settings)
+}
+
+fn roots_match_global_search_roots(
+    roots: &[std::path::PathBuf],
+    settings: &FileSearchSettings,
+) -> bool {
+    if roots.is_empty() {
+        return true;
+    }
+    if roots.len() != settings.global_search_roots.len() {
+        return false;
+    }
+    let mut request_roots: Vec<_> = roots
+        .iter()
+        .map(|p| crate::file_search::model::normalize_path_for_identity(p))
+        .collect();
+    let mut global_roots: Vec<_> = settings
+        .global_search_roots
+        .iter()
+        .map(|p| crate::file_search::model::normalize_path_for_identity(p))
+        .collect();
+    request_roots.sort();
+    global_roots.sort();
+    request_roots == global_roots
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file_search::model::{SearchKind, SearchScope};
+    use crate::file_search::model::{ContentMatchMode, FileTypeFilter};
+    use std::path::PathBuf;
     use std::sync::Mutex;
 
     #[derive(Default)]
     struct RecordingExecutor {
         calls: Mutex<Vec<SearchId>>,
     }
-
     impl RecordingExecutor {
         fn calls(&self) -> Vec<SearchId> {
             self.calls.lock().unwrap().clone()
         }
     }
-
     impl SearchExecutor for RecordingExecutor {
         fn execute(
             &self,
@@ -109,40 +216,45 @@ mod tests {
             included_extensions: Vec::new(),
             excluded_extensions: Vec::new(),
             excluded_directory_names: Vec::new(),
-            filename_match_mode: crate::file_search::model::FilenameMatchMode::RankedSubstring,
-            content_match_mode: crate::file_search::model::ContentMatchMode::ExactPhrase,
+            filename_match_mode: FilenameMatchMode::RankedSubstring,
+            content_match_mode: ContentMatchMode::ExactPhrase,
             whole_word: false,
-            file_type_filter: crate::file_search::model::FileTypeFilter::FilesAndDirectories,
+            file_type_filter: FileTypeFilter::FilesAndDirectories,
         }
     }
 
     fn dispatcher(
-        ripgrep: Arc<RecordingExecutor>,
-        walkdir: Arc<RecordingExecutor>,
-        everything: Arc<RecordingExecutor>,
-    ) -> FileSearchExecutor {
-        dispatcher_with_settings(FileSearchSettings::default(), ripgrep, walkdir, everything)
-    }
-
-    fn dispatcher_with_settings(
         settings: FileSearchSettings,
         ripgrep: Arc<RecordingExecutor>,
+        native: Arc<RecordingExecutor>,
         walkdir: Arc<RecordingExecutor>,
         everything: Arc<RecordingExecutor>,
     ) -> FileSearchExecutor {
-        FileSearchExecutor::with_backend_executors(settings, ripgrep, walkdir, everything)
+        FileSearchExecutor::with_backend_executors(settings, ripgrep, native, walkdir, everything)
     }
 
     #[test]
-    fn content_request_routes_to_ripgrep() {
+    fn available_ripgrep_selects_ripgrep() {
+        let Ok(rg) = resolve_ripgrep_executable(std::path::Path::new("rg")) else {
+            return;
+        };
         let ripgrep = Arc::new(RecordingExecutor::default());
+        let native = Arc::new(RecordingExecutor::default());
         let walkdir = Arc::new(RecordingExecutor::default());
         let everything = Arc::new(RecordingExecutor::default());
-        let executor = dispatcher(ripgrep.clone(), walkdir.clone(), everything.clone());
-
-        let (tx, _rx) = mpsc::channel();
+        let executor = dispatcher(
+            FileSearchSettings {
+                ripgrep_executable_path: rg,
+                ..FileSearchSettings::default()
+            },
+            ripgrep.clone(),
+            native.clone(),
+            walkdir.clone(),
+            everything.clone(),
+        );
+        let (tx, rx) = mpsc::channel();
         executor.execute(
-            SearchId(7),
+            SearchId(1),
             request(
                 SearchKind::Content,
                 SearchScope::Roots {
@@ -152,96 +264,99 @@ mod tests {
             CancellationToken::new(),
             tx,
         );
-
-        assert_eq!(ripgrep.calls(), vec![SearchId(7)]);
-        assert!(walkdir.calls().is_empty());
-        assert!(everything.calls().is_empty());
+        let events: Vec<_> = rx.try_iter().collect();
+        assert!(events.contains(&SearchEvent::Started {
+            id: SearchId(1),
+            backend: SearchBackend::Ripgrep
+        }));
+        assert_eq!(ripgrep.calls(), vec![SearchId(1)]);
+        assert!(native.calls().is_empty());
     }
 
     #[test]
-    fn directory_filename_request_routes_to_walkdir() {
+    fn missing_ripgrep_selects_native_and_started_reports_native_after_fallback() {
         let ripgrep = Arc::new(RecordingExecutor::default());
+        let native = Arc::new(RecordingExecutor::default());
         let walkdir = Arc::new(RecordingExecutor::default());
         let everything = Arc::new(RecordingExecutor::default());
-        let executor = dispatcher(ripgrep.clone(), walkdir.clone(), everything.clone());
-
-        let (tx, _rx) = mpsc::channel();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let executor = dispatcher(
+            FileSearchSettings {
+                ripgrep_executable_path: temp.path().join("missing-rg"),
+                ..FileSearchSettings::default()
+            },
+            ripgrep.clone(),
+            native.clone(),
+            walkdir.clone(),
+            everything.clone(),
+        );
+        let (tx, rx) = mpsc::channel();
         executor.execute(
-            SearchId(8),
+            SearchId(2),
             request(
-                SearchKind::Filename,
+                SearchKind::Content,
                 SearchScope::Roots {
-                    roots: vec![".".into()],
+                    roots: vec![temp.path().into()],
                 },
             ),
             CancellationToken::new(),
             tx,
         );
-
+        let events: Vec<_> = rx.try_iter().collect();
+        assert!(events.iter().any(|event| matches!(event, SearchEvent::BackendFallback { id: SearchId(2), from: SearchBackend::Ripgrep, to: SearchBackend::Native, reason } if reason.contains("ripgrep"))));
+        assert!(events.contains(&SearchEvent::Started {
+            id: SearchId(2),
+            backend: SearchBackend::Native
+        }));
+        assert!(events.contains(&SearchEvent::Completed { id: SearchId(2) }));
+        assert_eq!(native.calls(), vec![SearchId(2)]);
         assert!(ripgrep.calls().is_empty());
-        assert_eq!(walkdir.calls(), vec![SearchId(8)]);
-        assert!(everything.calls().is_empty());
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, SearchEvent::Failed { .. })));
     }
 
     #[test]
-    fn global_filename_request_routes_to_everything() {
-        let ripgrep = Arc::new(RecordingExecutor::default());
-        let walkdir = Arc::new(RecordingExecutor::default());
-        let everything = Arc::new(RecordingExecutor::default());
-        let executor = dispatcher_with_settings(
-            FileSearchSettings {
+    fn global_fuzzy_filename_does_not_plan_everything() {
+        let mut req = request(
+            SearchKind::Filename,
+            SearchScope::Roots { roots: Vec::new() },
+        );
+        req.filename_match_mode = FilenameMatchMode::Fuzzy;
+        let plan = FileSearchExecutor::plan_for_request(
+            &req,
+            &FileSearchSettings {
                 everything_enabled: true,
                 ..FileSearchSettings::default()
             },
-            ripgrep.clone(),
-            walkdir.clone(),
-            everything.clone(),
         );
-
-        let (tx, _rx) = mpsc::channel();
-        executor.execute(
-            SearchId(9),
-            request(
-                SearchKind::Filename,
-                SearchScope::Roots { roots: Vec::new() },
-            ),
-            CancellationToken::new(),
-            tx,
-        );
-
-        assert!(ripgrep.calls().is_empty());
-        assert!(walkdir.calls().is_empty());
-        assert_eq!(everything.calls(), vec![SearchId(9)]);
+        assert_eq!(plan.candidates, vec![SearchBackend::WalkDir]);
     }
 
     #[test]
-    fn global_filename_request_routes_to_ripgrep_when_everything_disabled() {
-        let ripgrep = Arc::new(RecordingExecutor::default());
-        let walkdir = Arc::new(RecordingExecutor::default());
-        let everything = Arc::new(RecordingExecutor::default());
-        let executor = dispatcher_with_settings(
-            FileSearchSettings {
-                everything_enabled: false,
-                ..FileSearchSettings::default()
-            },
-            ripgrep.clone(),
-            walkdir.clone(),
-            everything.clone(),
-        );
-
-        let (tx, _rx) = mpsc::channel();
-        executor.execute(
-            SearchId(10),
-            request(
-                SearchKind::Filename,
-                SearchScope::Roots { roots: Vec::new() },
+    fn newly_configured_path_is_used_by_next_search() {
+        let Ok(rg) = resolve_ripgrep_executable(std::path::Path::new("rg")) else {
+            return;
+        };
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings = FileSearchSettings {
+            ripgrep_executable_path: temp.path().join("missing-rg"),
+            ..FileSearchSettings::default()
+        };
+        let executor = FileSearchExecutor::new(FileSearchSettings {
+            ripgrep_executable_path: rg,
+            ..settings
+        });
+        let plan = FileSearchExecutor::plan_for_request(
+            &request(
+                SearchKind::Content,
+                SearchScope::Roots {
+                    roots: vec![PathBuf::from(".")],
+                },
             ),
-            CancellationToken::new(),
-            tx,
+            executor.settings(),
         );
-
-        assert_eq!(ripgrep.calls(), vec![SearchId(10)]);
-        assert!(walkdir.calls().is_empty());
-        assert!(everything.calls().is_empty());
+        assert_eq!(plan.candidates[0], SearchBackend::Ripgrep);
+        assert!(executor.availability(SearchBackend::Ripgrep).is_ok());
     }
 }

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -274,6 +274,12 @@ pub enum SearchEvent {
         id: SearchId,
         backend: SearchBackend,
     },
+    BackendFallback {
+        id: SearchId,
+        from: SearchBackend,
+        to: SearchBackend,
+        reason: String,
+    },
     Result {
         id: SearchId,
         result: SearchResult,

--- a/src/file_search/native.rs
+++ b/src/file_search/native.rs
@@ -1,4 +1,151 @@
-//! Native Rust content-search backend placeholder module.
-//!
-//! The production coordinator still routes content searches through ripgrep;
-//! this module exists to keep native backend code isolated as it is introduced.
+use crate::file_search::coordinator::{CancellationToken, SearchExecutor};
+use crate::file_search::model::{
+    ContentFileResultBuilder, ContentMatch, SearchEvent, SearchId, SearchKind, SearchProgress,
+    SearchRequest, SearchResult, SearchScope, SearchStatus,
+};
+use crate::file_search::settings::FileSearchSettings;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::sync::mpsc;
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone)]
+pub struct NativeSearchExecutor {
+    settings: FileSearchSettings,
+}
+
+impl NativeSearchExecutor {
+    pub fn new(settings: FileSearchSettings) -> Self {
+        Self { settings }
+    }
+}
+
+impl SearchExecutor for NativeSearchExecutor {
+    fn execute(
+        &self,
+        id: SearchId,
+        request: SearchRequest,
+        token: CancellationToken,
+        events: mpsc::Sender<SearchEvent>,
+    ) {
+        if let Err(error) = search_content_native(id, request, &self.settings, &token, &events) {
+            let _ = events.send(SearchEvent::Failed { id, error });
+        }
+    }
+}
+
+pub fn search_content_native(
+    id: SearchId,
+    request: SearchRequest,
+    settings: &FileSearchSettings,
+    cancellation: &CancellationToken,
+    events: &mpsc::Sender<SearchEvent>,
+) -> Result<(), String> {
+    if request.kind != SearchKind::Content {
+        return Err("native search only supports content requests".to_owned());
+    }
+    let roots = match &request.scope {
+        SearchScope::Roots { roots } if roots.is_empty() => settings.global_search_roots.clone(),
+        SearchScope::Roots { roots } => roots.clone(),
+        SearchScope::Files { files } => files.clone(),
+    };
+    let needle = if request.case_sensitive {
+        request.text.clone()
+    } else {
+        request.text.to_lowercase()
+    };
+    let mut files_scanned = 0;
+    let mut results_found = 0;
+    let mut cancelled = false;
+    for root in roots {
+        if cancellation.is_cancelled() {
+            cancelled = true;
+            break;
+        }
+        let paths: Box<dyn Iterator<Item = std::path::PathBuf>> = if root.is_file() {
+            Box::new(std::iter::once(root))
+        } else if root.is_dir() {
+            Box::new(
+                WalkDir::new(root)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().is_file())
+                    .map(|e| e.into_path()),
+            )
+        } else {
+            continue;
+        };
+        for path in paths {
+            if cancellation.is_cancelled() {
+                cancelled = true;
+                break;
+            }
+            let Ok(meta) = fs::metadata(&path) else {
+                continue;
+            };
+            if meta.len() > request.max_file_size_bytes {
+                continue;
+            }
+            files_scanned += 1;
+            let Ok(file) = fs::File::open(&path) else {
+                continue;
+            };
+            let mut builder =
+                ContentFileResultBuilder::new(path.clone(), settings.max_matches_per_content_file);
+            for (idx, line) in BufReader::new(file).lines().enumerate() {
+                let Ok(line) = line else {
+                    continue;
+                };
+                let hay = if request.case_sensitive {
+                    line.clone()
+                } else {
+                    line.to_lowercase()
+                };
+                if let Some(start) = hay.find(&needle) {
+                    builder.push_match(ContentMatch::new(
+                        idx + 1,
+                        line,
+                        start,
+                        start + needle.len(),
+                    ));
+                }
+            }
+            let result = builder.finish();
+            if result.total_matches > 0 {
+                results_found += 1;
+                if events
+                    .send(SearchEvent::Result {
+                        id,
+                        result: SearchResult::ContentFile(result),
+                    })
+                    .is_err()
+                {
+                    return Ok(());
+                }
+                if results_found >= request.max_results {
+                    break;
+                }
+            }
+        }
+    }
+    let status = if cancelled {
+        SearchStatus::Cancelled
+    } else {
+        SearchStatus::Completed
+    };
+    let _ = events.send(SearchEvent::Progress {
+        id,
+        progress: SearchProgress {
+            files_scanned,
+            directories_scanned: 0,
+            results_found,
+            status,
+        },
+    });
+    let _ = if cancelled {
+        events.send(SearchEvent::Cancelled { id })
+    } else {
+        events.send(SearchEvent::Completed { id })
+    };
+    Ok(())
+}

--- a/src/file_search/walkdir.rs
+++ b/src/file_search/walkdir.rs
@@ -57,7 +57,9 @@ pub fn search_filenames_in_directory(
     search_id: SearchId,
 ) -> Result<WalkDirSearchSummary, String> {
     let roots = match &request.scope {
-        SearchScope::Roots { roots } if roots.is_empty() => settings.global_search_roots.clone(),
+        SearchScope::Roots { roots } if roots.is_empty() => {
+            return Err("walkdir filename search requires at least one root".to_owned());
+        }
         SearchScope::Roots { roots } => roots.clone(),
         SearchScope::Files { files } => files.clone(),
     };

--- a/src/file_search/walkdir.rs
+++ b/src/file_search/walkdir.rs
@@ -56,21 +56,13 @@ pub fn search_filenames_in_directory(
     event_sender: &mpsc::Sender<SearchEvent>,
     search_id: SearchId,
 ) -> Result<WalkDirSearchSummary, String> {
-    let SearchScope::Roots { roots } = &request.scope else {
-        return Err("walkdir filename search requires a directory scope".to_owned());
+    let roots = match &request.scope {
+        SearchScope::Roots { roots } if roots.is_empty() => settings.global_search_roots.clone(),
+        SearchScope::Roots { roots } => roots.clone(),
+        SearchScope::Files { files } => files.clone(),
     };
-    if roots.len() != 1 {
-        return Err("walkdir filename search requires exactly one root".to_owned());
-    }
-    let root = &roots[0];
     if request.kind != SearchKind::Filename {
         return Err("walkdir filename search only supports filename requests".to_owned());
-    }
-    if !root.is_dir() {
-        return Err(format!(
-            "search root '{}' is not a directory",
-            root.display()
-        ));
     }
 
     let needle = if request.case_sensitive {
@@ -84,96 +76,93 @@ pub fn search_filenames_in_directory(
     let skipped_before_descent = Cell::new(0_u64);
     let mut ranked_results = Vec::new();
 
-    let iter = WalkDir::new(root).into_iter().filter_entry(|entry| {
-        if cancellation.is_cancelled() {
-            return false;
-        }
-        let descend = should_descend(entry, root, &excluded_names, include_hidden);
-        if !descend {
-            skipped_before_descent.set(skipped_before_descent.get().saturating_add(1));
-        }
-        descend
-    });
-
-    for entry in iter {
+    for root in roots {
         if cancellation.is_cancelled() {
             summary.cancelled = true;
             break;
         }
-
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(_) => {
-                summary.inaccessible_entries += 1;
-                continue;
-            }
-        };
-
-        if entry.path() != root && should_skip_entry(&entry, &excluded_names, include_hidden) {
-            summary.skipped_entries += 1;
+        if !root.is_dir() {
             continue;
         }
-
-        let metadata = match entry.metadata() {
-            Ok(metadata) => Some(metadata),
-            Err(_) => {
-                summary.inaccessible_entries += 1;
-                None
+        let iter = WalkDir::new(&root).into_iter().filter_entry(|entry| {
+            if cancellation.is_cancelled() {
+                return false;
             }
-        };
-        if metadata.as_ref().is_some_and(|metadata| metadata.is_dir()) {
-            summary.directories_scanned += 1;
-        } else {
-            summary.files_scanned += 1;
-        }
+            let descend = should_descend(entry, &root, &excluded_names, include_hidden);
+            if !descend {
+                skipped_before_descent.set(skipped_before_descent.get().saturating_add(1));
+            }
+            descend
+        });
 
-        let file_name = entry.file_name().to_string_lossy().to_string();
-        if let Some(rank) =
-            rank_filename_match(&file_name, entry.path(), &needle, request.case_sensitive)
-        {
+        for entry in iter {
             if cancellation.is_cancelled() {
                 summary.cancelled = true;
                 break;
             }
-            let result = FilenameResult {
-                path: entry.path().to_path_buf(),
-                file_name,
-                parent_directory: entry.path().parent().map(Path::to_path_buf),
-                kind: file_kind(metadata.as_ref()),
-                size: metadata.as_ref().filter(|m| m.is_file()).map(|m| m.len()),
-                modified: metadata.and_then(|m| m.modified().ok()),
-                rank,
-                match_quality: rank,
-                filename_match_ranges: Vec::new(),
-                path_match_ranges: Vec::new(),
-                arrival_index: ranked_results.len(),
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    summary.inaccessible_entries += 1;
+                    continue;
+                }
             };
-            if event_sender
-                .send(SearchEvent::Result {
-                    id: search_id,
-                    result: SearchResult::Filename(result.clone()),
-                })
-                .is_err()
-            {
-                break;
+            if entry.path() != root && should_skip_entry(&entry, &excluded_names, include_hidden) {
+                summary.skipped_entries += 1;
+                continue;
             }
-            ranked_results.push(result);
-            summary.results_found += 1;
-            if summary.results_found >= request.max_results {
-                break;
+            let metadata = match entry.metadata() {
+                Ok(metadata) => Some(metadata),
+                Err(_) => {
+                    summary.inaccessible_entries += 1;
+                    None
+                }
+            };
+            if metadata.as_ref().is_some_and(|metadata| metadata.is_dir()) {
+                summary.directories_scanned += 1;
+            } else {
+                summary.files_scanned += 1;
+            }
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if let Some(rank) =
+                rank_filename_match(&file_name, entry.path(), &needle, request.case_sensitive)
+            {
+                let result = FilenameResult {
+                    path: entry.path().to_path_buf(),
+                    file_name,
+                    parent_directory: entry.path().parent().map(Path::to_path_buf),
+                    kind: file_kind(metadata.as_ref()),
+                    size: metadata.as_ref().filter(|m| m.is_file()).map(|m| m.len()),
+                    modified: metadata.and_then(|m| m.modified().ok()),
+                    rank,
+                    match_quality: rank,
+                    filename_match_ranges: Vec::new(),
+                    path_match_ranges: Vec::new(),
+                    arrival_index: ranked_results.len(),
+                };
+                if event_sender
+                    .send(SearchEvent::Result {
+                        id: search_id,
+                        result: SearchResult::Filename(result.clone()),
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                ranked_results.push(result);
+                summary.results_found += 1;
+                if summary.results_found >= request.max_results {
+                    break;
+                }
             }
         }
-
-        if cancellation.is_cancelled() {
-            summary.cancelled = true;
+        if summary.results_found >= request.max_results {
             break;
         }
     }
-
     if cancellation.is_cancelled() {
         summary.cancelled = true;
     }
-
     summary.skipped_entries = summary
         .skipped_entries
         .saturating_add(skipped_before_descent.get());
@@ -197,7 +186,6 @@ pub fn search_filenames_in_directory(
     } else {
         event_sender.send(SearchEvent::Completed { id: search_id })
     };
-
     Ok(summary)
 }
 

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -4,11 +4,11 @@ mod keyboard;
 mod results;
 use crate::actions::clipboard;
 use crate::file_search::actions::{
-    ExplorerAction, InvocationTarget, containing_directory, copied_filename,
-    execute_explorer_action, nested_search_root, open_configured_terminal_in_directory,
-    open_in_configured_editor, open_path, resolve_explorer_action,
+    containing_directory, copied_filename, execute_explorer_action, nested_search_root,
+    open_configured_terminal_in_directory, open_in_configured_editor, open_path,
+    resolve_explorer_action, ExplorerAction, InvocationTarget,
 };
-use crate::file_search::coordinator::{SearchCoordinator, event_id};
+use crate::file_search::coordinator::{event_id, SearchCoordinator};
 use crate::file_search::model::{
     ContentMatch, FileKind, FileSearchResultKey, FileTypeFilter, PathIdentity, SearchBackend,
     SearchEvent, SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
@@ -217,6 +217,8 @@ pub struct FileSearchDialogState {
     pub ui_preferences_dirty: bool,
     pub request_search_focus: bool,
     pub request_immediate_repaint: bool,
+    pub show_ripgrep_missing_prompt: bool,
+    pub ripgrep_missing_prompt_dismissed: bool,
 }
 
 impl Default for FileSearchDialogState {
@@ -244,8 +246,19 @@ impl Default for FileSearchDialogState {
             ui_preferences_dirty: false,
             request_search_focus: false,
             request_immediate_repaint: false,
+            show_ripgrep_missing_prompt: false,
+            ripgrep_missing_prompt_dismissed: false,
         }
     }
+}
+
+fn validate_ripgrep_selection(path: &std::path::Path) -> Result<PathBuf, String> {
+    let absolute = path
+        .canonicalize()
+        .map_err(|err| format!("Selected ripgrep executable is invalid: {err}"))?;
+    crate::file_search::ripgrep::resolve_ripgrep_executable(&absolute)
+        .map(|_| absolute)
+        .map_err(|err| format!("Selected file is not a usable ripgrep executable: {err}"))
 }
 
 impl FileSearchDialogState {
@@ -407,6 +420,21 @@ impl FileSearchDialogState {
             SearchEvent::Started { backend, .. } => {
                 self.backend = Some(backend);
                 self.current_status = SearchStatus::Running;
+                false
+            }
+            SearchEvent::BackendFallback {
+                from, to, reason, ..
+            } => {
+                self.backend = Some(to);
+                self.warning_error_message = Some(format!(
+                    "Search backend fallback: {from:?} → {to:?}: {reason}"
+                ));
+                if from == SearchBackend::Ripgrep
+                    && to == SearchBackend::Native
+                    && !self.ripgrep_missing_prompt_dismissed
+                {
+                    self.show_ripgrep_missing_prompt = true;
+                }
                 false
             }
             SearchEvent::Result { result, .. } => {
@@ -762,6 +790,7 @@ impl FileSearchDialogState {
         if let Some(msg) = &self.warning_error_message {
             ui.colored_label(egui::Color32::YELLOW, msg);
         }
+        self.ripgrep_missing_prompt_ui(ui, coordinator);
         let results_region_size = ui.available_size();
         ui.allocate_ui_with_layout(results_region_size, *ui.layout(), |ui| {
             egui::ScrollArea::both()
@@ -772,6 +801,52 @@ impl FileSearchDialogState {
                     FileSearchMode::Content => self.content_results(ui, coordinator),
                 });
         });
+    }
+
+    fn ripgrep_missing_prompt_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        coordinator: &mut SearchCoordinator,
+    ) {
+        if !self.show_ripgrep_missing_prompt || self.ripgrep_missing_prompt_dismissed {
+            return;
+        }
+        ui.horizontal(|ui| {
+            ui.colored_label(egui::Color32::YELLOW, "ripgrep (rg) was not found. Native content search will continue; configure rg for faster future searches.");
+            if ui.button("Locate rg.exe").clicked() {
+                if let Some(path) = rfd::FileDialog::new().add_filter("Executable", &["exe", ""]).pick_file() {
+                    match validate_ripgrep_selection(&path) {
+                        Ok(abs) => {
+                            self.settings.ripgrep_executable_path = abs;
+                            coordinator.reconfigure_from_settings(self.settings.clone());
+                            self.show_ripgrep_missing_prompt = false;
+                            self.warning_error_message = Some("ripgrep path saved for future searches.".to_owned());
+                        }
+                        Err(err) => self.warning_error_message = Some(err),
+                    }
+                }
+            }
+            if ui.button("Dismiss").clicked() {
+                self.dismiss_ripgrep_missing_prompt();
+            }
+        });
+    }
+
+    pub fn dismiss_ripgrep_missing_prompt(&mut self) {
+        self.show_ripgrep_missing_prompt = false;
+        self.ripgrep_missing_prompt_dismissed = true;
+    }
+
+    pub fn configure_ripgrep_path_for_future_searches(
+        &mut self,
+        path: PathBuf,
+        coordinator: &mut SearchCoordinator,
+    ) -> Result<(), String> {
+        let abs = validate_ripgrep_selection(&path)?;
+        self.settings.ripgrep_executable_path = abs;
+        coordinator.reconfigure_from_settings(self.settings.clone());
+        self.show_ripgrep_missing_prompt = false;
+        Ok(())
     }
 
     fn filename_results(&mut self, ui: &mut egui::Ui, coordinator: &mut SearchCoordinator) {
@@ -1302,7 +1377,7 @@ mod tests {
     use crate::file_search::model::{
         ContentFileResult, ContentMatch, FileKind, FilenameRank, FilenameResult, SearchProgress,
     };
-    use std::sync::{Arc, Mutex, mpsc};
+    use std::sync::{mpsc, Arc, Mutex};
 
     struct RecordingExecutor {
         requests: Mutex<Vec<SearchRequest>>,
@@ -2656,12 +2731,10 @@ mod tests {
 
         assert!(action.is_none());
         assert_eq!(state.selected_result().cloned(), selected_before);
-        assert!(
-            state
-                .warning_error_message
-                .as_deref()
-                .is_some_and(|message| message.contains("missing or inaccessible"))
-        );
+        assert!(state
+            .warning_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("missing or inaccessible")));
     }
 
     #[test]
@@ -2798,5 +2871,28 @@ mod tests {
         assert_eq!(state.selected_result().cloned(), selected_before);
         assert_eq!(coordinator.diagnostics().started, 0);
         assert!(state.warning_error_message.is_none());
+    }
+    #[test]
+    fn dismissal_suppresses_repeated_ripgrep_missing_prompts_during_session() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(42)),
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::BackendFallback {
+            id: SearchId(42),
+            from: SearchBackend::Ripgrep,
+            to: SearchBackend::Native,
+            reason: "ripgrep missing".to_owned(),
+        });
+        assert!(state.show_ripgrep_missing_prompt);
+        state.dismiss_ripgrep_missing_prompt();
+        state.apply_event(SearchEvent::BackendFallback {
+            id: SearchId(42),
+            from: SearchBackend::Ripgrep,
+            to: SearchBackend::Native,
+            reason: "ripgrep still missing".to_owned(),
+        });
+        assert!(!state.show_ripgrep_missing_prompt);
+        assert!(state.ripgrep_missing_prompt_dismissed);
     }
 }

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -818,6 +818,7 @@ impl FileSearchDialogState {
                     match validate_ripgrep_selection(&path) {
                         Ok(abs) => {
                             self.settings.ripgrep_executable_path = abs;
+                            self.ui_preferences_dirty = true;
                             coordinator.reconfigure_from_settings(self.settings.clone());
                             self.show_ripgrep_missing_prompt = false;
                             self.warning_error_message = Some("ripgrep path saved for future searches.".to_owned());
@@ -844,6 +845,7 @@ impl FileSearchDialogState {
     ) -> Result<(), String> {
         let abs = validate_ripgrep_selection(&path)?;
         self.settings.ripgrep_executable_path = abs;
+        self.ui_preferences_dirty = true;
         coordinator.reconfigure_from_settings(self.settings.clone());
         self.show_ripgrep_missing_prompt = false;
         Ok(())
@@ -1674,7 +1676,7 @@ mod tests {
     }
 
     #[test]
-    fn global_filename_search_uses_ripgrep_backend_when_everything_is_disabled() {
+    fn global_filename_search_uses_walkdir_backend_when_everything_is_disabled() {
         let settings = FileSearchSettings {
             everything_enabled: false,
             ..FileSearchSettings::default()
@@ -1690,8 +1692,8 @@ mod tests {
 
         state.start_search(&mut coordinator);
 
-        assert_eq!(state.backend, Some(SearchBackend::Ripgrep));
-        assert_eq!(coordinator.last_backend(), Some(SearchBackend::Ripgrep));
+        assert_eq!(state.backend, Some(SearchBackend::WalkDir));
+        assert_eq!(coordinator.last_backend(), None);
     }
 
     #[test]
@@ -1706,7 +1708,7 @@ mod tests {
         let id = state.start_search(&mut coordinator);
 
         assert!(id.is_some());
-        assert_eq!(coordinator.diagnostics().started, 1);
+        assert_eq!(coordinator.diagnostics().started, 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure `SearchEvent::Started` reports the backend that will actually run by deferring backend resolution to the executor and to surface accurate diagnostics when a primary backend falls back.
- Prefer ripgrep for content searches but allow a native fallback when ripgrep is unavailable, and make Everything usage conservative for global filename searches.
- Present backend fallbacks in the UI as warnings (not hard failures) and provide a non-blocking ripgrep-missing prompt so users can configure `rg` without interrupting searches.

### Description
- Introduced `BackendPlan { candidates: Vec<SearchBackend> }` and `FileSearchExecutor::plan_for_request` to compute ordered backend candidates for a request, with rules: content → `Ripgrep` then `Native`; custom-root filename → `WalkDir`; global filename → `Everything` only when enabled and in ranked-substring mode, otherwise `WalkDir`; and disallow `Everything` for fuzzy global filename.
- Moved backend availability checks and `SearchEvent::Started` emission into `FileSearchExecutor::execute`, so the `Started` event indicates the backend that will actually run, and attempt fallbacks when the primary backend is unavailable.
- Added `SearchEvent::BackendFallback { id, from, to, reason }` and updated `SearchCoordinator::apply_event` to record fallback diagnostics without treating them as failed searches.
- Added a simple `NativeSearchExecutor` as a fallback content backend and updated `WalkDir` filename search to accept configured global roots (so global filename searches can fall back to `WalkDir` when `Everything`/`rg` are unavailable).
- Updated `FileSearchDialogState` to display fallback warnings (yellow), to show a non-blocking ripgrep-missing prompt with `Locate rg.exe` and `Dismiss` actions, to validate the selected executable via `resolve_ripgrep_executable` before persisting, and to suppress repeated prompts during the same session after dismissal.
- Added unit tests covering: available ripgrep selects `Ripgrep`; missing ripgrep selects `Native` and `Started` reports `Native` after fallback; native completion does not emit a ripgrep failure; fuzzy global filename does not plan `Everything`; newly configured ripgrep path is used by the next search; and dismissal suppresses repeated ripgrep-missing prompts during the session.

### Testing
- Added unit tests in `src/file_search/executor.rs` and `src/gui/file_search_dialog.rs` exercising backend selection and UI fallback behavior (tests included in the diff); the tests are designed to validate `Started` backend reporting, fallback emission, and ripgrep prompt flow.
- Ran `git diff --check` which passed without issues.
- Attempted `cargo check --lib` / `cargo test`, but the repository build in this Linux environment hit unrelated platform-specific build constraints (missing system libs / pkg-config for native X11/ALSA and non-target-gated Windows API imports), so a full compile/test run could not be completed here; these environment issues are external to the changes in this PR.
- Ran formatting on the changed files with `rustfmt`; a repository-wide `cargo fmt --check` reported unrelated formatting drift outside this change. Please run CI (or `cargo test` / `cargo check` in a platform matching the project CI) to validate all tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55369474ec833287fa4a378f98303e)