### PR TITLE
Persist MultiManager HWND bindings separately

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -24,7 +24,7 @@ impl LauncherApp {
             match event {
                 MultiManagerRuntimeEvent::WorkspaceActionCompleted { result, .. } => {
                     if result.bindings_changed {
-                        self.multi_manager.mark_dirty();
+                        self.multi_manager.mark_bindings_dirty();
                     }
                     self.multi_manager_report_activation(
                         "MultiManager hotkey activated workspace",
@@ -113,7 +113,7 @@ impl LauncherApp {
             return;
         };
         if result.bindings_changed {
-            self.multi_manager.mark_dirty();
+            self.multi_manager.mark_bindings_dirty();
         }
         self.multi_manager_report_activation("Sent all MultiManager windows home", result);
     }
@@ -139,7 +139,9 @@ impl LauncherApp {
             }
         };
 
-        self.multi_manager.mark_dirty();
+        if summary.binding_snapshot_changed {
+            self.multi_manager.mark_bindings_dirty();
+        }
         self.add_success_toast(format_reconnect_summary(summary));
     }
 
@@ -172,14 +174,7 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_save_bindings(&mut self) {
-        let result = self
-            .multi_manager
-            .workspaces
-            .lock()
-            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))
-            .and_then(|workspaces| {
-                bindings::save_bindings(&self.multi_manager.bindings_path, &workspaces)
-            });
+        let result = self.multi_manager.save_bindings_now();
         match result {
             Ok(()) => self.add_success_toast("Saved MultiManager window bindings"),
             Err(err) => self.report_error_message(
@@ -195,15 +190,18 @@ impl LauncherApp {
                 let restored = {
                     match self.multi_manager.workspaces.lock() {
                         Ok(mut workspaces) => {
+                            let before = binding_fingerprint(&workspaces);
                             bindings::restore_bindings(&mut workspaces, &snapshots);
-                            Ok(())
+                            Ok(before != binding_fingerprint(&workspaces))
                         }
                         Err(_) => Err(()),
                     }
                 };
                 match restored {
-                    Ok(()) => {
-                        self.multi_manager.mark_dirty();
+                    Ok(changed) => {
+                        if changed {
+                            self.multi_manager.mark_bindings_dirty();
+                        }
                         self.add_success_toast("Restored MultiManager window bindings");
                     }
                     Err(()) => self.report_error_message(
@@ -228,7 +226,6 @@ impl LauncherApp {
         };
         match changed {
             Ok(true) => {
-                self.multi_manager.mark_dirty();
                 self.add_success_toast("Refreshed MultiManager window titles");
             }
             Ok(false) => self.add_success_toast("MultiManager window titles already current"),
@@ -453,7 +450,7 @@ impl LauncherApp {
             return;
         };
         if result.bindings_changed {
-            self.multi_manager.mark_dirty();
+            self.multi_manager.mark_bindings_dirty();
         }
         self.multi_manager_report_activation(success_message, result);
     }
@@ -880,6 +877,7 @@ impl LauncherApp {
             ApplyCaptureResult::Applied => {
                 log_applied_capture(&action, &captured);
                 self.multi_manager.mark_dirty();
+                self.multi_manager.mark_bindings_dirty();
             }
             ApplyCaptureResult::MissingWorkspace => {
                 self.report_error_message(
@@ -1984,4 +1982,27 @@ mod tests {
 
         assert!(!app.is_launcher_capture(&captured(100, "Notepad")));
     }
+}
+
+fn binding_fingerprint(
+    workspaces: &[crate::multi_manager::model::MmWorkspace],
+) -> Vec<(usize, usize, usize, bool)> {
+    workspaces
+        .iter()
+        .enumerate()
+        .flat_map(|(workspace_index, workspace)| {
+            workspace
+                .windows
+                .iter()
+                .enumerate()
+                .map(move |(window_index, window)| {
+                    (
+                        workspace_index,
+                        window_index,
+                        window.hwnd,
+                        window.binding_verified,
+                    )
+                })
+        })
+        .collect()
 }

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -640,6 +640,7 @@ impl eframe::App for LauncherApp {
             self.launcher_hwnd = Some(hwnd.0 as usize);
         }
         self.multi_manager_drain_runtime_events();
+        self.multi_manager.maybe_auto_save_bindings();
         if self.enable_toasts {
             self.toasts.show(ctx);
         }
@@ -1347,6 +1348,9 @@ impl eframe::App for LauncherApp {
             && let Err(err) = self.multi_manager.save() {
                 self.report_error("multi_manager.save_on_exit", err);
             }
+        if let Err(err) = self.multi_manager.flush_bindings_if_dirty() {
+            self.report_error("multi_manager.bindings.save_on_exit", err);
+        }
         self.unregister_all_hotkeys();
         self.visible_flag.store(false, Ordering::SeqCst);
         self.last_visible = false;

--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -5,8 +5,10 @@ use crate::multi_manager::win::{self, EnumeratedWindow};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs::{self, File};
 use std::io::ErrorKind;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct WorkspaceBindingSnapshot {
@@ -36,7 +38,44 @@ pub struct DuplicateHwnd {
 }
 
 pub fn save_bindings(path: &Path, workspaces: &[MmWorkspace]) -> Result<()> {
-    let snapshots = workspaces
+    save_bindings_with_validator(path, workspaces, win::is_valid_window)
+}
+
+fn save_bindings_with_validator(
+    path: &Path,
+    workspaces: &[MmWorkspace],
+    is_valid_window: impl Fn(usize) -> bool,
+) -> Result<()> {
+    let snapshots = binding_snapshots_with_validator(workspaces, is_valid_window);
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let tmp_path = tmp_path_for(path);
+    let json = serde_json::to_vec_pretty(&snapshots)?;
+    {
+        let mut file = File::create(&tmp_path)
+            .with_context(|| format!("create temporary binding file {}", tmp_path.display()))?;
+        file.write_all(&json)
+            .with_context(|| format!("write temporary binding file {}", tmp_path.display()))?;
+        file.flush()
+            .with_context(|| format!("flush temporary binding file {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync temporary binding file {}", tmp_path.display()))?;
+    }
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "atomically replace {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })
+}
+
+fn binding_snapshots_with_validator(
+    workspaces: &[MmWorkspace],
+    is_valid_window: impl Fn(usize) -> bool,
+) -> Vec<WorkspaceBindingSnapshot> {
+    workspaces
         .iter()
         .map(|workspace| WorkspaceBindingSnapshot {
             workspace_id: (!workspace.id.is_empty()).then(|| workspace.id.clone()),
@@ -45,7 +84,7 @@ pub fn save_bindings(path: &Path, workspaces: &[MmWorkspace]) -> Result<()> {
                 .windows
                 .iter()
                 .enumerate()
-                .filter(|(_, window)| window.hwnd != 0 && win::is_valid_window(window.hwnd))
+                .filter(|(_, window)| window.hwnd != 0 && is_valid_window(window.hwnd))
                 .map(|(index, window)| WindowBindingSnapshot {
                     window_id: index,
                     window_index: index,
@@ -58,12 +97,16 @@ pub fn save_bindings(path: &Path, workspaces: &[MmWorkspace]) -> Result<()> {
                 })
                 .collect(),
         })
-        .collect::<Vec<_>>();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    }
-    std::fs::write(path, serde_json::to_string_pretty(&snapshots)?)
-        .with_context(|| format!("write {}", path.display()))
+        .collect()
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_else(|| "multi_manager_bindings.json".into());
+    name.push(".tmp");
+    path.with_file_name(name)
 }
 
 pub fn load_bindings(path: &Path) -> Result<Vec<WorkspaceBindingSnapshot>> {
@@ -509,5 +552,32 @@ mod tests {
         assert_eq!(workspaces[0].windows[0].captured_title, "old");
         assert_eq!(workspaces[0].windows[0].live_title, "new");
         assert_eq!(workspaces[0].windows[0].alias, "alias");
+    }
+    #[test]
+    fn cleared_hwnd_is_removed_from_next_snapshot() {
+        let snapshots =
+            binding_snapshots_with_validator(&[ws("id", "name", vec![win("a", "t", 0)])], |_| true);
+        assert!(snapshots[0].windows.is_empty());
+    }
+
+    #[test]
+    fn atomic_save_preserves_existing_snapshot_when_temp_create_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bindings.json");
+        std::fs::write(&path, "old complete snapshot").unwrap();
+        std::fs::create_dir(path.with_file_name("bindings.json.tmp")).unwrap();
+
+        let err = save_bindings_with_validator(
+            &path,
+            &[ws("id", "name", vec![win("a", "t", 123)])],
+            |_| true,
+        )
+        .expect_err("temporary file creation should fail");
+
+        assert!(err.to_string().contains("temporary binding file"));
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "old complete snapshot"
+        );
     }
 }

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -51,6 +51,7 @@ pub struct RuntimeControl {
     pub shutdown: AtomicBool,
     pub auto_reconnect_missing_windows: AtomicBool,
     pub auto_reconnect_interval_ms: AtomicU64,
+    pub bindings_dirty_signal: Arc<AtomicBool>,
 }
 
 impl RuntimeControl {
@@ -61,6 +62,7 @@ impl RuntimeControl {
             shutdown: AtomicBool::new(false),
             auto_reconnect_missing_windows: AtomicBool::new(true),
             auto_reconnect_interval_ms: AtomicU64::new(3000),
+            bindings_dirty_signal: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -120,6 +122,7 @@ impl MultiManagerRuntime {
         let event_queue = Arc::new(Mutex::new(VecDeque::new()));
         let thread_workspaces = Arc::clone(&workspaces);
         let thread_control = Arc::clone(&control);
+        let thread_bindings_dirty_signal = Arc::clone(&control.bindings_dirty_signal);
         let thread_last_hotkey_info = Arc::clone(&last_hotkey_info);
         let thread_event_queue = Arc::clone(&event_queue);
         let poll = Duration::from_millis(settings.hotkey_poll_ms);
@@ -132,14 +135,16 @@ impl MultiManagerRuntime {
             while !thread_control.shutdown.load(Ordering::Relaxed) {
                 thread::sleep(poll);
                 let now = Instant::now();
-                maybe_runtime_reconnect(
+                if maybe_runtime_reconnect(
                     &thread_workspaces,
                     &thread_control,
                     &mut last_reconnect,
                     now,
                     |hwnd| win::is_valid_window(hwnd),
                     || win::enumerate_top_level_windows().unwrap_or_default(),
-                );
+                ) {
+                    thread_bindings_dirty_signal.store(true, Ordering::Relaxed);
+                }
                 if let Ok(mut workspaces) = thread_workspaces.lock() {
                     runtime_tick(
                         &mut workspaces,
@@ -429,6 +434,9 @@ pub fn runtime_tick(
             &deps,
         )
         .unwrap_or_default();
+        if result.bindings_changed {
+            control.bindings_dirty_signal.store(true, Ordering::Relaxed);
+        }
         push_runtime_activation_events(
             event_queue,
             workspace_id.clone(),

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -10,9 +10,11 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
+const BINDINGS_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 
 pub struct MultiManagerState {
     pub dirty: bool,
+    pub bindings_dirty: bool,
     pub pending_capture: Option<PendingCaptureAction>,
     pub queued_capture: Option<PendingCaptureAction>,
     pub recapture_queue: VecDeque<RecaptureQueueItem>,
@@ -30,6 +32,9 @@ pub struct MultiManagerState {
     save_debounce: Duration,
     dirty_since: Option<Instant>,
     last_save_attempt: Option<Instant>,
+    binding_save_debounce: Duration,
+    pub bindings_dirty_since: Option<Instant>,
+    pub last_bindings_save_attempt: Option<Instant>,
 }
 
 impl MultiManagerState {
@@ -55,6 +60,7 @@ impl MultiManagerState {
 
         Self {
             dirty: false,
+            bindings_dirty: false,
             pending_capture: None,
             queued_capture: None,
             recapture_queue: VecDeque::new(),
@@ -72,6 +78,9 @@ impl MultiManagerState {
             save_debounce: AUTO_SAVE_DEBOUNCE,
             dirty_since: None,
             last_save_attempt: None,
+            binding_save_debounce: BINDINGS_SAVE_DEBOUNCE,
+            bindings_dirty_since: None,
+            last_bindings_save_attempt: None,
         }
     }
 
@@ -92,6 +101,27 @@ impl MultiManagerState {
         Ok(())
     }
 
+    pub fn save_bindings_now(&mut self) -> Result<()> {
+        let workspaces = self
+            .workspaces
+            .lock()
+            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))?;
+        bindings::save_bindings(&self.bindings_path, &workspaces).with_context(|| {
+            format!(
+                "failed to save MultiManager bindings to {}",
+                self.bindings_path.display()
+            )
+        })?;
+        self.bindings_dirty = false;
+        self.bindings_dirty_since = None;
+        self.runtime
+            .control
+            .bindings_dirty_signal
+            .store(false, Ordering::Relaxed);
+        self.last_bindings_save_attempt = Some(Instant::now());
+        Ok(())
+    }
+
     pub fn reload(&mut self) -> Result<()> {
         let mut loaded = store::load_workspaces(&self.workspace_path)?;
         restore_and_optionally_reconnect(
@@ -106,6 +136,12 @@ impl MultiManagerState {
         *workspaces = loaded;
         self.dirty = false;
         self.dirty_since = None;
+        self.bindings_dirty = false;
+        self.bindings_dirty_since = None;
+        self.runtime
+            .control
+            .bindings_dirty_signal
+            .store(false, Ordering::Relaxed);
         Ok(())
     }
 
@@ -116,12 +152,27 @@ impl MultiManagerState {
         }
     }
 
+    pub fn mark_bindings_dirty(&mut self) {
+        self.bindings_dirty = true;
+        if self.bindings_dirty_since.is_none() {
+            self.bindings_dirty_since = Some(Instant::now());
+        }
+    }
+
     pub fn save_debounced(&mut self) {
         self.mark_dirty();
         self.maybe_auto_save();
     }
 
     pub fn maybe_auto_save(&mut self) {
+        if self
+            .runtime
+            .control
+            .bindings_dirty_signal
+            .swap(false, Ordering::Relaxed)
+        {
+            self.mark_bindings_dirty();
+        }
         if !self.auto_save || !self.dirty {
             return;
         }
@@ -133,6 +184,43 @@ impl MultiManagerState {
             tracing::error!(error = %err, "failed to auto-save MultiManager workspaces");
             self.last_save_attempt = Some(Instant::now());
         }
+    }
+
+    pub fn maybe_auto_save_bindings(&mut self) {
+        if self
+            .runtime
+            .control
+            .bindings_dirty_signal
+            .swap(false, Ordering::Relaxed)
+        {
+            self.mark_bindings_dirty();
+        }
+        if !self.auto_save || !self.bindings_dirty {
+            return;
+        }
+        if self
+            .bindings_dirty_since
+            .is_some_and(|dirty_since| dirty_since.elapsed() >= self.binding_save_debounce)
+            && let Err(err) = self.save_bindings_now()
+        {
+            tracing::error!(error = %err, "failed to auto-save MultiManager bindings");
+            self.last_bindings_save_attempt = Some(Instant::now());
+        }
+    }
+
+    pub fn flush_bindings_if_dirty(&mut self) -> Result<()> {
+        if self
+            .runtime
+            .control
+            .bindings_dirty_signal
+            .swap(false, Ordering::Relaxed)
+        {
+            self.mark_bindings_dirty();
+        }
+        if self.bindings_dirty {
+            self.save_bindings_now()?;
+        }
+        Ok(())
     }
 
     pub fn validate_capture_state_debug(&self) {
@@ -188,6 +276,8 @@ impl MultiManagerState {
     #[cfg(test)]
     fn force_debounce_elapsed(&mut self) {
         self.dirty_since = Some(Instant::now() - self.save_debounce - Duration::from_millis(1));
+        self.bindings_dirty_since =
+            Some(Instant::now() - self.binding_save_debounce - Duration::from_millis(1));
     }
 }
 
@@ -536,5 +626,75 @@ mod tests {
         );
         state.shutdown();
         state.shutdown();
+    }
+    #[test]
+    fn capture_marks_bindings_dirty_without_workspace_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.mark_bindings_dirty();
+        assert!(state.bindings_dirty);
+        assert!(!state.dirty);
+    }
+
+    #[test]
+    fn fallback_reconnect_signal_marks_bindings_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state
+            .runtime
+            .control
+            .bindings_dirty_signal
+            .store(true, Ordering::Relaxed);
+        state.maybe_auto_save_bindings();
+        assert!(state.bindings_dirty);
+        assert!(!state.dirty);
+    }
+
+    #[test]
+    fn live_title_refresh_does_not_mark_bindings_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        assert!(!state.bindings_dirty);
+    }
+
+    #[test]
+    fn rapid_binding_changes_debounce_to_one_save_opportunity() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                auto_save: true,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.mark_bindings_dirty();
+        let first_dirty_since = state.bindings_dirty_since;
+        state.mark_bindings_dirty();
+        assert_eq!(state.bindings_dirty_since, first_dirty_since);
+        state.maybe_auto_save_bindings();
+        assert!(state.last_bindings_save_attempt.is_none());
     }
 }


### PR DESCRIPTION
### Motivation
- Separate transient HWND/binding changes from durable workspace identity changes so live-title/hwnd updates don't force full workspace JSON saves.
- Ensure the runtime can notify the GUI/state layer when reconnects or hotkey activations change HWND bindings so binding saves can be autoscheduled without interfering with workspace persistence.
- Make binding snapshot writes atomic to avoid leaving partial/invalid files when temporary writes fail.

### Description
- Added binding persistence fields and APIs to `MultiManagerState`: `bindings_dirty: bool`, `bindings_dirty_since: Option<Instant>`, `last_bindings_save_attempt: Option<Instant>`, `binding_save_debounce`, and methods `mark_bindings_dirty()`, `maybe_auto_save_bindings()`, `save_bindings_now()`, and `flush_bindings_if_dirty()` in `src/multi_manager/state.rs`.
- Introduced a shared runtime-to-state dirty signal `Arc<AtomicBool>` (`bindings_dirty_signal`) in `RuntimeControl` and wired runtime reconnect and activation code to set it when HWND bindings change in `src/multi_manager/runtime.rs`.
- Switched binding snapshot saving to an atomic temporary-file + rename pattern and omitted invalid/cleared HWNDs from snapshots via a new `save_bindings_with_validator`/`binding_snapshots_with_validator` helper in `src/multi_manager/bindings.rs`.
- Updated GUI behavior in `src/gui/multi_manager_actions.rs` and the main update loop in `src/gui/render.rs` so: manual "Save HWND Snapshot" calls `save_bindings_now()` (bypass debounce), manual restores detect whether HWNDs actually changed (compare a `binding_fingerprint`) and mark bindings dirty only when appropriate, and capture/recapture/fallback reconnects set binding-dirty rather than full workspace dirty for HWND-only changes.
- Ensured shutdown order in `LauncherApp::on_exit()` stops the runtime, saves workspaces (if configured), then flushes dirty bindings before final cleanup.
- Added unit tests covering binding dirty marking, runtime reconnect signaling, cleared-HWND omission from snapshots, debounce behavior, and atomic-save failure preservation in `src/multi_manager/state.rs` and `src/multi_manager/bindings.rs`.

### Testing
- Ran `cargo test multi_manager --lib`; execution was blocked by platform-specific build failures in the host environment (Windows-only `windows::Win32` APIs and related native deps) so the new tests could not be exercised end-to-end on this Linux CI host.
- Verified `git diff --check`/formatting and added unit tests for the new binding save behavior and debounce logic (tests are included but not executed successfully here due to the environment limitations described above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c0cb1da7c8332bdb472fd91469263)