### PR TITLE
Add file search test coverage and shared test fixtures

### DIFF
--- a/src/file_search.rs
+++ b/src/file_search.rs
@@ -14,4 +14,6 @@ pub mod query;
 pub mod ripgrep;
 pub mod settings;
 pub mod sorting;
+#[cfg(test)]
+pub mod test_fixtures;
 pub mod walkdir;

--- a/src/file_search/matching.rs
+++ b/src/file_search/matching.rs
@@ -1,6 +1,6 @@
 use crate::file_search::model::{FilenameMatchMode, FilenameRank, TextMatchRange};
-use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
 use std::path::Path;
 
 /// Returns true when `needle` occurs literally in `haystack`, ignoring case.
@@ -390,5 +390,50 @@ mod tests {
             |range| "FileSearchDialog".is_char_boundary(range.byte_start)
                 && "FileSearchDialog".is_char_boundary(range.byte_end)
         ));
+    }
+
+    #[test]
+    fn fuzzy_indices_survive_unicode_case_folding() {
+        let ranges = fuzzy_filename_match_ranges("ÅngströmReport.md", "ång", false).unwrap();
+        assert_eq!(
+            ranges.first().copied(),
+            Some(TextMatchRange {
+                byte_start: 0,
+                byte_end: "Ång".len()
+            })
+        );
+        assert!(
+            ranges
+                .iter()
+                .all(|r| "ÅngströmReport.md".is_char_boundary(r.byte_start)
+                    && "ÅngströmReport.md".is_char_boundary(r.byte_end))
+        );
+    }
+
+    #[test]
+    fn ranked_highlights_report_filename_and_path_ranges_separately() {
+        let filename_hit = filename_highlight_match(
+            "notes.txt",
+            "archive/notes.txt".as_ref(),
+            "note",
+            false,
+            FilenameMatchMode::RankedSubstring,
+        )
+        .unwrap();
+        assert_eq!(filename_hit.rank, FilenameRank::FilenameStartsWith);
+        assert!(!filename_hit.filename_match_ranges.is_empty());
+        assert!(filename_hit.path_match_ranges.is_empty());
+
+        let path_hit = filename_highlight_match(
+            "notes.txt",
+            "archive/project/notes.txt".as_ref(),
+            "project",
+            false,
+            FilenameMatchMode::RankedSubstring,
+        )
+        .unwrap();
+        assert_eq!(path_hit.rank, FilenameRank::FullPathContains);
+        assert!(path_hit.filename_match_ranges.is_empty());
+        assert!(!path_hit.path_match_ranges.is_empty());
     }
 }

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -442,7 +442,12 @@ mod tests {
         assert_eq!(identity.normalized_path, "a/b/file.txt");
 
         let relative = path_identity(std::path::Path::new("Cargo.toml"));
-        assert!(relative.normalized_path.ends_with("/Cargo.toml"));
+        assert!(
+            relative
+                .normalized_path
+                .to_lowercase()
+                .ends_with("/cargo.toml")
+        );
     }
 
     #[test]

--- a/src/file_search/model.rs
+++ b/src/file_search/model.rs
@@ -435,4 +435,29 @@ mod tests {
         assert_eq!(content_match.line, "abc needle");
         assert_eq!(content_match.ranges.len(), 1);
     }
+
+    #[test]
+    fn path_identity_normalizes_separators_and_relative_paths() {
+        let identity = PathIdentity::from_path(std::path::Path::new("a\\b\\file.txt"));
+        assert_eq!(identity.normalized_path, "a/b/file.txt");
+
+        let relative = path_identity(std::path::Path::new("Cargo.toml"));
+        assert!(relative.normalized_path.ends_with("/Cargo.toml"));
+    }
+
+    #[test]
+    fn result_keys_keep_filename_and_content_identities_distinct() {
+        let path = PathIdentity {
+            normalized_path: "/tmp/a.txt".into(),
+        };
+        let filename = FileSearchResultKey::Filename { path: path.clone() };
+        let content = FileSearchResultKey::Content {
+            path,
+            line_number: 1,
+            byte_start: 0,
+            byte_end: 6,
+            occurrence: 0,
+        };
+        assert_ne!(filename, content);
+    }
 }

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -944,6 +944,25 @@ mod tests {
     }
 
     #[test]
+    fn content_command_keeps_patterns_before_separator_and_roots_after() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let mut request = req(root.clone());
+        request.content_match_mode = crate::file_search::model::ContentMatchMode::AnyTerm;
+        request.text = "one two".to_owned();
+        let args = args(&build_ripgrep_command(
+            Path::new("rg"),
+            &request,
+            &FileSearchSettings::default(),
+            std::slice::from_ref(&root),
+        ));
+        let sep = args.iter().position(|arg| arg == "--").unwrap();
+        assert!(args[..sep].windows(2).any(|w| w == ["-e", "one"]));
+        assert!(args[..sep].windows(2).any(|w| w == ["-e", "two"]));
+        assert_eq!(args.last(), Some(&root.to_string_lossy().to_string()));
+    }
+
+    #[test]
     fn hidden_flag_only_when_enabled() {
         let temp = tempfile::tempdir().unwrap();
         let mut request = req(temp.path().to_path_buf());
@@ -1063,6 +1082,14 @@ mod tests {
         let summary = parse_ripgrep_json_limited(json, 25, 1).unwrap();
         assert_eq!(summary.results.len(), 1);
         assert!(summary.global_truncated);
+    }
+
+    #[test]
+    fn streaming_parser_finalizes_open_file_without_end_event() {
+        let json = r#"{"type":"match","data":{"path":{"text":"open.txt"},"lines":{"text":"needle\n"},"line_number":1,"submatches":[{"start":0,"end":6}]}}"#;
+        let summary = parse_ripgrep_json_reader(json.as_bytes(), 25, 10).unwrap();
+        assert_eq!(summary.results.len(), 1);
+        assert_eq!(summary.results[0].path, PathBuf::from("open.txt"));
     }
 
     #[cfg(unix)]

--- a/src/file_search/sorting.rs
+++ b/src/file_search/sorting.rs
@@ -224,22 +224,13 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::file_search::model::{FileKind, FilenameRank};
+    use crate::file_search::model::FilenameRank;
+    use crate::file_search::test_fixtures::{
+        content_file_result as fixture_content_file_result, content_match as fixture_content_match,
+        filename_result as fixture_filename_result,
+    };
     fn result(path: &str, rank: FilenameRank) -> FilenameResult {
-        let path = PathBuf::from(path);
-        FilenameResult {
-            file_name: path.file_name().unwrap().to_string_lossy().to_string(),
-            parent_directory: path.parent().map(Path::to_path_buf),
-            path,
-            kind: FileKind::File,
-            size: None,
-            modified: None,
-            rank,
-            match_quality: rank,
-            filename_match_ranges: vec![],
-            path_match_ranges: vec![],
-            arrival_index: 0,
-        }
+        fixture_filename_result(path, rank)
     }
     #[test]
     fn every_filename_sort_mode_is_deterministic() {
@@ -264,16 +255,7 @@ mod tests {
         }
     }
     fn cf(path: &str, arrival: usize, total: usize) -> ContentFileResult {
-        ContentFileResult {
-            path: path.into(),
-            file_name: path.into(),
-            modified: None,
-            filename_relevance: None,
-            arrival_index: arrival,
-            total_matches: total,
-            matches: vec![ContentMatch::new(arrival + 1, "x".into(), 0, 1)],
-            truncated: false,
-        }
+        fixture_content_file_result(path, arrival, total)
     }
     #[test]
     fn every_content_sort_mode_is_deterministic() {
@@ -379,38 +361,10 @@ mod tests {
     #[test]
     fn content_matches_sort_by_line_column_end_then_original_occurrence() {
         let mut matches = vec![
-            ContentMatch {
-                line_number: 2,
-                column: Some(0),
-                line: "d".into(),
-                byte_start: 0,
-                byte_end: 2,
-                ranges: vec![],
-            },
-            ContentMatch {
-                line_number: 1,
-                column: Some(4),
-                line: "c".into(),
-                byte_start: 4,
-                byte_end: 9,
-                ranges: vec![],
-            },
-            ContentMatch {
-                line_number: 1,
-                column: Some(4),
-                line: "b".into(),
-                byte_start: 4,
-                byte_end: 8,
-                ranges: vec![],
-            },
-            ContentMatch {
-                line_number: 1,
-                column: Some(1),
-                line: "a".into(),
-                byte_start: 1,
-                byte_end: 2,
-                ranges: vec![],
-            },
+            fixture_content_match(2, "d", 0, 2),
+            fixture_content_match(1, "c", 4, 9),
+            fixture_content_match(1, "b", 4, 8),
+            fixture_content_match(1, "a", 1, 2),
         ];
         sort_content_matches(&mut matches);
         assert_eq!(

--- a/src/file_search/test_fixtures.rs
+++ b/src/file_search/test_fixtures.rs
@@ -1,0 +1,64 @@
+use crate::file_search::model::{
+    ContentFileResult, ContentMatch, ContentMatchRange, FileKind, FilenameRank, FilenameResult,
+};
+use std::path::{Path, PathBuf};
+
+pub fn filename_result(path: impl Into<PathBuf>, rank: FilenameRank) -> FilenameResult {
+    let path = path.into();
+    FilenameResult {
+        file_name: path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string_lossy().to_string()),
+        parent_directory: path.parent().map(Path::to_path_buf),
+        path,
+        kind: FileKind::File,
+        size: None,
+        modified: None,
+        rank,
+        match_quality: rank,
+        filename_match_ranges: Vec::new(),
+        path_match_ranges: Vec::new(),
+        arrival_index: 0,
+    }
+}
+
+pub fn content_match(
+    line_number: usize,
+    line: impl Into<String>,
+    start: usize,
+    end: usize,
+) -> ContentMatch {
+    ContentMatch {
+        line_number,
+        column: Some(start),
+        line: line.into(),
+        byte_start: start,
+        byte_end: end,
+        ranges: vec![ContentMatchRange {
+            byte_start: start,
+            byte_end: end,
+        }],
+    }
+}
+
+pub fn content_file_result(
+    path: impl Into<PathBuf>,
+    arrival_index: usize,
+    total_matches: usize,
+) -> ContentFileResult {
+    let path = path.into();
+    ContentFileResult {
+        file_name: path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string_lossy().to_string()),
+        path,
+        modified: None,
+        filename_relevance: None,
+        arrival_index,
+        total_matches,
+        matches: vec![content_match(arrival_index + 1, "needle", 0, 6)],
+        truncated: false,
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated test boilerplate and expand unit/integration coverage across the file-search subsystem to validate matching, ranking, backend parsing/command construction, sorting, deduplication, and model identities.
- Make tests easier to author/maintain by centralizing common `FilenameResult`, `ContentFileResult`, and `ContentMatch` builders.

### Description
- Add a test-only helper module `file_search::test_fixtures` with constructors for `FilenameResult`, `ContentMatch`, and `ContentFileResult` and expose it under `#[cfg(test)]` in `src/file_search.rs`.
- Add model-level tests for `PathIdentity` normalization and distinct `FileSearchResultKey` variants in `src/file_search/model.rs`.
- Add matching tests for Unicode-aware fuzzy indices and separation of filename vs path highlight ranges in `src/file_search/matching.rs`.
- Add ripgrep backend tests covering pattern/`--` separator ordering and a streaming JSON parser case that finalizes an open file without an explicit `end` event in `src/file_search/ripgrep.rs`.
- Update sorting tests in `src/file_search/sorting.rs` to use the new shared fixtures and preserve deterministic sort, deduplication, and match-order assertions.

### Testing
- Ran `git diff --check` which reported no issues and passed.
- Ran `cargo fmt` to ensure formatting consistency for the modified files.
- Attempted `cargo test file_search --lib`, but the run was blocked by environment-specific platform dependencies (initial `alsa`/X11 pkg-config failures which were then installed) and ultimately by unrelated Windows-specific symbol resolution errors for `windows::Win32`/`windows::core` when compiling the project in this Linux environment, so the full test suite could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a597b1b27b88332a6d634663b6d5946)