### PR TITLE
Centralize background command configuration

### DIFF
--- a/src/file_search/discovery.rs
+++ b/src/file_search/discovery.rs
@@ -1,4 +1,5 @@
 use crate::file_search::error::FileSearchError;
+use crate::process::configure_background_command;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -166,7 +167,10 @@ fn validate_ripgrep_candidate(executable: &Path) -> CandidateValidation {
     if !executable.is_file() {
         return CandidateValidation::Invalid("path does not exist or is not a file".to_owned());
     }
-    let output = match Command::new(executable).arg("--version").output() {
+    let mut command = Command::new(executable);
+    command.arg("--version");
+    configure_background_command(&mut command);
+    let output = match command.output() {
         Ok(output) => output,
         Err(error) => return CandidateValidation::Invalid(format!("failed to start: {error}")),
     };

--- a/src/file_search/everything.rs
+++ b/src/file_search/everything.rs
@@ -5,6 +5,7 @@ use crate::file_search::model::{
     SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::settings::FileSearchSettings;
+use crate::process::configure_background_command;
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
@@ -296,10 +297,13 @@ fn run_everything_command(
     search_id: SearchId,
     seen: &mut HashSet<String>,
 ) -> Result<usize, String> {
-    let mut child = Command::new(&spec.executable)
+    let mut command = Command::new(&spec.executable);
+    command
         .args(&spec.args)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_background_command(&mut command);
+    let mut child = command
         .spawn()
         .map_err(|e| {
             format!(

--- a/src/file_search/ripgrep.rs
+++ b/src/file_search/ripgrep.rs
@@ -11,6 +11,7 @@ use crate::file_search::model::{
     SearchKind, SearchProgress, SearchRequest, SearchResult, SearchScope, SearchStatus,
 };
 use crate::file_search::settings::FileSearchSettings;
+use crate::process::configure_background_command;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read};
@@ -513,6 +514,7 @@ pub fn build_ripgrep_command(
     roots: &[PathBuf],
 ) -> Command {
     let mut command = Command::new(executable);
+    configure_background_command(&mut command);
     command.arg("--json").arg("--no-ignore");
     if request.case_sensitive {
         command.arg("--case-sensitive");
@@ -566,6 +568,7 @@ pub fn build_ripgrep_files_command(
     roots: &[PathBuf],
 ) -> Command {
     let mut command = Command::new(executable);
+    configure_background_command(&mut command);
     command.arg("--files").arg("--no-ignore");
     if request.include_hidden_files {
         command.arg("--hidden");

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -12,6 +12,7 @@ use crate::plugins::note::{
     save_note,
 };
 use crate::plugins::todo::{TODO_FILE, load_todos, todo_version};
+use crate::process::configure_background_command;
 use crate::settings::{NoteSettings, NoteViewMode};
 use eframe::egui::{self, Color32, FontId, Key, RichText, popup};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
@@ -24,8 +25,6 @@ use regex::Regex;
 use rfd::FileDialog;
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::process::Command;
 use std::{
     env,
@@ -3581,10 +3580,7 @@ pub fn build_nvim_command(note_path: &Path) -> (Command, String) {
 pub fn build_wezterm_command(note_path: &Path) -> (Command, String) {
     let mut cmd = Command::new("wezterm");
     cmd.arg("start").arg("--").arg("nvim").arg(note_path);
-    #[cfg(windows)]
-    {
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
+    configure_background_command(&mut cmd);
     let cmd_str = format!("{:?}", cmd);
     (cmd, cmd_str)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod platform;
 pub mod plugin;
 pub mod plugin_editor;
 pub mod plugins;
+pub mod process;
 pub mod plugins_builtin;
 pub mod settings;
 pub mod settings_editor;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Configure a command intended to run in the background without interactive UI.
+pub fn configure_background_command(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::configure_background_command;
+    use std::process::Command;
+
+    #[test]
+    #[cfg(not(windows))]
+    fn configure_background_command_preserves_arguments_on_non_windows() {
+        let mut command = Command::new("rg");
+        command.arg("--json").arg("needle");
+
+        configure_background_command(&mut command);
+
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["--json", "needle"]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single helper to consistently configure noninteractive/background `Command` instances and to centralize Windows `CREATE_NO_WINDOW` handling.
- Replace ad-hoc `creation_flags` usage with a small, cross-platform helper so background commands are applied uniformly across file-search and UI code.

### Description
- Add `src/process.rs` with `pub fn configure_background_command(command: &mut std::process::Command)` that sets `creation_flags(CREATE_NO_WINDOW)` on Windows and is a no-op on other platforms, and include a non-Windows unit test (`configure_background_command_preserves_arguments_on_non_windows`).
- Export the module by adding `pub mod process;` to `src/lib.rs`.
- Use the helper in `src/file_search/discovery.rs` by converting the ripgrep `--version` probe into a mutable `Command`, calling `configure_background_command`, then `.output()`.
- Apply the helper in `src/file_search/ripgrep.rs` for `build_ripgrep_command` and `build_ripgrep_files_command` so ripgrep invocations are configured for background/noninteractive use.
- Apply the helper in `src/file_search/everything.rs` in `run_everything_command` to configure the `Everything` process before `.spawn()`.
- Replace the hard-coded `creation_flags(0x08000000)` call in `src/gui/note_panel.rs` (`build_wezterm_command`) with `configure_background_command(&mut cmd)`.

### Testing
- Ran `git diff --check`, which passed.
- Added a unit test `configure_background_command_preserves_arguments_on_non_windows` in `src/process.rs` intended to verify the helper is a no-op on non-Windows and preserves constructed args.
- Attempted `cargo test` (including the helper and ripgrep tests); initial runs failed due to missing system libraries, after which system packages (`libasound2-dev`, X11/Wayland dev libs) were installed and compilation progressed but ultimately the test run could not complete because the workspace fails to compile on this Linux environment due to pre-existing unresolved `windows::Win32` / `windows::core` imports and other platform-specific build checks unrelated to these changes. The added helper and non-Windows test are present but could not be executed to completion in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ac32fd2e083328496577ee288cc32)