### PR TITLE
Remove obsolete MultiManager periodic reconnect settings

### DIFF
--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -2,11 +2,11 @@ use crate::multi_manager::activation::{
     self, ActivationDeps, ActivationOperation, ActivationResult,
 };
 use crate::multi_manager::model::{MmHotkey, MmRect, MmWorkspace};
-use crate::multi_manager::{reconnect, win};
+use crate::multi_manager::win;
 use crate::settings::MultiManagerSettings;
 use anyhow::Result;
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -49,8 +49,6 @@ pub struct RuntimeControl {
     pub enabled: AtomicBool,
     pub capture_pending: AtomicBool,
     pub shutdown: AtomicBool,
-    pub auto_reconnect_missing_windows: AtomicBool,
-    pub auto_reconnect_interval_ms: AtomicU64,
     pub bindings_dirty_signal: Arc<AtomicBool>,
 }
 
@@ -60,8 +58,6 @@ impl RuntimeControl {
             enabled: AtomicBool::new(enabled),
             capture_pending: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
-            auto_reconnect_missing_windows: AtomicBool::new(true),
-            auto_reconnect_interval_ms: AtomicU64::new(3000),
             bindings_dirty_signal: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -112,39 +108,20 @@ impl MultiManagerRuntime {
 
     pub fn start(workspaces: Arc<Mutex<Vec<MmWorkspace>>>, settings: MultiManagerSettings) -> Self {
         let control = Arc::new(RuntimeControl::new(settings.enabled));
-        control
-            .auto_reconnect_missing_windows
-            .store(settings.auto_reconnect_missing_windows, Ordering::Relaxed);
-        control
-            .auto_reconnect_interval_ms
-            .store(settings.auto_reconnect_interval_ms, Ordering::Relaxed);
         let last_hotkey_info = Arc::new(Mutex::new(None));
         let event_queue = Arc::new(Mutex::new(VecDeque::new()));
         let thread_workspaces = Arc::clone(&workspaces);
         let thread_control = Arc::clone(&control);
-        let thread_bindings_dirty_signal = Arc::clone(&control.bindings_dirty_signal);
         let thread_last_hotkey_info = Arc::clone(&last_hotkey_info);
         let thread_event_queue = Arc::clone(&event_queue);
         let poll = Duration::from_millis(settings.hotkey_poll_ms);
-        let reconnect_interval = Duration::from_millis(settings.auto_reconnect_interval_ms);
         let join_handle = thread::spawn(move || {
             let mut debounce = HashMap::new();
-            let mut last_reconnect = Instant::now() - reconnect_interval;
             let win_ops = WinWindowOps;
             let hotkey_ops = WinHotkeyOps;
             while !thread_control.shutdown.load(Ordering::Relaxed) {
                 thread::sleep(poll);
                 let now = Instant::now();
-                if maybe_runtime_reconnect(
-                    &thread_workspaces,
-                    &thread_control,
-                    &mut last_reconnect,
-                    now,
-                    |hwnd| win::is_valid_window(hwnd),
-                    || win::enumerate_top_level_windows().unwrap_or_default(),
-                ) {
-                    thread_bindings_dirty_signal.store(true, Ordering::Relaxed);
-                }
                 if let Ok(mut workspaces) = thread_workspaces.lock() {
                     runtime_tick(
                         &mut workspaces,
@@ -336,61 +313,6 @@ fn hotkey_sequence(hotkey: &MmHotkey) -> Option<String> {
     Some(parts.join("+"))
 }
 
-pub fn maybe_runtime_reconnect(
-    workspaces: &Arc<Mutex<Vec<MmWorkspace>>>,
-    control: &RuntimeControl,
-    last_reconnect: &mut Instant,
-    now: Instant,
-    is_window: impl Fn(usize) -> bool,
-    enumerate: impl FnOnce() -> Vec<win::EnumeratedWindow>,
-) -> bool {
-    let reconnect_interval =
-        Duration::from_millis(control.auto_reconnect_interval_ms.load(Ordering::Relaxed));
-    if !control.enabled.load(Ordering::Relaxed)
-        || !control
-            .auto_reconnect_missing_windows
-            .load(Ordering::Relaxed)
-        || control.capture_pending.load(Ordering::Relaxed)
-        || now.duration_since(*last_reconnect) < reconnect_interval
-    {
-        return false;
-    }
-
-    let Ok(mut workspaces) = workspaces.lock() else {
-        return false;
-    };
-
-    let mut hwnd_changed = false;
-    for window in workspaces
-        .iter_mut()
-        .filter(|workspace| !workspace.disabled)
-        .flat_map(|workspace| &mut workspace.windows)
-        .filter(|window| !window.disabled && window.hwnd != 0)
-    {
-        if is_window(window.hwnd) {
-            continue;
-        }
-        window.mark_closed();
-        hwnd_changed = true;
-    }
-
-    let has_unresolved = workspaces
-        .iter()
-        .filter(|workspace| !workspace.disabled)
-        .flat_map(|workspace| &workspace.windows)
-        .any(|window| !window.disabled && (window.hwnd == 0 || !window.valid));
-
-    if has_unresolved {
-        let live = enumerate();
-        let summary =
-            reconnect::reconnect_unresolved_workspaces_with_windows(&mut workspaces, &live);
-        hwnd_changed |= summary.binding_snapshot_changed;
-    }
-
-    *last_reconnect = now;
-    hwnd_changed
-}
-
 pub fn runtime_tick(
     workspaces: &mut [MmWorkspace],
     control: &RuntimeControl,
@@ -476,7 +398,7 @@ mod tests {
     use super::*;
     use crate::multi_manager::model::{MmHotkey, MmWindow};
     use crate::multi_manager::win::EnumeratedWindow;
-    use std::cell::{Cell, RefCell};
+    use std::cell::RefCell;
 
     fn rect(x: i32) -> MmRect {
         MmRect {
@@ -666,203 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_reconnect_skipped_during_capture() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        workspaces.lock().unwrap()[0].windows[0].hwnd = 0;
-        let control = RuntimeControl::new(true);
-        control.capture_pending.store(true, Ordering::Relaxed);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-        let enumerated = RefCell::new(false);
-
-        let reconnected = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| true,
-            || {
-                *enumerated.borrow_mut() = true;
-                vec![live(10, "anything")]
-            },
-        );
-
-        assert!(!reconnected);
-        assert!(!*enumerated.borrow());
-    }
-
-    #[test]
-    fn runtime_reconnect_does_not_enumerate_when_all_windows_are_valid() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-        let is_window_calls = Cell::new(0);
-        let enumerations = Cell::new(0);
-
-        let reconnected = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| {
-                is_window_calls.set(is_window_calls.get() + 1);
-                true
-            },
-            || {
-                enumerations.set(enumerations.get() + 1);
-                Vec::new()
-            },
-        );
-
-        assert!(!reconnected);
-        assert_eq!(is_window_calls.get(), 2);
-        assert_eq!(enumerations.get(), 0);
-    }
-
-    #[test]
-    fn runtime_reconnect_enumerates_once_when_one_hwnd_is_invalid() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-        let enumerations = Cell::new(0);
-
-        let changed = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |hwnd| hwnd != 1,
-            || {
-                enumerations.set(enumerations.get() + 1);
-                Vec::new()
-            },
-        );
-
-        assert!(changed);
-        assert_eq!(enumerations.get(), 1);
-        assert_eq!(workspaces.lock().unwrap()[0].windows[0].hwnd, 0);
-    }
-
-    #[test]
-    fn runtime_reconnect_clears_closed_hwnd_even_when_previously_valid() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-
-        let changed = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |hwnd| hwnd != 1,
-            || Vec::new(),
-        );
-
-        let locked = workspaces.lock().unwrap();
-        assert!(changed);
-        assert_eq!(locked[0].windows[0].hwnd, 0);
-        assert!(!locked[0].windows[0].valid);
-        assert_eq!(locked[0].windows[1].hwnd, 2);
-        assert!(locked[0].windows[1].valid);
-    }
-
-    #[test]
-    fn runtime_reconnect_leaves_unresolved_window_disconnected_without_affecting_valid_bindings() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        {
-            let mut locked = workspaces.lock().unwrap();
-            locked[0].windows[0].hwnd = 0;
-            locked[0].windows[0].valid = false;
-            locked[0].windows[0].captured_title = "Missing".into();
-        }
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-
-        let changed = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| true,
-            || vec![live(99, "Other")],
-        );
-
-        let locked = workspaces.lock().unwrap();
-        assert!(!changed);
-        assert_eq!(locked[0].windows[0].hwnd, 0);
-        assert!(!locked[0].windows[0].valid);
-        assert_eq!(locked[0].windows[1].hwnd, 2);
-        assert!(locked[0].windows[1].valid);
-    }
-
-    #[test]
-    fn runtime_reconnect_assigns_missing_window_from_unique_candidate() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        {
-            let mut locked = workspaces.lock().unwrap();
-            locked[0].windows[0].hwnd = 0;
-            locked[0].windows[0].captured_title = "Notes".into();
-            locked[0].windows[0].executable = "app.exe".into();
-            locked[0].windows[0].class_name = "AppClass".into();
-            locked[0].windows[0].process_path = "C:/app.exe".into();
-        }
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-
-        let reconnected = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| true,
-            || vec![live(42, "Notes")],
-        );
-
-        assert!(reconnected);
-        assert_eq!(workspaces.lock().unwrap()[0].windows[0].hwnd, 42);
-    }
-
-    #[test]
-    fn runtime_reconnect_runs_when_existing_hwnd_is_stale() {
-        let workspaces = Arc::new(Mutex::new(vec![workspace()]));
-        {
-            let mut locked = workspaces.lock().unwrap();
-            locked[0].windows[0].hwnd = 7;
-            locked[0].windows[0].valid = false;
-            locked[0].windows[0].captured_title = "Notes".into();
-            locked[0].windows[0].executable = "app.exe".into();
-            locked[0].windows[0].class_name = "AppClass".into();
-            locked[0].windows[0].process_path = "C:/app.exe".into();
-        }
-        let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-        let enumerated = RefCell::new(false);
-
-        let reconnected = maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| true,
-            || {
-                *enumerated.borrow_mut() = true;
-                vec![live(42, "Notes")]
-            },
-        );
-
-        assert!(reconnected);
-        assert!(*enumerated.borrow());
-        assert_eq!(workspaces.lock().unwrap()[0].windows[0].hwnd, 42);
-    }
-
-    #[test]
-    fn runtime_hotkey_toggle_works_after_reconnect_assigns_hwnd() {
+    fn runtime_hotkey_toggle_works_with_assigned_hwnd() {
         let workspaces = Arc::new(Mutex::new(vec![workspace()]));
         {
             let mut locked = workspaces.lock().unwrap();
@@ -873,16 +599,7 @@ mod tests {
             locked[0].windows[0].process_path = "C:/app.exe".into();
         }
         let control = RuntimeControl::new(true);
-        let now = Instant::now();
-        let mut last = now - Duration::from_secs(10);
-        assert!(maybe_runtime_reconnect(
-            &workspaces,
-            &control,
-            &mut last,
-            now,
-            |_| true,
-            || vec![live(42, "Notes")],
-        ));
+        workspaces.lock().unwrap()[0].windows[0].hwnd = 42;
 
         let info = Arc::new(Mutex::new(None));
         let mut debounce = HashMap::new();
@@ -899,7 +616,7 @@ mod tests {
             &FakeHotkeyOps(true),
             &|hwnd| hwnd != 0,
             &|| Vec::new(),
-            now + Duration::from_secs(1),
+            Instant::now(),
         );
 
         assert_eq!(*ops.moves.borrow(), vec![(42, rect(11))]);

--- a/src/multi_manager/settings.rs
+++ b/src/multi_manager/settings.rs
@@ -40,8 +40,6 @@ mod tests {
             show_force_recapture_prompt: true,
             hotkey_poll_ms: 250,
             auto_reconnect_on_load: false,
-            auto_reconnect_missing_windows: false,
-            auto_reconnect_interval_ms: 10_000,
             hide_launcher_before_toggle: true,
             ignore_launcher_window_on_capture: false,
         };

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -28,8 +28,6 @@ pub struct MultiManagerState {
     pub bindings_path: PathBuf,
     pub auto_save: bool,
     pub auto_reconnect_on_load: bool,
-    pub auto_reconnect_missing_windows: bool,
-    pub reconnect_interval: Duration,
     save_debounce: Duration,
     dirty_since: Option<Instant>,
     last_save_attempt: Option<Instant>,
@@ -50,7 +48,6 @@ impl MultiManagerState {
         // Startup always attempts to restore saved HWND binding snapshots first.
         // `auto_reconnect_on_load` only controls the exact-title fallback for windows
         // that snapshot restore could not resolve during startup/reload.
-        // `auto_reconnect_missing_windows` controls the runtime's periodic reconnect loop.
         let loaded = prepare_workspaces_for_startup(
             store::load_or_default(&workspace_path),
             &bindings_path,
@@ -75,8 +72,6 @@ impl MultiManagerState {
             bindings_path,
             auto_save: settings.auto_save,
             auto_reconnect_on_load: settings.auto_reconnect_on_load,
-            auto_reconnect_missing_windows: settings.auto_reconnect_missing_windows,
-            reconnect_interval: Duration::from_millis(settings.auto_reconnect_interval_ms),
             save_debounce: AUTO_SAVE_DEBOUNCE,
             dirty_since: None,
             last_save_attempt: None,

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -630,20 +630,6 @@ impl MultiManagerSettingsDialog {
                     .changed();
                 changed |= ui
                     .checkbox(
-                        &mut s.auto_reconnect_missing_windows,
-                        "Auto-reconnect missing windows while running",
-                    )
-                    .changed();
-                changed |= ui
-                    .add(
-                        egui::DragValue::new(&mut s.auto_reconnect_interval_ms)
-                            .clamp_range(500..=60000)
-                            .prefix("Auto-reconnect interval ")
-                            .suffix(" ms"),
-                    )
-                    .changed();
-                changed |= ui
-                    .checkbox(
                         &mut s.ignore_launcher_window_on_capture,
                         "Ignore launcher window on capture",
                     )
@@ -658,18 +644,8 @@ impl MultiManagerSettingsDialog {
                     app.multi_manager_settings = s.clone();
                     app.multi_manager.auto_save = s.auto_save;
                     app.multi_manager.auto_reconnect_on_load = s.auto_reconnect_on_load;
-                    app.multi_manager.auto_reconnect_missing_windows =
-                        s.auto_reconnect_missing_windows;
-                    app.multi_manager.reconnect_interval =
-                        std::time::Duration::from_millis(s.auto_reconnect_interval_ms);
                     let control = &app.multi_manager.runtime.control;
                     control.enabled.store(s.enabled, Ordering::Relaxed);
-                    control
-                        .auto_reconnect_missing_windows
-                        .store(s.auto_reconnect_missing_windows, Ordering::Relaxed);
-                    control
-                        .auto_reconnect_interval_ms
-                        .store(s.auto_reconnect_interval_ms, Ordering::Relaxed);
                 }
                 ui.separator();
                 if ui.button("Save MultiManager Settings").clicked() {

--- a/src/settings/defaults.rs
+++ b/src/settings/defaults.rs
@@ -115,6 +115,3 @@ pub fn default_multi_manager_bindings_path() -> String {
 pub fn default_multi_manager_hotkey_poll_ms() -> u64 {
     50
 }
-pub fn default_multi_manager_reconnect_interval_ms() -> u64 {
-    3000
-}

--- a/src/settings/model.rs
+++ b/src/settings/model.rs
@@ -373,10 +373,6 @@ pub struct MultiManagerSettings {
     pub hotkey_poll_ms: u64,
     #[serde(default = "default_true")]
     pub auto_reconnect_on_load: bool,
-    #[serde(default = "default_true")]
-    pub auto_reconnect_missing_windows: bool,
-    #[serde(default = "default_multi_manager_reconnect_interval_ms")]
-    pub auto_reconnect_interval_ms: u64,
     #[serde(default)]
     pub hide_launcher_before_toggle: bool,
     #[serde(default = "default_true")]
@@ -395,8 +391,6 @@ impl Default for MultiManagerSettings {
             show_force_recapture_prompt: false,
             hotkey_poll_ms: default_multi_manager_hotkey_poll_ms(),
             auto_reconnect_on_load: true,
-            auto_reconnect_missing_windows: true,
-            auto_reconnect_interval_ms: default_multi_manager_reconnect_interval_ms(),
             hide_launcher_before_toggle: false,
             ignore_launcher_window_on_capture: true,
         }
@@ -772,18 +766,23 @@ mod tests {
     }
 
     #[test]
-    fn multi_manager_reconnect_settings_round_trip_serialization() {
+    fn multi_manager_auto_reconnect_on_load_defaults_true() {
+        let parsed: Settings = serde_json::from_str("{}").expect("settings should deserialize");
+        assert!(parsed.multi_manager.auto_reconnect_on_load);
+    }
+
+    #[test]
+    fn multi_manager_auto_reconnect_on_load_round_trip_serialization() {
         let mut settings = Settings::default();
         settings.multi_manager.auto_reconnect_on_load = false;
-        settings.multi_manager.auto_reconnect_missing_windows = false;
-        settings.multi_manager.auto_reconnect_interval_ms = 7500;
         let json = serde_json::to_string(&settings).expect("serialize settings");
         let restored: Settings = serde_json::from_str(&json).expect("deserialize settings");
+        assert!(!restored.multi_manager.auto_reconnect_on_load);
         assert_eq!(restored.multi_manager, settings.multi_manager);
     }
 
     #[test]
-    fn old_multi_manager_settings_default_reconnect_fields() {
+    fn old_multi_manager_settings_with_periodic_reconnect_fields_deserializes() {
         let parsed: Settings = serde_json::from_str(
             r#"{
                 "multi_manager": {
@@ -792,6 +791,8 @@ mod tests {
                     "bindings_path": "legacy_bindings.json",
                     "auto_save": false,
                     "save_on_exit": false,
+                    "auto_reconnect_missing_windows": false,
+                    "auto_reconnect_interval_ms": 7500,
                     "developer_debugging": true,
                     "show_force_recapture_prompt": true,
                     "hotkey_poll_ms": 100,
@@ -803,8 +804,14 @@ mod tests {
         .expect("legacy settings should deserialize");
 
         assert!(parsed.multi_manager.auto_reconnect_on_load);
-        assert!(parsed.multi_manager.auto_reconnect_missing_windows);
-        assert_eq!(parsed.multi_manager.auto_reconnect_interval_ms, 3000);
+
+        let reserialized = serde_json::to_value(&parsed).expect("serialize parsed settings");
+        let multi_manager = reserialized
+            .get("multi_manager")
+            .and_then(serde_json::Value::as_object)
+            .expect("multi_manager object");
+        assert!(!multi_manager.contains_key("auto_reconnect_missing_windows"));
+        assert!(!multi_manager.contains_key("auto_reconnect_interval_ms"));
     }
 
     #[test]
@@ -846,8 +853,6 @@ mod tests {
                 "show_force_recapture_prompt": parsed.multi_manager.show_force_recapture_prompt,
                 "hotkey_poll_ms": parsed.multi_manager.hotkey_poll_ms,
                 "auto_reconnect_on_load": parsed.multi_manager.auto_reconnect_on_load,
-                "auto_reconnect_missing_windows": parsed.multi_manager.auto_reconnect_missing_windows,
-                "auto_reconnect_interval_ms": parsed.multi_manager.auto_reconnect_interval_ms,
                 "hide_launcher_before_toggle": parsed.multi_manager.hide_launcher_before_toggle,
                 "ignore_launcher_window_on_capture": parsed.multi_manager.ignore_launcher_window_on_capture,
             },
@@ -861,7 +866,7 @@ mod tests {
         });
         assert_eq!(
             serde_json::to_string_pretty(&snapshot).unwrap(),
-            "{\n  \"multi_manager\": {\n    \"auto_reconnect_interval_ms\": 3000,\n    \"auto_reconnect_missing_windows\": true,\n    \"auto_reconnect_on_load\": true,\n    \"auto_save\": true,\n    \"bindings_path\": \"multi_manager_bindings.json\",\n    \"developer_debugging\": false,\n    \"enabled\": true,\n    \"hide_launcher_before_toggle\": false,\n    \"hotkey_poll_ms\": 50,\n    \"ignore_launcher_window_on_capture\": true,\n    \"save_on_exit\": true,\n    \"show_force_recapture_prompt\": false,\n    \"workspaces_path\": \"multi_manager_workspaces.json\"\n  },\n  \"note_show_details\": false,\n  \"query_results_layout\": {\n    \"cols\": 2,\n    \"enabled\": false,\n    \"plugin_opt_out\": [],\n    \"respect_plugin_capability\": true,\n    \"rows\": 3\n  },\n  \"show_error_toasts\": true,\n  \"show_inline_errors\": true\n}"
+            "{\n  \"multi_manager\": {\n    \"auto_reconnect_on_load\": true,\n    \"auto_save\": true,\n    \"bindings_path\": \"multi_manager_bindings.json\",\n    \"developer_debugging\": false,\n    \"enabled\": true,\n    \"hide_launcher_before_toggle\": false,\n    \"hotkey_poll_ms\": 50,\n    \"ignore_launcher_window_on_capture\": true,\n    \"save_on_exit\": true,\n    \"show_force_recapture_prompt\": false,\n    \"workspaces_path\": \"multi_manager_workspaces.json\"\n  },\n  \"note_show_details\": false,\n  \"query_results_layout\": {\n    \"cols\": 2,\n    \"enabled\": false,\n    \"plugin_opt_out\": [],\n    \"respect_plugin_capability\": true,\n    \"rows\": 3\n  },\n  \"show_error_toasts\": true,\n  \"show_inline_errors\": true\n}"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Remove the periodic runtime reconnect configuration and state to simplify MultiManager behaviour while preserving the initial startup fallback controlled by `auto_reconnect_on_load`.
- Keep `auto_reconnect_on_load` enabled by default so startup reconnect behaviour is unchanged.
- Ensure backward compatibility so older settings JSON that contains the removed fields still deserializes cleanly and reserializes without the obsolete keys.

### Description
- Remove `auto_reconnect_missing_windows` and `auto_reconnect_interval_ms` from `MultiManagerSettings` and drop `default_multi_manager_reconnect_interval_ms` from `src/settings/defaults.rs`.
- Remove periodic reconnect state and derived fields from `src/multi_manager/state.rs` and remove runtime atomics/control updates and the `maybe_runtime_reconnect` control path from `src/multi_manager/runtime.rs`.
- Remove the UI controls for the periodic reconnect options from `src/multi_manager/ui.rs` and stop applying them to runtime control/state.
- Update `Default` implementations, `src/multi_manager/settings.rs` test helpers, and settings round-trip / snapshot tests in `src/settings/model.rs` so reserialized settings only include `"auto_reconnect_on_load": true` (and omit the removed fields), and add tests to ensure legacy JSON still deserializes.

### Testing
- Ran repository checks with `rg` and `git diff --check` to validate references to the removed identifiers and to ensure no leftover references remained, and those checks passed.
- Updated/added unit tests: `multi_manager_auto_reconnect_on_load_defaults_true`, `multi_manager_auto_reconnect_on_load_round_trip_serialization`, and `old_multi_manager_settings_with_periodic_reconnect_fields_deserializes` (these tests assert the default for `auto_reconnect_on_load`, round-trip serialization, legacy JSON deserialization, and that reserialized JSON omits the obsolete keys).
- Attempted to run `cargo test settings::model::tests::multi_manager --lib` and `cargo fmt --check` in this environment; `rg`/static checks passed but the `cargo test` and `cargo fmt` runs failed due to platform-specific build issues in this Linux CI (missing platform system libs and Windows Win32 surface when compiling platform-specific code), not due to the settings changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cc2a06dac8332bc89ecbb8d7203c2)