### PR TITLE
Move file search sorting and deduplication to shared layer

### DIFF
--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -11,7 +11,6 @@ use crate::file_search::model::{
     SearchScope, SearchStatus, TextMatchRange,
 };
 use crate::file_search::settings::FileSearchSettings;
-use crate::file_search::sorting::sort_filename_results;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read};
@@ -382,7 +381,6 @@ pub fn search_filenames_with_ripgrep(
             }
         }
     }
-    sort_filename_results(&mut results);
     summary.results = results;
     Ok(summary)
 }

--- a/src/file_search/settings.rs
+++ b/src/file_search/settings.rs
@@ -33,15 +33,27 @@ pub struct FileSearchSettings {
 #[serde(rename_all = "snake_case")]
 pub enum FileSearchFilenameSort {
     Relevance,
-    Name,
-    Path,
+    #[serde(alias = "name")]
+    FilenameAscending,
+    FilenameDescending,
+    #[serde(alias = "path")]
+    FullPathAscending,
+    ModifiedNewest,
+    ModifiedOldest,
+    SizeLargest,
+    SizeSmallest,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FileSearchContentSort {
+    DiscoveryOrder,
     PathThenLine,
-    LineThenPath,
+    MatchCountDescending,
+    ModifiedNewest,
+    FilenameRelevance,
+    #[serde(alias = "line_then_path")]
+    LineNumber,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/src/file_search/sorting.rs
+++ b/src/file_search/sorting.rs
@@ -1,53 +1,299 @@
-use crate::file_search::model::FilenameResult;
+use crate::file_search::model::{
+    ContentFileResult, ContentMatch, FilenameResult, PathIdentity, SearchResult,
+};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 pub const FILENAME_SORT_LABEL: &str = "Filename";
 pub const CONTENT_SORT_LABEL: &str = "Content";
 
-pub fn sort_filename_results(results: &mut [FilenameResult]) {
-    results.sort_by(|a, b| {
-        a.rank
-            .cmp(&b.rank)
-            .then_with(|| a.file_name.to_lowercase().cmp(&b.file_name.to_lowercase()))
-            .then_with(|| a.path.cmp(&b.path))
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilenameSort {
+    Relevance,
+    FilenameAscending,
+    FilenameDescending,
+    FullPathAscending,
+    ModifiedNewest,
+    ModifiedOldest,
+    SizeLargest,
+    SizeSmallest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContentSort {
+    DiscoveryOrder,
+    PathThenLine,
+    MatchCountDescending,
+    ModifiedNewest,
+    FilenameRelevance,
+    LineNumber,
+}
+
+pub fn path_identity(path: &Path) -> PathIdentity {
+    if let Ok(canonical) = path.canonicalize() {
+        return PathIdentity::from_path(&canonical);
+    }
+    if path.is_absolute() {
+        return PathIdentity::from_path(path);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        return PathIdentity::from_path(&cwd.join(path));
+    }
+    PathIdentity::from_path(path)
+}
+
+fn normalized_path(path: &Path) -> String {
+    path_identity(path).normalized_path
+}
+
+fn lower(s: &str) -> String {
+    s.to_lowercase()
+}
+fn file_tie(a: &FilenameResult, b: &FilenameResult) -> std::cmp::Ordering {
+    lower(&a.file_name)
+        .cmp(&lower(&b.file_name))
+        .then_with(|| normalized_path(&a.path).cmp(&normalized_path(&b.path)))
+        .then_with(|| a.arrival_index.cmp(&b.arrival_index))
+}
+fn content_file_tie(a: &ContentFileResult, b: &ContentFileResult) -> std::cmp::Ordering {
+    lower(&normalized_path(&a.path))
+        .cmp(&lower(&normalized_path(&b.path)))
+        .then_with(|| a.arrival_index.cmp(&b.arrival_index))
+}
+
+pub fn sort_filename_results_by(results: &mut [FilenameResult], sort: FilenameSort) {
+    results.sort_by(|a, b| match sort {
+        FilenameSort::Relevance => a.rank.cmp(&b.rank).then_with(|| file_tie(a, b)),
+        FilenameSort::FilenameAscending => file_tie(a, b),
+        FilenameSort::FilenameDescending => file_tie(b, a),
+        FilenameSort::FullPathAscending => normalized_path(&a.path)
+            .cmp(&normalized_path(&b.path))
+            .then_with(|| a.arrival_index.cmp(&b.arrival_index)),
+        FilenameSort::ModifiedNewest => b.modified.cmp(&a.modified).then_with(|| file_tie(a, b)),
+        FilenameSort::ModifiedOldest => a.modified.cmp(&b.modified).then_with(|| file_tie(a, b)),
+        FilenameSort::SizeLargest => b.size.cmp(&a.size).then_with(|| file_tie(a, b)),
+        FilenameSort::SizeSmallest => a.size.cmp(&b.size).then_with(|| file_tie(a, b)),
     });
+}
+
+pub fn sort_filename_results(results: &mut [FilenameResult]) {
+    sort_filename_results_by(results, FilenameSort::Relevance);
+}
+
+fn match_key(m: &ContentMatch, occurrence: usize) -> (usize, usize, usize, usize) {
+    (
+        m.line_number,
+        m.column.unwrap_or(usize::MAX),
+        m.byte_end,
+        occurrence,
+    )
+}
+
+pub fn sort_content_matches(matches: &mut [ContentMatch]) {
+    let mut seen: HashMap<(usize, usize, usize), usize> = HashMap::new();
+    let keys: Vec<_> = matches
+        .iter()
+        .map(|m| {
+            let base = (m.line_number, m.byte_start, m.byte_end);
+            let occ = *seen.entry(base).or_insert(0);
+            *seen.get_mut(&base).unwrap() += 1;
+            match_key(m, occ)
+        })
+        .collect();
+    let mut indexed: Vec<_> = matches.iter().cloned().zip(keys).collect();
+    indexed.sort_by_key(|(_, k)| *k);
+    for (slot, (m, _)) in matches.iter_mut().zip(indexed) {
+        *slot = m;
+    }
+}
+
+pub fn sort_content_results_by(results: &mut [ContentFileResult], sort: ContentSort) {
+    for r in results.iter_mut() {
+        sort_content_matches(&mut r.matches);
+    }
+    results.sort_by(|a, b| match sort {
+        ContentSort::DiscoveryOrder => a
+            .arrival_index
+            .cmp(&b.arrival_index)
+            .then_with(|| content_file_tie(a, b)),
+        ContentSort::PathThenLine => content_file_tie(a, b),
+        ContentSort::MatchCountDescending => b
+            .total_matches
+            .cmp(&a.total_matches)
+            .then_with(|| content_file_tie(a, b)),
+        ContentSort::ModifiedNewest => b
+            .modified
+            .cmp(&a.modified)
+            .then_with(|| content_file_tie(a, b)),
+        ContentSort::FilenameRelevance => a
+            .filename_relevance
+            .cmp(&b.filename_relevance)
+            .then_with(|| content_file_tie(a, b)),
+        ContentSort::LineNumber => a
+            .matches
+            .first()
+            .map(|m| m.line_number)
+            .cmp(&b.matches.first().map(|m| m.line_number))
+            .then_with(|| content_file_tie(a, b)),
+    });
+}
+
+pub fn dedup_filename_results(results: Vec<FilenameResult>) -> Vec<FilenameResult> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for r in results {
+        if seen.insert(path_identity(&r.path)) {
+            out.push(r);
+        }
+    }
+    out
+}
+
+pub fn dedup_content_results(results: Vec<ContentFileResult>) -> Vec<ContentFileResult> {
+    let mut order = Vec::<PathIdentity>::new();
+    let mut groups: HashMap<PathIdentity, ContentFileResult> = HashMap::new();
+    for mut r in results {
+        let id = path_identity(&r.path);
+        if let Some(existing) = groups.get_mut(&id) {
+            existing.total_matches = existing.total_matches.max(r.total_matches);
+            existing.truncated |= r.truncated;
+            let mut keys: HashSet<_> = existing
+                .matches
+                .iter()
+                .map(|m| (m.line_number, m.byte_start, m.byte_end, m.line.clone()))
+                .collect();
+            for m in r.matches.drain(..) {
+                if keys.insert((m.line_number, m.byte_start, m.byte_end, m.line.clone())) {
+                    existing.matches.push(m);
+                }
+            }
+        } else {
+            order.push(id.clone());
+            groups.insert(id, r);
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|id| groups.remove(&id))
+        .collect()
+}
+
+pub fn sort_and_dedup_results(
+    results: Vec<SearchResult>,
+    filename_sort: FilenameSort,
+    content_sort: ContentSort,
+) -> Vec<SearchResult> {
+    let mut files = Vec::new();
+    let mut contents = Vec::new();
+    for r in results {
+        match r {
+            SearchResult::Filename(f) => files.push(f),
+            SearchResult::ContentFile(c) => contents.push(c),
+        }
+    }
+    files = dedup_filename_results(files);
+    contents = dedup_content_results(contents);
+    sort_filename_results_by(&mut files, filename_sort);
+    sort_content_results_by(&mut contents, content_sort);
+    files
+        .into_iter()
+        .map(SearchResult::Filename)
+        .chain(contents.into_iter().map(SearchResult::ContentFile))
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::file_search::model::{FileKind, FilenameRank};
-
     fn result(path: &str, rank: FilenameRank) -> FilenameResult {
-        let path = std::path::PathBuf::from(path);
+        let path = PathBuf::from(path);
         FilenameResult {
             file_name: path.file_name().unwrap().to_string_lossy().to_string(),
-            parent_directory: path.parent().map(std::path::Path::to_path_buf),
+            parent_directory: path.parent().map(Path::to_path_buf),
             path,
             kind: FileKind::File,
             size: None,
             modified: None,
             rank,
             match_quality: rank,
-            filename_match_ranges: Vec::new(),
-            path_match_ranges: Vec::new(),
+            filename_match_ranges: vec![],
+            path_match_ranges: vec![],
             arrival_index: 0,
         }
     }
-
     #[test]
-    fn sort_is_stable_by_rank_name_then_path() {
-        let mut results = vec![
-            result("b/foo.txt", FilenameRank::FilenameContains),
-            result("a/foo.txt", FilenameRank::FilenameContains),
-            result("z/foo.txt", FilenameRank::ExactFilename),
+    fn every_filename_sort_mode_is_deterministic() {
+        let mut rs = vec![
+            result("b/z.txt", FilenameRank::FilenameContains),
+            result("a/a.txt", FilenameRank::ExactFilename),
         ];
-        sort_filename_results(&mut results);
-        assert_eq!(
-            results
-                .iter()
-                .map(|r| r.path.to_string_lossy().to_string())
-                .collect::<Vec<_>>(),
-            vec!["z/foo.txt", "a/foo.txt", "b/foo.txt"]
-        );
+        for s in [
+            FilenameSort::Relevance,
+            FilenameSort::FilenameAscending,
+            FilenameSort::FilenameDescending,
+            FilenameSort::FullPathAscending,
+            FilenameSort::ModifiedNewest,
+            FilenameSort::ModifiedOldest,
+            FilenameSort::SizeLargest,
+            FilenameSort::SizeSmallest,
+        ] {
+            sort_filename_results_by(&mut rs, s);
+            let once = rs.clone();
+            sort_filename_results_by(&mut rs, s);
+            assert_eq!(rs, once);
+        }
+    }
+    fn cf(path: &str, arrival: usize, total: usize) -> ContentFileResult {
+        ContentFileResult {
+            path: path.into(),
+            file_name: path.into(),
+            modified: None,
+            filename_relevance: None,
+            arrival_index: arrival,
+            total_matches: total,
+            matches: vec![ContentMatch::new(arrival + 1, "x".into(), 0, 1)],
+            truncated: false,
+        }
+    }
+    #[test]
+    fn every_content_sort_mode_is_deterministic() {
+        let mut rs = vec![cf("b", 1, 2), cf("a", 0, 1)];
+        for s in [
+            ContentSort::DiscoveryOrder,
+            ContentSort::PathThenLine,
+            ContentSort::MatchCountDescending,
+            ContentSort::ModifiedNewest,
+            ContentSort::FilenameRelevance,
+            ContentSort::LineNumber,
+        ] {
+            sort_content_results_by(&mut rs, s);
+            let once = rs.clone();
+            sort_content_results_by(&mut rs, s);
+            assert_eq!(rs, once);
+        }
+    }
+    #[test]
+    fn null_size_and_modified_sort_consistently() {
+        let mut rs = vec![
+            result("b", FilenameRank::ExactFilename),
+            result("a", FilenameRank::ExactFilename),
+        ];
+        rs[0].size = Some(1);
+        sort_filename_results_by(&mut rs, FilenameSort::SizeLargest);
+        assert_eq!(rs[0].path, PathBuf::from("b"));
+        sort_filename_results_by(&mut rs, FilenameSort::ModifiedNewest);
+        assert_eq!(rs[0].path, PathBuf::from("a"));
+    }
+    #[test]
+    fn duplicate_content_matches_merge_to_one() {
+        let mut a = cf("same", 0, 1);
+        let b = cf("same", 1, 3);
+        a.truncated = true;
+        let out = dedup_content_results(vec![a, b]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].total_matches, 3);
+        assert!(out[0].truncated);
+        assert_eq!(out[0].matches.len(), 1);
     }
 }

--- a/src/file_search/sorting.rs
+++ b/src/file_search/sorting.rs
@@ -288,7 +288,8 @@ mod tests {
     #[test]
     fn duplicate_content_matches_merge_to_one() {
         let mut a = cf("same", 0, 1);
-        let b = cf("same", 1, 3);
+        let mut b = cf("same", 1, 3);
+        b.matches[0] = a.matches[0].clone();
         a.truncated = true;
         let out = dedup_content_results(vec![a, b]);
         assert_eq!(out.len(), 1);

--- a/src/file_search/walkdir.rs
+++ b/src/file_search/walkdir.rs
@@ -5,7 +5,6 @@ use crate::file_search::model::{
     SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::settings::FileSearchSettings;
-use crate::file_search::sorting::sort_filename_results;
 use std::cell::Cell;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -193,7 +192,6 @@ pub fn search_filenames_in_directory(
     summary.skipped_entries = summary
         .skipped_entries
         .saturating_add(skipped_before_descent.get());
-    sort_filename_results(&mut ranked_results);
     let status = if summary.cancelled {
         SearchStatus::Cancelled
     } else {

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -14,7 +14,9 @@ use crate::file_search::model::{
     SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::preview::PreviewRequest;
-use crate::file_search::settings::{FileSearchSettings, FileSearchUiPreferences};
+use crate::file_search::settings::{
+    FileSearchContentSort, FileSearchFilenameSort, FileSearchSettings, FileSearchUiPreferences,
+};
 use crate::gui::file_search_preview_dialog::FileSearchPreviewDialogState;
 use eframe::egui;
 use std::path::PathBuf;
@@ -25,6 +27,34 @@ const ACTIVE_SEARCH_REPAINT_INTERVAL: Duration = Duration::from_millis(50);
 
 pub const FILE_SEARCH_SEARCH_FIELD_ID_SOURCE: &str = "file_search_search_text";
 pub const FILE_SEARCH_ROOT_FIELD_ID_SOURCE: &str = "file_search_root_directory";
+
+impl From<FileSearchFilenameSort> for crate::file_search::sorting::FilenameSort {
+    fn from(value: FileSearchFilenameSort) -> Self {
+        match value {
+            FileSearchFilenameSort::Relevance => Self::Relevance,
+            FileSearchFilenameSort::FilenameAscending => Self::FilenameAscending,
+            FileSearchFilenameSort::FilenameDescending => Self::FilenameDescending,
+            FileSearchFilenameSort::FullPathAscending => Self::FullPathAscending,
+            FileSearchFilenameSort::ModifiedNewest => Self::ModifiedNewest,
+            FileSearchFilenameSort::ModifiedOldest => Self::ModifiedOldest,
+            FileSearchFilenameSort::SizeLargest => Self::SizeLargest,
+            FileSearchFilenameSort::SizeSmallest => Self::SizeSmallest,
+        }
+    }
+}
+
+impl From<FileSearchContentSort> for crate::file_search::sorting::ContentSort {
+    fn from(value: FileSearchContentSort) -> Self {
+        match value {
+            FileSearchContentSort::DiscoveryOrder => Self::DiscoveryOrder,
+            FileSearchContentSort::PathThenLine => Self::PathThenLine,
+            FileSearchContentSort::MatchCountDescending => Self::MatchCountDescending,
+            FileSearchContentSort::ModifiedNewest => Self::ModifiedNewest,
+            FileSearchContentSort::FilenameRelevance => Self::FilenameRelevance,
+            FileSearchContentSort::LineNumber => Self::LineNumber,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FileSearchMode {
@@ -433,6 +463,7 @@ impl FileSearchDialogState {
             }
             SearchEvent::Completed { .. } => {
                 self.current_status = SearchStatus::Completed;
+                self.finalize_completed_results();
                 self.request_immediate_repaint = true;
                 true
             }
@@ -450,6 +481,56 @@ impl FileSearchDialogState {
         };
         self.selection_is_valid();
         observed_terminal_event
+    }
+
+    fn selected_result_key(&self) -> Option<FileSearchResultKey> {
+        self.selected_result
+            .as_ref()
+            .map(|s| s.row_id.result_key.clone())
+    }
+
+    fn restore_selection_by_key(&mut self, key: Option<FileSearchResultKey>) {
+        let Some(key) = key else {
+            return;
+        };
+        if let Some(row) = self
+            .result_rows
+            .iter()
+            .find(|row| row.id.result_key == key)
+            .cloned()
+        {
+            self.select_result(&row);
+        } else {
+            self.clear_selection();
+        }
+    }
+
+    pub fn handle_sort_changed(&mut self) {
+        self.mark_ui_preferences_dirty();
+        if self.current_status == SearchStatus::Completed {
+            self.finalize_completed_results();
+            self.request_immediate_repaint = true;
+        }
+    }
+
+    fn finalize_completed_results(&mut self) {
+        let selected_key = self.selected_result_key();
+        let results = std::mem::take(&mut self.results);
+        self.results = crate::file_search::sorting::sort_and_dedup_results(
+            results,
+            self.ui_preferences.filename_sort.into(),
+            self.ui_preferences.content_sort.into(),
+        );
+        self.rebuild_result_rows();
+        self.restore_selection_by_key(selected_key);
+    }
+
+    fn rebuild_result_rows(&mut self) {
+        let results = self.results.clone();
+        self.result_rows.clear();
+        for result in results {
+            self.push_result_row(&result);
+        }
     }
 
     pub fn clear_selection(&mut self) {
@@ -501,8 +582,13 @@ impl FileSearchDialogState {
     }
 
     fn push_result(&mut self, result: SearchResult) {
+        self.push_result_row(&result);
+        self.results.push(result);
+    }
+
+    fn push_result_row(&mut self, result: &SearchResult) {
         let search_id = self.active_search_id.unwrap_or(SearchId(0));
-        match &result {
+        match result {
             SearchResult::Filename(item) => {
                 self.result_rows.push(FileSearchResultRow {
                     id: FileSearchResultRowId {
@@ -565,7 +651,6 @@ impl FileSearchDialogState {
                 }
             }
         }
-        self.results.push(result);
     }
 
     pub fn result_counts(&self) -> FileSearchResultCounts {
@@ -926,6 +1011,9 @@ impl FileSearchDialogState {
                 let response = results::non_wrapping_selectable_label(ui, is_selected, row_text)
                     .on_hover_text(path.display().to_string());
                 let double_clicked = response.double_clicked();
+                if is_selected {
+                    response.scroll_to_me(Some(egui::Align::Center));
+                }
                 if response.clicked() {
                     self.select_result(&FileSearchResultRow {
                         id: row_id.clone(),
@@ -1019,6 +1107,9 @@ impl FileSearchDialogState {
                 let response = results::non_wrapping_selectable_label(ui, is_selected, row_text)
                     .on_hover_text(path.display().to_string());
                 let double_clicked = response.double_clicked();
+                if is_selected {
+                    response.scroll_to_me(Some(egui::Align::Center));
+                }
                 if response.clicked() {
                     self.select_result(&FileSearchResultRow {
                         id: row_id.clone(),
@@ -2619,6 +2710,97 @@ mod tests {
                 .collect(),
             truncated,
         })
+    }
+
+    #[test]
+    fn sorting_is_deferred_while_running_and_applied_on_completion() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(1)),
+            current_status: SearchStatus::Running,
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(1),
+            result: filename_search_result("/tmp/b.txt"),
+        });
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(1),
+            result: filename_search_result("/tmp/a.txt"),
+        });
+        state.ui_preferences.filename_sort = FileSearchFilenameSort::FilenameAscending;
+        state.handle_sort_changed();
+        assert_eq!(state.result_rows[0].id.path, PathBuf::from("/tmp/b.txt"));
+
+        state.apply_event(SearchEvent::Completed { id: SearchId(1) });
+
+        assert_eq!(state.result_rows[0].id.path, PathBuf::from("/tmp/a.txt"));
+    }
+
+    #[test]
+    fn selection_survives_sorting_after_completion() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(2)),
+            current_status: SearchStatus::Running,
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(2),
+            result: filename_search_result("/tmp/b.txt"),
+        });
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(2),
+            result: filename_search_result("/tmp/a.txt"),
+        });
+        let selected = state.result_rows[0].clone();
+        state.select_result(&selected);
+        state.ui_preferences.filename_sort = FileSearchFilenameSort::FilenameAscending;
+        state.apply_event(SearchEvent::Completed { id: SearchId(2) });
+        assert_eq!(
+            state.selected_result().unwrap().row_id.path,
+            PathBuf::from("/tmp/b.txt")
+        );
+    }
+
+    #[test]
+    fn duplicate_filename_paths_produce_one_row_on_completion() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(3)),
+            current_status: SearchStatus::Running,
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(3),
+            result: filename_search_result("/tmp/dup.txt"),
+        });
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(3),
+            result: filename_search_result("/tmp/dup.txt"),
+        });
+        assert_eq!(state.filename_row_count(), 2);
+        state.apply_event(SearchEvent::Completed { id: SearchId(3) });
+        assert_eq!(state.filename_row_count(), 1);
+    }
+
+    #[test]
+    fn duplicate_content_matches_produce_one_row_on_completion() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(4)),
+            current_status: SearchStatus::Running,
+            selected_mode: FileSearchMode::Content,
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(4),
+            result: content_search_result("/tmp/dup.txt", 1, 1, false),
+        });
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(4),
+            result: content_search_result("/tmp/dup.txt", 1, 1, true),
+        });
+        state.apply_event(SearchEvent::Completed { id: SearchId(4) });
+        assert_eq!(state.content_matched_file_count(), 1);
+        assert_eq!(state.content_displayed_match_row_count(), 1);
+        assert_eq!(state.content_truncated_displayed_match_count(), 1);
     }
 
     #[test]

--- a/src/gui/file_search_dialog/filters.rs
+++ b/src/gui/file_search_dialog/filters.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use crate::file_search::model::{
     ContentMatchMode, FileTypeFilter, FilenameMatchMode, SearchRequest, SearchScope,
 };
+use crate::file_search::settings::{FileSearchContentSort, FileSearchFilenameSort};
 use eframe::egui;
 
 use super::{
@@ -104,6 +105,7 @@ impl FileSearchDialogState {
     }
 
     pub fn filters_ui(&mut self, ui: &mut egui::Ui) {
+        let prefs_before = self.ui_preferences.clone();
         egui::CollapsingHeader::new("Filters")
             .default_open(false)
             .show(ui, |ui| {
@@ -141,6 +143,89 @@ impl FileSearchDialogState {
                     }
                 }
 
+                ui.separator();
+                match self.selected_mode {
+                    FileSearchMode::Filename => {
+                        ui.label("Sort");
+                        ui.horizontal_wrapped(|ui| {
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::Relevance,
+                                "Relevance",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::FilenameAscending,
+                                "Filename ↑",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::FilenameDescending,
+                                "Filename ↓",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::FullPathAscending,
+                                "Path ↑",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::ModifiedNewest,
+                                "Modified newest",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::ModifiedOldest,
+                                "Modified oldest",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::SizeLargest,
+                                "Size largest",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.filename_sort,
+                                FileSearchFilenameSort::SizeSmallest,
+                                "Size smallest",
+                            );
+                        });
+                    }
+                    FileSearchMode::Content => {
+                        ui.label("Sort");
+                        ui.horizontal_wrapped(|ui| {
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::DiscoveryOrder,
+                                "Discovery",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::PathThenLine,
+                                "Path then line",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::MatchCountDescending,
+                                "Match count",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::ModifiedNewest,
+                                "Modified newest",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::FilenameRelevance,
+                                "Filename relevance",
+                            );
+                            ui.radio_value(
+                                &mut self.ui_preferences.content_sort,
+                                FileSearchContentSort::LineNumber,
+                                "Line number",
+                            );
+                        });
+                    }
+                }
                 ui.separator();
                 ui.horizontal(|ui| {
                     ui.label("Type");
@@ -224,6 +309,9 @@ impl FileSearchDialogState {
                     }
                 });
             });
+        if self.ui_preferences != prefs_before {
+            self.handle_sort_changed();
+        }
         if self.filters_changed_since_last_search() {
             ui.colored_label(
                 egui::Color32::YELLOW,


### PR DESCRIPTION
### Motivation
- Centralize filename/content sorting and deduplication into a backend-independent layer to ensure deterministic, stable display ordering and consistent dedup semantics across backends.
- Preserve arrival-order behavior while a search is running and only apply user-selected sorting and defensive deduplication once the search completes so selection and UX remain stable.
- Ensure deterministic ordering within files and across files with clear tie-breakers and robust path identity handling (canonicalization with fallbacks).

### Description
- Added shared sort enums and APIs: `FilenameSort` and `ContentSort` with modes including `Relevance`, `FilenameAscending/Descending`, `FullPathAscending`, `ModifiedNewest/Oldest`, `SizeLargest/Smallest`, and `DiscoveryOrder`, `PathThenLine`, `MatchCountDescending`, `ModifiedNewest`, `FilenameRelevance`, `LineNumber` respectively, implemented in `src/file_search/sorting.rs` and exposed helpers `sort_*_results_by` and `sort_and_dedup_results`.
- Implemented deterministic comparators and tie-breakers: case-insensitive filename comparison, normalized full path comparison, and `arrival_index` fallback for filename results; case-insensitive normalized path plus `arrival_index` for content file groups; and deterministic in-file match ordering by `line_number`, `column` (option), `byte_end`, then original occurrence.
- Implemented robust path identity normalization and canonicalization fallback via `path_identity`/`normalized_path` so deduplication prefers canonical paths when available but falls back to normalized absolute or relative paths without failing discovery, and added `dedup_filename_results` and `dedup_content_results` that merge duplicates while preserving `total_matches` and `truncated` semantics.
- Moved completion-time finalization into the UI layer (`FileSearchDialogState`): while running results are appended in arrival order (`push_result_row`), and on terminal events `finalize_completed_results` runs `sort_and_dedup_results`, rebuilds display rows, restores selection via a stable `FileSearchResultKey`, and requests repaint; also added `handle_sort_changed` to apply selected sort immediately when searches are completed.
- Removed backend-side filename sorting calls from backends (`ripgrep`, `walkdir`) so backends emit arrival order and the shared layer controls final ordering.
- Added UI changes: sort controls in the file-search `Filters` UI for filename/content sort modes, `From` conversions from persisted `FileSearchFilenameSort`/`FileSearchContentSort` to the new shared enums, and behavior to scroll the currently selected row into view when rendered.
- Added unit tests and test coverage for deterministic filename/content sort modes, null size/modified sorting consistency, selection surviving sorting, duplicate filename/content dedup behavior, deferred sorting while running and application on completion, and repeated-sort determinism (tests placed in `src/file_search/sorting.rs` and `src/gui/file_search_dialog.rs`).

### Testing
- Ran `git diff --check` to validate formatting/whitespace checks which passed.
- Attempted `cargo test file_search::sorting --lib` to run the new sorting tests, but running the crate test suite in this Linux environment encountered unrelated platform-specific build failures (Windows-only `windows::Win32` / `windows::core` and some system library pkg-config issues) that prevented executing the full test run; the sorting/unit tests were added and compile/run locally on a compatible platform should exercise the new behavior.
- Manual code-level validation: removed backend-side `sort_filename_results` calls and wired finalization path through `FileSearchDialogState::finalize_completed_results` so the search UI preserves arrival order while running and applies the user-selected sort on completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a558ac4cc608332bbb46e177a55cf8b)