### PR TITLE
File search: Add Filters UI and centralized request builder

### DIFF
--- a/src/file_search/executor.rs
+++ b/src/file_search/executor.rs
@@ -1,13 +1,14 @@
 use crate::file_search::coordinator::{CancellationToken, SearchExecutor};
-use crate::file_search::everything::{everything_diagnostic, EverythingSearchExecutor};
+use crate::file_search::everything::{EverythingSearchExecutor, everything_diagnostic};
 use crate::file_search::model::{
-    FilenameMatchMode, SearchBackend, SearchEvent, SearchId, SearchKind, SearchRequest, SearchScope,
+    FileTypeFilter, FilenameMatchMode, SearchBackend, SearchEvent, SearchId, SearchKind,
+    SearchRequest, SearchScope,
 };
 use crate::file_search::native::NativeSearchExecutor;
-use crate::file_search::ripgrep::{resolve_ripgrep_executable, RipgrepSearchExecutor};
+use crate::file_search::ripgrep::{RipgrepSearchExecutor, resolve_ripgrep_executable};
 use crate::file_search::settings::FileSearchSettings;
 use crate::file_search::walkdir::WalkDirSearchExecutor;
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackendPlan {
@@ -68,7 +69,13 @@ impl FileSearchExecutor {
                 if settings.everything_enabled
                     && request.filename_match_mode == FilenameMatchMode::RankedSubstring =>
             {
-                vec![SearchBackend::Everything, SearchBackend::WalkDir]
+                if !request.included_extensions.is_empty()
+                    && request.file_type_filter != FileTypeFilter::FilesOnly
+                {
+                    vec![SearchBackend::WalkDir]
+                } else {
+                    vec![SearchBackend::Everything, SearchBackend::WalkDir]
+                }
             }
             (SearchKind::Filename, SearchScope::Roots { .. }) => vec![SearchBackend::WalkDir],
             (SearchKind::Filename, SearchScope::Files { .. }) => vec![SearchBackend::WalkDir],
@@ -343,9 +350,11 @@ mod tests {
         assert!(events.contains(&SearchEvent::Completed { id: SearchId(2) }));
         assert_eq!(native.calls(), vec![SearchId(2)]);
         assert!(ripgrep.calls().is_empty());
-        assert!(!events
-            .iter()
-            .any(|event| matches!(event, SearchEvent::Failed { .. })));
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, SearchEvent::Failed { .. }))
+        );
     }
 
     #[test]
@@ -362,6 +371,26 @@ mod tests {
                 ..FileSearchSettings::default()
             },
         );
+        assert_eq!(plan.candidates, vec![SearchBackend::WalkDir]);
+    }
+
+    #[test]
+    fn filename_include_extensions_with_directories_stays_on_walkdir() {
+        let mut req = request(
+            SearchKind::Filename,
+            SearchScope::Roots { roots: Vec::new() },
+        );
+        req.included_extensions = vec!["rs".into()];
+        req.file_type_filter = FileTypeFilter::FilesAndDirectories;
+
+        let plan = FileSearchExecutor::plan_for_request(
+            &req,
+            &FileSearchSettings {
+                everything_enabled: true,
+                ..FileSearchSettings::default()
+            },
+        );
+
         assert_eq!(plan.candidates, vec![SearchBackend::WalkDir]);
     }
 

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -4,11 +4,11 @@ mod keyboard;
 mod results;
 use crate::actions::clipboard;
 use crate::file_search::actions::{
-    ExplorerAction, InvocationTarget, containing_directory, copied_filename,
-    execute_explorer_action, nested_search_root, open_configured_terminal_in_directory,
-    open_in_configured_editor, open_path, resolve_explorer_action,
+    containing_directory, copied_filename, execute_explorer_action, nested_search_root,
+    open_configured_terminal_in_directory, open_in_configured_editor, open_path,
+    resolve_explorer_action, ExplorerAction, InvocationTarget,
 };
-use crate::file_search::coordinator::{SearchCoordinator, event_id};
+use crate::file_search::coordinator::{event_id, SearchCoordinator};
 use crate::file_search::model::{
     ContentMatch, FileKind, FileSearchResultKey, PathIdentity, SearchBackend, SearchEvent,
     SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
@@ -361,9 +361,10 @@ impl FileSearchDialogState {
             &request,
             Some(&self.settings),
         ));
+        let submitted_request = request.clone();
         let id = coordinator.start_search(request);
         self.active_search_id = Some(id);
-        self.last_submitted_request = self.build_search_request().ok();
+        self.last_submitted_request = Some(submitted_request);
         self.request_immediate_repaint = true;
         Some(id)
     }
@@ -1263,9 +1264,10 @@ impl FileSearchDialogState {
             &request,
             Some(&self.settings),
         ));
+        let submitted_request = request.clone();
         let id = coordinator.start_search(request);
         self.active_search_id = Some(id);
-        self.last_submitted_request = self.build_search_request().ok();
+        self.last_submitted_request = Some(submitted_request);
         self.request_immediate_repaint = true;
     }
 
@@ -1409,7 +1411,7 @@ mod tests {
     use crate::file_search::model::{
         ContentFileResult, ContentMatch, FileKind, FilenameRank, FilenameResult, SearchProgress,
     };
-    use std::sync::{Arc, Mutex, mpsc};
+    use std::sync::{mpsc, Arc, Mutex};
 
     struct RecordingExecutor {
         requests: Mutex<Vec<SearchRequest>>,
@@ -1441,9 +1443,20 @@ mod tests {
         executor: &Arc<RecordingExecutor>,
     ) -> SearchRequest {
         let mut coordinator = SearchCoordinator::with_executor(executor.clone());
-        state.start_search(&mut coordinator);
-        std::thread::sleep(Duration::from_millis(20));
-        executor.requests.lock().unwrap().last().unwrap().clone()
+        let search_id = state
+            .start_search(&mut coordinator)
+            .expect("search should start");
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Some(request) = executor.requests.lock().unwrap().last().cloned() {
+                return request;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for recorded request for search {search_id:?}"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
     }
 
     #[test]
@@ -2771,12 +2784,10 @@ mod tests {
 
         assert!(action.is_none());
         assert_eq!(state.selected_result().cloned(), selected_before);
-        assert!(
-            state
-                .warning_error_message
-                .as_deref()
-                .is_some_and(|message| message.contains("missing or inaccessible"))
-        );
+        assert!(state
+            .warning_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("missing or inaccessible")));
     }
 
     #[test]

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -4,14 +4,14 @@ mod keyboard;
 mod results;
 use crate::actions::clipboard;
 use crate::file_search::actions::{
-    containing_directory, copied_filename, execute_explorer_action, nested_search_root,
-    open_configured_terminal_in_directory, open_in_configured_editor, open_path,
-    resolve_explorer_action, ExplorerAction, InvocationTarget,
+    ExplorerAction, InvocationTarget, containing_directory, copied_filename,
+    execute_explorer_action, nested_search_root, open_configured_terminal_in_directory,
+    open_in_configured_editor, open_path, resolve_explorer_action,
 };
-use crate::file_search::coordinator::{event_id, SearchCoordinator};
+use crate::file_search::coordinator::{SearchCoordinator, event_id};
 use crate::file_search::model::{
-    ContentMatch, FileKind, FileSearchResultKey, FileTypeFilter, PathIdentity, SearchBackend,
-    SearchEvent, SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
+    ContentMatch, FileKind, FileSearchResultKey, PathIdentity, SearchBackend, SearchEvent,
+    SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::preview::PreviewRequest;
 use crate::file_search::settings::{FileSearchSettings, FileSearchUiPreferences};
@@ -51,6 +51,13 @@ pub enum FileSearchScopeMode {
 pub enum FileSearchEscapeAction {
     Cancel,
     Close,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileSearchRequestError {
+    EmptySearchText,
+    EmptyGlobalRoots,
+    EmptyDirectoryRoots,
 }
 
 pub fn handle_escape_action(status: SearchStatus) -> FileSearchEscapeAction {
@@ -230,6 +237,8 @@ pub struct FileSearchDialogState {
     pub request_immediate_repaint: bool,
     pub show_ripgrep_missing_prompt: bool,
     pub ripgrep_missing_prompt_dismissed: bool,
+    pub excluded_directory_names_overridden: bool,
+    pub last_submitted_request: Option<SearchRequest>,
 }
 
 impl Default for FileSearchDialogState {
@@ -259,6 +268,8 @@ impl Default for FileSearchDialogState {
             request_immediate_repaint: false,
             show_ripgrep_missing_prompt: false,
             ripgrep_missing_prompt_dismissed: false,
+            excluded_directory_names_overridden: false,
+            last_submitted_request: None,
         }
     }
 }
@@ -335,55 +346,12 @@ impl FileSearchDialogState {
     }
 
     pub fn start_search(&mut self, coordinator: &mut SearchCoordinator) -> Option<SearchId> {
-        let text = self.search_text.trim();
-        if text.is_empty() {
-            self.warning_error_message = Some("Enter search text before searching.".to_string());
-            return None;
-        }
-        let scope = match self.selected_scope {
-            FileSearchScopeMode::Global => {
-                let roots = resolve_valid_roots(self.settings.global_search_roots.clone());
-                if roots.is_empty() {
-                    self.warning_error_message = Some(
-                        "Configure at least one valid global search root in File Search settings."
-                            .to_string(),
-                    );
-                    return None;
-                }
-                SearchScope::Roots { roots }
+        let request = match self.build_search_request() {
+            Ok(request) => request,
+            Err(error) => {
+                self.warning_error_message = Some(error.user_message().to_string());
+                return None;
             }
-            FileSearchScopeMode::Directory => {
-                let roots = resolve_valid_roots(self.custom_roots.iter().map(PathBuf::from));
-                if roots.is_empty() {
-                    self.warning_error_message =
-                        Some("Choose at least one valid root directory first.".to_string());
-                    return None;
-                }
-                SearchScope::Roots { roots }
-            }
-        };
-        let request = SearchRequest {
-            kind: self.selected_mode.into(),
-            scope,
-            text: text.to_string(),
-            case_sensitive: self.case_sensitive,
-            include_hidden_files: self.include_hidden,
-            max_results: self.settings.max_search_results.max(1),
-            max_file_size_bytes: self.settings.max_content_search_file_size_bytes.max(1),
-            included_extensions: self.ui_preferences.included_extensions.clone(),
-            excluded_extensions: self.ui_preferences.excluded_extensions.clone(),
-            excluded_directory_names: if self.ui_preferences.excluded_directory_names.is_empty() {
-                self.settings.excluded_directory_names.clone()
-            } else {
-                self.ui_preferences.excluded_directory_names.clone()
-            },
-            filename_match_mode: self.ui_preferences.filename_match_mode,
-            content_match_mode: self.ui_preferences.content_match_mode,
-            whole_word: self.ui_preferences.whole_word,
-            file_type_filter: match self.selected_mode {
-                FileSearchMode::Filename => self.ui_preferences.file_type_filter,
-                FileSearchMode::Content => FileTypeFilter::FilesOnly,
-            },
         };
         self.clear_results_and_selection();
         self.warning_error_message = None;
@@ -395,6 +363,7 @@ impl FileSearchDialogState {
         ));
         let id = coordinator.start_search(request);
         self.active_search_id = Some(id);
+        self.last_submitted_request = self.build_search_request().ok();
         self.request_immediate_repaint = true;
         Some(id)
     }
@@ -849,6 +818,7 @@ impl FileSearchDialogState {
                 ui.ctx().request_repaint();
             }
         });
+        self.filters_ui(ui);
         ui.label(format!(
             "Backend: {} | Status: {:?} | {} | Inaccessible-path warnings: {}",
             self.backend
@@ -1268,35 +1238,23 @@ impl FileSearchDialogState {
         path: &std::path::Path,
         coordinator: &mut SearchCoordinator,
     ) {
-        let text = self.search_text.trim();
-        if text.is_empty() {
+        if self.search_text.trim().is_empty() {
             self.warning_error_message =
                 Some("Enter search text before searching this file.".to_string());
             return;
         }
-        let request = SearchRequest {
-            kind: SearchKind::Content,
-            scope: SearchScope::Files {
-                files: vec![path.to_path_buf()],
-            },
-            text: text.to_string(),
-            case_sensitive: self.case_sensitive,
-            include_hidden_files: self.include_hidden,
-            max_results: 1,
-            max_file_size_bytes: self.settings.max_content_search_file_size_bytes.max(1),
-            included_extensions: self.ui_preferences.included_extensions.clone(),
-            excluded_extensions: self.ui_preferences.excluded_extensions.clone(),
-            excluded_directory_names: if self.ui_preferences.excluded_directory_names.is_empty() {
-                self.settings.excluded_directory_names.clone()
-            } else {
-                self.ui_preferences.excluded_directory_names.clone()
-            },
-            filename_match_mode: self.ui_preferences.filename_match_mode,
-            content_match_mode: self.ui_preferences.content_match_mode,
-            whole_word: self.ui_preferences.whole_word,
-            file_type_filter: FileTypeFilter::FilesOnly,
-        };
         self.selected_mode = FileSearchMode::Content;
+        let mut request = match self.build_search_request() {
+            Ok(request) => request,
+            Err(error) => {
+                self.warning_error_message = Some(error.user_message().to_string());
+                return;
+            }
+        };
+        request.scope = SearchScope::Files {
+            files: vec![path.to_path_buf()],
+        };
+        request.max_results = 1;
         self.clear_results_and_selection();
         self.warning_error_message = None;
         self.inaccessible_path_warnings = 0;
@@ -1307,6 +1265,7 @@ impl FileSearchDialogState {
         ));
         let id = coordinator.start_search(request);
         self.active_search_id = Some(id);
+        self.last_submitted_request = self.build_search_request().ok();
         self.request_immediate_repaint = true;
     }
 
@@ -1450,7 +1409,7 @@ mod tests {
     use crate::file_search::model::{
         ContentFileResult, ContentMatch, FileKind, FilenameRank, FilenameResult, SearchProgress,
     };
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
 
     struct RecordingExecutor {
         requests: Mutex<Vec<SearchRequest>>,
@@ -2812,10 +2771,12 @@ mod tests {
 
         assert!(action.is_none());
         assert_eq!(state.selected_result().cloned(), selected_before);
-        assert!(state
-            .warning_error_message
-            .as_deref()
-            .is_some_and(|message| message.contains("missing or inaccessible")));
+        assert!(
+            state
+                .warning_error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("missing or inaccessible"))
+        );
     }
 
     #[test]

--- a/src/gui/file_search_dialog/filters.rs
+++ b/src/gui/file_search_dialog/filters.rs
@@ -9,8 +9,8 @@ use crate::file_search::model::{
 use eframe::egui;
 
 use super::{
-    FileSearchDialogState, FileSearchMode, FileSearchRequestError, FileSearchScopeMode,
-    resolve_valid_roots,
+    resolve_valid_roots, FileSearchDialogState, FileSearchMode, FileSearchRequestError,
+    FileSearchScopeMode,
 };
 
 impl FileSearchRequestError {

--- a/src/gui/file_search_dialog/filters.rs
+++ b/src/gui/file_search_dialog/filters.rs
@@ -1,1 +1,351 @@
 //! Filter controls for the file-search dialog.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::file_search::model::{
+    ContentMatchMode, FileTypeFilter, FilenameMatchMode, SearchRequest, SearchScope,
+};
+use eframe::egui;
+
+use super::{
+    FileSearchDialogState, FileSearchMode, FileSearchRequestError, FileSearchScopeMode,
+    resolve_valid_roots,
+};
+
+impl FileSearchRequestError {
+    pub fn user_message(&self) -> &'static str {
+        match self {
+            Self::EmptySearchText => "Enter search text before searching.",
+            Self::EmptyGlobalRoots => {
+                "Configure at least one valid global search root in File Search settings."
+            }
+            Self::EmptyDirectoryRoots => "Choose at least one valid root directory first.",
+        }
+    }
+}
+
+pub fn normalize_extension_input(input: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for ext in input.split(',') {
+        let ext = ext.trim().trim_start_matches('.').to_ascii_lowercase();
+        if !ext.is_empty() && seen.insert(ext.clone()) {
+            out.push(ext);
+        }
+    }
+    out
+}
+
+fn extension_list_text(values: &[String]) -> String {
+    values.join(", ")
+}
+
+impl FileSearchDialogState {
+    pub fn effective_excluded_directory_names(&self) -> Vec<String> {
+        if self.excluded_directory_names_overridden {
+            self.ui_preferences.excluded_directory_names.clone()
+        } else {
+            self.settings.excluded_directory_names.clone()
+        }
+    }
+
+    pub fn build_search_request(&self) -> Result<SearchRequest, FileSearchRequestError> {
+        let text = self.search_text.trim();
+        if text.is_empty() {
+            return Err(FileSearchRequestError::EmptySearchText);
+        }
+        let scope = match self.selected_scope {
+            FileSearchScopeMode::Global => {
+                let roots = resolve_valid_roots(self.settings.global_search_roots.clone());
+                if roots.is_empty() {
+                    return Err(FileSearchRequestError::EmptyGlobalRoots);
+                }
+                SearchScope::Roots { roots }
+            }
+            FileSearchScopeMode::Directory => {
+                let roots = resolve_valid_roots(self.custom_roots.iter().map(PathBuf::from));
+                if roots.is_empty() {
+                    return Err(FileSearchRequestError::EmptyDirectoryRoots);
+                }
+                SearchScope::Roots { roots }
+            }
+        };
+
+        Ok(SearchRequest {
+            kind: self.selected_mode.into(),
+            scope,
+            text: text.to_string(),
+            case_sensitive: self.case_sensitive,
+            include_hidden_files: self.include_hidden,
+            max_results: self.settings.max_search_results.max(1),
+            max_file_size_bytes: self.settings.max_content_search_file_size_bytes.max(1),
+            included_extensions: self.ui_preferences.included_extensions.clone(),
+            excluded_extensions: self.ui_preferences.excluded_extensions.clone(),
+            excluded_directory_names: self.effective_excluded_directory_names(),
+            filename_match_mode: self.ui_preferences.filename_match_mode,
+            content_match_mode: self.ui_preferences.content_match_mode,
+            whole_word: self.ui_preferences.whole_word,
+            file_type_filter: match self.selected_mode {
+                FileSearchMode::Filename => self.ui_preferences.file_type_filter,
+                FileSearchMode::Content => FileTypeFilter::FilesOnly,
+            },
+        })
+    }
+
+    pub fn filters_changed_since_last_search(&self) -> bool {
+        matches!(
+            self.current_status,
+            crate::file_search::model::SearchStatus::Completed
+        ) && self
+            .last_submitted_request
+            .as_ref()
+            .is_some_and(|last| self.build_search_request().ok().as_ref() != Some(last))
+    }
+
+    pub fn filters_ui(&mut self, ui: &mut egui::Ui) {
+        egui::CollapsingHeader::new("Filters")
+            .default_open(false)
+            .show(ui, |ui| {
+                match self.selected_mode {
+                    FileSearchMode::Filename => {
+                        ui.label("Filename matching");
+                        ui.horizontal(|ui| {
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_match_mode,
+                                FilenameMatchMode::RankedSubstring,
+                                "Ranked substring",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_match_mode,
+                                FilenameMatchMode::Fuzzy,
+                                "Fuzzy",
+                            );
+                        });
+                    }
+                    FileSearchMode::Content => {
+                        ui.label("Content matching");
+                        ui.horizontal(|ui| {
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_match_mode,
+                                ContentMatchMode::ExactPhrase,
+                                "Exact phrase",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_match_mode,
+                                ContentMatchMode::AnyTerm,
+                                "Match any term",
+                            );
+                            ui.checkbox(&mut self.ui_preferences.whole_word, "Whole word");
+                        });
+                    }
+                }
+
+                ui.separator();
+                ui.horizontal(|ui| {
+                    ui.label("Type");
+                    let enabled = self.selected_mode == FileSearchMode::Filename;
+                    ui.add_enabled_ui(enabled, |ui| {
+                        ui.radio_value(
+                            &mut self.ui_preferences.file_type_filter,
+                            FileTypeFilter::FilesOnly,
+                            "Files",
+                        );
+                        ui.radio_value(
+                            &mut self.ui_preferences.file_type_filter,
+                            FileTypeFilter::DirectoriesOnly,
+                            "Directories",
+                        );
+                        ui.radio_value(
+                            &mut self.ui_preferences.file_type_filter,
+                            FileTypeFilter::FilesAndDirectories,
+                            "Files and directories",
+                        );
+                    })
+                    .response
+                    .on_hover_text(
+                        "Content search reads file contents, so it always searches files only.",
+                    );
+                });
+
+                ui.horizontal(|ui| {
+                    ui.label("Include extensions");
+                    let mut text = extension_list_text(&self.ui_preferences.included_extensions);
+                    if ui.text_edit_singleline(&mut text).changed() {
+                        self.ui_preferences.included_extensions = normalize_extension_input(&text);
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Exclude extensions");
+                    let mut text = extension_list_text(&self.ui_preferences.excluded_extensions);
+                    if ui.text_edit_singleline(&mut text).changed() {
+                        self.ui_preferences.excluded_extensions = normalize_extension_input(&text);
+                    }
+                });
+
+                ui.separator();
+                ui.label("Excluded directories");
+                if !self.excluded_directory_names_overridden {
+                    self.ui_preferences.excluded_directory_names =
+                        self.settings.excluded_directory_names.clone();
+                    self.excluded_directory_names_overridden = true;
+                }
+                let mut remove = None;
+                for (idx, value) in self
+                    .ui_preferences
+                    .excluded_directory_names
+                    .iter_mut()
+                    .enumerate()
+                {
+                    ui.horizontal(|ui| {
+                        ui.text_edit_singleline(value);
+                        if ui.button("Remove").clicked() {
+                            remove = Some(idx);
+                        }
+                    });
+                }
+                if let Some(idx) = remove {
+                    self.ui_preferences.excluded_directory_names.remove(idx);
+                }
+                ui.horizontal(|ui| {
+                    if ui.button("Add exclusion").clicked() {
+                        self.ui_preferences
+                            .excluded_directory_names
+                            .push(String::new());
+                    }
+                    if ui.button("Restore defaults").clicked() {
+                        self.ui_preferences.excluded_directory_names =
+                            self.settings.excluded_directory_names.clone();
+                        self.excluded_directory_names_overridden = true;
+                    }
+                    if ui.button("Clear").clicked() {
+                        self.ui_preferences.excluded_directory_names.clear();
+                        self.excluded_directory_names_overridden = true;
+                    }
+                });
+            });
+        if self.filters_changed_since_last_search() {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                "Search again to apply changed filters",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_search::settings::FileSearchSettings;
+    use tempfile::tempdir;
+
+    #[test]
+    fn extension_parsing_splits_trims_and_drops_empty_values() {
+        assert_eq!(
+            normalize_extension_input(" rs, toml, , md "),
+            vec!["rs", "toml", "md"]
+        );
+    }
+
+    #[test]
+    fn leading_dot_normalization_lowercases_extensions() {
+        assert_eq!(normalize_extension_input(".RS, .Toml"), vec!["rs", "toml"]);
+    }
+
+    #[test]
+    fn duplicate_extension_removal_preserves_first_order() {
+        assert_eq!(
+            normalize_extension_input("rs, .RS, toml, rs"),
+            vec!["rs", "toml"]
+        );
+    }
+
+    #[test]
+    fn invalid_empty_root_validation() {
+        let state = FileSearchDialogState {
+            search_text: "needle".into(),
+            selected_scope: FileSearchScopeMode::Directory,
+            custom_roots: vec!["/definitely/missing/root".into()],
+            ..Default::default()
+        };
+        assert_eq!(
+            state.build_search_request().unwrap_err(),
+            FileSearchRequestError::EmptyDirectoryRoots
+        );
+    }
+
+    #[test]
+    fn empty_search_text_validation() {
+        let state = FileSearchDialogState::default();
+        assert_eq!(
+            state.build_search_request().unwrap_err(),
+            FileSearchRequestError::EmptySearchText
+        );
+    }
+
+    #[test]
+    fn temporary_removal_of_target_reflected_in_request() {
+        let temp = tempdir().unwrap();
+        let mut state = FileSearchDialogState {
+            search_text: "needle".into(),
+            selected_scope: FileSearchScopeMode::Directory,
+            custom_roots: vec![temp.path().display().to_string()],
+            settings: FileSearchSettings {
+                excluded_directory_names: vec!["target".into(), ".git".into()],
+                ..Default::default()
+            },
+            excluded_directory_names_overridden: true,
+            ..Default::default()
+        };
+        state.ui_preferences.excluded_directory_names = vec![".git".into()];
+        let request = state.build_search_request().unwrap();
+        assert_eq!(request.excluded_directory_names, vec![".git"]);
+    }
+
+    #[test]
+    fn cleared_settings_exclusions_are_not_readded_to_request() {
+        let temp = tempdir().unwrap();
+        let state = FileSearchDialogState {
+            search_text: "needle".into(),
+            selected_scope: FileSearchScopeMode::Directory,
+            custom_roots: vec![temp.path().display().to_string()],
+            settings: FileSearchSettings {
+                excluded_directory_names: vec!["target".into()],
+                ..Default::default()
+            },
+            excluded_directory_names_overridden: true,
+            ..Default::default()
+        };
+
+        let request = state.build_search_request().unwrap();
+
+        assert!(request.excluded_directory_names.is_empty());
+    }
+
+    #[test]
+    fn content_mode_always_produces_files_only() {
+        let temp = tempdir().unwrap();
+        let mut state = FileSearchDialogState {
+            search_text: "needle".into(),
+            selected_mode: FileSearchMode::Content,
+            selected_scope: FileSearchScopeMode::Directory,
+            custom_roots: vec![temp.path().display().to_string()],
+            ..Default::default()
+        };
+        state.ui_preferences.file_type_filter = FileTypeFilter::DirectoriesOnly;
+        let request = state.build_search_request().unwrap();
+        assert_eq!(request.file_type_filter, FileTypeFilter::FilesOnly);
+    }
+
+    #[test]
+    fn changing_filters_does_not_start_search_automatically() {
+        let mut state = FileSearchDialogState::default();
+        assert!(state.active_search_id.is_none());
+        state.ui_preferences.included_extensions = normalize_extension_input("rs");
+        assert!(state.active_search_id.is_none());
+        assert_eq!(
+            state.current_status,
+            crate::file_search::model::SearchStatus::Pending
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single, validated place to build backend `SearchRequest`s and ensure all search entry points use the same semantics. 
- Expose a compact, editable Filters UI so users can control match modes, type selection, extensions, and excluded directories.
- Normalize user-provided extension input so extension comparisons are robust and consistent across backends.
- Ensure backend selection logic respects filter semantics (e.g. preserve directory results when appropriate). 

### Description
- Added `src/gui/file_search_dialog/filters.rs` that implements `build_search_request(&self) -> Result<SearchRequest, FileSearchRequestError>` and the new collapsible Filters UI with filename/content match modes, file-type selector, include/exclude extension text fields, and editable excluded-directory rows plus `Restore defaults`, `Clear`, and `Add exclusion` actions.
- Introduced `FileSearchRequestError` and request-tracking fields (`last_submitted_request`, `excluded_directory_names_overridden`) in `FileSearchDialogState` and replaced duplicate inline request construction by routing searches through `build_search_request`; updated `start_search` and `start_file_content_search` to use the builder.
- Implemented extension normalization via `normalize_extension_input` to split on commas, trim whitespace, strip leading dots, lowercase, remove empties, and deduplicate; UI updates write back normalized lists to `ui_preferences`.
- Enforced filter semantics in the builder: content mode forces `FilesOnly` and disables the type selector UI; included/excluded extensions are applied only to files; excluded-directory names are sourced from either settings or temporary UI overrides and exposed via `effective_excluded_directory_names`.
- Adjusted backend planning in `src/file_search/executor.rs` so global filename searches that include extensions but still allow directories stay with `WalkDir` (preventing `Everything` from suppressing directories when extensions are used); added a unit test for that routing case.
- Added unit tests in `src/gui/file_search_dialog/filters.rs` and `src/file_search/executor.rs` covering extension parsing, leading-dot normalization, duplicate removal, invalid/empty root validation, temporary removal of `target` reflected in request, cleared settings exclusions not re-added, content mode producing `FilesOnly`, filter changes not auto-starting searches, and the WalkDir routing case.

### Testing
- Ran formatting and static checks with `cargo fmt` and `git diff --check` successfully.
- Attempted `cargo test file_search_dialog --lib`; compilation started but test execution did not complete in this Linux environment because unrelated platform-specific build failures (`windows::Win32` / `windows::core` imports in other parts of the repo) prevented finishing the test run after installing missing system libs (e.g. `libasound2-dev`, `libxi-dev`, `libxtst-dev`).
- The new unit tests were added and compile-paths updated, but their run was blocked by unrelated cross-platform build issues in the CI/dev container environment; tests themselves are present and expected to pass once the repository is built in an environment that resolves the platform-specific dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55721143888332a0143404733aede8)