### PR TITLE
Remove timed MultiManager reconnect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,8 +652,6 @@ MultiManager paths can be customized under the `multi_manager` settings object:
     "auto_save": true,
     "save_on_exit": true,
     "auto_reconnect_on_load": true,
-    "auto_reconnect_missing_windows": true,
-    "auto_reconnect_interval_ms": 3000,
     "ignore_launcher_window_on_capture": true
   }
 }

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -32,10 +32,6 @@ impl LauncherApp {
                         result,
                     );
                 }
-                MultiManagerRuntimeEvent::BindingReconnected { .. } => {
-                    // The completed action event carries the same activation summary; avoid
-                    // duplicate toasts while still preserving this structured runtime event.
-                }
                 MultiManagerRuntimeEvent::MovementFailed {
                     workspace_id,
                     errors,

--- a/src/multi_manager/reconnect.rs
+++ b/src/multi_manager/reconnect.rs
@@ -355,13 +355,6 @@ pub fn reconnect_unresolved_workspaces_with_windows(
     summary
 }
 
-pub fn needs_reconnect(workspaces: &[MmWorkspace]) -> bool {
-    workspaces
-        .iter()
-        .flat_map(|workspace| &workspace.windows)
-        .any(|window| window.hwnd == 0 || !window.valid)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -70,10 +70,6 @@ pub enum MultiManagerRuntimeEvent {
         operation: ActivationOperation,
         result: ActivationResult,
     },
-    BindingReconnected {
-        workspace_id: String,
-        result: ActivationResult,
-    },
     MovementFailed {
         workspace_id: String,
         errors: Vec<String>,
@@ -380,12 +376,6 @@ fn push_runtime_activation_events(
     let Ok(mut events) = event_queue.lock() else {
         return;
     };
-    if result.reconnected > 0 {
-        events.push_back(MultiManagerRuntimeEvent::BindingReconnected {
-            workspace_id: workspace_id.clone(),
-            result: result.clone(),
-        });
-    }
     events.push_back(MultiManagerRuntimeEvent::WorkspaceActionCompleted {
         workspace_id,
         operation,
@@ -398,7 +388,7 @@ mod tests {
     use super::*;
     use crate::multi_manager::model::{MmHotkey, MmWindow};
     use crate::multi_manager::win::EnumeratedWindow;
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
 
     fn rect(x: i32) -> MmRect {
         MmRect {
@@ -585,6 +575,43 @@ mod tests {
         );
         assert!(ops.moves.borrow().is_empty());
         assert!(info.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn repeated_runtime_ticks_do_not_periodically_reconnect_unresolved_windows() {
+        let mut workspaces = vec![workspace()];
+        workspaces[0].windows = vec![window(0, false, rect(1), rect(11))];
+        workspaces[0].windows[0].captured_title = "Notes".into();
+        let control = RuntimeControl::new(true);
+        let info = Arc::new(Mutex::new(None));
+        let events = event_queue();
+        let mut debounce = HashMap::new();
+        let ops = FakeWindowOps::default();
+        let enumerations = Cell::new(0);
+        let now = Instant::now();
+
+        for offset_ms in [0, 500, 1_000, 5_000, 10_000, 60_000] {
+            runtime_tick(
+                &mut workspaces,
+                &control,
+                &info,
+                &events,
+                &mut debounce,
+                DEFAULT_DEBOUNCE,
+                &ops,
+                &FakeHotkeyOps(false),
+                &|hwnd| hwnd == 42,
+                &|| {
+                    enumerations.set(enumerations.get() + 1);
+                    vec![live(42, "Notes")]
+                },
+                now + Duration::from_millis(offset_ms),
+            );
+        }
+
+        assert_eq!(workspaces[0].windows[0].hwnd, 0);
+        assert!(events.lock().unwrap().is_empty());
+        assert_eq!(enumerations.get(), 0);
     }
 
     #[test]

--- a/src/settings/model.rs
+++ b/src/settings/model.rs
@@ -782,39 +782,6 @@ mod tests {
     }
 
     #[test]
-    fn old_multi_manager_settings_with_periodic_reconnect_fields_deserializes() {
-        let parsed: Settings = serde_json::from_str(
-            r#"{
-                "multi_manager": {
-                    "enabled": true,
-                    "workspaces_path": "legacy_workspaces.json",
-                    "bindings_path": "legacy_bindings.json",
-                    "auto_save": false,
-                    "save_on_exit": false,
-                    "auto_reconnect_missing_windows": false,
-                    "auto_reconnect_interval_ms": 7500,
-                    "developer_debugging": true,
-                    "show_force_recapture_prompt": true,
-                    "hotkey_poll_ms": 100,
-                    "hide_launcher_before_toggle": true,
-                    "ignore_launcher_window_on_capture": false
-                }
-            }"#,
-        )
-        .expect("legacy settings should deserialize");
-
-        assert!(parsed.multi_manager.auto_reconnect_on_load);
-
-        let reserialized = serde_json::to_value(&parsed).expect("serialize parsed settings");
-        let multi_manager = reserialized
-            .get("multi_manager")
-            .and_then(serde_json::Value::as_object)
-            .expect("multi_manager object");
-        assert!(!multi_manager.contains_key("auto_reconnect_missing_windows"));
-        assert!(!multi_manager.contains_key("auto_reconnect_interval_ms"));
-    }
-
-    #[test]
     fn query_results_layout_defaults_are_backward_compatible() {
         let parsed: Settings = serde_json::from_str("{}").expect("settings should deserialize");
         assert_eq!(


### PR DESCRIPTION
### Motivation
- Remove the periodic/timed runtime reconnect path that triggered window reconnect attempts from the runtime loop and simplify runtime event flow. 
- Avoid emitting runtime-only reconnect events and avoid dirty-binding signals caused solely by elapsed-time reconnect attempts. 
- Add a deterministic regression test to prevent future regressions where repeated runtime ticks could trigger periodic reconnect behavior.

### Description
- Removed the `BindingReconnected` runtime event and the runtime code path that enqueued it so activation now only emits `WorkspaceActionCompleted` with its `ActivationResult`. 
- Deleted the unused `needs_reconnect` helper from `src/multi_manager/reconnect.rs` and removed periodic reconnect references from documentation. 
- Updated GUI runtime event processing in `src/gui/multi_manager_actions.rs` to stop matching `BindingReconnected` while preserving handling of `WorkspaceActionCompleted` dirty-binding side effects. 
- Added a runtime regression test `repeated_runtime_ticks_do_not_periodically_reconnect_unresolved_windows` in `src/multi_manager/runtime.rs` that simulates repeated ticks with unresolved windows and asserts that no HWND is assigned, no reconnect event is emitted, and no enumeration callback is invoked. 
- Removed an obsolete test and README entries related to periodic reconnect settings to reflect the removal of the timed reconnect feature.

### Testing
- Added unit test `repeated_runtime_ticks_do_not_periodically_reconnect_unresolved_windows` under `src/multi_manager/runtime.rs`; this test is present but was not executed to completion in this environment. 
- Attempted to run `cargo test multi_manager::runtime`, but the run failed to complete in the current Linux CI environment due to platform-specific Windows bindings (`windows::Win32` / `windows::core`) that prevent the crate from compiling for this target, so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cc95bd2e48332bfb001d4777ac33f)