### PR TITLE
Add multi-manager binding state regression test

### DIFF
--- a/src/multi_manager/model.rs
+++ b/src/multi_manager/model.rs
@@ -524,6 +524,33 @@ mod tests {
     }
 
     #[test]
+    fn zero_hwnd_binding_helpers_reset_to_missing_state() {
+        let mut bound = MmWindow::default();
+        bound.mark_bound(0);
+        assert_eq!(
+            (
+                bound.valid,
+                bound.hwnd,
+                bound.binding_status,
+                bound.binding_verified
+            ),
+            (false, 0, MmBindingStatus::Missing, false)
+        );
+
+        let mut reconnected = MmWindow::default();
+        reconnected.mark_reconnected(0);
+        assert_eq!(
+            (
+                reconnected.valid,
+                reconnected.hwnd,
+                reconnected.binding_status,
+                reconnected.binding_verified
+            ),
+            (false, 0, MmBindingStatus::Missing, false)
+        );
+    }
+
+    #[test]
     fn activation_helpers_keep_legacy_valid_hwnd_compatibility() {
         let window = MmWindow {
             hwnd: 9,


### PR DESCRIPTION
### Motivation
- Add a regression test to ensure zero-HWND binding helpers reset runtime binding state to a safe "missing" state when `mark_bound(0)` or `mark_reconnected(0)` are called.

### Description
- Added `zero_hwnd_binding_helpers_reset_to_missing_state` in `src/multi_manager/model.rs` which verifies that `mark_bound(0)` and `mark_reconnected(0)` result in `valid == false`, `hwnd == 0`, `binding_status == MmBindingStatus::Missing`, and `binding_verified == false`.

### Testing
- Ran the targeted test with `cargo test --lib multi_manager::model::tests::zero_hwnd_binding_helpers_reset_to_missing_state`, which could not complete in this environment due to a missing system ALSA development package (`alsa.pc`).
- Attempted `cargo test multi_manager --lib`, which was likewise blocked by the missing system ALSA dependency in the build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cb6077f4483328bb6a466746885e8)