### PR TITLE
Avoid executing external probes during diagnostics render; add explicit Refresh and cached probe state

### DIFF
--- a/src/file_search/settings.rs
+++ b/src/file_search/settings.rs
@@ -147,10 +147,27 @@ impl fmt::Display for FileSearchSettingsDiagnostic {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileSearchExecutableProbe {
+    NotChecked,
+    NotDetected,
+    Detected(PathBuf),
+}
+
+impl FileSearchExecutableProbe {
+    fn display_label(&self) -> String {
+        match self {
+            Self::NotChecked => "not checked".to_owned(),
+            Self::NotDetected => "not detected".to_owned(),
+            Self::Detected(path) => path.display().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileSearchDiagnosticsState {
     pub everything_enabled: bool,
-    pub detected_everything: Option<PathBuf>,
-    pub detected_ripgrep: Option<PathBuf>,
+    pub detected_everything: FileSearchExecutableProbe,
+    pub detected_ripgrep: FileSearchExecutableProbe,
     pub valid_roots: Vec<PathBuf>,
     pub invalid_roots: Vec<PathBuf>,
     pub current_backend: Option<String>,
@@ -176,10 +193,8 @@ impl FileSearchDiagnosticsState {
         }
         Self {
             everything_enabled: settings.everything_enabled,
-            detected_everything: crate::file_search::everything::detect_everything_executable(
-                settings,
-            ),
-            detected_ripgrep: detect_ripgrep_executable(settings),
+            detected_everything: FileSearchExecutableProbe::NotChecked,
+            detected_ripgrep: FileSearchExecutableProbe::NotChecked,
             valid_roots,
             invalid_roots,
             current_backend: None,
@@ -200,14 +215,8 @@ impl fmt::Display for FileSearchDiagnosticsState {
             f,
             "Use Everything for global filename search: {}; detected es.exe: {}; detected rg: {}; valid roots: {}; invalid roots: {}; current backend: {}; active search state: {}; last search duration: {}; last result count: {}; last backend error: {}; inaccessible entries: {}; preview cache: {}; full-file preview limit: {} bytes",
             self.everything_enabled,
-            self.detected_everything
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "not detected".into()),
-            self.detected_ripgrep
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "not detected".into()),
+            self.detected_everything.display_label(),
+            self.detected_ripgrep.display_label(),
             self.valid_roots.len(),
             self.invalid_roots.len(),
             self.current_backend.as_deref().unwrap_or("none"),
@@ -743,11 +752,61 @@ mod diagnostics_state_tests {
     }
 
     #[test]
+    fn diagnostics_from_settings_leaves_executables_not_checked() {
+        let settings = FileSearchSettings {
+            ripgrep_executable_path: PathBuf::from("/definitely/missing/rg"),
+            everything_executable_path: PathBuf::from("/definitely/missing/es.exe"),
+            everything_enabled: true,
+            ..FileSearchSettings::default()
+        };
+
+        let state = FileSearchDiagnosticsState::from_settings(&settings);
+
+        assert_eq!(
+            state.detected_ripgrep,
+            FileSearchExecutableProbe::NotChecked
+        );
+        assert_eq!(
+            state.detected_everything,
+            FileSearchExecutableProbe::NotChecked
+        );
+        assert!(state.to_string().contains("detected rg: not checked"));
+        assert!(state.to_string().contains("detected es.exe: not checked"));
+    }
+
+    #[test]
+    fn diagnostics_can_display_cached_detected_state() {
+        let mut state = FileSearchDiagnosticsState::from_settings(&FileSearchSettings::default());
+        state.detected_ripgrep = FileSearchExecutableProbe::Detected(PathBuf::from("/tmp/rg"));
+        state.detected_everything = FileSearchExecutableProbe::NotDetected;
+
+        let formatted = state.to_string();
+
+        assert!(formatted.contains("detected rg: /tmp/rg"));
+        assert!(formatted.contains("detected es.exe: not detected"));
+    }
+
+    #[test]
+    fn diagnostics_from_settings_reports_invalid_roots_with_static_checks() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing");
+        let settings = FileSearchSettings {
+            global_search_roots: vec![temp.path().to_path_buf(), missing.clone()],
+            ..FileSearchSettings::default()
+        };
+
+        let state = FileSearchDiagnosticsState::from_settings(&settings);
+
+        assert_eq!(state.valid_roots, vec![temp.path().to_path_buf()]);
+        assert_eq!(state.invalid_roots, vec![missing]);
+    }
+
+    #[test]
     fn diagnostics_formatting_includes_expected_fields() {
         let state = FileSearchDiagnosticsState {
             everything_enabled: true,
-            detected_everything: Some(PathBuf::from("es.exe")),
-            detected_ripgrep: Some(PathBuf::from("rg")),
+            detected_everything: FileSearchExecutableProbe::Detected(PathBuf::from("es.exe")),
+            detected_ripgrep: FileSearchExecutableProbe::Detected(PathBuf::from("rg")),
             valid_roots: vec![PathBuf::from("/")],
             invalid_roots: vec![PathBuf::from("/missing")],
             current_backend: Some("ripgrep".into()),

--- a/src/plugins/file_search.rs
+++ b/src/plugins/file_search.rs
@@ -7,7 +7,8 @@ use crate::file_search::discovery::{self, ExecutableResolutionSource, Executable
 use crate::file_search::model::SearchKind;
 use crate::file_search::query::{FileSearchCommand, SearchRequestDraft};
 use crate::file_search::settings::{
-    DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES, FileSearchDiagnosticsState, FileSearchSettings,
+    DEFAULT_MAX_FULL_PREVIEW_FILE_SIZE_BYTES, FileSearchDiagnosticsState,
+    FileSearchExecutableProbe, FileSearchSettings,
 };
 use crate::plugin::Plugin;
 use eframe::egui;
@@ -17,6 +18,7 @@ use std::path::{Path, PathBuf};
 pub struct FileSearchPlugin {
     settings: FileSearchSettings,
     ripgrep_ui: RipgrepSettingsUiState,
+    diagnostics: Option<FileSearchDiagnosticsState>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -139,13 +141,33 @@ impl Plugin for FileSearchPlugin {
             ui.colored_label(egui::Color32::YELLOW, diagnostic.to_string());
         }
         ui.collapsing("Diagnostics", |ui| {
-            ui.monospace(FileSearchDiagnosticsState::from_settings(&cfg).to_string());
+            if ui.button("Refresh diagnostics").clicked() {
+                self.diagnostics = Some(refreshed_diagnostics(&cfg));
+            }
+            let diagnostics = self
+                .diagnostics
+                .clone()
+                .unwrap_or_else(|| FileSearchDiagnosticsState::from_settings(&cfg));
+            ui.monospace(diagnostics.to_string());
         });
         self.settings = cfg.clone();
         if let Ok(v) = serde_json::to_value(&cfg) {
             *value = v;
         }
     }
+}
+
+fn refreshed_diagnostics(settings: &FileSearchSettings) -> FileSearchDiagnosticsState {
+    let mut diagnostics = FileSearchDiagnosticsState::from_settings(settings);
+    diagnostics.detected_everything =
+        crate::file_search::everything::detect_everything_executable(settings)
+            .map(FileSearchExecutableProbe::Detected)
+            .unwrap_or(FileSearchExecutableProbe::NotDetected);
+    diagnostics.detected_ripgrep =
+        crate::file_search::settings::detect_ripgrep_executable(settings)
+            .map(FileSearchExecutableProbe::Detected)
+            .unwrap_or(FileSearchExecutableProbe::NotDetected);
+    diagnostics
 }
 
 const BYTES_PER_MIB: u64 = 1024 * 1024;


### PR DESCRIPTION
### Motivation
- Prevent the diagnostics panel from running expensive external detection (ripgrep/Everything) when the settings UI opens or repaints by performing only cheap/static filesystem checks by default. 
- Provide a clear, explicit mechanism to run the expensive detection only on demand and cache the result for subsequent renders.

### Description
- Introduce `FileSearchExecutableProbe` (`NotChecked` / `NotDetected` / `Detected(PathBuf)`) and replace optional `PathBuf` executable fields with this enum in `FileSearchDiagnosticsState` so diagnostics can represent a cached or unprobed state without spawning processes (`src/file_search/settings.rs`).
- Change `FileSearchDiagnosticsState::from_settings(&FileSearchSettings)` to only run static filesystem checks (valid/invalid roots) and initialize executable probes to `NotChecked` so construction is process-free (`src/file_search/settings.rs`).
- Update `Display` formatting to render probe labels via `FileSearchExecutableProbe::display_label()` rather than triggering detection (`src/file_search/settings.rs`).
- Add a transient `diagnostics: Option<FileSearchDiagnosticsState>` to `FileSearchPlugin` and a `Refresh diagnostics` button in the settings UI that calls `refreshed_diagnostics(&cfg)`; that helper runs `detect_everything_executable` and `detect_ripgrep_executable` once and caches `Detected`/`NotDetected` results for subsequent renders (`src/plugins/file_search.rs`).
- Ensure `ui.collapsing("Diagnostics", ...)` renders cached/static content only and that everything/ripgrep detection remain behind the explicit refresh path.
- Add unit tests covering: `from_settings` leaves executable probes as `NotChecked`, diagnostics can display cached `Detected`/`NotDetected` states, and invalid roots are still reported by the static filesystem checks (`src/file_search/settings.rs` tests).

### Testing
- Ran formatting with `rustfmt --edition 2024 src/file_search/settings.rs src/plugins/file_search.rs` which completed successfully.
- Performed `git diff --check` which returned clean results for the modified files.
- Added unit tests and attempted `cargo test --lib file_search::settings::tests::diagnostics -- --nocapture`, but test execution was blocked in this CI-like Linux environment due to unrelated platform-native build failures (native dependencies and non-Linux/Windows-specific crates caused compilation errors), so the new diagnostics tests were not able to run to completion here; the tests themselves are process-free and use temporary directories only where needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5aba6b19a48332bb909226da138307)