### PR TITLE
Add async MultiManager reconnect lifecycle

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -6,11 +6,13 @@ use crate::multi_manager::capture;
 use crate::multi_manager::model::MmBindingStatus;
 use crate::multi_manager::model::{PendingCaptureAction, RecaptureQueueItem};
 use crate::multi_manager::runtime::MultiManagerRuntimeEvent;
+use crate::multi_manager::state::{ReconnectStartResult, ReconnectTrigger};
 use crate::multi_manager::win::{self, CaptureKeyAction, CapturedWindow};
 use std::sync::atomic::Ordering;
 
 impl LauncherApp {
     pub(crate) fn multi_manager_drain_runtime_events(&mut self) {
+        self.multi_manager.reap_reconnect_worker();
         let events = if let Ok(mut queue) = self.multi_manager.runtime.event_queue.lock() {
             queue.drain(..).collect::<Vec<_>>()
         } else {
@@ -54,6 +56,18 @@ impl LauncherApp {
                     self.report_error_message(
                         "multi_manager.runtime",
                         format!("Failed to enumerate MultiManager windows for {context}: {error}"),
+                    );
+                }
+                MultiManagerRuntimeEvent::ReconnectCompleted { summary, .. } => {
+                    if summary.binding_snapshot_changed {
+                        self.multi_manager.mark_bindings_dirty();
+                    }
+                    self.add_success_toast(format_reconnect_summary(summary));
+                }
+                MultiManagerRuntimeEvent::ReconnectFailed { error, .. } => {
+                    self.report_error_message(
+                        "multi_manager.reconnect",
+                        format!("Failed to reconnect MultiManager windows: {error}"),
                     );
                 }
             }
@@ -116,30 +130,23 @@ impl LauncherApp {
     }
 
     pub fn multi_manager_reconnect_windows(&mut self) {
-        let reconnect_result = self
-            .multi_manager
-            .workspaces
-            .lock()
-            .map(|mut workspaces| {
-                crate::multi_manager::reconnect::reconnect_workspaces(&mut workspaces)
-            })
-            .map_err(|_| ());
-
-        let summary = match reconnect_result {
-            Ok(summary) => summary,
-            Err(()) => {
+        match self.multi_manager.start_reconnect(ReconnectTrigger::Manual) {
+            ReconnectStartResult::Started => {
+                self.add_success_toast("Started MultiManager window reconnect".to_string());
+            }
+            ReconnectStartResult::AlreadyRunning => {
+                self.report_error_message(
+                    "multi_manager.reconnect",
+                    "A MultiManager reconnect is already running",
+                );
+            }
+            ReconnectStartResult::SnapshotLockFailed => {
                 self.report_error_message(
                     "multi_manager.reconnect",
                     "Failed to lock MultiManager workspaces to reconnect windows",
                 );
-                return;
             }
-        };
-
-        if summary.binding_snapshot_changed {
-            self.multi_manager.mark_bindings_dirty();
         }
-        self.add_success_toast(format_reconnect_summary(summary));
     }
 
     pub fn multi_manager_start_recapture_all(&mut self) {

--- a/src/multi_manager/runtime.rs
+++ b/src/multi_manager/runtime.rs
@@ -2,6 +2,8 @@ use crate::multi_manager::activation::{
     self, ActivationDeps, ActivationOperation, ActivationResult,
 };
 use crate::multi_manager::model::{MmHotkey, MmRect, MmWorkspace};
+use crate::multi_manager::reconnect::ReconnectSummary;
+use crate::multi_manager::state::ReconnectTrigger;
 use crate::multi_manager::win;
 use crate::settings::MultiManagerSettings;
 use anyhow::Result;
@@ -79,6 +81,14 @@ pub enum MultiManagerRuntimeEvent {
     },
     EnumerationFailed {
         context: String,
+        error: String,
+    },
+    ReconnectCompleted {
+        trigger: ReconnectTrigger,
+        summary: ReconnectSummary,
+    },
+    ReconnectFailed {
+        trigger: ReconnectTrigger,
         error: String,
     },
 }

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -568,6 +568,7 @@ mod tests {
         let state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -686,6 +687,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -728,6 +730,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -743,6 +746,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -757,6 +761,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -773,6 +778,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -794,6 +800,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -814,6 +821,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -839,6 +847,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -865,6 +874,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -886,6 +896,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -906,6 +917,7 @@ mod tests {
         let mut state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),
@@ -926,6 +938,7 @@ mod tests {
         let state = MultiManagerState::load_or_default(
             &MultiManagerSettings {
                 enabled: false,
+                auto_reconnect_on_load: false,
                 ..Default::default()
             },
             settings_path.to_str().unwrap(),

--- a/src/multi_manager/state.rs
+++ b/src/multi_manager/state.rs
@@ -1,17 +1,43 @@
 use crate::multi_manager::model::{MmWorkspace, PendingCaptureAction, RecaptureQueueItem};
-use crate::multi_manager::runtime::MultiManagerRuntime;
+use crate::multi_manager::runtime::{MultiManagerRuntime, MultiManagerRuntimeEvent};
 use crate::multi_manager::{bindings, reconnect, store, win};
 use crate::settings::MultiManagerSettings;
 use anyhow::{Context, Result};
 use std::collections::VecDeque;
+use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, TryLockError};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 const AUTO_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 const BINDINGS_SAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 pub const LIVE_TITLE_REFRESH_INTERVAL: Duration = Duration::from_millis(750);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconnectTrigger {
+    Startup,
+    Reload,
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconnectStartResult {
+    Started,
+    AlreadyRunning,
+    SnapshotLockFailed,
+}
+
+struct ReconnectInProgressGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl Drop for ReconnectInProgressGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
+}
 
 pub struct MultiManagerState {
     pub dirty: bool,
@@ -35,6 +61,10 @@ pub struct MultiManagerState {
     pub bindings_dirty_since: Option<Instant>,
     pub last_bindings_save_attempt: Option<Instant>,
     pub last_live_title_refresh: Option<Instant>,
+    pub reconnect_in_progress: Arc<AtomicBool>,
+    pub reconnect_job: Option<JoinHandle<()>>,
+    pub pending_automatic_reconnect: bool,
+    pub shutdown_started: bool,
 }
 
 impl MultiManagerState {
@@ -57,7 +87,7 @@ impl MultiManagerState {
         let runtime = start_runtime_after_restore(Arc::clone(&workspaces), settings);
         let last_hotkey_info = Arc::clone(&runtime.last_hotkey_info);
 
-        Self {
+        let mut state = Self {
             dirty: false,
             bindings_dirty: false,
             pending_capture: None,
@@ -79,7 +109,15 @@ impl MultiManagerState {
             bindings_dirty_since: None,
             last_bindings_save_attempt: None,
             last_live_title_refresh: None,
+            reconnect_in_progress: Arc::new(AtomicBool::new(false)),
+            reconnect_job: None,
+            pending_automatic_reconnect: false,
+            shutdown_started: false,
+        };
+        if settings.auto_reconnect_on_load {
+            let _ = state.start_reconnect(ReconnectTrigger::Startup);
         }
+        state
     }
 
     pub fn save(&mut self) -> Result<()> {
@@ -122,16 +160,14 @@ impl MultiManagerState {
 
     pub fn reload(&mut self) -> Result<()> {
         let mut loaded = store::load_workspaces(&self.workspace_path)?;
-        restore_and_optionally_reconnect(
-            &mut loaded,
-            &self.bindings_path,
-            self.auto_reconnect_on_load,
-        );
-        let mut workspaces = self
-            .workspaces
-            .lock()
-            .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))?;
-        *workspaces = loaded;
+        restore_bindings_for_load(&mut loaded, &self.bindings_path);
+        {
+            let mut workspaces = self
+                .workspaces
+                .lock()
+                .map_err(|_| anyhow::anyhow!("MultiManager workspace lock poisoned"))?;
+            *workspaces = loaded;
+        }
         self.dirty = false;
         self.dirty_since = None;
         self.bindings_dirty = false;
@@ -140,7 +176,98 @@ impl MultiManagerState {
             .control
             .bindings_dirty_signal
             .store(false, Ordering::Relaxed);
+        if self.auto_reconnect_on_load {
+            let _ = self.start_reconnect(ReconnectTrigger::Reload);
+        }
         Ok(())
+    }
+
+    pub fn start_reconnect(&mut self, trigger: ReconnectTrigger) -> ReconnectStartResult {
+        self.reap_reconnect_worker();
+        if self.shutdown_started || self.runtime.control.shutdown.load(Ordering::Acquire) {
+            return ReconnectStartResult::AlreadyRunning;
+        }
+        if self
+            .reconnect_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            if trigger != ReconnectTrigger::Manual {
+                self.pending_automatic_reconnect = true;
+            }
+            return ReconnectStartResult::AlreadyRunning;
+        }
+        match self.workspaces.try_lock() {
+            Ok(_) => {}
+            Err(TryLockError::Poisoned(_)) | Err(TryLockError::WouldBlock) => {
+                self.reconnect_in_progress.store(false, Ordering::Release);
+                return ReconnectStartResult::SnapshotLockFailed;
+            }
+        }
+        let workspaces = Arc::clone(&self.workspaces);
+        let events = Arc::clone(&self.runtime.event_queue);
+        let bindings_dirty = Arc::clone(&self.runtime.control.bindings_dirty_signal);
+        let in_progress = Arc::clone(&self.reconnect_in_progress);
+        self.reconnect_job = Some(thread::spawn(move || {
+            let _guard = ReconnectInProgressGuard { flag: in_progress };
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let snapshot = {
+                    let guard = workspaces.lock().map_err(|_| {
+                        "workspace lock poisoned during reconnect snapshot".to_string()
+                    })?;
+                    reconnect::collect_reconnect_snapshot(&guard)
+                };
+                let is_window = |hwnd| win::is_valid_window(hwnd);
+                let query_identity = |hwnd| Some(win::query_hwnd_identity(hwnd));
+                let enumerate = || win::enumerate_top_level_windows().unwrap_or_default();
+                let (_worker_summary, patches) = reconnect::build_reconnect_patches(
+                    &snapshot,
+                    reconnect::ReconnectDeps {
+                        is_window: &is_window,
+                        query_identity: &query_identity,
+                        enumerate_top_level_windows: &enumerate,
+                    },
+                );
+                let mut guard = workspaces
+                    .lock()
+                    .map_err(|_| "workspace lock poisoned during reconnect apply".to_string())?;
+                let summary = reconnect::apply_reconnect_patches(&mut guard, &patches);
+                if summary.binding_snapshot_changed {
+                    bindings_dirty.store(true, Ordering::Relaxed);
+                }
+                Ok::<_, String>(summary)
+            }));
+            let event = match result {
+                Ok(Ok(summary)) => {
+                    MultiManagerRuntimeEvent::ReconnectCompleted { trigger, summary }
+                }
+                Ok(Err(error)) => MultiManagerRuntimeEvent::ReconnectFailed { trigger, error },
+                Err(_) => MultiManagerRuntimeEvent::ReconnectFailed {
+                    trigger,
+                    error: "reconnect worker panicked".to_string(),
+                },
+            };
+            if let Ok(mut queue) = events.lock() {
+                queue.push_back(event);
+            }
+        }));
+        ReconnectStartResult::Started
+    }
+
+    pub fn reap_reconnect_worker(&mut self) {
+        if self
+            .reconnect_job
+            .as_ref()
+            .is_some_and(|job| job.is_finished())
+        {
+            if let Some(job) = self.reconnect_job.take() {
+                let _ = job.join();
+            }
+            if self.pending_automatic_reconnect && !self.shutdown_started {
+                self.pending_automatic_reconnect = false;
+                let _ = self.start_reconnect(ReconnectTrigger::Reload);
+            }
+        }
     }
 
     pub fn mark_dirty(&mut self) {
@@ -251,9 +378,14 @@ impl MultiManagerState {
     }
 
     pub fn shutdown(&mut self) {
+        self.shutdown_started = true;
+        self.pending_automatic_reconnect = false;
         self.capture_session = None;
         self.pending_capture = None;
         self.queued_capture = None;
+        if let Some(job) = self.reconnect_job.take() {
+            let _ = job.join();
+        }
         self.runtime.shutdown();
     }
 
@@ -319,17 +451,13 @@ fn capture_action_target(action: &PendingCaptureAction) -> (&str, Option<usize>)
 fn prepare_workspaces_for_startup(
     mut workspaces: Vec<MmWorkspace>,
     bindings_path: &Path,
-    auto_reconnect_on_load: bool,
+    _auto_reconnect_on_load: bool,
 ) -> Vec<MmWorkspace> {
-    restore_and_optionally_reconnect(&mut workspaces, bindings_path, auto_reconnect_on_load);
+    restore_bindings_for_load(&mut workspaces, bindings_path);
     workspaces
 }
 
-fn restore_and_optionally_reconnect(
-    workspaces: &mut [MmWorkspace],
-    bindings_path: &Path,
-    auto_reconnect_on_load: bool,
-) {
+fn restore_bindings_for_load(workspaces: &mut [MmWorkspace], bindings_path: &Path) {
     let snapshots_loaded = match bindings::load_bindings_if_exists(bindings_path) {
         Ok(Some(snapshots)) => {
             bindings::restore_bindings(workspaces, &snapshots);
@@ -345,10 +473,7 @@ fn restore_and_optionally_reconnect(
         }
     };
 
-    if snapshots_loaded && auto_reconnect_on_load {
-        let live = win::enumerate_top_level_windows().unwrap_or_default();
-        reconnect::reconnect_unresolved_workspaces_with_windows(workspaces, &live);
-    }
+    let _ = snapshots_loaded;
 }
 
 fn start_runtime_after_restore(
@@ -660,6 +785,138 @@ mod tests {
         state.maybe_auto_save_bindings();
         assert!(state.bindings_dirty);
         assert!(!state.dirty);
+    }
+
+    #[test]
+    fn only_one_reconnect_job_can_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.reconnect_in_progress.store(true, Ordering::Relaxed);
+
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::AlreadyRunning
+        );
+        assert!(state.reconnect_job.is_none());
+    }
+
+    #[test]
+    fn concurrent_automatic_reconnect_keeps_one_pending_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.reconnect_in_progress.store(true, Ordering::Relaxed);
+
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Reload),
+            ReconnectStartResult::AlreadyRunning
+        );
+        assert!(state.pending_automatic_reconnect);
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Startup),
+            ReconnectStartResult::AlreadyRunning
+        );
+        assert!(state.pending_automatic_reconnect);
+    }
+
+    #[test]
+    fn failed_manual_reconnect_can_be_retried_successfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        let workspaces = Arc::clone(&state.workspaces);
+        let held = workspaces.lock().unwrap();
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::SnapshotLockFailed
+        );
+        drop(held);
+
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::Started
+        );
+        state.shutdown();
+    }
+
+    #[test]
+    fn in_progress_flag_resets_on_snapshot_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        let workspaces = Arc::clone(&state.workspaces);
+        let held = workspaces.lock().unwrap();
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::SnapshotLockFailed
+        );
+        assert!(!state.reconnect_in_progress.load(Ordering::Relaxed));
+        drop(held);
+    }
+
+    #[test]
+    fn reconnect_worker_is_joined_by_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::Started
+        );
+        state.shutdown();
+        assert!(state.reconnect_job.is_none());
+        assert!(!state.reconnect_in_progress.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn no_new_reconnect_starts_after_shutdown_begins() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        let mut state = MultiManagerState::load_or_default(
+            &MultiManagerSettings {
+                enabled: false,
+                ..Default::default()
+            },
+            settings_path.to_str().unwrap(),
+        );
+        state.shutdown_started = true;
+
+        assert_eq!(
+            state.start_reconnect(ReconnectTrigger::Manual),
+            ReconnectStartResult::AlreadyRunning
+        );
+        assert!(state.reconnect_job.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a robust lifecycle for async reconnect workers so reconnect work is single-flight, joinable, and coordinated with shutdown and automatic-reconnect semantics.
- Ensure reconnect workers do not mutate GUI state directly and instead report results through the existing runtime event queue.
- Make reconnect behavior deterministic for startup/reload/manual triggers and handle snapshot-lock failures and panic/unwind cases safely.

### Description
- Add `ReconnectTrigger` and `ReconnectStartResult` enums and new `MultiManagerState` fields: `reconnect_in_progress: Arc<AtomicBool>`, `reconnect_job: Option<JoinHandle<()>>`, `pending_automatic_reconnect: bool`, and `shutdown_started: bool` in `src/multi_manager/state.rs`.
- Implement `start_reconnect` which single-flights using `compare_exchange(false, true, ...)`, returns `AlreadyRunning`/`SnapshotLockFailed`/`Started`, captures a snapshot, spawns a worker thread, and stores the `JoinHandle`.
- Add an RAII `ReconnectInProgressGuard` that resets the `reconnect_in_progress` atomic on all worker exit paths (including panics via `catch_unwind`), and ensure worker only builds snapshot, computes patches, applies patches under the workspace lock, and enqueues `MultiManagerRuntimeEvent::ReconnectCompleted { trigger, summary }` or `ReconnectFailed { trigger, error }` to the runtime `event_queue` (no direct GUI mutation or toasts from worker).
- Provide `reap_reconnect_worker` to join finished workers during normal GUI/runtime updates and to handle the single pending automatic reconnect trigger; join active reconnect work during `shutdown` and prevent new reconnect starts once shutdown begins.
- Add runtime event variants and GUI wiring: new `MultiManagerRuntimeEvent::ReconnectCompleted`/`ReconnectFailed` in `src/multi_manager/runtime.rs` and handle them in `src/gui/multi_manager_actions.rs`; replace the synchronous reconnect call with `start_reconnect` and show a toast/error based on the start result.
- Replace startup/load binding behavior to invoke `start_reconnect` when `auto_reconnect_on_load` is enabled and factor out binding-restore helper (`restore_bindings_for_load`).
- Add unit tests in `src/multi_manager/state.rs` covering: only one reconnect job can run, concurrent automatic reconnect keeps a single pending request, failed manual reconnect can be retried, in-progress flag resets on snapshot error, reconnect worker is joined by shutdown, and no new reconnect starts after shutdown begins.

### Testing
- Built the project for the Windows GNU target with `cargo check --target x86_64-pc-windows-gnu` which completed successfully.
- Added unit tests and compiled targeted tests (build-only) for the Windows target with `cargo test --target x86_64-pc-windows-gnu --no-run` (test execution was not run end-to-end due to long compile/link time in this environment).
- `cargo check` on the host Linux target and `cargo fmt --check` reported unrelated environment/tooling issues: the repo contains many Windows-only `windows::Win32` usages (so Linux host check fails) and there were unrelated rustfmt diffs across other files; the three modified files were formatted as part of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cdcc2787c8332bef4de7c75b9408a)