### PR TITLE
Improve file search diagnostics

### DIFF
--- a/src/file_search/coordinator.rs
+++ b/src/file_search/coordinator.rs
@@ -228,7 +228,9 @@ impl SearchCoordinator {
                 self.last_backend = Some(*to);
                 self.diagnostics.last_error = Some(reason.clone());
             }
-            SearchEvent::Result { .. } | SearchEvent::Progress { .. } => {}
+            SearchEvent::Result { .. }
+            | SearchEvent::Progress { .. }
+            | SearchEvent::Diagnostic { .. } => {}
             SearchEvent::Completed { .. } => {
                 self.active_status = SearchStatus::Completed;
                 self.diagnostics.completed += 1;
@@ -279,6 +281,7 @@ pub fn event_id(event: &SearchEvent) -> SearchId {
         | SearchEvent::BackendFallback { id, .. }
         | SearchEvent::Result { id, .. }
         | SearchEvent::Progress { id, .. }
+        | SearchEvent::Diagnostic { id, .. }
         | SearchEvent::Completed { id }
         | SearchEvent::Cancelled { id }
         | SearchEvent::Failed { id, .. } => *id,

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -102,6 +102,31 @@ pub struct SearchProgress {
     pub global_truncated: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InaccessiblePathDetail {
+    pub path: PathBuf,
+    pub operation: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchDiagnostic {
+    Warning(String),
+    BackendStderr(String),
+    InaccessiblePath(InaccessiblePathDetail),
+    PerFileContentTruncated {
+        path: PathBuf,
+        total_matches: usize,
+        displayed_matches: usize,
+    },
+    GlobalMatchedFilesTruncated {
+        limit: usize,
+    },
+    FilenameResultsTruncated {
+        limit: usize,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FileKind {
     File,
@@ -280,6 +305,10 @@ pub enum SearchEvent {
         from: SearchBackend,
         to: SearchBackend,
         reason: String,
+    },
+    Diagnostic {
+        id: SearchId,
+        diagnostic: SearchDiagnostic,
     },
     Result {
         id: SearchId,

--- a/src/file_search/native.rs
+++ b/src/file_search/native.rs
@@ -1,8 +1,8 @@
 use crate::file_search::coordinator::{CancellationToken, SearchExecutor};
 use crate::file_search::model::{
     ContentFileResult, ContentFileResultBuilder, ContentMatch, ContentMatchMode, ContentMatchRange,
-    SearchEvent, SearchId, SearchKind, SearchProgress, SearchRequest, SearchResult, SearchScope,
-    SearchStatus,
+    InaccessiblePathDetail, SearchDiagnostic, SearchEvent, SearchId, SearchKind, SearchProgress,
+    SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::settings::FileSearchSettings;
 use std::collections::HashSet;
@@ -45,6 +45,7 @@ pub struct NativeSearchSummary {
     pub directories_scanned: u64,
     pub cancelled: bool,
     pub global_truncated: bool,
+    pub inaccessible_paths: Vec<InaccessiblePathDetail>,
 }
 
 pub fn search_content_native(
@@ -55,6 +56,12 @@ pub fn search_content_native(
     events: &mpsc::Sender<SearchEvent>,
 ) -> Result<(), String> {
     let summary = search_content_native_summary(request, settings, cancellation)?;
+    for detail in summary.inaccessible_paths.iter().cloned() {
+        let _ = events.send(SearchEvent::Diagnostic {
+            id,
+            diagnostic: SearchDiagnostic::InaccessiblePath(detail),
+        });
+    }
     for result in summary.results.iter().cloned() {
         if cancellation.is_cancelled() {
             let mut cancelled_summary = summary.clone();
@@ -163,11 +170,22 @@ fn collect_paths(
                     summary.cancelled = true;
                     break;
                 }
-                if root.is_file() {
+                let root_meta = match fs::metadata(root) {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        summary.inaccessible_paths.push(InaccessiblePathDetail {
+                            path: root.clone(),
+                            operation: "stat root".to_string(),
+                            error: err.to_string(),
+                        });
+                        continue;
+                    }
+                };
+                if root_meta.is_file() {
                     if accept_file_path(root, request, seen) {
                         out.push(root.clone());
                     }
-                } else if root.is_dir() {
+                } else if root_meta.is_dir() {
                     let walker = WalkDir::new(root)
                         .follow_links(false)
                         .into_iter()
@@ -177,7 +195,20 @@ fn collect_paths(
                             summary.cancelled = true;
                             break;
                         }
-                        let Ok(entry) = entry else { continue };
+                        let entry = match entry {
+                            Ok(entry) => entry,
+                            Err(err) => {
+                                summary.inaccessible_paths.push(InaccessiblePathDetail {
+                                    path: err
+                                        .path()
+                                        .map(|p| p.to_path_buf())
+                                        .unwrap_or_else(|| root.clone()),
+                                    operation: "read directory entry".to_string(),
+                                    error: err.to_string(),
+                                });
+                                continue;
+                            }
+                        };
                         if entry.file_type().is_dir() {
                             summary.directories_scanned += 1;
                             continue;
@@ -263,7 +294,17 @@ fn search_file(
         summary.cancelled = true;
         return None;
     }
-    let meta = fs::metadata(path).ok()?;
+    let meta = match fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(err) => {
+            summary.inaccessible_paths.push(InaccessiblePathDetail {
+                path: path.to_path_buf(),
+                operation: "metadata".to_string(),
+                error: err.to_string(),
+            });
+            return None;
+        }
+    };
     if !meta.is_file() || meta.len() > request.max_file_size_bytes {
         return None;
     }
@@ -272,7 +313,17 @@ fn search_file(
         summary.cancelled = true;
         return None;
     }
-    let file = File::open(path).ok()?;
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) => {
+            summary.inaccessible_paths.push(InaccessiblePathDetail {
+                path: path.to_path_buf(),
+                operation: "open file".to_string(),
+                error: err.to_string(),
+            });
+            return None;
+        }
+    };
     let mut reader = BufReader::new(file);
     if reader.fill_buf().ok().is_some_and(|b| b.contains(&0)) {
         return None;
@@ -617,5 +668,30 @@ mod tests {
         write(&d.path().join("unicodé/雪.txt"), "café ☕\n".as_bytes());
         let s = run(req(d.path().into(), "fé"));
         assert_eq!(s.results[0].matches[0].byte_start, 2);
+    }
+
+    #[test]
+    fn inaccessible_missing_root_is_recorded_from_actual_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing = temp.path().join("missing");
+        let summary = run(SearchRequest {
+            scope: SearchScope::Roots {
+                roots: vec![missing.clone()],
+            },
+            ..req(temp.path().into(), "needle")
+        });
+        assert_eq!(summary.inaccessible_paths.len(), 1);
+        assert_eq!(summary.inaccessible_paths[0].path, missing);
+        assert_eq!(summary.inaccessible_paths[0].operation, "stat root");
+    }
+
+    #[test]
+    fn directory_file_count_mismatch_does_not_create_fake_inaccessible_warning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("subdir")).unwrap();
+        std::fs::write(temp.path().join("haystack.txt"), "needle").unwrap();
+        let summary = run(req(temp.path().into(), "needle"));
+        assert!(summary.directories_scanned > summary.files_scanned);
+        assert!(summary.inaccessible_paths.is_empty());
     }
 }

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -7,8 +7,8 @@ use crate::file_search::error::FileSearchError;
 use crate::file_search::matching::rank_filename_match;
 use crate::file_search::model::{
     ContentFileResult, ContentFileResultBuilder, ContentMatch, FileKind, FileTypeFilter,
-    FilenameResult, SearchEvent, SearchId, SearchKind, SearchProgress, SearchRequest, SearchResult,
-    SearchScope, SearchStatus, TextMatchRange,
+    FilenameResult, SearchDiagnostic, SearchEvent, SearchId, SearchKind, SearchProgress,
+    SearchRequest, SearchResult, SearchScope, SearchStatus, TextMatchRange,
 };
 use crate::file_search::settings::FileSearchSettings;
 use serde_json::Value;
@@ -74,6 +74,7 @@ fn execute_content_search(
     events: &mpsc::Sender<SearchEvent>,
 ) -> Result<(), FileSearchError> {
     let summary = search_content_with_ripgrep(request, settings, token)?;
+    send_bounded_stderr_diagnostic(id, &summary.stderr, events);
     for result in summary.results {
         if events
             .send(SearchEvent::Result {
@@ -116,6 +117,7 @@ fn execute_filename_search(
     events: &mpsc::Sender<SearchEvent>,
 ) -> Result<(), FileSearchError> {
     let summary = search_filenames_with_ripgrep(request, settings, token)?;
+    send_bounded_stderr_diagnostic(id, &summary.stderr, events);
     for result in summary.results {
         if events
             .send(SearchEvent::Result {
@@ -148,6 +150,17 @@ fn execute_filename_search(
         events.send(SearchEvent::Completed { id })
     };
     Ok(())
+}
+
+fn send_bounded_stderr_diagnostic(id: SearchId, stderr: &str, events: &mpsc::Sender<SearchEvent>) {
+    if stderr.trim().is_empty() {
+        return;
+    }
+    let snippet: String = stderr.chars().take(4096).collect();
+    let _ = events.send(SearchEvent::Diagnostic {
+        id,
+        diagnostic: SearchDiagnostic::BackendStderr(snippet),
+    });
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -10,14 +10,15 @@ use crate::file_search::actions::{
 };
 use crate::file_search::coordinator::{event_id, SearchCoordinator};
 use crate::file_search::model::{
-    ContentMatch, FileKind, FileSearchResultKey, PathIdentity, SearchBackend, SearchEvent,
-    SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
+    ContentMatch, FileKind, FileSearchResultKey, PathIdentity, SearchBackend, SearchDiagnostic,
+    SearchEvent, SearchId, SearchKind, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::preview::PreviewRequest;
 use crate::file_search::settings::{
     FileSearchContentSort, FileSearchFilenameSort, FileSearchSettings, FileSearchUiPreferences,
 };
 use crate::gui::file_search_preview_dialog::FileSearchPreviewDialogState;
+use diagnostics::FileSearchDiagnostics;
 use eframe::egui;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -264,6 +265,7 @@ pub struct FileSearchDialogState {
     pub selected_result: Option<SelectedFileSearchResult>,
     pub warning_error_message: Option<String>,
     pub inaccessible_path_warnings: usize,
+    pub diagnostics: FileSearchDiagnostics,
     pub preview_dialog: FileSearchPreviewDialogState,
     pub persisted_window_size: egui::Vec2,
     pub settings: FileSearchSettings,
@@ -295,6 +297,7 @@ impl Default for FileSearchDialogState {
             selected_result: None,
             warning_error_message: None,
             inaccessible_path_warnings: 0,
+            diagnostics: FileSearchDiagnostics::default(),
             preview_dialog: FileSearchPreviewDialogState::default(),
             persisted_window_size: DEFAULT_WINDOW_SIZE,
             settings: FileSearchSettings::default(),
@@ -392,6 +395,7 @@ impl FileSearchDialogState {
         self.clear_results_and_selection();
         self.warning_error_message = None;
         self.inaccessible_path_warnings = 0;
+        self.diagnostics.clear();
         self.current_status = SearchStatus::Running;
         self.backend = Some(SearchCoordinator::select_backend_with_settings(
             &request,
@@ -434,57 +438,98 @@ impl FileSearchDialogState {
         if Some(event_id(&event)) != self.active_search_id {
             return false;
         }
-        let observed_terminal_event = match event {
-            SearchEvent::Started { backend, .. } => {
-                self.backend = Some(backend);
-                self.current_status = SearchStatus::Running;
-                false
-            }
-            SearchEvent::BackendFallback {
-                from, to, reason, ..
-            } => {
-                self.backend = Some(to);
-                self.warning_error_message = Some(format!(
-                    "Search backend fallback: {from:?} → {to:?}: {reason}"
-                ));
-                if from == SearchBackend::Ripgrep
-                    && to == SearchBackend::Native
-                    && !self.ripgrep_missing_prompt_dismissed
-                {
-                    self.show_ripgrep_missing_prompt = true;
+        let observed_terminal_event =
+            match event {
+                SearchEvent::Started { backend, .. } => {
+                    self.backend = Some(backend);
+                    self.diagnostics.backend = Some(backend);
+                    self.current_status = SearchStatus::Running;
+                    false
                 }
-                false
-            }
-            SearchEvent::Result { result, .. } => {
-                self.push_result(result);
-                false
-            }
-            SearchEvent::Progress { progress, .. } => {
-                self.inaccessible_path_warnings = progress
-                    .directories_scanned
-                    .saturating_sub(progress.files_scanned)
-                    .try_into()
-                    .unwrap_or(usize::MAX);
-                false
-            }
-            SearchEvent::Completed { .. } => {
-                self.current_status = SearchStatus::Completed;
-                self.finalize_completed_results();
-                self.request_immediate_repaint = true;
-                true
-            }
-            SearchEvent::Cancelled { .. } => {
-                self.current_status = SearchStatus::Cancelled;
-                self.request_immediate_repaint = true;
-                true
-            }
-            SearchEvent::Failed { error, .. } => {
-                self.current_status = SearchStatus::Failed;
-                self.warning_error_message = Some(error);
-                self.request_immediate_repaint = true;
-                true
-            }
-        };
+                SearchEvent::BackendFallback {
+                    from, to, reason, ..
+                } => {
+                    self.backend = Some(to);
+                    self.diagnostics.backend = Some(to);
+                    let warning = if from == SearchBackend::Ripgrep && to == SearchBackend::Native {
+                        "ripgrep was not found. Native content search is being used.".to_string()
+                    } else {
+                        format!("Search backend fallback: {from:?} → {to:?}: {reason}")
+                    };
+                    self.warning_error_message = Some(warning.clone());
+                    self.diagnostics.record(SearchDiagnostic::Warning(format!(
+                        "{warning} Reason: {reason}"
+                    )));
+                    if from == SearchBackend::Ripgrep
+                        && to == SearchBackend::Native
+                        && !self.ripgrep_missing_prompt_dismissed
+                    {
+                        self.show_ripgrep_missing_prompt = true;
+                    }
+                    false
+                }
+                SearchEvent::Result { result, .. } => {
+                    if let SearchResult::ContentFile(content) = &result {
+                        if content.truncated {
+                            self.diagnostics
+                                .record(SearchDiagnostic::PerFileContentTruncated {
+                                    path: content.path.clone(),
+                                    total_matches: content.total_matches,
+                                    displayed_matches: content.matches.len(),
+                                });
+                        }
+                    }
+                    self.push_result(result);
+                    false
+                }
+                SearchEvent::Progress { progress, .. } => {
+                    if progress.global_truncated {
+                        match self.selected_mode {
+                            FileSearchMode::Filename => self.diagnostics.record(
+                                SearchDiagnostic::FilenameResultsTruncated {
+                                    limit: self
+                                        .last_submitted_request
+                                        .as_ref()
+                                        .map(|r| r.max_results)
+                                        .unwrap_or(progress.results_found),
+                                },
+                            ),
+                            FileSearchMode::Content => self.diagnostics.record(
+                                SearchDiagnostic::GlobalMatchedFilesTruncated {
+                                    limit: self
+                                        .last_submitted_request
+                                        .as_ref()
+                                        .map(|r| r.max_results)
+                                        .unwrap_or(progress.results_found),
+                                },
+                            ),
+                        }
+                    }
+                    false
+                }
+                SearchEvent::Diagnostic { diagnostic, .. } => {
+                    self.diagnostics.record(diagnostic);
+                    self.inaccessible_path_warnings = self.diagnostics.inaccessible_paths.len();
+                    false
+                }
+                SearchEvent::Completed { .. } => {
+                    self.current_status = SearchStatus::Completed;
+                    self.finalize_completed_results();
+                    self.request_immediate_repaint = true;
+                    true
+                }
+                SearchEvent::Cancelled { .. } => {
+                    self.current_status = SearchStatus::Cancelled;
+                    self.request_immediate_repaint = true;
+                    true
+                }
+                SearchEvent::Failed { error, .. } => {
+                    self.current_status = SearchStatus::Failed;
+                    self.warning_error_message = Some(error);
+                    self.request_immediate_repaint = true;
+                    true
+                }
+            };
         self.selection_is_valid();
         observed_terminal_event
     }
@@ -950,14 +995,18 @@ impl FileSearchDialogState {
         });
         self.filters_ui(ui);
         ui.label(format!(
-            "Backend: {} | Status: {:?} | {} | Inaccessible-path warnings: {}",
-            self.backend
-                .map(|b| format!("{b:?}"))
-                .unwrap_or_else(|| "not selected".to_string()),
+            "Status: {:?} | {} | Warnings: {}",
             self.current_status,
             self.result_count_status_text(),
-            self.inaccessible_path_warnings
+            self.diagnostics.warning_count()
         ));
+        egui::CollapsingHeader::new("Diagnostics")
+            .default_open(false)
+            .show(ui, |ui| {
+                for line in self.diagnostics.summary_lines() {
+                    ui.label(line);
+                }
+            });
         if let Some(msg) = &self.warning_error_message {
             ui.colored_label(egui::Color32::YELLOW, msg);
         }
@@ -1486,6 +1535,7 @@ impl FileSearchDialogState {
         self.clear_results_and_selection();
         self.warning_error_message = None;
         self.inaccessible_path_warnings = 0;
+        self.diagnostics.clear();
         self.current_status = SearchStatus::Running;
         self.backend = Some(SearchCoordinator::select_backend_with_settings(
             &request,
@@ -2122,7 +2172,7 @@ mod tests {
         state.apply_event(SearchEvent::Completed { id: SearchId(7) });
         assert_eq!(state.backend, Some(SearchBackend::WalkDir));
         assert_eq!(state.results.len(), 1);
-        assert_eq!(state.inaccessible_path_warnings, 3);
+        assert_eq!(state.inaccessible_path_warnings, 0);
         assert_eq!(state.current_status, SearchStatus::Completed);
     }
 
@@ -3365,6 +3415,26 @@ mod tests {
             .warning_error_message
             .as_deref()
             .is_some_and(|message| message.contains("/tmp/a.txt")));
+    }
+
+    #[test]
+    fn fallback_warning_does_not_mark_successful_search_failed() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(99)),
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::BackendFallback {
+            id: SearchId(99),
+            from: SearchBackend::Ripgrep,
+            to: SearchBackend::Native,
+            reason: "not found".to_string(),
+        });
+        state.apply_event(SearchEvent::Completed { id: SearchId(99) });
+        assert_eq!(state.current_status, SearchStatus::Completed);
+        assert!(state
+            .warning_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("Native content search is being used")));
     }
 
     #[test]

--- a/src/gui/file_search_dialog/diagnostics.rs
+++ b/src/gui/file_search_dialog/diagnostics.rs
@@ -1,1 +1,134 @@
 //! Diagnostics rendering helpers for the file-search dialog.
+
+use crate::file_search::model::{InaccessiblePathDetail, SearchBackend, SearchDiagnostic};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FileSearchDiagnostics {
+    pub backend: Option<SearchBackend>,
+    pub fallback_warnings: Vec<String>,
+    pub inaccessible_paths: Vec<InaccessiblePathDetail>,
+    pub per_file_truncations: Vec<(PathBuf, usize, usize)>,
+    pub global_matched_file_truncation: Option<usize>,
+    pub filename_result_limit_truncation: Option<usize>,
+    pub backend_stderr_snippets: Vec<String>,
+}
+
+impl FileSearchDiagnostics {
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn record(&mut self, diagnostic: SearchDiagnostic) {
+        match diagnostic {
+            SearchDiagnostic::Warning(message) => self.fallback_warnings.push(message),
+            SearchDiagnostic::BackendStderr(snippet) => {
+                let bounded: String = snippet.chars().take(4096).collect();
+                if !bounded.trim().is_empty() {
+                    self.backend_stderr_snippets.push(bounded);
+                }
+            }
+            SearchDiagnostic::InaccessiblePath(detail) => self.inaccessible_paths.push(detail),
+            SearchDiagnostic::PerFileContentTruncated {
+                path,
+                total_matches,
+                displayed_matches,
+            } => {
+                self.per_file_truncations
+                    .push((path, total_matches, displayed_matches));
+            }
+            SearchDiagnostic::GlobalMatchedFilesTruncated { limit } => {
+                self.global_matched_file_truncation = Some(limit);
+            }
+            SearchDiagnostic::FilenameResultsTruncated { limit } => {
+                self.filename_result_limit_truncation = Some(limit);
+            }
+        }
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.fallback_warnings.len() + self.inaccessible_paths.len()
+    }
+
+    pub fn summary_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(backend) = self.backend {
+            lines.push(format!("Backend: {backend:?}"));
+        }
+        lines.extend(self.fallback_warnings.iter().cloned());
+        for detail in &self.inaccessible_paths {
+            lines.push(format!(
+                "Inaccessible path: {} ({}: {})",
+                detail.path.display(),
+                detail.operation,
+                detail.error
+            ));
+        }
+        for (path, total, displayed) in &self.per_file_truncations {
+            lines.push(format!("Per-file content matches truncated for {}: showing {displayed} of {total} matches.", path.display()));
+        }
+        if let Some(limit) = self.global_matched_file_truncation {
+            lines.push(format!("Matched-file results truncated at {limit}."));
+        }
+        if let Some(limit) = self.filename_result_limit_truncation {
+            lines.push(format!("Filename results truncated at {limit}."));
+        }
+        for snippet in &self.backend_stderr_snippets {
+            lines.push(format!("Backend stderr: {}", snippet.trim()));
+        }
+        lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_search::model::{InaccessiblePathDetail, SearchDiagnostic};
+
+    #[test]
+    fn fallback_warning_is_diagnostic_not_failure() {
+        let mut diagnostics = FileSearchDiagnostics::default();
+        diagnostics.record(SearchDiagnostic::Warning(
+            "ripgrep was not found. Native content search is being used.".to_string(),
+        ));
+        assert_eq!(diagnostics.warning_count(), 1);
+        assert!(diagnostics.summary_lines()[0].contains("Native content search"));
+    }
+
+    #[test]
+    fn bounded_stderr_display_is_limited() {
+        let mut diagnostics = FileSearchDiagnostics::default();
+        diagnostics.record(SearchDiagnostic::BackendStderr("x".repeat(10_000)));
+        assert_eq!(diagnostics.backend_stderr_snippets[0].len(), 4096);
+    }
+
+    #[test]
+    fn truncation_lines_are_consistent() {
+        let mut diagnostics = FileSearchDiagnostics::default();
+        diagnostics.record(SearchDiagnostic::PerFileContentTruncated {
+            path: "a.txt".into(),
+            total_matches: 4,
+            displayed_matches: 2,
+        });
+        diagnostics.record(SearchDiagnostic::GlobalMatchedFilesTruncated { limit: 10 });
+        diagnostics.record(SearchDiagnostic::FilenameResultsTruncated { limit: 20 });
+        let lines = diagnostics.summary_lines().join("\n");
+        assert!(lines.contains("showing 2 of 4"));
+        assert!(lines.contains("Matched-file results truncated at 10"));
+        assert!(lines.contains("Filename results truncated at 20"));
+    }
+
+    #[test]
+    fn inaccessible_details_include_path_operation_and_error() {
+        let mut diagnostics = FileSearchDiagnostics::default();
+        diagnostics.record(SearchDiagnostic::InaccessiblePath(InaccessiblePathDetail {
+            path: "/missing".into(),
+            operation: "metadata".to_string(),
+            error: "denied".to_string(),
+        }));
+        let line = diagnostics.summary_lines().join("\n");
+        assert!(line.contains("/missing"));
+        assert!(line.contains("metadata"));
+        assert!(line.contains("denied"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Make backend diagnostics explicit and actionable by moving detailed backend information out of the status bar and into a dedicated diagnostics view. 
- Surface real filesystem failures (inaccessible roots/entries/files) and truncation events so users can act on them instead of seeing misleading counts. 
- Capture bounded backend stderr snippets and present fallback warnings as informative diagnostics without treating successful fallbacks as failures.

### Description
- Add `src/gui/file_search_dialog/diagnostics.rs` and a `FileSearchDiagnostics` helper used by the dialog UI to collect warnings, inaccessible-path details, truncation notices, and bounded backend stderr snippets. 
- Add `InaccessiblePathDetail` and `SearchDiagnostic` types to `src/file_search/model.rs` and extend `SearchEvent` with a `Diagnostic` variant to carry structured diagnostics. 
- Emit diagnostics from backends: native search now records `InaccessiblePathDetail` entries (roots, directory entry read errors, file metadata/open errors) and ripgrep now sends bounded stderr diagnostics; diagnostics are collected and shown in a collapsible diagnostics section in the UI while the status line remains focused on user-facing progress/result summaries. 
- Update coordinator to propagate diagnostic events, record truncation as diagnostics (`PerFileContentTruncated`, `GlobalMatchedFilesTruncated`, `FilenameResultsTruncated`), and add unit tests exercising the new diagnostics behaviors.

### Testing
- Ran `git diff --check` and applied `rustfmt` to changed files (no whitespace errors). 
- Added unit tests for diagnostics behavior in `src/gui/file_search_dialog/diagnostics.rs` and native search unreachable-path tests in `src/file_search/native.rs`. 
- Attempted `cargo test -q file_search` to exercise the file-search test subset, but a full test run in this Linux environment was blocked by unrelated platform-specific compile errors (Windows API and other system crates) before the repository-level suite could finish; the new diagnostics unit tests are included and expected to run in CI where platform-specific features compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56d4eff988833280a9f4dce769906b)