### PR TITLE
Refresh MultiManager live titles without dirtying state

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -218,9 +218,10 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_refresh_titles(&mut self) {
+        self.multi_manager.last_live_title_refresh = Some(std::time::Instant::now());
         let changed = {
             match self.multi_manager.workspaces.lock() {
-                Ok(mut workspaces) => Ok(bindings::refresh_titles(&mut workspaces)),
+                Ok(mut workspaces) => Ok(bindings::refresh_live_titles(&mut workspaces)),
                 Err(_) => Err(()),
             }
         };

--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -257,29 +257,34 @@ pub fn duplicate_hwnds(workspaces: &[MmWorkspace]) -> Vec<DuplicateHwnd> {
     duplicates
 }
 
-pub fn refresh_titles_with(
+pub fn refresh_live_titles_with(
     workspaces: &mut [MmWorkspace],
-    is_valid: impl Fn(usize) -> bool,
-    title: impl Fn(usize) -> Option<String>,
+    mut is_valid: impl FnMut(usize) -> bool,
+    mut window_title: impl FnMut(usize) -> Option<String>,
 ) -> bool {
-    let mut changed = false;
+    let mut runtime_cache_changed = false;
     for workspace in workspaces {
         for window in &mut workspace.windows {
-            if window.hwnd != 0
-                && is_valid(window.hwnd)
-                && let Some(new_title) = title(window.hwnd)
+            if !window.has_bound_hwnd() {
+                continue;
+            }
+            let hwnd = window.hwnd;
+            if !is_valid(hwnd) {
+                continue;
+            }
+            if let Some(new_title) = window_title(hwnd)
                 && window.live_title != new_title
             {
                 window.live_title = new_title;
-                changed = true;
+                runtime_cache_changed = true;
             }
         }
     }
-    changed
+    runtime_cache_changed
 }
 
-pub fn refresh_titles(workspaces: &mut [MmWorkspace]) -> bool {
-    refresh_titles_with(workspaces, win::is_valid_window, win::window_title)
+pub fn refresh_live_titles(workspaces: &mut [MmWorkspace]) -> bool {
+    refresh_live_titles_with(workspaces, win::is_valid_window, win::window_title)
 }
 
 #[cfg(test)]
@@ -542,9 +547,9 @@ mod tests {
     }
 
     #[test]
-    fn title_refresh_preserves_aliases() {
+    fn live_title_refresh_preserves_aliases_and_captured_title() {
         let mut workspaces = vec![ws("id", "name", vec![win("alias", "old", 4)])];
-        assert!(refresh_titles_with(
+        assert!(refresh_live_titles_with(
             &mut workspaces,
             |_| true,
             |_| Some("new".into())
@@ -552,6 +557,56 @@ mod tests {
         assert_eq!(workspaces[0].windows[0].captured_title, "old");
         assert_eq!(workspaces[0].windows[0].live_title, "new");
         assert_eq!(workspaces[0].windows[0].alias, "alias");
+    }
+
+    #[test]
+    fn live_title_refresh_only_queries_valid_bound_nonzero_hwnds() {
+        let mut valid_window = win("", "captured", 4);
+        valid_window.live_title = "old-live".into();
+        let mut invalid_bound_window = win("", "invalid", 5);
+        invalid_bound_window.valid = false;
+        let mut zero_hwnd_window = win("", "zero", 0);
+        zero_hwnd_window.valid = true;
+        let mut workspaces = vec![ws(
+            "id",
+            "name",
+            vec![valid_window, invalid_bound_window, zero_hwnd_window],
+        )];
+        let mut valid_queries = Vec::new();
+        let mut title_queries = Vec::new();
+
+        assert!(refresh_live_titles_with(
+            &mut workspaces,
+            |hwnd| {
+                valid_queries.push(hwnd);
+                hwnd == 4
+            },
+            |hwnd| {
+                title_queries.push(hwnd);
+                Some("new-live".into())
+            },
+        ));
+
+        assert_eq!(valid_queries, vec![4]);
+        assert_eq!(title_queries, vec![4]);
+        assert_eq!(workspaces[0].windows[0].captured_title, "captured");
+        assert_eq!(workspaces[0].windows[0].live_title, "new-live");
+        assert_eq!(workspaces[0].windows[1].live_title, "");
+    }
+
+    #[test]
+    fn live_title_refresh_performs_no_enumeration_or_fallback_matching() {
+        let mut workspaces = vec![ws("id", "name", vec![win("", "captured", 8)])];
+
+        assert!(!refresh_live_titles_with(
+            &mut workspaces,
+            |_| true,
+            |_| None
+        ));
+
+        assert_eq!(workspaces[0].windows[0].hwnd, 8);
+        assert_eq!(workspaces[0].windows[0].captured_title, "captured");
+        assert_eq!(workspaces[0].windows[0].live_title, "");
     }
     #[test]
     fn cleared_hwnd_is_removed_from_next_snapshot() {

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 
 const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 const BINDINGS_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
+pub const LIVE_TITLE_REFRESH_INTERVAL: Duration = Duration::from_millis(750);
 
 pub struct MultiManagerState {
     pub dirty: bool,
@@ -35,6 +36,7 @@ pub struct MultiManagerState {
     binding_save_debounce: Duration,
     pub bindings_dirty_since: Option<Instant>,
     pub last_bindings_save_attempt: Option<Instant>,
+    pub last_live_title_refresh: Option<Instant>,
 }
 
 impl MultiManagerState {
@@ -81,6 +83,7 @@ impl MultiManagerState {
             binding_save_debounce: BINDINGS_SAVE_DEBOUNCE,
             bindings_dirty_since: None,
             last_bindings_save_attempt: None,
+            last_live_title_refresh: None,
         }
     }
 

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -7,6 +7,7 @@ use crate::multi_manager::model::{
 use crate::multi_manager::win;
 use eframe::egui;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 #[derive(Debug, Default)]
 pub struct MultiManagerDialog {
@@ -53,6 +54,7 @@ impl MultiManagerDialog {
         if !self.open {
             return;
         }
+        refresh_live_titles_if_due(app, ctx, false);
         let mut open = self.open;
         egui::Window::new("MultiManager")
             .open(&mut open)
@@ -445,6 +447,44 @@ impl MultiManagerDialog {
             });
         });
     }
+}
+
+fn refresh_live_titles_if_due(app: &mut LauncherApp, ctx: &egui::Context, force: bool) -> bool {
+    let now = Instant::now();
+    let Ok(mut workspaces) = app.multi_manager.workspaces.lock() else {
+        return false;
+    };
+    let changed = refresh_live_titles_throttled_with(
+        &mut workspaces,
+        &mut app.multi_manager.last_live_title_refresh,
+        now,
+        force,
+        crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL,
+        win::is_valid_window,
+        win::window_title,
+    );
+    if changed {
+        ctx.request_repaint();
+    }
+    changed
+}
+
+pub(crate) fn refresh_live_titles_throttled_with(
+    workspaces: &mut [MmWorkspace],
+    last_refresh: &mut Option<Instant>,
+    now: Instant,
+    force: bool,
+    interval: std::time::Duration,
+    is_valid: impl FnMut(usize) -> bool,
+    window_title: impl FnMut(usize) -> Option<String>,
+) -> bool {
+    if !force
+        && last_refresh.is_some_and(|last_refresh| now.duration_since(last_refresh) < interval)
+    {
+        return false;
+    }
+    *last_refresh = Some(now);
+    bindings::refresh_live_titles_with(workspaces, is_valid, window_title)
 }
 
 fn capture_banner_text(action: &PendingCaptureAction) -> &'static str {
@@ -1305,6 +1345,100 @@ mod tests {
                 if err.contains("Missing window row for capture")
         ));
         assert!(workspaces[0].windows.is_empty());
+    }
+
+    #[test]
+    fn throttle_prevents_repeated_title_queries() {
+        let mut workspaces = vec![workspace_with_window(None, None)];
+        let start = Instant::now();
+        let mut last = None;
+        let mut title_queries = 0;
+
+        assert!(refresh_live_titles_throttled_with(
+            &mut workspaces,
+            &mut last,
+            start,
+            false,
+            crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL,
+            |_| true,
+            |_| {
+                title_queries += 1;
+                Some("Live one".into())
+            },
+        ));
+        assert!(!refresh_live_titles_throttled_with(
+            &mut workspaces,
+            &mut last,
+            start + crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL / 2,
+            false,
+            crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL,
+            |_| true,
+            |_| {
+                title_queries += 1;
+                Some("Live two".into())
+            },
+        ));
+
+        assert_eq!(title_queries, 1);
+        assert_eq!(workspaces[0].windows[0].live_title, "Live one");
+        assert_eq!(workspaces[0].windows[0].captured_title, "Title");
+    }
+
+    #[test]
+    fn live_title_refresh_helper_does_not_mark_workspace_or_bindings_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = crate::multi_manager::state::MultiManagerState::load_or_default(
+            &crate::settings::MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state
+            .workspaces
+            .lock()
+            .unwrap()
+            .push(workspace_with_window(None, None));
+        let mut last = None;
+
+        assert!(refresh_live_titles_throttled_with(
+            &mut state.workspaces.lock().unwrap(),
+            &mut last,
+            Instant::now(),
+            false,
+            crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL,
+            |_| true,
+            |_| Some("Runtime only".into()),
+        ));
+
+        assert!(!state.dirty);
+        assert!(!state.bindings_dirty);
+    }
+
+    #[test]
+    fn manual_refresh_bypasses_throttle() {
+        let mut workspaces = vec![workspace_with_window(None, None)];
+        let start = Instant::now();
+        let mut last = Some(start);
+        let mut title_queries = 0;
+
+        assert!(refresh_live_titles_throttled_with(
+            &mut workspaces,
+            &mut last,
+            start,
+            true,
+            crate::multi_manager::state::LIVE_TITLE_REFRESH_INTERVAL,
+            |_| true,
+            |_| {
+                title_queries += 1;
+                Some("Manual live".into())
+            },
+        ));
+
+        assert_eq!(title_queries, 1);
+        assert_eq!(workspaces[0].windows[0].live_title, "Manual live");
+        assert_eq!(workspaces[0].windows[0].captured_title, "Title");
     }
 
     fn workspace_with_window(


### PR DESCRIPTION
### Motivation
- Provide a runtime-only "live title" refresh that updates `MmWindow.live_title` for bound HWNDs without changing `captured_title` or stable metadata and without triggering fallback matching or marking workspace/bindings dirty.
- Avoid enumerating top-level windows from the UI while the dialog is open and throttle frequent live-title checks to limit cost and repaint only when runtime cache changed.
- Allow the existing **Refresh Titles** button to force an immediate live-title update while still avoiding workspace/bindings dirtying.

### Description
- Replaced the previous title refresh with a runtime-only `refresh_live_titles_with` that iterates only bound nonzero HWNDs, calls `is_valid(hwnd)` before `window_title(hwnd)`, updates only `window.live_title`, and returns whether the runtime cache changed (file: `src/multi_manager/bindings.rs`).
- Added throttling state and constant: `LIVE_TITLE_REFRESH_INTERVAL` and `last_live_title_refresh: Option<Instant>` on `MultiManagerState` (file: `src/multi_manager/state.rs`).
- Added UI-side throttled helper `refresh_live_titles_if_due` / `refresh_live_titles_throttled_with` that runs only while the MultiManager dialog is open, queries only currently bound HWNDs, requests repaint when runtime cache changed, and does not enumerate top-level windows (file: `src/multi_manager/ui.rs`).
- Updated the GUI action `multi_manager_refresh_titles` to force an immediate live-title refresh and bypass the throttle timestamp while not marking workspace or bindings dirty (file: `src/gui/multi_manager_actions.rs`).
- Added unit tests covering: `live_title` preservation of `captured_title`, filtering to valid/bound nonzero HWNDs, lack of enumeration/fallback matching, throttle suppression, manual throttle bypass, and that helper refresh does not mark workspace or bindings dirty (files: `src/multi_manager/bindings.rs` and `src/multi_manager/ui.rs`).

### Testing
- Ran formatting and style checks with `rustfmt --edition 2024 --check` on modified files, which succeeded.
- Ran `git diff --check` to validate diffs, which succeeded.
- Attempted `cargo test -q live_title_refresh --lib` to exercise the new unit tests, but test execution was blocked by environment-specific build failures in this Linux CI container (native pkg-config dependencies and unresolved Windows-specific `windows::Win32` imports); as a result the Rust unit tests could not be completed here. The new tests were added and compile/run locally on a representative Windows/dev environment should validate: `live_title_refresh_preserves_aliases_and_captured_title`, `live_title_refresh_only_queries_valid_bound_nonzero_hwnds`, `live_title_refresh_performs_no_enumeration_or_fallback_matching`, `throttle_prevents_repeated_title_queries`, `manual_refresh_bypasses_throttle`, and `live_title_refresh_helper_does_not_mark_workspace_or_bindings_dirty`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c1cf99b4883328fe61b583101ec0e)