### PR TITLE
Add Export menu and TSV export helpers to File Search

### DIFF
--- a/src/file_search/export.rs
+++ b/src/file_search/export.rs
@@ -1,26 +1,26 @@
 use crate::actions::clipboard;
 use crate::file_search::model::{
-    ContentFileResult, ContentMatch, FilenameMatchQuality, FilenameResult,
+    ContentFileResult, ContentMatch, FileKind, FilenameMatchQuality, FilenameResult,
 };
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 const FILENAME_TSV_HEADER: &[&str] = &[
-    "path",
-    "file name",
-    "directory",
-    "size",
-    "modified time",
-    "match quality",
+    "Name",
+    "Directory",
+    "Full Path",
+    "Type",
+    "Size",
+    "Modified",
+    "Match Quality",
 ];
 const CONTENT_TSV_HEADER: &[&str] = &[
-    "path",
-    "file name",
-    "directory",
-    "line number",
-    "line preview",
-    "modified time",
-    "match quality",
+    "Full Path",
+    "Line",
+    "Column",
+    "Matching Text",
+    "Total Matches In File",
+    "File Truncated",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,6 +28,7 @@ pub struct FilenameExportRow {
     pub path: PathBuf,
     pub file_name: String,
     pub directory: String,
+    pub kind: FileKind,
     pub size: Option<u64>,
     pub modified: Option<SystemTime>,
     pub match_quality: Option<FilenameMatchQuality>,
@@ -41,8 +42,8 @@ pub struct ContentExportRow {
     pub line_number: usize,
     pub column: Option<usize>,
     pub line_preview: String,
-    pub modified: Option<SystemTime>,
-    pub match_quality: Option<FilenameMatchQuality>,
+    pub total_matches_in_file: usize,
+    pub file_truncated: bool,
 }
 
 pub fn selected_filename_result_path(result: &FilenameResult) -> String {
@@ -85,6 +86,26 @@ pub fn all_visible_content_results<'a>(
         .join("\n")
 }
 
+pub fn visible_full_paths<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Result<String, String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut lines = Vec::new();
+    for path in paths {
+        let key = crate::file_search::sorting::path_identity(path);
+        if seen.insert(key) {
+            lines.push(path.display().to_string());
+        }
+    }
+    non_empty_export(lines.join("\n"))
+}
+
+pub fn non_empty_export(payload: String) -> Result<String, String> {
+    if payload.is_empty() {
+        Err("There are no visible file-search results to export.".to_string())
+    } else {
+        Ok(payload)
+    }
+}
+
 pub fn filename_export_row(result: &FilenameResult) -> FilenameExportRow {
     FilenameExportRow {
         path: result.path.clone(),
@@ -94,6 +115,7 @@ pub fn filename_export_row(result: &FilenameResult) -> FilenameExportRow {
             .as_ref()
             .map(|p| p.display().to_string())
             .unwrap_or_default(),
+        kind: result.kind,
         size: result.size,
         modified: result.modified,
         match_quality: Some(result.match_quality),
@@ -116,8 +138,8 @@ pub fn content_export_rows(result: &ContentFileResult) -> Vec<ContentExportRow> 
             line_number: m.line_number,
             column: m.column,
             line_preview: m.line.clone(),
-            modified: result.modified,
-            match_quality: result.filename_relevance,
+            total_matches_in_file: result.total_matches,
+            file_truncated: result.truncated,
         })
         .collect()
 }
@@ -126,9 +148,10 @@ pub fn filename_results_tsv<'a>(rows: impl IntoIterator<Item = &'a FilenameExpor
     let mut lines = vec![tsv_row(FILENAME_TSV_HEADER)];
     lines.extend(rows.into_iter().map(|row| {
         tsv_row(&[
-            row.path.display().to_string(),
             row.file_name.clone(),
             row.directory.clone(),
+            row.path.display().to_string(),
+            format!("{:?}", row.kind),
             row.size.map(|s| s.to_string()).unwrap_or_default(),
             format_system_time(row.modified),
             row.match_quality
@@ -144,14 +167,13 @@ pub fn content_results_tsv<'a>(rows: impl IntoIterator<Item = &'a ContentExportR
     lines.extend(rows.into_iter().map(|row| {
         tsv_row(&[
             row.path.display().to_string(),
-            row.file_name.clone(),
-            row.directory.clone(),
             row.line_number.to_string(),
-            row.line_preview.clone(),
-            format_system_time(row.modified),
-            row.match_quality
-                .map(|q| format!("{q:?}"))
+            row.column
+                .map(|column| column.saturating_add(1).to_string())
                 .unwrap_or_default(),
+            row.line_preview.clone(),
+            row.total_matches_in_file.to_string(),
+            row.file_truncated.to_string(),
         ])
     }));
     lines.join("\n")
@@ -218,17 +240,27 @@ mod tests {
     }
 
     #[test]
+    fn tsv_field_escaping_replaces_tabs() {
+        assert_eq!(escape_tsv_field("left\tright"), "left right");
+    }
+
+    #[test]
+    fn tsv_field_escaping_replaces_newlines() {
+        assert_eq!(escape_tsv_field("top\nbottom\rmore"), "top bottom more");
+    }
+
+    #[test]
     fn filename_export_columns_are_stable() {
         let row = filename_export_row(&filename_result());
         let tsv = filename_results_tsv([&row]);
         let lines: Vec<_> = tsv.lines().collect();
         assert_eq!(
             lines[0],
-            "path\tfile name\tdirectory\tsize\tmodified time\tmatch quality"
+            "Name\tDirectory\tFull Path\tType\tSize\tModified\tMatch Quality"
         );
         assert_eq!(
             lines[1],
-            "/tmp/project/src/main.rs\tmain.rs\t/tmp/project/src\t42\t\tExactFilename"
+            "main.rs\t/tmp/project/src\t/tmp/project/src/main.rs\tFile\t42\t\tExactFilename"
         );
     }
 
@@ -240,20 +272,20 @@ mod tests {
             modified: None,
             filename_relevance: Some(FilenameRank::FilenameContains),
             arrival_index: 0,
-            total_matches: 1,
+            total_matches: 3,
             matches: vec![ContentMatch::new(7, "needle line".into(), 0, 6)],
-            truncated: false,
+            truncated: true,
         };
         let rows = content_export_rows(&result);
         let tsv = content_results_tsv(rows.iter());
         let lines: Vec<_> = tsv.lines().collect();
         assert_eq!(
             lines[0],
-            "path\tfile name\tdirectory\tline number\tline preview\tmodified time\tmatch quality"
+            "Full Path\tLine\tColumn\tMatching Text\tTotal Matches In File\tFile Truncated"
         );
         assert_eq!(
             lines[1],
-            "/tmp/project/src/lib.rs\tlib.rs\t/tmp/project/src\t7\tneedle line\t\tFilenameContains"
+            "/tmp/project/src/lib.rs\t7\t1\tneedle line\t3\ttrue"
         );
     }
 
@@ -272,8 +304,22 @@ mod tests {
     }
 
     #[test]
+    fn visible_full_paths_are_deduplicated_in_order() {
+        let a = PathBuf::from("/tmp/a.txt");
+        let b = PathBuf::from("/tmp/b.txt");
+        assert_eq!(
+            visible_full_paths([a.as_path(), b.as_path(), a.as_path()]).unwrap(),
+            "/tmp/a.txt\n/tmp/b.txt"
+        );
+    }
+
+    #[test]
     fn empty_result_export_has_header_only_and_empty_copy_payload() {
         assert_eq!(all_visible_filename_results([].iter()), "");
+        assert_eq!(
+            non_empty_export(String::new()).unwrap_err(),
+            "There are no visible file-search results to export."
+        );
         assert_eq!(
             filename_results_tsv([].iter()),
             FILENAME_TSV_HEADER.join("\t")

--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -1168,35 +1168,37 @@ impl FileSearchDialogState {
                 self.open_selected_result();
                 ui.ctx().request_repaint();
             }
-            if ui
-                .add_enabled(
-                    self.selected_result().is_some(),
-                    egui::Button::new("Copy selected"),
-                )
-                .clicked()
-                && let Some(payload) = self.copy_selected_payload()
-            {
-                self.copy_text_payload("copy selected", payload);
-            }
-            if ui
-                .add_enabled(
-                    self.visible_selectable_result_rows().next().is_some(),
-                    egui::Button::new("Copy all visible"),
-                )
-                .clicked()
-                && let Some(payload) = self.copy_all_visible_results_payload()
-            {
-                self.copy_text_payload("copy visible results", payload);
-            }
-            if ui
-                .add_enabled(
-                    self.visible_selectable_result_rows().next().is_some(),
-                    egui::Button::new("Export visible results…"),
-                )
-                .clicked()
-            {
-                self.export_visible_results_to_file();
-            }
+            ui.menu_button("Export", |ui| {
+                if ui.button("Copy visible results").clicked() {
+                    match self.copy_all_visible_results_payload() {
+                        Ok(payload) => self.copy_text_payload("copy visible results", payload),
+                        Err(err) => self.warning_error_message = Some(err),
+                    }
+                    ui.close_menu();
+                }
+                if ui.button("Save visible results as TSV…").clicked() {
+                    self.export_visible_results_to_file();
+                    ui.close_menu();
+                }
+                if ui
+                    .add_enabled(
+                        self.selected_result().is_some(),
+                        egui::Button::new("Copy selected result"),
+                    )
+                    .clicked()
+                    && let Some(payload) = self.copy_selected_payload()
+                {
+                    self.copy_text_payload("copy selected", payload);
+                    ui.close_menu();
+                }
+                if ui.button("Copy visible full paths").clicked() {
+                    match self.copy_visible_full_paths_payload() {
+                        Ok(payload) => self.copy_text_payload("copy visible full paths", payload),
+                        Err(err) => self.warning_error_message = Some(err),
+                    }
+                    ui.close_menu();
+                }
+            });
         });
         ui.horizontal(|ui| {
             ui.label("Filter");
@@ -3458,7 +3460,59 @@ mod tests {
         );
         assert_eq!(
             state.copy_all_visible_results_payload().as_deref(),
-            Some("/tmp/match.txt:1:6: line 0 needle")
+            Ok("/tmp/match.txt:1:6: line 0 needle")
+        );
+    }
+
+    #[test]
+    fn visible_export_uses_filtered_rows_only() {
+        let mut state = FileSearchDialogState {
+            active_search_id: Some(SearchId(12)),
+            ..Default::default()
+        };
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(12),
+            result: filename_search_result("/tmp/keep.txt"),
+        });
+        state.apply_event(SearchEvent::Result {
+            id: SearchId(12),
+            result: filename_search_result("/tmp/drop.txt"),
+        });
+        state.set_refinement_text("keep");
+
+        assert_eq!(
+            state.copy_all_visible_results_payload().as_deref(),
+            Ok("/tmp/keep.txt")
+        );
+        assert!(
+            state
+                .export_visible_results_tsv()
+                .unwrap()
+                .contains("keep.txt")
+        );
+        assert!(
+            !state
+                .export_visible_results_tsv()
+                .unwrap()
+                .contains("drop.txt")
+        );
+    }
+
+    #[test]
+    fn empty_visible_export_returns_user_facing_error() {
+        let state = FileSearchDialogState::default();
+
+        assert_eq!(
+            state.copy_all_visible_results_payload().unwrap_err(),
+            "There are no visible file-search results to export."
+        );
+        assert_eq!(
+            state.copy_visible_full_paths_payload().unwrap_err(),
+            "There are no visible file-search results to export."
+        );
+        assert_eq!(
+            state.export_visible_results_tsv().unwrap_err(),
+            "There are no visible file-search results to export."
         );
     }
 

--- a/src/gui/file_search_dialog/keyboard.rs
+++ b/src/gui/file_search_dialog/keyboard.rs
@@ -4,8 +4,8 @@ use super::{
     SelectedFileSearchResultPayload,
 };
 use crate::file_search::actions::{
-    containing_directory, execute_explorer_action, open_in_configured_editor, open_path,
-    resolve_explorer_action, InvocationTarget,
+    InvocationTarget, containing_directory, execute_explorer_action, open_in_configured_editor,
+    open_path, resolve_explorer_action,
 };
 use crate::file_search::coordinator::SearchCoordinator;
 use crate::file_search::export;
@@ -229,11 +229,8 @@ impl FileSearchDialogState {
             })
     }
 
-    pub(super) fn copy_all_visible_results_payload(&self) -> Option<String> {
-        if self.visible_selectable_result_rows().next().is_none() {
-            return None;
-        }
-        Some(match self.selected_mode {
+    pub(super) fn copy_all_visible_results_payload(&self) -> Result<String, String> {
+        let payload = match self.selected_mode {
             super::FileSearchMode::Filename => {
                 let rows = self.visible_filename_export_rows();
                 export::all_visible_filename_results(rows.iter())
@@ -242,11 +239,16 @@ impl FileSearchDialogState {
                 let rows = self.visible_content_export_rows();
                 export::all_visible_content_results(rows.iter())
             }
-        })
+        };
+        export::non_empty_export(payload)
     }
 
-    pub(super) fn export_visible_results_tsv(&self) -> String {
-        match self.selected_mode {
+    pub(super) fn export_visible_results_tsv(&self) -> Result<String, String> {
+        let has_rows = self.visible_selectable_result_rows().next().is_some();
+        if !has_rows {
+            return Err("There are no visible file-search results to export.".to_string());
+        }
+        Ok(match self.selected_mode {
             super::FileSearchMode::Filename => {
                 let rows = self.visible_filename_export_rows();
                 export::filename_results_tsv(rows.iter())
@@ -255,7 +257,12 @@ impl FileSearchDialogState {
                 let rows = self.visible_content_export_rows();
                 export::content_results_tsv(rows.iter())
             }
-        }
+        })
+    }
+
+    pub(super) fn copy_visible_full_paths_payload(&self) -> Result<String, String> {
+        let rows = self.visible_selectable_result_rows().collect::<Vec<_>>();
+        export::visible_full_paths(rows.iter().map(|row| row.id.path.as_path()))
     }
 
     pub(super) fn export_visible_results_to_file(&mut self) {
@@ -270,9 +277,15 @@ impl FileSearchDialogState {
         else {
             return;
         };
-        let payload = self.export_visible_results_tsv();
+        let payload = match self.export_visible_results_tsv() {
+            Ok(payload) => payload,
+            Err(err) => {
+                self.warning_error_message = Some(err);
+                return;
+            }
+        };
         self.run_result_action("export visible results", || {
-            std::fs::write(&path, payload)?;
+            std::fs::write(&path, payload.as_bytes())?;
             Ok(())
         });
     }
@@ -292,6 +305,7 @@ impl FileSearchDialogState {
                     path,
                     display_filename,
                     parent_directory_display,
+                    kind,
                     size,
                     modified,
                     match_quality,
@@ -300,6 +314,7 @@ impl FileSearchDialogState {
                     path: path.clone(),
                     file_name: display_filename.clone(),
                     directory: parent_directory_display.clone(),
+                    kind: *kind,
                     size: *size,
                     modified: *modified,
                     match_quality: Some(*match_quality),
@@ -335,8 +350,8 @@ impl FileSearchDialogState {
                         line_number: content_match.line_number,
                         column: content_match.column,
                         line_preview: content_match.line.clone(),
-                        modified: source.and_then(|file| file.modified),
-                        match_quality: source.and_then(|file| file.filename_relevance),
+                        total_matches_in_file: source.map(|file| file.total_matches).unwrap_or(1),
+                        file_truncated: source.map(|file| file.truncated).unwrap_or(false),
                     })
                 }
                 FileSearchRowPayload::Filename { .. }


### PR DESCRIPTION
### Motivation

- Provide export actions for file-search results (copy/save visible results, copy selected row, copy visible full paths) that respect current sort/mode/refinement order.  
- Produce TSV outputs with the requested column shapes for filename and content results, using UTF-8 and normalizing embedded tabs/newlines so the TSV shape remains valid.  
- Surface user-visible errors for empty-result exports and write failures so the dialog can inform the user via `warning_error_message`.

### Description

- Add an `Export` menu to the file-search dialog UI with actions: `Copy visible results`, `Save visible results as TSV…`, `Copy selected result`, and `Copy visible full paths`.  
- Implement pure formatting helpers in `src/file_search/export.rs` including `filename_results_tsv`, `content_results_tsv`, `tsv_row`, `escape_tsv_field`, `visible_full_paths`, and `non_empty_export`, and adapt `filename_export_row` / `content_export_rows` to produce the required columns.  
- Wire dialog/keyboard helpers in `src/gui/file_search_dialog/keyboard.rs` and UI in `src/gui/file_search_dialog.rs` to use the visible rows (`visible_result_rows()` / `visible_selectable_result_rows()`), call `rfd::FileDialog` for TSV destination selection, write UTF-8 bytes (`.as_bytes()`), deduplicate paths while preserving visible order, and set `warning_error_message` for write/empty errors.  
- Add unit tests covering filename/content TSV formatting, escaping tabs/newlines, deduplicated full-path export, visible-only exports after refinement, and a clear empty-result export error.

### Testing

- Attempted to run unit tests for the new export helpers with `cargo test file_search::export --lib`, but the full crate build was blocked by unrelated platform-specific build dependencies in this environment (Windows-only API usages in other modules) which prevented completing the test run.  
- System packages required by native crates (e.g. `libasound2-dev`, X11/Wayland dev packages) were installed to resolve native build failures, but remaining Windows-targeted compile errors still prevented executing the full test suite here.  
- The new pure helpers include unit tests in `src/file_search/export.rs` and dialog-level tests in `src/gui/file_search_dialog.rs`, which should pass in CI or a platform build where the entire crate compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5828dd30788332944a9b7e70acd5fa)