### PR TITLE
Tighten MultiManager reconnect matching

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -877,8 +877,8 @@ pub(crate) fn format_reconnect_summary(
     summary: crate::multi_manager::reconnect::ReconnectSummary,
 ) -> String {
     format!(
-        "Reconnected MultiManager windows: {} reconnected, {} missing, {} ambiguous",
-        summary.reconnected, summary.missing, summary.ambiguous
+        "Reconnected MultiManager windows: {} reconnected, {} missing, {} ambiguous, {} metadata mismatches",
+        summary.reconnected, summary.missing, summary.ambiguous, summary.metadata_mismatch
     )
 }
 

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -2,7 +2,15 @@ use std::collections::HashSet;
 
 use crate::multi_manager::identity;
 use crate::multi_manager::model::{MmWindow, MmWorkspace};
-use crate::multi_manager::win::{self, EnumeratedWindow};
+use crate::multi_manager::win::{self, EnumeratedWindow, WindowIdentitySnapshot};
+
+pub type DirectHwndIdentity = WindowIdentitySnapshot;
+
+pub struct ReconnectDeps<'a> {
+    pub is_window: &'a (dyn Fn(usize) -> bool + 'a),
+    pub query_identity: &'a (dyn Fn(usize) -> Option<DirectHwndIdentity> + 'a),
+    pub enumerate_top_level_windows: &'a (dyn Fn() -> Vec<EnumeratedWindow> + 'a),
+}
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ReconnectSummary {
@@ -11,6 +19,8 @@ pub struct ReconnectSummary {
     pub missing: usize,
     pub ambiguous: usize,
     pub invalidated: usize,
+    pub metadata_mismatch: usize,
+    pub binding_snapshot_changed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,134 +30,95 @@ pub enum ReconnectOutcome {
     Missing,
     Ambiguous,
     Invalidated,
+    MetadataMismatch,
+    Closed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct MatchCandidate {
     index: usize,
-    score: u8,
 }
 
 fn normalized(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
 
-fn same_stored(value: &str, live: &str) -> bool {
+fn same_title(value: &str, live: &str) -> bool {
     let stored = normalized(value);
     !stored.is_empty() && stored == normalized(live)
 }
 
-fn has_only_title_metadata(window: &MmWindow) -> bool {
-    !window.captured_title.trim().is_empty()
-        && window.executable.trim().is_empty()
-        && window.class_name.trim().is_empty()
-        && window.process_path.trim().is_empty()
+fn can_validate_stable_metadata(window: &MmWindow, live: &EnumeratedWindow) -> bool {
+    identity::stable_identity_matches_enumerated(window, live)
 }
 
-fn identity_score(window: &MmWindow, live: &EnumeratedWindow) -> Option<u8> {
-    let title = same_stored(&window.captured_title, &live.title);
-    if !title || !identity::stable_identity_matches_enumerated(window, live) {
-        return None;
-    }
-
-    let process_path = identity::same_process_path(&window.process_path, &live.process_path);
-    let executable = identity::same_value(&window.executable, &live.executable);
-    let class_name = identity::same_value(&window.class_name, &live.class_name);
-
-    if process_path && class_name {
-        Some(100)
-    } else if process_path {
-        Some(90)
-    } else if executable && class_name {
-        Some(80)
-    } else if executable {
-        Some(70)
-    } else if class_name {
-        Some(60)
-    } else {
-        None
-    }
+fn direct_identity_matches(window: &MmWindow, live: &DirectHwndIdentity) -> bool {
+    identity::stable_identity_matches(window, live)
 }
 
-fn matching_existing_hwnd<'a>(
-    window: &MmWindow,
-    live: &'a [EnumeratedWindow],
-    assigned: &HashSet<usize>,
-) -> Option<&'a EnumeratedWindow> {
-    if window.hwnd == 0 || assigned.contains(&window.hwnd) {
-        return None;
-    }
-
-    live.iter().find(|candidate| {
-        candidate.hwnd == window.hwnd
-            && identity::stable_identity_matches_enumerated(window, candidate)
-    })
-}
-
-fn best_match(
+fn viable_exact_title_candidates(
     window: &MmWindow,
     live: &[EnumeratedWindow],
     assigned: &HashSet<usize>,
-) -> Result<Option<MatchCandidate>, ()> {
-    let mut matches: Vec<MatchCandidate> = live
+) -> (usize, Vec<MatchCandidate>) {
+    let exact_title: Vec<(usize, &EnumeratedWindow)> = live
         .iter()
         .enumerate()
         .filter(|(_, candidate)| !assigned.contains(&candidate.hwnd))
-        .filter_map(|(index, candidate)| {
-            identity_score(window, candidate).map(|score| MatchCandidate { index, score })
-        })
+        .filter(|(_, candidate)| same_title(window.fallback_title(), &candidate.title))
         .collect();
 
-    if matches.is_empty() {
-        return Ok(None);
-    }
-
-    matches.sort_by_key(|candidate| std::cmp::Reverse(candidate.score));
-    let best_score = matches[0].score;
-    let best_count = matches
-        .iter()
-        .filter(|candidate| candidate.score == best_score)
-        .count();
-
-    if best_score == 40 && has_only_title_metadata(window) && best_count != 1 {
-        return Err(());
-    }
-
-    if best_count == 1 {
-        Ok(Some(matches[0]))
+    let exact_count = exact_title.len();
+    if identity::has_stable_metadata(window) {
+        let viable = exact_title
+            .into_iter()
+            .filter(|(_, candidate)| can_validate_stable_metadata(window, candidate))
+            .map(|(index, _)| MatchCandidate { index })
+            .collect();
+        (exact_count, viable)
     } else {
-        Err(())
+        let viable = exact_title
+            .into_iter()
+            .map(|(index, _)| MatchCandidate { index })
+            .collect();
+        (exact_count, viable)
     }
 }
 
-fn match_saved_window(
+fn match_unbound_fallback(
     window: &MmWindow,
     live: &[EnumeratedWindow],
     assigned: &HashSet<usize>,
 ) -> (ReconnectOutcome, Option<usize>) {
-    if let Some(candidate) = matching_existing_hwnd(window, live, assigned) {
-        return (ReconnectOutcome::AlreadyValid, Some(candidate.hwnd));
+    let (exact_count, viable) = viable_exact_title_candidates(window, live, assigned);
+    if exact_count == 0 {
+        return (ReconnectOutcome::Missing, None);
+    }
+    if viable.is_empty() {
+        return (ReconnectOutcome::MetadataMismatch, None);
+    }
+    if viable.len() > 1 {
+        return (ReconnectOutcome::Ambiguous, None);
+    }
+    (
+        ReconnectOutcome::Reconnected,
+        Some(live[viable[0].index].hwnd),
+    )
+}
+
+fn match_restored_hwnd(
+    window: &MmWindow,
+    deps: &ReconnectDeps<'_>,
+) -> (ReconnectOutcome, Option<usize>) {
+    if !(deps.is_window)(window.hwnd) {
+        return (ReconnectOutcome::Closed, None);
     }
 
-    let stale_rejected = window.hwnd != 0;
-    match best_match(window, live, assigned) {
-        Ok(Some(candidate)) => {
-            let outcome = if stale_rejected {
-                ReconnectOutcome::Invalidated
-            } else {
-                ReconnectOutcome::Reconnected
-            };
-            (outcome, Some(live[candidate.index].hwnd))
+    match (deps.query_identity)(window.hwnd) {
+        Some(identity) if direct_identity_matches(window, &identity) => {
+            (ReconnectOutcome::AlreadyValid, Some(window.hwnd))
         }
-        Ok(None) => {
-            let outcome = if stale_rejected {
-                ReconnectOutcome::Invalidated
-            } else {
-                ReconnectOutcome::Missing
-            };
-            (outcome, None)
-        }
-        Err(()) => (ReconnectOutcome::Ambiguous, None),
+        _ => (ReconnectOutcome::MetadataMismatch, None),
     }
 }
 
@@ -155,7 +126,7 @@ pub fn match_saved_window_against_candidates(
     window: &MmWindow,
     live: &[EnumeratedWindow],
 ) -> (ReconnectOutcome, Option<usize>) {
-    match_saved_window(window, live, &HashSet::new())
+    match_unbound_fallback(window, live, &HashSet::new())
 }
 
 pub fn match_saved_workspace_against_candidates(
@@ -167,7 +138,7 @@ pub fn match_saved_workspace_against_candidates(
         .windows
         .iter()
         .map(|window| {
-            let result = match_saved_window(window, live, &assigned);
+            let result = match_unbound_fallback(window, live, &assigned);
             if let Some(hwnd) = result.1 {
                 assigned.insert(hwnd);
             }
@@ -177,70 +148,141 @@ pub fn match_saved_workspace_against_candidates(
 }
 
 pub fn reconnect_workspaces(workspaces: &mut [MmWorkspace]) -> ReconnectSummary {
-    let live = win::enumerate_top_level_windows().unwrap_or_default();
-    reconnect_workspaces_with_windows(workspaces, &live)
+    let is_window = |hwnd| win::is_valid_window(hwnd);
+    let query_identity = |hwnd| Some(win::query_hwnd_identity(hwnd));
+    let enumerate = || win::enumerate_top_level_windows().unwrap_or_default();
+    reconnect_workspaces_with_deps(
+        workspaces,
+        ReconnectDeps {
+            is_window: &is_window,
+            query_identity: &query_identity,
+            enumerate_top_level_windows: &enumerate,
+        },
+    )
 }
 
 pub fn reconnect_workspaces_with_windows(
     workspaces: &mut [MmWorkspace],
     live: &[EnumeratedWindow],
 ) -> ReconnectSummary {
+    let is_window = |hwnd| live.iter().any(|candidate| candidate.hwnd == hwnd);
+    let query_identity = |hwnd| {
+        live.iter()
+            .find(|candidate| candidate.hwnd == hwnd)
+            .map(|candidate| DirectHwndIdentity {
+                hwnd: candidate.hwnd,
+                is_window: true,
+                live_title: candidate.title.clone(),
+                process_path: candidate.process_path.clone(),
+                executable: candidate.executable.clone(),
+                class_name: candidate.class_name.clone(),
+            })
+    };
+    let enumerate = || live.to_vec();
+    reconnect_workspaces_with_deps(
+        workspaces,
+        ReconnectDeps {
+            is_window: &is_window,
+            query_identity: &query_identity,
+            enumerate_top_level_windows: &enumerate,
+        },
+    )
+}
+
+pub fn reconnect_workspaces_with_deps(
+    workspaces: &mut [MmWorkspace],
+    deps: ReconnectDeps<'_>,
+) -> ReconnectSummary {
+    let before: Vec<(usize, bool)> = workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.windows)
+        .map(|window| (window.hwnd, window.binding_verified))
+        .collect();
     let mut summary = ReconnectSummary::default();
     let mut assigned = HashSet::new();
+    let mut live_cache: Option<Vec<EnumeratedWindow>> = None;
 
     for window in workspaces
         .iter_mut()
         .flat_map(|workspace| &mut workspace.windows)
     {
-        let (outcome, hwnd) = match_saved_window(window, live, &assigned);
+        if window.disabled {
+            continue;
+        }
 
-        match outcome {
-            ReconnectOutcome::AlreadyValid => {
+        if window.hwnd != 0 && window.binding_verified {
+            if (deps.is_window)(window.hwnd) {
                 summary.already_valid += 1;
-                if let Some(hwnd) = hwnd {
-                    window.mark_bound(hwnd);
-                } else {
-                    window.mark_missing();
-                }
+                assigned.insert(window.hwnd);
+                continue;
             }
+            summary.invalidated += 1;
+            window.mark_closed();
+            window.live_title.clear();
+        } else if window.hwnd != 0 {
+            let (outcome, hwnd) = match_restored_hwnd(window, &deps);
+            match outcome {
+                ReconnectOutcome::AlreadyValid => {
+                    summary.already_valid += 1;
+                    window.mark_bound(hwnd.unwrap_or(window.hwnd));
+                    assigned.insert(window.hwnd);
+                    continue;
+                }
+                ReconnectOutcome::Closed => {
+                    summary.invalidated += 1;
+                    window.mark_closed();
+                    window.live_title.clear();
+                    continue;
+                }
+                ReconnectOutcome::MetadataMismatch => {
+                    summary.metadata_mismatch += 1;
+                    window.mark_metadata_mismatch();
+                    window.live_title.clear();
+                    continue;
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        let live = live_cache.get_or_insert_with(|| (deps.enumerate_top_level_windows)());
+        let (outcome, hwnd) = match_unbound_fallback(window, live, &assigned);
+        match outcome {
             ReconnectOutcome::Reconnected => {
                 summary.reconnected += 1;
                 if let Some(hwnd) = hwnd {
                     window.mark_reconnected(hwnd);
-                } else {
-                    window.mark_missing();
-                }
-            }
-            ReconnectOutcome::Invalidated => {
-                summary.invalidated += 1;
-                if let Some(hwnd) = hwnd {
-                    summary.reconnected += 1;
-                    window.mark_reconnected(hwnd);
-                } else {
-                    summary.missing += 1;
-                    window.mark_metadata_mismatch();
+                    if let Some(live_window) = live.iter().find(|candidate| candidate.hwnd == hwnd)
+                    {
+                        window.live_title = live_window.title.clone();
+                    }
+                    assigned.insert(hwnd);
                 }
             }
             ReconnectOutcome::Ambiguous => {
                 summary.ambiguous += 1;
                 window.mark_ambiguous();
+                window.live_title.clear();
+            }
+            ReconnectOutcome::MetadataMismatch => {
+                summary.metadata_mismatch += 1;
+                window.mark_metadata_mismatch();
+                window.live_title.clear();
             }
             ReconnectOutcome::Missing => {
                 summary.missing += 1;
                 window.mark_missing();
+                window.live_title.clear();
             }
-        }
-
-        if let Some(hwnd) = hwnd {
-            if let Some(live_window) = live.iter().find(|candidate| candidate.hwnd == hwnd) {
-                window.live_title = live_window.title.clone();
-            }
-            assigned.insert(hwnd);
-        } else {
-            window.live_title.clear();
+            _ => unreachable!(),
         }
     }
 
+    let after: Vec<(usize, bool)> = workspaces
+        .iter()
+        .flat_map(|workspace| &workspace.windows)
+        .map(|window| (window.hwnd, window.binding_verified))
+        .collect();
+    summary.binding_snapshot_changed = before != after;
     summary
 }
 
@@ -255,6 +297,7 @@ pub fn needs_reconnect(workspaces: &[MmWorkspace]) -> bool {
 mod tests {
     use super::*;
     use crate::multi_manager::model::MmRect;
+    use std::cell::Cell;
 
     fn rect() -> MmRect {
         MmRect {
@@ -267,18 +310,29 @@ mod tests {
 
     fn live(
         hwnd: usize,
-        captured_title: &str,
+        title: &str,
         executable: &str,
         class_name: &str,
         process_path: &str,
     ) -> EnumeratedWindow {
         EnumeratedWindow {
             hwnd,
-            title: captured_title.into(),
+            title: title.into(),
             executable: executable.into(),
             class_name: class_name.into(),
             process_path: process_path.into(),
             rect: rect(),
+        }
+    }
+
+    fn identity_from(candidate: &EnumeratedWindow) -> DirectHwndIdentity {
+        DirectHwndIdentity {
+            hwnd: candidate.hwnd,
+            is_window: true,
+            live_title: candidate.title.clone(),
+            process_path: candidate.process_path.clone(),
+            executable: candidate.executable.clone(),
+            class_name: candidate.class_name.clone(),
         }
     }
 
@@ -290,103 +344,180 @@ mod tests {
     }
 
     #[test]
-    fn title_only_legacy_reconnect_is_missing() {
+    fn valid_hwnd_survives_changed_title() {
         let mut workspaces = workspace(MmWindow {
-            captured_title: " Notes ".into(),
-            valid: false,
+            hwnd: 5,
+            binding_verified: true,
+            live_title: "Old".into(),
             ..MmWindow::default()
         });
-        let summary =
-            reconnect_workspaces_with_windows(&mut workspaces, &[live(10, "notes", "", "", "")]);
-        assert_eq!(summary.missing, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 0);
-        assert!(!workspaces[0].windows[0].valid);
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 5,
+                query_identity: &|_| panic!("identity should not be queried"),
+                enumerate_top_level_windows: &|| panic!("should not enumerate"),
+            },
+        );
+        assert_eq!(summary.already_valid, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 5);
+        assert!(workspaces[0].windows[0].binding_verified);
     }
 
     #[test]
-    fn duplicate_title_only_candidates_are_ambiguous() {
+    fn valid_hwnd_does_not_invoke_enumeration() {
+        let enumerated = Cell::new(false);
         let mut workspaces = workspace(MmWindow {
-            captured_title: "Notes".into(),
-            executable: "notes.exe".into(),
+            hwnd: 5,
+            binding_verified: true,
+            ..MmWindow::default()
+        });
+        reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|_| true,
+                query_identity: &|_| None,
+                enumerate_top_level_windows: &|| {
+                    enumerated.set(true);
+                    Vec::new()
+                },
+            },
+        );
+        assert!(!enumerated.get());
+    }
+
+    #[test]
+    fn invalid_hwnd_is_cleared() {
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 5,
+            binding_verified: true,
+            captured_title: "Doc".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|_| false,
+                query_identity: &|_| None,
+                enumerate_top_level_windows: &|| Vec::new(),
+            },
+        );
+        assert_eq!(summary.invalidated, 1);
+        assert_eq!(summary.missing, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+        assert!(!workspaces[0].windows[0].binding_verified);
+    }
+
+    #[test]
+    fn invalid_hwnd_reconnects_to_one_exact_title_candidate() {
+        let candidate = live(9, "Doc", "edit.exe", "Editor", "C:/Apps/edit.exe");
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 5,
+            binding_verified: true,
+            captured_title: "Doc".into(),
+            executable: "edit.exe".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 9,
+                query_identity: &|_| None,
+                enumerate_top_level_windows: &|| vec![candidate.clone()],
+            },
+        );
+        assert_eq!(summary.invalidated, 1);
+        assert_eq!(summary.reconnected, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 9);
+        assert!(workspaces[0].windows[0].binding_verified);
+    }
+
+    #[test]
+    fn different_title_with_identical_executable_does_not_reconnect() {
+        let mut workspaces = workspace(MmWindow {
+            captured_title: "Doc".into(),
+            executable: "edit.exe".into(),
             ..MmWindow::default()
         });
         let summary = reconnect_workspaces_with_windows(
             &mut workspaces,
-            &[
-                live(10, "Notes", "notes.exe", "", ""),
-                live(11, " notes ", "notes.exe", "", ""),
-            ],
+            &[live(10, "Other", "edit.exe", "", "")],
+        );
+        assert_eq!(summary.missing, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+    }
+
+    #[test]
+    fn duplicate_exact_title_candidates_are_ambiguous() {
+        let mut workspaces = workspace(MmWindow {
+            captured_title: "Doc".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_windows(
+            &mut workspaces,
+            &[live(10, "Doc", "", "", ""), live(11, " doc ", "", "", "")],
         );
         assert_eq!(summary.ambiguous, 1);
         assert_eq!(workspaces[0].windows[0].hwnd, 0);
-        assert!(!workspaces[0].windows[0].valid);
     }
 
     #[test]
-    fn process_path_class_title_strong_match() {
+    fn stable_metadata_disambiguates_duplicate_exact_titles() {
         let mut workspaces = workspace(MmWindow {
             captured_title: "Doc".into(),
-            class_name: "Editor".into(),
-            process_path: "C:/Apps/Edit.exe".into(),
-            ..MmWindow::default()
-        });
-        let live_windows = [
-            live(10, "Doc", "other.exe", "Other", "C:/Other.exe"),
-            live(12, " doc ", "edit.exe", "editor", "c:/apps/edit.exe"),
-        ];
-        let summary = reconnect_workspaces_with_windows(&mut workspaces, &live_windows);
-        assert_eq!(summary.reconnected, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 12);
-    }
-
-    #[test]
-    fn stale_hwnd_invalidated() {
-        let mut workspaces = workspace(MmWindow {
-            hwnd: 5,
-            captured_title: "Doc".into(),
-            executable: "edit.exe".into(),
             process_path: "C:/Apps/edit.exe".into(),
             ..MmWindow::default()
         });
         let summary = reconnect_workspaces_with_windows(
             &mut workspaces,
-            &[live(5, "Other", "edit.exe", "", "C:/Other/edit.exe")],
+            &[
+                live(10, "Doc", "edit.exe", "", "C:/Other/edit.exe"),
+                live(11, "Doc", "edit.exe", "", "C:/Apps/edit.exe"),
+            ],
         );
-        assert_eq!(summary.invalidated, 1);
-        assert_eq!(summary.missing, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 0);
-        assert!(!workspaces[0].windows[0].valid);
+        assert_eq!(summary.reconnected, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 11);
     }
 
     #[test]
-    fn valid_matching_hwnd_preserved() {
+    fn exact_title_candidate_with_metadata_mismatch_is_rejected() {
         let mut workspaces = workspace(MmWindow {
-            hwnd: 5,
             captured_title: "Doc".into(),
-            executable: "Edit.EXE".into(),
+            process_path: "C:/Apps/edit.exe".into(),
             ..MmWindow::default()
         });
         let summary = reconnect_workspaces_with_windows(
             &mut workspaces,
-            &[live(5, " doc ", "edit.exe", "", "")],
+            &[live(10, "Doc", "edit.exe", "", "C:/Other/edit.exe")],
         );
-        assert_eq!(summary.already_valid, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 5);
-        assert!(workspaces[0].windows[0].valid);
+        assert_eq!(summary.metadata_mismatch, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
     }
 
     #[test]
-    fn same_hwnd_cannot_be_assigned_twice() {
+    fn legacy_title_only_entry_reconnects_when_exactly_one_candidate_exists() {
+        let mut workspaces = workspace(MmWindow {
+            captured_title: "Legacy App".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_windows(
+            &mut workspaces,
+            &[live(77, "legacy app", "app.exe", "Class", "C:/app.exe")],
+        );
+        assert_eq!(summary.reconnected, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 77);
+    }
+
+    #[test]
+    fn one_hwnd_cannot_be_assigned_to_two_entries() {
         let mut workspaces = vec![MmWorkspace {
             windows: vec![
                 MmWindow {
                     captured_title: "Doc".into(),
-                    executable: "app.exe".into(),
                     ..MmWindow::default()
                 },
                 MmWindow {
                     captured_title: "Doc".into(),
-                    executable: "app.exe".into(),
                     ..MmWindow::default()
                 },
             ],
@@ -403,17 +534,47 @@ mod tests {
     }
 
     #[test]
-    fn legacy_saved_window_with_only_title_does_not_reconnect() {
+    fn bound_hwnd_is_never_replaced_by_better_looking_title_match() {
         let mut workspaces = workspace(MmWindow {
-            alias: "Old".into(),
-            captured_title: "Legacy App".into(),
+            hwnd: 5,
+            binding_verified: true,
+            captured_title: "Doc".into(),
+            executable: "edit.exe".into(),
             ..MmWindow::default()
         });
-        let summary = reconnect_workspaces_with_windows(
+        let summary = reconnect_workspaces_with_deps(
             &mut workspaces,
-            &[live(77, "legacy app", "app.exe", "Class", "C:/app.exe")],
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 5,
+                query_identity: &|_| None,
+                enumerate_top_level_windows: &|| vec![live(9, "Doc", "edit.exe", "", "")],
+            },
         );
-        assert_eq!(summary.missing, 1);
-        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+        assert_eq!(summary.already_valid, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 5);
+    }
+
+    #[test]
+    fn restored_unverified_hwnd_validates_stable_metadata_without_title() {
+        let candidate = live(5, "Changed", "edit.exe", "Editor", "C:/Apps/edit.exe");
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 5,
+            binding_verified: false,
+            captured_title: "Doc".into(),
+            process_path: "C:/Apps/edit.exe".into(),
+            class_name: "Editor".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|_| true,
+                query_identity: &|_| Some(identity_from(&candidate)),
+                enumerate_top_level_windows: &|| panic!("should not enumerate"),
+            },
+        );
+        assert_eq!(summary.already_valid, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 5);
+        assert!(workspaces[0].windows[0].binding_verified);
     }
 }

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -230,9 +230,12 @@ pub fn reconnect_workspaces_with_deps(
                 }
                 ReconnectOutcome::Closed => {
                     summary.invalidated += 1;
+                    let was_already_invalid = !window.valid;
                     window.mark_closed();
                     window.live_title.clear();
-                    continue;
+                    if !was_already_invalid {
+                        continue;
+                    }
                 }
                 ReconnectOutcome::MetadataMismatch => {
                     summary.metadata_mismatch += 1;
@@ -429,6 +432,33 @@ mod tests {
         assert_eq!(summary.invalidated, 1);
         assert_eq!(summary.reconnected, 1);
         assert_eq!(workspaces[0].windows[0].hwnd, 9);
+        assert!(workspaces[0].windows[0].binding_verified);
+    }
+
+    #[test]
+    fn stale_unverified_invalid_hwnd_reconnects_to_one_exact_title_candidate() {
+        let candidate = live(42, "Notes", "app.exe", "AppClass", "C:/app.exe");
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 7,
+            valid: false,
+            binding_verified: false,
+            captured_title: "Notes".into(),
+            executable: "app.exe".into(),
+            class_name: "AppClass".into(),
+            process_path: "C:/app.exe".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 42,
+                query_identity: &|_| None,
+                enumerate_top_level_windows: &|| vec![candidate.clone()],
+            },
+        );
+        assert_eq!(summary.invalidated, 1);
+        assert_eq!(summary.reconnected, 1);
+        assert_eq!(workspaces[0].windows[0].hwnd, 42);
         assert!(workspaces[0].windows[0].binding_verified);
     }
 

--- a/tests/mouse_gestures_service.rs
+++ b/tests/mouse_gestures_service.rs
@@ -383,7 +383,8 @@ fn hint_text_includes_best_guess_and_match_type() {
     service.update_config(config);
 
     assert!(handle.emit(HookEvent::RButtonDown));
-    sleep(Duration::from_millis(5));
+    // Give the worker time to capture the initial cursor position before moving.
+    sleep(Duration::from_millis(50));
     cursor_provider.set_position((50.0, 0.0));
     sleep(Duration::from_millis(50));
 


### PR DESCRIPTION
### Motivation

- Replace fragile score/fuzzy reconnect logic with stricter exact-title + stable-metadata validation to avoid incorrect window rebindings and make behavior deterministic.
- Make reconnect logic injectable so tests can simulate `IsWindow`, direct HWND identity queries, and top-level enumeration without touching global platform APIs.

### Description

- Remove score-based matching and fuzzy/substring title acceptance and implement exact normalized fallback-title filtering plus optional stable metadata validation via `identity::stable_identity_matches_enumerated`.
- Add injectable dependencies in a `ReconnectDeps` struct: `is_window: Fn(usize) -> bool`, `query_identity: Fn(usize) -> Option<DirectHwndIdentity>`, and `enumerate_top_level_windows: Fn() -> Vec<EnumeratedWindow>` and provide production adapters (`reconnect_workspaces`) and a test-friendly adapter (`reconnect_workspaces_with_windows`).
- Implement Path A for verified HWNDs to only call `IsWindow` and preserve or clear the HWND accordingly, and Path A for restored but unverified HWNDs to validate stable metadata directly (ignoring title) before accepting or clearing the handle.
- Implement Path B unbound fallback that enumerates top-level windows once per reconnect pass, filters out already-assigned HWNDs, keeps only exact normalized-title matches, validates stable metadata for candidates when stored metadata exists, and resolves outcomes into `Reconnected`, `MetadataMismatch`, `Ambiguous`, or `Missing` as specified.
- Expand `ReconnectSummary` with `metadata_mismatch` and `binding_snapshot_changed` fields and update the GUI summary formatting to include metadata mismatch counts.
- Add unit tests in `src/multi_manager/reconnect.rs` covering verified HWND survival, no enumeration for verified HWNDs, clearing invalid HWNDs, reconnecting invalid HWNDs to a single exact-title candidate, rejecting different-title matches even with identical executables, ambiguous duplicate exact-title candidates, metadata-based disambiguation, metadata mismatch rejection, legacy title-only reconnect behavior, single-HWND assignment enforcement, and ensuring bound HWNDs are not replaced.

### Testing

- Ran code formatting check with `rustfmt --edition 2024 src/multi_manager/reconnect.rs src/gui/multi_manager_actions.rs` which succeeded.
- Ran `git diff --check` and repository hygiene checks which reported no diff-check errors for the modified files.
- Attempted to run `cargo test reconnect --quiet`; the test run could not complete in this environment due to platform/build issues unrelated to the reconnect changes (missing system dev packages initially for ALSA/X11 which were installed, and remaining compilation failures against Windows-specific crates and cross-platform imports prevented the test suite from executing the reconnect unit tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5be328c9708332b550afcac02fdbd7)