### PR TITLE
Add stable MultiManager HWND identity verification

### DIFF
--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -1,3 +1,4 @@
+use crate::multi_manager::identity;
 use crate::multi_manager::model::{MmWindow, MmWorkspace};
 use crate::multi_manager::reconnect;
 use crate::multi_manager::win::{self, EnumeratedWindow};
@@ -70,7 +71,34 @@ pub fn load_bindings(path: &Path) -> Result<Vec<WorkspaceBindingSnapshot>> {
 }
 
 pub fn restore_bindings(workspaces: &mut [MmWorkspace], snapshots: &[WorkspaceBindingSnapshot]) {
-    let live = win::enumerate_top_level_windows().unwrap_or_default();
+    let mut live = win::enumerate_top_level_windows().unwrap_or_default();
+    for window_snapshot in snapshots.iter().flat_map(|snapshot| &snapshot.windows) {
+        if window_snapshot.hwnd == 0
+            || live
+                .iter()
+                .any(|window| window.hwnd == window_snapshot.hwnd)
+        {
+            continue;
+        }
+        let direct = win::query_hwnd_identity(window_snapshot.hwnd);
+        if direct.is_window {
+            live.push(EnumeratedWindow {
+                hwnd: direct.hwnd,
+                title: direct.live_title,
+                executable: direct.executable,
+                class_name: direct.class_name,
+                process_path: direct.process_path,
+                rect: win::window_rect(window_snapshot.hwnd).unwrap_or(
+                    crate::multi_manager::model::MmRect {
+                        x: 0,
+                        y: 0,
+                        w: 0,
+                        h: 0,
+                    },
+                ),
+            });
+        }
+    }
     restore_bindings_with_windows(workspaces, snapshots, &live);
 }
 
@@ -99,7 +127,15 @@ fn restore_bindings_with_windows(
                 continue;
             };
             let saved_window = window_from_snapshot(window_snapshot);
-            let (_, hwnd) = reconnect::match_saved_window_against_candidates(&saved_window, live);
+            let direct_match = live.iter().find(|candidate| {
+                candidate.hwnd == window_snapshot.hwnd
+                    && identity::stable_identity_matches_enumerated(&saved_window, candidate)
+            });
+            let hwnd = direct_match.map(|candidate| candidate.hwnd).or_else(|| {
+                let (_, hwnd) =
+                    reconnect::match_saved_window_against_candidates(&saved_window, live);
+                hwnd
+            });
             if let Some(hwnd) = hwnd {
                 workspace.windows[window_index].mark_reconnected(hwnd);
                 if let Some(live_window) = live.iter().find(|candidate| candidate.hwnd == hwnd) {
@@ -264,10 +300,17 @@ mod tests {
             windows: vec![WindowBindingSnapshot {
                 hwnd: 7,
                 captured_title: "Doc".into(),
+                executable: Some("editor.exe".into()),
+                class_name: Some("Editor".into()),
+                process_path: Some("C:/Apps/editor.exe".into()),
                 ..Default::default()
             }],
         }];
-        restore_bindings_with_windows(&mut workspaces, &snapshots, &[live(7, "Doc", "", "", "")]);
+        restore_bindings_with_windows(
+            &mut workspaces,
+            &snapshots,
+            &[live(7, "Doc", "editor.exe", "Editor", "C:/Apps/editor.exe")],
+        );
         assert_eq!(workspaces[0].windows[0].hwnd, 7);
         assert_eq!(workspaces[1].windows[0].hwnd, 0);
     }
@@ -281,10 +324,17 @@ mod tests {
             windows: vec![WindowBindingSnapshot {
                 hwnd: 8,
                 captured_title: "Doc".into(),
+                executable: Some("editor.exe".into()),
+                class_name: Some("Editor".into()),
+                process_path: Some("C:/Apps/editor.exe".into()),
                 ..Default::default()
             }],
         }];
-        restore_bindings_with_windows(&mut workspaces, &snapshots, &[live(8, "Doc", "", "", "")]);
+        restore_bindings_with_windows(
+            &mut workspaces,
+            &snapshots,
+            &[live(8, "Doc", "editor.exe", "Editor", "C:/Apps/editor.exe")],
+        );
         assert_eq!(workspaces[0].windows[0].hwnd, 8);
     }
 

--- a/src/multi_manager/identity.rs
+++ b/src/multi_manager/identity.rs
@@ -1,0 +1,164 @@
+use crate::multi_manager::model::MmWindow;
+use crate::multi_manager::win::WindowIdentitySnapshot;
+
+fn trimmed(value: &str) -> &str {
+    value.trim()
+}
+
+pub fn normalize_path(value: &str) -> String {
+    trimmed(value).replace('/', "\\").to_ascii_lowercase()
+}
+
+pub fn normalize_value(value: &str) -> String {
+    trimmed(value).to_ascii_lowercase()
+}
+
+pub fn same_process_path(stored: &str, live: &str) -> bool {
+    let stored = normalize_path(stored);
+    !stored.is_empty() && stored == normalize_path(live)
+}
+
+pub fn same_value(stored: &str, live: &str) -> bool {
+    let stored = normalize_value(stored);
+    !stored.is_empty() && stored == normalize_value(live)
+}
+
+pub fn has_stable_metadata(window: &MmWindow) -> bool {
+    !window.process_path.trim().is_empty()
+        || !window.executable.trim().is_empty()
+        || !window.class_name.trim().is_empty()
+}
+
+pub fn stable_identity_matches(window: &MmWindow, live: &WindowIdentitySnapshot) -> bool {
+    if !live.is_window {
+        return false;
+    }
+
+    let stored_process_path = window.process_path.trim();
+    let stored_class_name = window.class_name.trim();
+    let stored_executable = window.executable.trim();
+
+    if stored_process_path.is_empty()
+        && stored_class_name.is_empty()
+        && stored_executable.is_empty()
+    {
+        return false;
+    }
+
+    if !stored_process_path.is_empty()
+        && !same_process_path(stored_process_path, &live.process_path)
+    {
+        return false;
+    }
+
+    if !stored_class_name.is_empty() && !same_value(stored_class_name, &live.class_name) {
+        return false;
+    }
+
+    if stored_process_path.is_empty()
+        && !stored_executable.is_empty()
+        && !same_value(stored_executable, &live.executable)
+    {
+        return false;
+    }
+
+    true
+}
+
+pub fn stable_identity_matches_enumerated(
+    window: &MmWindow,
+    live: &crate::multi_manager::win::EnumeratedWindow,
+) -> bool {
+    stable_identity_matches(
+        window,
+        &WindowIdentitySnapshot {
+            hwnd: live.hwnd,
+            is_window: true,
+            live_title: live.title.clone(),
+            process_path: live.process_path.clone(),
+            executable: live.executable.clone(),
+            class_name: live.class_name.clone(),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window(process_path: &str, executable: &str, class_name: &str, title: &str) -> MmWindow {
+        MmWindow {
+            process_path: process_path.into(),
+            executable: executable.into(),
+            class_name: class_name.into(),
+            captured_title: title.into(),
+            hwnd: 10,
+            ..Default::default()
+        }
+    }
+
+    fn live(
+        process_path: &str,
+        executable: &str,
+        class_name: &str,
+        title: &str,
+    ) -> WindowIdentitySnapshot {
+        WindowIdentitySnapshot {
+            hwnd: 10,
+            is_window: true,
+            live_title: title.into(),
+            process_path: process_path.into(),
+            executable: executable.into(),
+            class_name: class_name.into(),
+        }
+    }
+
+    #[test]
+    fn case_insensitive_process_path_comparison() {
+        assert!(same_process_path(
+            r" C:\Apps\EDITOR.EXE ",
+            r"c:\apps\editor.exe"
+        ));
+    }
+
+    #[test]
+    fn slash_normalization() {
+        assert!(same_process_path(
+            "C:/Apps/editor.exe",
+            r"c:\apps\EDITOR.exe"
+        ));
+    }
+
+    #[test]
+    fn title_ignored_during_existing_hwnd_verification() {
+        let stored = window("C:/Apps/editor.exe", "", "Editor", "Original Title");
+        let live = live(
+            "c:/apps/editor.exe",
+            "editor.exe",
+            "editor",
+            "Completely Different",
+        );
+        assert!(stable_identity_matches(&stored, &live));
+    }
+
+    #[test]
+    fn process_path_mismatch_rejection() {
+        let stored = window("C:/Apps/editor.exe", "editor.exe", "Editor", "Doc");
+        let live = live("C:/Other/other.exe", "editor.exe", "Editor", "Doc");
+        assert!(!stable_identity_matches(&stored, &live));
+    }
+
+    #[test]
+    fn executable_class_fallback_when_process_path_is_absent() {
+        let stored = window("", "EDITOR.EXE", " EditorClass ", "Doc");
+        let live = live("", "editor.exe", "editorclass", "Other");
+        assert!(stable_identity_matches(&stored, &live));
+    }
+
+    #[test]
+    fn missing_stable_metadata_cannot_safely_verify_hwnd_across_restart() {
+        let stored = window("", "", "", "Doc");
+        let live = live("", "", "", "Doc");
+        assert!(!stable_identity_matches(&stored, &live));
+    }
+}

--- a/src/multi_manager/mod.rs
+++ b/src/multi_manager/mod.rs
@@ -2,6 +2,7 @@ pub mod apply_capture;
 pub mod bindings;
 pub mod capture;
 pub mod commands;
+pub mod identity;
 pub mod model;
 pub mod reconnect;
 pub mod runtime;

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -345,11 +345,12 @@ mod tests {
             hwnd: 5,
             captured_title: "Doc".into(),
             executable: "edit.exe".into(),
+            process_path: "C:/Apps/edit.exe".into(),
             ..MmWindow::default()
         });
         let summary = reconnect_workspaces_with_windows(
             &mut workspaces,
-            &[live(5, "Other", "edit.exe", "", "")],
+            &[live(5, "Other", "edit.exe", "", "C:/Other/edit.exe")],
         );
         assert_eq!(summary.invalidated, 1);
         assert_eq!(summary.missing, 1);

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::multi_manager::identity;
 use crate::multi_manager::model::{MmWindow, MmWorkspace};
 use crate::multi_manager::win::{self, EnumeratedWindow};
 
@@ -45,22 +46,24 @@ fn has_only_title_metadata(window: &MmWindow) -> bool {
 
 fn identity_score(window: &MmWindow, live: &EnumeratedWindow) -> Option<u8> {
     let title = same_stored(&window.captured_title, &live.title);
-    let process_path = same_stored(&window.process_path, &live.process_path);
-    let executable = same_stored(&window.executable, &live.executable);
-    let class_name = same_stored(&window.class_name, &live.class_name);
+    if !title || !identity::stable_identity_matches_enumerated(window, live) {
+        return None;
+    }
 
-    if process_path && class_name && title {
+    let process_path = identity::same_process_path(&window.process_path, &live.process_path);
+    let executable = identity::same_value(&window.executable, &live.executable);
+    let class_name = identity::same_value(&window.class_name, &live.class_name);
+
+    if process_path && class_name {
         Some(100)
-    } else if process_path && title {
+    } else if process_path {
         Some(90)
-    } else if executable && class_name && title {
+    } else if executable && class_name {
         Some(80)
-    } else if executable && title {
+    } else if executable {
         Some(70)
-    } else if class_name && title {
+    } else if class_name {
         Some(60)
-    } else if title {
-        Some(40)
     } else {
         None
     }
@@ -76,7 +79,8 @@ fn matching_existing_hwnd<'a>(
     }
 
     live.iter().find(|candidate| {
-        candidate.hwnd == window.hwnd && identity_score(window, candidate).is_some()
+        candidate.hwnd == window.hwnd
+            && identity::stable_identity_matches_enumerated(window, candidate)
     })
 }
 
@@ -286,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn unique_title_only_legacy_reconnect() {
+    fn title_only_legacy_reconnect_is_missing() {
         let mut workspaces = workspace(MmWindow {
             captured_title: " Notes ".into(),
             valid: false,
@@ -294,22 +298,23 @@ mod tests {
         });
         let summary =
             reconnect_workspaces_with_windows(&mut workspaces, &[live(10, "notes", "", "", "")]);
-        assert_eq!(summary.reconnected, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 10);
-        assert!(workspaces[0].windows[0].valid);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+        assert!(!workspaces[0].windows[0].valid);
     }
 
     #[test]
     fn duplicate_title_only_candidates_are_ambiguous() {
         let mut workspaces = workspace(MmWindow {
             captured_title: "Notes".into(),
+            executable: "notes.exe".into(),
             ..MmWindow::default()
         });
         let summary = reconnect_workspaces_with_windows(
             &mut workspaces,
             &[
-                live(10, "Notes", "", "", ""),
-                live(11, " notes ", "", "", ""),
+                live(10, "Notes", "notes.exe", "", ""),
+                live(11, " notes ", "notes.exe", "", ""),
             ],
         );
         assert_eq!(summary.ambiguous, 1);
@@ -375,17 +380,21 @@ mod tests {
             windows: vec![
                 MmWindow {
                     captured_title: "Doc".into(),
+                    executable: "app.exe".into(),
                     ..MmWindow::default()
                 },
                 MmWindow {
                     captured_title: "Doc".into(),
+                    executable: "app.exe".into(),
                     ..MmWindow::default()
                 },
             ],
             ..MmWorkspace::default()
         }];
-        let summary =
-            reconnect_workspaces_with_windows(&mut workspaces, &[live(8, "Doc", "", "", "")]);
+        let summary = reconnect_workspaces_with_windows(
+            &mut workspaces,
+            &[live(8, "Doc", "app.exe", "", "")],
+        );
         assert_eq!(summary.reconnected, 1);
         assert_eq!(summary.missing, 1);
         assert_eq!(workspaces[0].windows[0].hwnd, 8);
@@ -393,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_saved_window_with_only_title_still_reconnects() {
+    fn legacy_saved_window_with_only_title_does_not_reconnect() {
         let mut workspaces = workspace(MmWindow {
             alias: "Old".into(),
             captured_title: "Legacy App".into(),
@@ -403,7 +412,7 @@ mod tests {
             &mut workspaces,
             &[live(77, "legacy app", "app.exe", "Class", "C:/app.exe")],
         );
-        assert_eq!(summary.reconnected, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 77);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
     }
 }

--- a/src/multi_manager/win.rs
+++ b/src/multi_manager/win.rs
@@ -21,6 +21,16 @@ pub struct EnumeratedWindow {
     pub rect: MmRect,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowIdentitySnapshot {
+    pub hwnd: usize,
+    pub is_window: bool,
+    pub live_title: String,
+    pub process_path: String,
+    pub executable: String,
+    pub class_name: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaptureKeyAction {
     Confirm,
@@ -256,6 +266,41 @@ pub fn window_executable(hwnd: usize) -> Option<String> {
 #[cfg(not(windows))]
 pub fn window_executable(_hwnd: usize) -> Option<String> {
     None
+}
+
+pub fn query_hwnd_identity(hwnd: usize) -> WindowIdentitySnapshot {
+    let is_window = is_valid_window(hwnd);
+    let live_title = if is_window {
+        window_title(hwnd).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let process_path = if is_window {
+        window_process_path(hwnd).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let executable = if is_window {
+        executable_from_process_path(&process_path)
+            .or_else(|| window_executable(hwnd))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let class_name = if is_window {
+        window_class_name(hwnd).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    WindowIdentitySnapshot {
+        hwnd,
+        is_window,
+        live_title,
+        process_path,
+        executable,
+        class_name,
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
### Motivation
- Improve safety and stability when restoring saved HWNDs across process restarts by validating stable metadata instead of trusting titles or raw handles alone.
- Provide a direct HWND snapshot query path to check a saved handle without enumerating top-level windows.
- Normalize comparisons for process paths, executables, and class names to avoid spurious mismatches caused by case or slash differences.

### Description
- Add `src/multi_manager/identity.rs` implementing normalization helpers (`normalize_path`, `normalize_value`), comparison helpers (`same_process_path`, `same_value`), `has_stable_metadata`, and `stable_identity_matches` without performing filesystem canonicalization.
- Export the new module from `src/multi_manager/mod.rs` with `pub mod identity;`.
- In `src/multi_manager/win.rs` add a `WindowIdentitySnapshot` struct and a `query_hwnd_identity(hwnd: usize) -> WindowIdentitySnapshot` function that directly queries `hwnd` and returns `{ hwnd, is_window, live_title, process_path, executable, class_name }` without enumerating top-level windows.
- Update restore logic in `src/multi_manager/bindings.rs` to merge direct HWND snapshots into the live candidates and only accept a saved HWND when `identity::stable_identity_matches_enumerated` passes; otherwise fall back to the existing candidate-matching flow.
- Update reconnect logic in `src/multi_manager/reconnect.rs` so that existing-HWND verification ignores title changes and requires stable metadata via `stable_identity_matches_enumerated`, and make fallback matching require title plus stable metadata.
- Add unit tests in `src/multi_manager/identity.rs` to cover case-insensitive process path comparison, slash normalization, title-ignored existing-HWND verification, process path mismatch rejection, executable/class fallback, and missing-stable-metadata rejection.

### Testing
- Ran `git diff --cached --check` and committed the changes successfully.
- Attempted `cargo test -q multi_manager::identity`, but the test build could not complete in this Linux environment due to unrelated platform/dependency constraints (native system libs and cross-platform `windows`/X11/ALSA dependencies), so unit tests could not be executed here.
- Ran `rustfmt` and formatting checks on modified files as part of the rollout changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bd62de344833295871e6b9cda7ea4)