### PR TITLE
File-search: return UI commands and centralize settings reconfiguration

### DIFF
--- a/src/gui/file_search_dialog.rs
+++ b/src/gui/file_search_dialog.rs
@@ -258,6 +258,12 @@ pub enum FileSearchContextMenuAction {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum FileSearchUiCommand {
+    ConfigureRipgrep(PathBuf),
+    PersistPreferences(FileSearchUiPreferences),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct FileSearchDialogState {
     pub open: bool,
     pub selected_mode: FileSearchMode,
@@ -970,7 +976,11 @@ impl FileSearchDialogState {
         prefix
     }
 
-    pub fn ui(&mut self, ctx: &egui::Context, coordinator: &mut SearchCoordinator) {
+    pub fn ui(
+        &mut self,
+        ctx: &egui::Context,
+        coordinator: &mut SearchCoordinator,
+    ) -> Vec<FileSearchUiCommand> {
         self.drain_events(coordinator);
         if self.consume_immediate_repaint_request() {
             ctx.request_repaint();
@@ -979,7 +989,7 @@ impl FileSearchDialogState {
             ctx.request_repaint_after(ACTIVE_SEARCH_REPAINT_INTERVAL);
         }
         if !self.open {
-            return;
+            return Vec::new();
         }
         if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
             if self.handle_escape(coordinator) == FileSearchEscapeAction::Cancel {
@@ -988,6 +998,7 @@ impl FileSearchDialogState {
             ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
         }
         let mut open = self.open;
+        let mut commands = Vec::new();
         if let Some(resp) = egui::Window::new("File Search")
             .open(&mut open)
             .default_size(DEFAULT_WINDOW_SIZE)
@@ -996,8 +1007,10 @@ impl FileSearchDialogState {
             .show(ctx, |ui| self.contents(ui, coordinator))
         {
             self.persisted_window_size = resp.response.rect.size();
+            commands = resp.inner.unwrap_or_default();
         }
         self.open = open;
+        commands
     }
 
     pub fn set_ui_preferences(&mut self, preferences: FileSearchUiPreferences) {
@@ -1031,7 +1044,12 @@ impl FileSearchDialogState {
         self.ui_preferences_dirty = false;
     }
 
-    fn contents(&mut self, ui: &mut egui::Ui, coordinator: &mut SearchCoordinator) {
+    fn contents(
+        &mut self,
+        ui: &mut egui::Ui,
+        coordinator: &mut SearchCoordinator,
+    ) -> Vec<FileSearchUiCommand> {
+        let mut commands = Vec::new();
         self.handle_result_keyboard_shortcuts(ui, coordinator);
         let previously_selected_mode = self.selected_mode;
         ui.horizontal(|ui| {
@@ -1254,7 +1272,7 @@ impl FileSearchDialogState {
         if let Some(msg) = &self.warning_error_message {
             ui.colored_label(egui::Color32::YELLOW, msg);
         }
-        self.ripgrep_missing_prompt_ui(ui, coordinator);
+        commands.extend(self.ripgrep_missing_prompt_ui(ui));
         let results_region_size = ui.available_size();
         ui.allocate_ui_with_layout(results_region_size, *ui.layout(), |ui| {
             ui.push_id(Self::result_list_id(), |ui| {
@@ -1267,15 +1285,18 @@ impl FileSearchDialogState {
                     });
             });
         });
+        if self.ui_preferences_dirty {
+            commands.push(FileSearchUiCommand::PersistPreferences(
+                self.ui_preferences.clone(),
+            ));
+        }
+        commands
     }
 
-    fn ripgrep_missing_prompt_ui(
-        &mut self,
-        ui: &mut egui::Ui,
-        coordinator: &mut SearchCoordinator,
-    ) {
+    fn ripgrep_missing_prompt_ui(&mut self, ui: &mut egui::Ui) -> Vec<FileSearchUiCommand> {
+        let mut commands = Vec::new();
         if !self.show_ripgrep_missing_prompt || self.ripgrep_missing_prompt_dismissed {
-            return;
+            return commands;
         }
         ui.horizontal(|ui| {
             ui.colored_label(egui::Color32::YELLOW, "ripgrep (rg) was not found. Native content search will continue; configure rg for faster future searches.");
@@ -1283,11 +1304,8 @@ impl FileSearchDialogState {
                 && let Some(path) = rfd::FileDialog::new().add_filter("Executable", &["exe", ""]).pick_file() {
                     match validate_ripgrep_selection(&path) {
                         Ok(abs) => {
-                            self.settings.ripgrep_executable_path = abs;
-                            self.ui_preferences_dirty = true;
-                            coordinator.reconfigure_from_settings(self.settings.clone());
+                            commands.push(FileSearchUiCommand::ConfigureRipgrep(abs));
                             self.show_ripgrep_missing_prompt = false;
-                            self.warning_error_message = Some("ripgrep path saved for future searches.".to_owned());
                         }
                         Err(err) => self.warning_error_message = Some(err),
                     }
@@ -1296,6 +1314,7 @@ impl FileSearchDialogState {
                 self.dismiss_ripgrep_missing_prompt();
             }
         });
+        commands
     }
 
     pub fn dismiss_ripgrep_missing_prompt(&mut self) {
@@ -1306,14 +1325,10 @@ impl FileSearchDialogState {
     pub fn configure_ripgrep_path_for_future_searches(
         &mut self,
         path: PathBuf,
-        coordinator: &mut SearchCoordinator,
-    ) -> Result<(), String> {
+    ) -> Result<FileSearchUiCommand, String> {
         let abs = validate_ripgrep_selection(&path)?;
-        self.settings.ripgrep_executable_path = abs;
-        self.ui_preferences_dirty = true;
-        coordinator.reconfigure_from_settings(self.settings.clone());
         self.show_ripgrep_missing_prompt = false;
-        Ok(())
+        Ok(FileSearchUiCommand::ConfigureRipgrep(abs))
     }
 
     fn filename_results(&mut self, ui: &mut egui::Ui, coordinator: &mut SearchCoordinator) {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -54,7 +54,7 @@ pub use clipboard_dialog::ClipboardDialog;
 pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;
 pub use fav_dialog::FavDialog;
-pub use file_search_dialog::{FileSearchDialogState, FileSearchMode, FileSearchScopeMode};
+pub use file_search_dialog::{FileSearchDialogState, FileSearchMode, FileSearchScopeMode, FileSearchUiCommand};
 pub use file_search_preview_dialog::FileSearchPreviewDialogState;
 pub use image_panel::ImagePanel;
 pub use macro_dialog::MacroDialog;
@@ -607,8 +607,14 @@ impl LauncherApp {
 
     pub fn apply_file_search_settings(
         &mut self,
-        settings: crate::file_search::settings::FileSearchSettings,
+        mut settings: crate::file_search::settings::FileSearchSettings,
     ) {
+        if self.file_search_dialog.ui_preferences_dirty {
+            settings.ui_preferences = self.file_search_dialog.ui_preferences.clone();
+        }
+        for diagnostic in settings.validate() {
+            tracing::warn!(%diagnostic, "file_search settings warning during runtime apply");
+        }
         self.file_search_dialog
             .cancel_search(&mut self.file_search_coordinator);
         self.file_search_coordinator
@@ -621,17 +627,73 @@ impl LauncherApp {
     }
 
     pub(crate) fn save_file_search_ui_preferences_if_dirty(&mut self) {
-        if !self.file_search_dialog.ui_preferences_dirty {
-            return;
+        if self.file_search_dialog.ui_preferences_dirty {
+            self.handle_file_search_ui_command(FileSearchUiCommand::PersistPreferences(
+                self.file_search_dialog.ui_preferences.clone(),
+            ));
         }
-        self.file_search_dialog.save_dirty_ui_preferences();
-        if let Ok(mut settings) = crate::settings::Settings::load(&self.settings_path)
-            && let Ok(value) = serde_json::to_value(&self.file_search_dialog.settings) {
-                settings
-                    .plugin_settings
-                    .insert("file_search".to_owned(), value);
-                let _ = settings.save(&self.settings_path);
+    }
+
+    pub(crate) fn handle_file_search_ui_command(&mut self, command: FileSearchUiCommand) {
+        match command {
+            FileSearchUiCommand::PersistPreferences(preferences) => {
+                self.file_search_dialog.settings.ui_preferences = preferences.clone();
+                self.file_search_dialog.set_ui_preferences(preferences);
+                match crate::settings::Settings::load(&self.settings_path) {
+                    Ok(mut settings) => {
+                        let mut cfg = settings
+                            .plugin_settings
+                            .get("file_search")
+                            .and_then(|value| serde_json::from_value(value.clone()).ok())
+                            .unwrap_or_else(crate::file_search::settings::FileSearchSettings::default);
+                        cfg.ui_preferences = self.file_search_dialog.ui_preferences.clone();
+                        if let Ok(value) = serde_json::to_value(&cfg) {
+                            settings.plugin_settings.insert("file_search".to_owned(), value.clone());
+                            self.settings_editor.set_plugin_setting_value("file_search", value);
+                            if let Err(error) = settings.save(&self.settings_path) {
+                                self.report_error_message("file_search.preferences.save", format!("Failed to save file-search preferences: {error}"));
+                            }
+                        }
+                    }
+                    Err(error) => self.report_error_message(
+                        "file_search.preferences.load",
+                        format!("Failed to load settings: {error}"),
+                    ),
+                }
             }
+            FileSearchUiCommand::ConfigureRipgrep(path) => {
+                match crate::settings::Settings::load(&self.settings_path) {
+                    Ok(mut settings) => {
+                        let mut cfg = settings
+                            .plugin_settings
+                            .get("file_search")
+                            .and_then(|value| serde_json::from_value(value.clone()).ok())
+                            .unwrap_or_else(crate::file_search::settings::FileSearchSettings::default);
+                        cfg.ripgrep_executable_path = path;
+                        if let Ok(value) = serde_json::to_value(&cfg) {
+                            settings.plugin_settings.insert("file_search".to_owned(), value.clone());
+                            self.settings_editor.set_plugin_setting_value("file_search", value);
+                            match settings.save(&self.settings_path) {
+                                Ok(()) => {
+                                    self.apply_file_search_settings(cfg);
+                                    self.file_search_dialog.warning_error_message = Some(
+                                        "ripgrep path saved for future searches.".to_owned(),
+                                    );
+                                }
+                                Err(error) => self.report_error_message(
+                                    "file_search.ripgrep.save",
+                                    format!("Failed to save ripgrep path: {error}"),
+                                ),
+                            }
+                        }
+                    }
+                    Err(error) => self.report_error_message(
+                        "file_search.ripgrep.load",
+                        format!("Failed to load settings: {error}"),
+                    ),
+                }
+            }
+        }
     }
 
     pub(crate) fn merge_file_search_ui_preferences_into_settings(

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1232,8 +1232,12 @@ impl eframe::App for LauncherApp {
         fav_dlg.ui(ctx, self);
         self.fav_dialog = fav_dlg;
         let file_search_was_open = self.file_search_dialog.open;
-        self.file_search_dialog
+        let file_search_commands = self
+            .file_search_dialog
             .ui(ctx, &mut self.file_search_coordinator);
+        for command in file_search_commands {
+            self.handle_file_search_ui_command(command);
+        }
         if file_search_was_open && !self.file_search_dialog.open {
             self.save_file_search_ui_preferences_if_dirty();
         }


### PR DESCRIPTION
### Motivation

- Prevent the file-search dialog from writing global settings directly and instead surface user intent as UI commands so the main app can persist and reconfigure runtime state consistently.
- Ensure runtime reconfiguration preserves active UI preferences, cancels/updates active searches and executors, validates roots, and updates the Settings editor value when necessary.

### Description

- Added `FileSearchUiCommand` with variants `ConfigureRipgrep(PathBuf)` and `PersistPreferences(FileSearchUiPreferences)` and updated the file-search dialog to return `Vec<FileSearchUiCommand>` from its `ui`/`contents` rendering instead of mutating global settings directly (`src/gui/file_search_dialog.rs`).
- Dialog now emits `PersistPreferences` when UI preferences are dirty and `ConfigureRipgrep` when the user picks a ripgrep binary from the missing-ripgrep prompt; the dialog no longer saves to disk itself (`src/gui/file_search_dialog.rs`).
- Implemented `LauncherApp::handle_file_search_ui_command` to load/save plugin `file_search` settings via the app `settings_path`, synchronize the Settings editor plugin value, call `apply_file_search_settings` (which cancels active searches, reconfigures coordinator executors, updates dialog defaults, preserves UI preferences where appropriate, and validates settings), and surface success/error feedback (`src/gui/mod.rs`).
- Dispatch commands returned from the dialog after rendering so app-level persistence/reconfiguration occurs in the central place, and wire `save_file_search_ui_preferences_if_dirty` to use the new command path (`src/gui/render.rs`, `src/gui/mod.rs`).
- Small tidy/formatting fixes in the file-search plugin UI helper to maintain style only (`src/plugins/file_search.rs`) and ensured the Settings editor still applies saved file-search plugin settings (`src/settings_editor/save.rs`).

### Testing

- Ran `cargo test file_search --lib`; build/test run was attempted but could not complete due to missing system build dependencies and platform-specific compile failures in this Linux CI environment (initial `alsa`/pkg-config errors, then further unrelated `windows::Win32`/`windows::core` resolution errors), so file-search tests did not complete successfully.
- Ran `cargo check --lib`; the check reported unrelated platform/feature compilation failures involving Windows API imports and other system libraries, and did not indicate new type errors originating from the modified file-search GUI code paths.
- Verified via local code inspection and `cargo fmt` that the dialog now returns commands and that `LauncherApp` handles persistence and runtime reconfiguration paths; no functional tests of persistence succeeded end-to-end in this environment due to the unrelated build failures above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59721c93b083329165f64612244ace)