### PR TITLE
Fix MultiManager HWND reconnect flows

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -3,6 +3,7 @@ use crate::multi_manager::activation::{self, ActivationOperation, ActivationResu
 use crate::multi_manager::apply_capture::{self, ApplyCaptureResult};
 use crate::multi_manager::bindings;
 use crate::multi_manager::capture;
+use crate::multi_manager::model::MmBindingStatus;
 use crate::multi_manager::model::{PendingCaptureAction, RecaptureQueueItem};
 use crate::multi_manager::runtime::MultiManagerRuntimeEvent;
 use crate::multi_manager::win::{self, CaptureKeyAction, CapturedWindow};
@@ -1001,13 +1002,25 @@ pub(crate) fn build_recapture_queue(
 ) -> Vec<RecaptureQueueItem> {
     workspaces
         .iter()
+        .filter(|workspace| !workspace.disabled)
         .flat_map(|workspace| {
             workspace
                 .windows
                 .iter()
                 .enumerate()
                 .filter(|&(_window_index, window)| {
-                    window.hwnd == 0 || !win::is_valid_window(window.hwnd)
+                    !window.disabled
+                        && (matches!(
+                            window.binding_status,
+                            MmBindingStatus::Missing
+                                | MmBindingStatus::Closed
+                                | MmBindingStatus::Ambiguous
+                                | MmBindingStatus::MetadataMismatch
+                        ) || (window.hwnd == 0 || !win::is_valid_window(window.hwnd))
+                            && !matches!(
+                                window.binding_status,
+                                MmBindingStatus::Bound | MmBindingStatus::Reconnected
+                            ))
                 })
                 .map(|(window_index, _window)| RecaptureQueueItem {
                     workspace_id: workspace.id.clone(),
@@ -1238,6 +1251,60 @@ mod tests {
         assert_eq!(queue.pop_front().unwrap().window_index, 1); // queue advanced
         queue.clear(); // Escape cancels remaining queue
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn recapture_all_includes_unresolved_statuses_and_excludes_bound_reconnected() {
+        use crate::multi_manager::model::MmBindingStatus;
+
+        let mut bound = MmWindow {
+            hwnd: 1,
+            binding_status: MmBindingStatus::Bound,
+            ..Default::default()
+        };
+        bound.valid = true;
+        let mut reconnected = MmWindow {
+            hwnd: 2,
+            binding_status: MmBindingStatus::Reconnected,
+            ..Default::default()
+        };
+        reconnected.valid = true;
+        let unresolved = [
+            MmBindingStatus::Missing,
+            MmBindingStatus::Closed,
+            MmBindingStatus::Ambiguous,
+            MmBindingStatus::MetadataMismatch,
+        ]
+        .into_iter()
+        .map(|status| MmWindow {
+            hwnd: 99,
+            binding_status: status,
+            ..Default::default()
+        });
+        let disabled_unresolved = MmWindow {
+            disabled: true,
+            binding_status: MmBindingStatus::Missing,
+            ..Default::default()
+        };
+        let workspaces = vec![MmWorkspace {
+            id: "w".into(),
+            windows: std::iter::once(bound)
+                .chain(std::iter::once(reconnected))
+                .chain(unresolved)
+                .chain(std::iter::once(disabled_unresolved))
+                .collect(),
+            ..Default::default()
+        }];
+
+        let queue = build_recapture_queue(&workspaces);
+
+        assert_eq!(
+            queue
+                .iter()
+                .map(|item| item.window_index)
+                .collect::<Vec<_>>(),
+            vec![2, 3, 4, 5]
+        );
     }
 
     fn set_workspaces(app: &mut LauncherApp, workspaces: Vec<MmWorkspace>) {

--- a/src/multi_manager/bindings.rs
+++ b/src/multi_manager/bindings.rs
@@ -189,7 +189,11 @@ fn restore_bindings_with_windows(
                 workspace.windows[window_index].mark_reconnected(candidate.hwnd);
                 workspace.windows[window_index].live_title = candidate.title.clone();
             } else if workspace.windows[window_index].hwnd == window_snapshot.hwnd {
-                workspace.windows[window_index].mark_missing();
+                if identity::has_stable_metadata(&saved_window) {
+                    workspace.windows[window_index].mark_metadata_mismatch();
+                } else {
+                    workspace.windows[window_index].mark_missing();
+                }
                 workspace.windows[window_index].live_title.clear();
             }
         }
@@ -450,6 +454,10 @@ mod tests {
 
         assert_eq!(workspaces[0].windows[0].hwnd, 0);
         assert!(!workspaces[0].windows[0].valid);
+        assert_eq!(
+            workspaces[0].windows[0].binding_status,
+            crate::multi_manager::model::MmBindingStatus::MetadataMismatch
+        );
     }
 
     #[test]

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -230,12 +230,8 @@ pub fn reconnect_workspaces_with_deps(
                 }
                 ReconnectOutcome::Closed => {
                     summary.invalidated += 1;
-                    let was_already_invalid = !window.valid;
                     window.mark_closed();
                     window.live_title.clear();
-                    if !was_already_invalid {
-                        continue;
-                    }
                 }
                 ReconnectOutcome::MetadataMismatch => {
                     summary.metadata_mismatch += 1;
@@ -652,6 +648,60 @@ mod tests {
         );
         assert_eq!(summary.already_valid, 1);
         assert_eq!(workspaces[0].windows[0].hwnd, 5);
+    }
+
+    #[test]
+    fn verified_valid_hwnd_is_preserved_without_metadata_even_when_fallback_matches_other_hwnd() {
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 5,
+            binding_verified: true,
+            captured_title: "Doc".into(),
+            executable: "edit.exe".into(),
+            class_name: "Editor".into(),
+            process_path: "C:/Apps/edit.exe".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 5,
+                query_identity: &|_| panic!("verified HWND preservation must only call IsWindow"),
+                enumerate_top_level_windows: &|| {
+                    vec![live(9, "Doc", "edit.exe", "Editor", "C:/Apps/edit.exe")]
+                },
+            },
+        );
+        assert_eq!(summary.already_valid, 1);
+        assert!(!summary.binding_snapshot_changed);
+        assert_eq!(workspaces[0].windows[0].hwnd, 5);
+        assert!(workspaces[0].windows[0].binding_verified);
+    }
+
+    #[test]
+    fn closed_unverified_hwnd_runs_exact_title_fallback() {
+        let candidate = live(42, "Doc", "edit.exe", "Editor", "C:/Apps/edit.exe");
+        let mut workspaces = workspace(MmWindow {
+            hwnd: 5,
+            binding_verified: false,
+            valid: true,
+            captured_title: "Doc".into(),
+            executable: "edit.exe".into(),
+            class_name: "Editor".into(),
+            process_path: "C:/Apps/edit.exe".into(),
+            ..MmWindow::default()
+        });
+        let summary = reconnect_workspaces_with_deps(
+            &mut workspaces,
+            ReconnectDeps {
+                is_window: &|hwnd| hwnd == 42,
+                query_identity: &|_| panic!("closed HWND identity should not be queried"),
+                enumerate_top_level_windows: &|| vec![candidate.clone()],
+            },
+        );
+        assert_eq!(summary.invalidated, 1);
+        assert_eq!(summary.reconnected, 1);
+        assert!(summary.binding_snapshot_changed);
+        assert_eq!(workspaces[0].windows[0].hwnd, 42);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Preserve existing verified HWND bindings by validating them with `IsWindow` only and avoid replacing valid verified HWNDs during reconnect fallback.
- Make snapshot restore conservative by verifying saved HWNDs with stable metadata and explicitly mark `MetadataMismatch` when metadata differs rather than silently rebinding a different HWND.
- Include all unresolved binding statuses in the Recapture All queue while continuing to skip Bound/Reconnected and disabled entries, and keep title refresh focused on `live_title` only.

### Description
- Reworked reconnect logic in `reconnect_workspaces_with_deps` to preserve already-verified HWNDs using only the provided `is_window` check, clear invalid HWNDs immediately, and continue unresolved/closed entries to exact-title fallback via enumeration. (src/multi_manager/reconnect.rs)
- Adjusted restore snapshot flow in `restore_bindings_with_windows` to verify saved HWNDs via stable metadata checks and mark windows as `MetadataMismatch` when metadata mismatches occur instead of treating them as generic missing entries. (src/multi_manager/bindings.rs)
- Updated Recapture All queue builder to iterate only enabled workspaces and include windows with unresolved statuses (`Missing`, `Closed`, `Ambiguous`, `MetadataMismatch`) while excluding `Bound`/`Reconnected` and disabled windows. (src/gui/multi_manager_actions.rs)
- Added unit tests exercising: verified HWND preservation behavior, closed/unverified HWND exact-title fallback, explicit metadata-mismatch marking on restore, and Recapture All queue inclusion/exclusion rules. (tests added in the modified modules)

### Testing
- Ran `rustfmt` and `git diff --check` which succeeded to ensure formatting and basic diff hygiene.
- Attempted `cargo test multi_manager` and targeted test runs, but full test execution failed in this Linux CI environment due to platform-specific native dependencies and unresolved Windows API imports (the crate contains unguarded Windows-targeted code), so the added Windows-targeted unit tests could not be executed here. 
- The changes are covered by new unit tests in the MultiManager modules and should pass on a Windows build or CI that provides the Windows APIs and required native libraries; re-run `cargo test` on a Windows host to verify all tests succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cadf8ec94833292a1ea90525a0965)