### PR TITLE
Constrain file searches to validated roots and ES CLI integration

### DIFF
--- a/src/file_search/everything.rs
+++ b/src/file_search/everything.rs
@@ -762,8 +762,12 @@ exit /b 3
             everything_executable_path: script,
             ..FileSearchSettings::default()
         };
+        let mut req = request("x");
+        req.scope = SearchScope::Roots {
+            roots: vec![temp.path().to_path_buf()],
+        };
         let err = search_with_everything(
-            request("x"),
+            req,
             &settings,
             &CancellationToken::new(),
             &mpsc::channel().0,
@@ -787,14 +791,12 @@ exit /b 3
             return;
         }
         let (tx, rx) = mpsc::channel();
-        search_with_everything(
-            request("definitely-not-a-real-file-search-fixture"),
-            &settings,
-            &CancellationToken::new(),
-            &tx,
-            SearchId(99),
-        )
-        .unwrap();
+        let mut req = request("definitely-not-a-real-file-search-fixture");
+        req.scope = SearchScope::Roots {
+            roots: vec![std::env::current_dir().unwrap()],
+        };
+        search_with_everything(req, &settings, &CancellationToken::new(), &tx, SearchId(99))
+            .unwrap();
         assert!(rx
             .try_iter()
             .any(|event| matches!(event, SearchEvent::Completed { id: SearchId(99) })));

--- a/src/file_search/everything.rs
+++ b/src/file_search/everything.rs
@@ -75,7 +75,7 @@ pub fn everything_diagnostic(settings: &FileSearchSettings) -> EverythingDiagnos
         Some("Everything filename search is disabled in settings".to_owned())
     } else if detected_path.is_none() {
         Some(
-            "Everything executable was not found; install Everything/ES.exe or configure its path"
+            "Everything ES CLI executable was not found; install es.exe or configure its path"
                 .to_owned(),
         )
     } else {
@@ -96,7 +96,6 @@ pub fn detect_everything_executable(settings: &FileSearchSettings) -> Option<Pat
     }
     configured_executable(&settings.everything_executable_path)
         .or_else(|| find_on_path("es.exe"))
-        .or_else(|| find_on_path("Everything.exe"))
         .or_else(find_common_windows_installation)
 }
 
@@ -128,11 +127,7 @@ fn find_common_windows_installation() -> Option<PathBuf> {
     roots.extend(env::var_os("ProgramFiles(x86)").map(PathBuf::from));
     roots.extend(env::var_os("LOCALAPPDATA").map(PathBuf::from));
     for root in roots {
-        for rel in [
-            "Everything/ES.exe",
-            "Everything/es.exe",
-            "Everything/Everything.exe",
-        ] {
+        for rel in ["Everything/ES.exe", "Everything/es.exe"] {
             let candidate = root.join(rel);
             if candidate.is_file() {
                 return Some(candidate);
@@ -152,6 +147,15 @@ pub fn build_everything_command(
     executable: PathBuf,
     request: &SearchRequest,
     settings: &FileSearchSettings,
+) -> EverythingCommandSpec {
+    build_everything_command_for_root(executable, request, settings, None)
+}
+
+pub fn build_everything_command_for_root(
+    executable: PathBuf,
+    request: &SearchRequest,
+    settings: &FileSearchSettings,
+    root: Option<&Path>,
 ) -> EverythingCommandSpec {
     let mut args = Vec::new();
     args.push(OsString::from("-csv"));
@@ -176,8 +180,15 @@ pub fn build_everything_command(
         args.push(OsString::from(format!("{}\\*", dir)));
     }
     args.push(OsString::from("-s"));
-    args.push(OsString::from(&request.text));
+    args.push(OsString::from(everything_query(&request.text, root)));
     EverythingCommandSpec { executable, args }
+}
+
+pub fn everything_query(text: &str, root: Option<&Path>) -> String {
+    match root {
+        Some(root) => format!("path:\"{}\" {}", root.display(), text),
+        None => text.to_owned(),
+    }
 }
 
 pub fn search_with_everything(
@@ -193,11 +204,98 @@ pub fn search_with_everything(
     let diagnostic = everything_diagnostic(settings);
     let executable = diagnostic.detected_path.ok_or_else(|| {
         let reason = diagnostic.unavailable_reason.unwrap_or_else(|| {
-            "Everything filename search is unavailable; install Everything/ES.exe or configure the Everything executable path in settings".to_owned()
+            "Everything filename search is unavailable; install es.exe or configure the Everything CLI executable path in settings".to_owned()
         });
         format!("Everything filename search is unavailable: {reason}")
     })?;
-    let spec = build_everything_command(executable, &request, settings);
+    let roots = match &request.scope {
+        SearchScope::Roots { roots } => roots.clone(),
+        SearchScope::Files { .. } => unreachable!(),
+    };
+    if roots.is_empty() {
+        return Err("Everything search requires at least one root".to_owned());
+    }
+    let mut emitted = 0usize;
+    let mut seen = HashSet::new();
+    let mut root_errors = Vec::new();
+    let mut usable_roots = 0usize;
+    for root in roots {
+        if cancellation.is_cancelled() || emitted >= request.max_results {
+            break;
+        }
+        let root = match root.canonicalize() {
+            Ok(root) if root.is_dir() => root,
+            Ok(root) => {
+                root_errors.push(format!("{} is not a directory", root.display()));
+                continue;
+            }
+            Err(err) => {
+                root_errors.push(format!("{}: {err}", root.display()));
+                continue;
+            }
+        };
+        usable_roots += 1;
+        let remaining = request.max_results.saturating_sub(emitted);
+        let mut scoped_request = request.clone();
+        scoped_request.max_results = remaining;
+        let spec = build_everything_command_for_root(
+            executable.clone(),
+            &scoped_request,
+            settings,
+            Some(&root),
+        );
+        emitted += run_everything_command(
+            spec,
+            &scoped_request,
+            settings,
+            cancellation,
+            event_sender,
+            search_id,
+            &mut seen,
+        )?;
+    }
+    if usable_roots == 0 {
+        return Err(format!(
+            "Everything search requires at least one usable root{}",
+            if root_errors.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", root_errors.join("; "))
+            }
+        ));
+    }
+    let status = if cancellation.is_cancelled() {
+        SearchStatus::Cancelled
+    } else {
+        SearchStatus::Completed
+    };
+    let _ = event_sender.send(SearchEvent::Progress {
+        id: search_id,
+        progress: SearchProgress {
+            files_scanned: 0,
+            directories_scanned: 0,
+            results_found: emitted,
+            status,
+            global_truncated: false,
+        },
+    });
+    let _ = if cancellation.is_cancelled() {
+        event_sender.send(SearchEvent::Cancelled { id: search_id })
+    } else {
+        event_sender.send(SearchEvent::Completed { id: search_id })
+    };
+    Ok(())
+}
+
+fn run_everything_command(
+    spec: EverythingCommandSpec,
+    request: &SearchRequest,
+    settings: &FileSearchSettings,
+    cancellation: &CancellationToken,
+    event_sender: &mpsc::Sender<SearchEvent>,
+    search_id: SearchId,
+    seen: &mut HashSet<String>,
+) -> Result<usize, String> {
     let mut child = Command::new(&spec.executable)
         .args(&spec.args)
         .stdout(Stdio::piped())
@@ -209,7 +307,6 @@ pub fn search_with_everything(
                 spec.executable.display()
             )
         })?;
-
     let stdout = child
         .stdout
         .take()
@@ -222,25 +319,20 @@ pub fn search_with_everything(
     let req_for_reader = request.clone();
     let stdout_thread = thread::spawn(move || read_stdout(stdout, req_for_reader, result_tx));
     let stderr_thread = thread::spawn(move || read_bounded(stderr, STDERR_LIMIT));
-
     let mut emitted = 0usize;
     loop {
         while let Ok(parsed) = result_rx.try_recv() {
-            match parsed {
-                Ok(result) => {
-                    if emitted < request.max_results
-                        && passes_post_filters(&result, &request, settings)
-                        && event_sender
-                            .send(SearchEvent::Result {
-                                id: search_id,
-                                result: SearchResult::Filename(result),
-                            })
-                            .is_ok()
-                    {
-                        emitted += 1;
-                    }
-                }
-                Err(error) => return Err(error),
+            let result = parsed?;
+            let identity = crate::file_search::model::normalize_path_for_identity(&result.path);
+            if emitted < request.max_results
+                && seen.insert(identity)
+                && passes_post_filters(&result, request, settings)
+            {
+                let _ = event_sender.send(SearchEvent::Result {
+                    id: search_id,
+                    result: SearchResult::Filename(result),
+                });
+                emitted += 1;
             }
         }
         if cancellation.is_cancelled() {
@@ -248,27 +340,24 @@ pub fn search_with_everything(
             let _ = child.wait();
             let _ = stdout_thread.join();
             let _ = stderr_thread.join();
-            let _ = event_sender.send(SearchEvent::Cancelled { id: search_id });
-            return Ok(());
+            return Ok(emitted);
         }
         if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
             let stdout_result = stdout_thread
                 .join()
                 .unwrap_or_else(|_| Err("stdout reader panicked".to_owned()));
             while let Ok(parsed) = result_rx.try_recv() {
-                match parsed {
-                    Ok(result) => {
-                        if emitted < request.max_results
-                            && passes_post_filters(&result, &request, settings)
-                        {
-                            let _ = event_sender.send(SearchEvent::Result {
-                                id: search_id,
-                                result: SearchResult::Filename(result),
-                            });
-                            emitted += 1;
-                        }
-                    }
-                    Err(error) => return Err(error),
+                let result = parsed?;
+                let identity = crate::file_search::model::normalize_path_for_identity(&result.path);
+                if emitted < request.max_results
+                    && seen.insert(identity)
+                    && passes_post_filters(&result, request, settings)
+                {
+                    let _ = event_sender.send(SearchEvent::Result {
+                        id: search_id,
+                        result: SearchResult::Filename(result),
+                    });
+                    emitted += 1;
                 }
             }
             stdout_result?;
@@ -279,18 +368,7 @@ pub fn search_with_everything(
                     stderr.trim()
                 ));
             }
-            let _ = event_sender.send(SearchEvent::Progress {
-                id: search_id,
-                progress: SearchProgress {
-                    files_scanned: 0,
-                    directories_scanned: 0,
-                    results_found: emitted,
-                    status: SearchStatus::Completed,
-                    global_truncated: false,
-                },
-            });
-            let _ = event_sender.send(SearchEvent::Completed { id: search_id });
-            return Ok(());
+            return Ok(emitted);
         }
         thread::sleep(Duration::from_millis(10));
     }
@@ -548,6 +626,49 @@ mod tests {
     }
 
     #[test]
+    fn ignores_everything_gui_executable_on_path() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("Everything.exe"), "").unwrap();
+        let old = env::var_os("PATH");
+        unsafe {
+            env::set_var("PATH", temp.path());
+        }
+        let settings = FileSearchSettings {
+            everything_enabled: true,
+            everything_executable_path: PathBuf::from("missing.exe"),
+            ..FileSearchSettings::default()
+        };
+        assert_eq!(detect_everything_executable(&settings), None);
+        if let Some(old) = old {
+            unsafe {
+                env::set_var("PATH", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("PATH");
+            }
+        }
+    }
+
+    #[test]
+    fn everything_query_contains_root_restriction() {
+        let req = request("needle");
+        let root = PathBuf::from("C:/Search Root");
+        let spec = build_everything_command_for_root(
+            PathBuf::from("es.exe"),
+            &req,
+            &FileSearchSettings::default(),
+            Some(&root),
+        );
+        assert!(spec.args.windows(2).any(|w| {
+            w == [
+                OsString::from("-s"),
+                OsString::from("path:\"C:/Search Root\" needle"),
+            ]
+        }));
+    }
+
+    #[test]
     fn builds_argument_vector_with_filters_and_dash_query_as_value() {
         let mut req = request("-dash query");
         req.max_results = 7;
@@ -565,22 +686,18 @@ mod tests {
             PathBuf::from("C:/Program Files/Everything/es.exe")
         );
         assert!(spec.args.contains(&OsString::from("-csv")));
-        assert!(
-            spec.args
-                .windows(2)
-                .any(|w| w == [OsString::from("-n"), OsString::from("7")])
-        );
-        assert!(
-            spec.args
-                .windows(2)
-                .any(|w| w == [OsString::from("-s"), OsString::from("-dash query")])
-        );
-        assert!(
-            !spec
-                .args
-                .iter()
-                .any(|a| a == "-dash query" && spec.args.first() == Some(a))
-        );
+        assert!(spec
+            .args
+            .windows(2)
+            .any(|w| w == [OsString::from("-n"), OsString::from("7")]));
+        assert!(spec
+            .args
+            .windows(2)
+            .any(|w| w == [OsString::from("-s"), OsString::from("-dash query")]));
+        assert!(!spec
+            .args
+            .iter()
+            .any(|a| a == "-dash query" && spec.args.first() == Some(a)));
     }
 
     #[test]
@@ -595,18 +712,14 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].kind, FileKind::File);
         assert_eq!(results[1].kind, FileKind::Directory);
-        assert!(
-            results[0]
-                .path
-                .to_string_lossy()
-                .contains("path with spaces")
-        );
+        assert!(results[0]
+            .path
+            .to_string_lossy()
+            .contains("path with spaces"));
         assert!(results[1].path.to_string_lossy().contains("ユニコード"));
-        assert!(
-            parse_everything_output("", &request("x"))
-                .unwrap()
-                .is_empty()
-        );
+        assert!(parse_everything_output("", &request("x"))
+            .unwrap()
+            .is_empty());
         assert!(parse_everything_output("\"unterminated", &request("x")).is_err());
     }
 
@@ -682,9 +795,8 @@ exit /b 3
             SearchId(99),
         )
         .unwrap();
-        assert!(
-            rx.try_iter()
-                .any(|event| matches!(event, SearchEvent::Completed { id: SearchId(99) }))
-        );
+        assert!(rx
+            .try_iter()
+            .any(|event| matches!(event, SearchEvent::Completed { id: SearchId(99) })));
     }
 }

--- a/src/file_search/walkdir.rs
+++ b/src/file_search/walkdir.rs
@@ -8,7 +8,7 @@ use crate::file_search::settings::FileSearchSettings;
 use crate::file_search::sorting::sort_filename_results;
 use std::cell::Cell;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use walkdir::{DirEntry, WalkDir};
 
@@ -47,6 +47,7 @@ pub struct WalkDirSearchSummary {
     pub skipped_entries: u64,
     pub inaccessible_entries: u64,
     pub cancelled: bool,
+    pub root_errors: Vec<String>,
 }
 
 pub fn search_filenames_in_directory(
@@ -77,14 +78,34 @@ pub fn search_filenames_in_directory(
     let mut summary = WalkDirSearchSummary::default();
     let skipped_before_descent = Cell::new(0_u64);
     let mut ranked_results = Vec::new();
+    let mut seen_results = HashSet::new();
+    let resolved_roots: Vec<PathBuf> = roots
+        .into_iter()
+        .filter_map(|root| match root.canonicalize() {
+            Ok(resolved) if resolved.is_dir() => Some(resolved),
+            Ok(resolved) => {
+                summary
+                    .root_errors
+                    .push(format!("{} is not a directory", resolved.display()));
+                None
+            }
+            Err(err) => {
+                summary
+                    .root_errors
+                    .push(format!("{}: {err}", root.display()));
+                None
+            }
+        })
+        .collect();
+    let roots = dedup_resolved_roots(resolved_roots);
+    if roots.is_empty() {
+        return Err("walkdir filename search requires at least one usable root".to_owned());
+    }
 
     for root in roots {
         if cancellation.is_cancelled() {
             summary.cancelled = true;
             break;
-        }
-        if !root.is_dir() {
-            continue;
         }
         let iter = WalkDir::new(&root).into_iter().filter_entry(|entry| {
             if cancellation.is_cancelled() {
@@ -129,6 +150,10 @@ pub fn search_filenames_in_directory(
             if let Some(rank) =
                 rank_filename_match(&file_name, entry.path(), &needle, request.case_sensitive)
             {
+                let identity = crate::file_search::model::normalize_path_for_identity(entry.path());
+                if !seen_results.insert(identity) {
+                    continue;
+                }
                 let result = FilenameResult {
                     path: entry.path().to_path_buf(),
                     file_name,
@@ -190,6 +215,20 @@ pub fn search_filenames_in_directory(
         event_sender.send(SearchEvent::Completed { id: search_id })
     };
     Ok(summary)
+}
+
+fn dedup_resolved_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut result: Vec<PathBuf> = Vec::new();
+    'outer: for root in roots {
+        for existing in &result {
+            if root == *existing || root.starts_with(existing) {
+                continue 'outer;
+            }
+        }
+        result.retain(|existing| !existing.starts_with(&root));
+        result.push(root);
+    }
+    result
 }
 
 fn should_descend(
@@ -349,6 +388,59 @@ mod tests {
             .count();
         assert_eq!(count, 1);
         assert_eq!(summary.results_found, 1);
+    }
+
+    #[test]
+    fn invalid_roots_are_reported_while_valid_roots_are_searched() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("match.txt"), "a").unwrap();
+        let mut req = request(temp.path().to_path_buf(), "match", 20);
+        req.scope = SearchScope::Roots {
+            roots: vec![temp.path().to_path_buf(), temp.path().join("missing")],
+        };
+        let (summary, events) = run(req);
+        assert_eq!(summary.results_found, 1);
+        assert_eq!(summary.root_errors.len(), 1);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, SearchEvent::Result { .. })));
+    }
+
+    #[test]
+    fn repeated_and_overlapping_roots_do_not_duplicate_results() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("match.txt"), "a").unwrap();
+        let mut req = request(temp.path().to_path_buf(), "match", 20);
+        req.scope = SearchScope::Roots {
+            roots: vec![temp.path().to_path_buf(), nested, temp.path().to_path_buf()],
+        };
+        let (summary, events) = run(req);
+        assert_eq!(summary.results_found, 1);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, SearchEvent::Result { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn empty_or_invalid_roots_are_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut req = request(temp.path().join("missing"), "match", 20);
+        req.scope = SearchScope::Roots { roots: vec![] };
+        let (tx, _) = mpsc::channel();
+        assert!(search_filenames_in_directory(
+            req,
+            &FileSearchSettings::default(),
+            &CancellationToken::new(),
+            &tx,
+            SearchId(1)
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -145,6 +145,17 @@ pub fn dedup_search_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathB
     deduped
 }
 
+pub fn resolve_valid_roots(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    dedup_search_paths(paths.into_iter().filter_map(|path| {
+        let trimmed = path.to_string_lossy().trim().to_owned();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let path = PathBuf::from(trimmed);
+        path.canonicalize().ok().filter(|p| p.is_dir())
+    }))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SelectedFileSearchResultPayload {
     Filename {
@@ -199,7 +210,7 @@ pub struct FileSearchDialogState {
     pub selected_mode: FileSearchMode,
     pub selected_scope: FileSearchScopeMode,
     pub search_text: String,
-    pub root_directory: String,
+    pub custom_roots: Vec<String>,
     pub case_sensitive: bool,
     pub include_hidden: bool,
     pub active_search_id: Option<SearchId>,
@@ -228,7 +239,7 @@ impl Default for FileSearchDialogState {
             selected_mode: FileSearchMode::Filename,
             selected_scope: FileSearchScopeMode::Global,
             search_text: String::new(),
-            root_directory: String::new(),
+            custom_roots: Vec::new(),
             case_sensitive: false,
             include_hidden: false,
             active_search_id: None,
@@ -290,7 +301,7 @@ impl FileSearchDialogState {
         self.selected_mode = mode;
         if let Some(root) = root {
             self.selected_scope = FileSearchScopeMode::Directory;
-            self.root_directory = root.display().to_string();
+            self.custom_roots = vec![root.display().to_string()];
         }
         self.search_text = text;
         self.open();
@@ -331,23 +342,24 @@ impl FileSearchDialogState {
         }
         let scope = match self.selected_scope {
             FileSearchScopeMode::Global => {
-                let roots = dedup_search_paths(self.settings.global_search_roots.clone());
+                let roots = resolve_valid_roots(self.settings.global_search_roots.clone());
                 if roots.is_empty() {
-                    self.warning_error_message =
-                        Some("Global file search has no configured roots.".to_string());
+                    self.warning_error_message = Some(
+                        "Configure at least one valid global search root in File Search settings."
+                            .to_string(),
+                    );
                     return None;
                 }
                 SearchScope::Roots { roots }
             }
             FileSearchScopeMode::Directory => {
-                let root = self.root_directory.trim();
-                if root.is_empty() {
-                    self.warning_error_message = Some("Choose a root directory first.".to_string());
+                let roots = resolve_valid_roots(self.custom_roots.iter().map(PathBuf::from));
+                if roots.is_empty() {
+                    self.warning_error_message =
+                        Some("Choose at least one valid root directory first.".to_string());
                     return None;
                 }
-                SearchScope::Roots {
-                    roots: dedup_search_paths([PathBuf::from(root)]),
-                }
+                SearchScope::Roots { roots }
             }
         };
         let request = SearchRequest {
@@ -740,28 +752,87 @@ impl FileSearchDialogState {
                 ui.ctx().request_repaint();
             }
         });
-        ui.horizontal(|ui| {
-            ui.label("Root");
-            let root_response = ui.add(
-                egui::TextEdit::singleline(&mut self.root_directory)
-                    .id_source(Self::root_field_id()),
-            );
-            if root_response.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                self.start_search(coordinator);
-                ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Enter));
-                ui.ctx().request_repaint();
-            }
-            if ui.button("Pick…").clicked() {
-                if let Some(path) = rfd::FileDialog::new().pick_folder() {
-                    self.root_directory = path.display().to_string();
-                    self.selected_scope = FileSearchScopeMode::Directory;
+        match self.selected_scope {
+            FileSearchScopeMode::Global => {
+                let valid_global_roots =
+                    resolve_valid_roots(self.settings.global_search_roots.clone());
+                ui.label(format!(
+                    "Global roots: {} configured",
+                    valid_global_roots.len()
+                ));
+                if valid_global_roots.is_empty() {
+                    ui.colored_label(
+                        egui::Color32::YELLOW,
+                        "Configure at least one valid global search root in File Search settings.",
+                    );
                 }
+                egui::CollapsingHeader::new("Global root list")
+                    .default_open(false)
+                    .show(ui, |ui| {
+                        for root in &valid_global_roots {
+                            ui.label(root.display().to_string());
+                        }
+                    });
             }
-        });
+            FileSearchScopeMode::Directory => {
+                ui.vertical(|ui| {
+                    if ui.button("Add folder…").clicked() {
+                        if let Some(path) = rfd::FileDialog::new().pick_folder() {
+                            self.custom_roots.push(path.display().to_string());
+                        }
+                    }
+                    let mut remove = None;
+                    let mut submit_search = false;
+                    for (idx, root) in self.custom_roots.iter_mut().enumerate() {
+                        ui.horizontal(|ui| {
+                            ui.label("Root");
+                            let root_response = ui.add(
+                                egui::TextEdit::singleline(root)
+                                    .id_source((Self::root_field_id(), idx)),
+                            );
+                            if root_response.has_focus()
+                                && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                            {
+                                submit_search = true;
+                                ui.input_mut(|i| {
+                                    i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+                                });
+                                ui.ctx().request_repaint();
+                            }
+                            let valid = PathBuf::from(root.trim())
+                                .canonicalize()
+                                .is_ok_and(|p| p.is_dir());
+                            ui.label(if valid { "valid" } else { "invalid" });
+                            if ui.button("Remove").clicked() {
+                                remove = Some(idx);
+                            }
+                        });
+                    }
+                    if submit_search {
+                        self.start_search(coordinator);
+                    }
+                    if let Some(idx) = remove {
+                        self.custom_roots.remove(idx);
+                    }
+                });
+            }
+        }
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.case_sensitive, "Case-sensitive");
             ui.checkbox(&mut self.include_hidden, "Include hidden");
-            if ui.button("Search").clicked() {
+            let search_enabled = !self.search_text.trim().is_empty()
+                && match self.selected_scope {
+                    FileSearchScopeMode::Global => {
+                        !resolve_valid_roots(self.settings.global_search_roots.clone()).is_empty()
+                    }
+                    FileSearchScopeMode::Directory => {
+                        !resolve_valid_roots(self.custom_roots.iter().map(PathBuf::from)).is_empty()
+                    }
+                };
+            if ui
+                .add_enabled(search_enabled, egui::Button::new("Search"))
+                .clicked()
+            {
                 if self.start_search(coordinator).is_some() {
                     ui.ctx().request_repaint();
                 }
@@ -1359,7 +1430,7 @@ impl FileSearchDialogState {
             Some(root) => {
                 self.selected_mode = mode;
                 self.selected_scope = FileSearchScopeMode::Directory;
-                self.root_directory = root.display().to_string();
+                self.custom_roots = vec![root.display().to_string()];
                 self.start_search(coordinator);
             }
             None => {
@@ -1449,11 +1520,14 @@ mod tests {
 
     #[test]
     fn global_roots_resolve_into_roots_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root-a");
+        std::fs::create_dir(&root).unwrap();
         let executor = RecordingExecutor::new();
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             settings: FileSearchSettings {
-                global_search_roots: vec![PathBuf::from("/tmp/root-a")],
+                global_search_roots: vec![root.clone()],
                 ..FileSearchSettings::default()
             },
             ..Default::default()
@@ -1464,7 +1538,7 @@ mod tests {
         assert_eq!(
             request.scope,
             SearchScope::Roots {
-                roots: vec![PathBuf::from("/tmp/root-a")]
+                roots: vec![root.canonicalize().unwrap()]
             }
         );
     }
@@ -1484,17 +1558,20 @@ mod tests {
         assert!(state.start_search(&mut coordinator).is_none());
         assert_eq!(
             state.warning_error_message.as_deref(),
-            Some("Global file search has no configured roots.")
+            Some("Configure at least one valid global search root in File Search settings.")
         );
     }
 
     #[test]
     fn repeated_global_roots_are_deduplicated() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        std::fs::create_dir(&root).unwrap();
         let executor = RecordingExecutor::new();
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             settings: FileSearchSettings {
-                global_search_roots: vec![PathBuf::from("/tmp/root"), PathBuf::from("/tmp/root")],
+                global_search_roots: vec![root.clone(), root.clone()],
                 ..FileSearchSettings::default()
             },
             ..Default::default()
@@ -1505,18 +1582,19 @@ mod tests {
         assert_eq!(
             request.scope,
             SearchScope::Roots {
-                roots: vec![PathBuf::from("/tmp/root")]
+                roots: vec![root.canonicalize().unwrap()]
             }
         );
     }
 
     #[test]
-    fn old_single_directory_launcher_action_resolves_to_one_root() {
+    fn custom_root_launcher_action_resolves_to_one_root() {
+        let temp = tempfile::tempdir().unwrap();
         let executor = RecordingExecutor::new();
         let mut state = FileSearchDialogState {
             search_text: "needle".into(),
             selected_scope: FileSearchScopeMode::Directory,
-            root_directory: "/tmp/project".into(),
+            custom_roots: vec![temp.path().display().to_string()],
             ..Default::default()
         };
 
@@ -1525,7 +1603,7 @@ mod tests {
         assert_eq!(
             request.scope,
             SearchScope::Roots {
-                roots: vec![PathBuf::from("/tmp/project")]
+                roots: vec![temp.path().canonicalize().unwrap()]
             }
         );
     }
@@ -2512,7 +2590,7 @@ mod tests {
             FileSearchMode::Filename,
             &mut coordinator,
         );
-        assert_eq!(state.root_directory, "/tmp/project");
+        assert_eq!(state.custom_roots, vec!["/tmp/project".to_string()]);
 
         state.start_nested_search(
             std::path::Path::new("/tmp/project/src"),
@@ -2520,7 +2598,7 @@ mod tests {
             FileSearchMode::Content,
             &mut coordinator,
         );
-        assert_eq!(state.root_directory, "/tmp/project/src");
+        assert_eq!(state.custom_roots, vec!["/tmp/project/src".to_string()]);
         assert_eq!(state.selected_mode, FileSearchMode::Content);
     }
     fn filename_search_result(path: &str) -> SearchResult {

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -109,12 +109,14 @@ impl Plugin for FileSearchPlugin {
         ui.checkbox(&mut cfg.case_sensitive, "Case-sensitive by default");
         ui.checkbox(
             &mut cfg.everything_enabled,
-            "Use Everything for global filename search",
+            "Use Everything ES CLI for global filename search",
         );
-        ui.label("When disabled, global filename searches use the configured ripgrep executable.");
+        ui.label(
+            "When disabled, global filename searches fall back to WalkDir/ripgrep as applicable.",
+        );
         path_field(
             ui,
-            "Everything executable path",
+            "Everything ES CLI executable path (es.exe)",
             &mut cfg.everything_executable_path,
         );
         ripgrep_settings_ui(ui, &mut cfg.ripgrep_executable_path);


### PR DESCRIPTION
### Motivation

- Ensure all file searches run only against resolved, validated roots so global searches never wander outside configured roots and directory searches accept multiple custom roots. 
- Harden backends so traversal, cancellation, deduplication and progress are coordinated across multiple roots and invalid roots are reported but do not silently block valid work. 
- Treat the Everything integration as the ES CLI (`es.exe`) rather than assuming the GUI executable is interchangeable, and make command construction pure and testable.

### Description

- GUI state and API: replaced the single `root_directory: String` with `custom_roots: Vec<String>` in `src/gui/file_search_dialog.rs`, updated launcher/nested-search behaviors to set `custom_roots`, and added `resolve_valid_roots` helper for canonicalizing/validating roots. 
- UI changes: when `Global` scope is selected the dialog now resolves only `settings.global_search_roots`, shows a summary like `Global roots: N configured` with an expandable read-only list, shows the message `Configure at least one valid global search root in File Search settings.` when empty, and disables Search when no valid global roots exist; when `Directory` scope is selected a `Add folder…` button, per-root rows (editable text, per-root validation label, remove button) and per-row validation are provided, and pressing Enter in a row can submit a search. (see `src/gui/file_search_dialog.rs`).
- WalkDir backend: `src/file_search/walkdir.rs` now canonicalizes and validates all supplied roots, accumulates `root_errors` for invalid roots, deduplicates and coalesces overlapping/nested roots with `dedup_resolved_roots`, shares a single deduplication set so repeated/overlapping roots do not duplicate results, and returns an error only when no usable root exists; progress and cancellation are preserved while continuing past inaccessible roots.
- Everything (ES CLI) integration: `src/file_search/everything.rs` now treats Everything as the ES CLI backend; detection prefers `es.exe` and no longer silently accepts the GUI `Everything.exe` unless explicitly configured, the settings UI label was clarified to indicate `es.exe`, and `everything_diagnostic` messages were updated. Command building was refactored into a pure, root-aware `build_everything_command_for_root` and an `everything_query` that injects a `path:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a555ef377988332af523df5810d30a9)