### PR TITLE
Refine MultiManager reconnect UI state

### DIFF
--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -1011,7 +1011,7 @@ pub(crate) fn format_reconnect_summary(
     summary: crate::multi_manager::reconnect::ReconnectSummary,
 ) -> String {
     let mut text = format!(
-        "MultiManager reconnect complete: {} already valid, {} reconnected, {} missing, {} ambiguous, {} metadata mismatches",
+        "MultiManager reconnect complete — valid: {}, reconnected: {}, needs recapture: {} missing / {} ambiguous / {} metadata mismatches",
         summary.already_valid,
         summary.reconnected,
         summary.missing,
@@ -1020,7 +1020,7 @@ pub(crate) fn format_reconnect_summary(
     );
     if summary.stale_results_discarded > 0 {
         text.push_str(&format!(
-            ", {} stale-result discards",
+            ", stale results ignored: {}",
             summary.stale_results_discarded
         ));
     }
@@ -1169,8 +1169,12 @@ mod tests {
     fn manual_reconnect_completion_produces_one_terminal_toast() {
         let mut app = test_app();
         clear_toast_log();
-        app.multi_manager.runtime.event_queue.lock().unwrap().push_back(
-            MultiManagerRuntimeEvent::ReconnectCompleted {
+        app.multi_manager
+            .runtime
+            .event_queue
+            .lock()
+            .unwrap()
+            .push_back(MultiManagerRuntimeEvent::ReconnectCompleted {
                 trigger: ReconnectTrigger::Manual,
                 summary: ReconnectSummary {
                     already_valid: 4,
@@ -1181,15 +1185,14 @@ mod tests {
                     binding_snapshot_changed: true,
                     ..Default::default()
                 },
-            },
-        );
+            });
 
         app.multi_manager_drain_runtime_events();
 
         let log = toast_log_contents();
-        assert_eq!(log.matches("MultiManager reconnect complete:").count(), 1);
+        assert_eq!(log.matches("MultiManager reconnect complete").count(), 1);
         assert!(log.contains(
-            "4 already valid, 2 reconnected, 1 missing, 0 ambiguous, 3 metadata mismatches, 5 stale-result discards"
+            "valid: 4, reconnected: 2, needs recapture: 1 missing / 0 ambiguous / 3 metadata mismatches, stale results ignored: 5"
         ));
         assert!(app.multi_manager.bindings_dirty);
     }
@@ -1197,12 +1200,15 @@ mod tests {
     #[test]
     fn failed_manual_reconnect_reports_error_and_retry_can_start() {
         let mut app = test_app();
-        app.multi_manager.runtime.event_queue.lock().unwrap().push_back(
-            MultiManagerRuntimeEvent::ReconnectFailed {
+        app.multi_manager
+            .runtime
+            .event_queue
+            .lock()
+            .unwrap()
+            .push_back(MultiManagerRuntimeEvent::ReconnectFailed {
                 trigger: ReconnectTrigger::Manual,
                 error: "boom".into(),
-            },
-        );
+            });
 
         app.multi_manager_drain_runtime_events();
 

--- a/src/gui/multi_manager_actions.rs
+++ b/src/gui/multi_manager_actions.rs
@@ -1238,12 +1238,10 @@ mod tests {
 
         let text = format_reconnect_summary(summary);
 
-        assert!(text.contains("1 already valid"));
-        assert!(text.contains("2 reconnected"));
-        assert!(text.contains("3 missing"));
-        assert!(text.contains("4 ambiguous"));
-        assert!(text.contains("5 metadata mismatches"));
-        assert!(text.contains("6 stale-result discards"));
+        assert!(text.contains("valid: 1"));
+        assert!(text.contains("reconnected: 2"));
+        assert!(text.contains("needs recapture: 3 missing / 4 ambiguous / 5 metadata mismatches"));
+        assert!(text.contains("stale results ignored: 6"));
     }
 
     fn test_app() -> LauncherApp {

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -641,6 +641,13 @@ impl eframe::App for LauncherApp {
         }
         self.multi_manager_drain_runtime_events();
         let _ = self.multi_manager.start_pending_automatic_reconnect();
+        if self
+            .multi_manager
+            .reconnect_in_progress
+            .load(Ordering::Acquire)
+        {
+            ctx.request_repaint_after(Duration::from_millis(150));
+        }
         self.multi_manager.maybe_auto_save_bindings();
         if self.enable_toasts {
             self.toasts.show(ctx);

--- a/src/multi_manager/ui.rs
+++ b/src/multi_manager/ui.rs
@@ -78,7 +78,17 @@ impl MultiManagerDialog {
                         if ui.button("Restore HWND Snapshot").clicked() {
                             app.multi_manager_restore_bindings();
                         }
-                        if ui.button("Reconnect Windows").clicked() {
+                        let reconnect_active = app
+                            .multi_manager
+                            .reconnect_in_progress
+                            .load(Ordering::Acquire);
+                        if ui
+                            .add_enabled(
+                                reconnect_button_enabled(reconnect_active),
+                                egui::Button::new(reconnect_button_text(reconnect_active)),
+                            )
+                            .clicked()
+                        {
                             app.multi_manager_start_manual_reconnect();
                         }
                         if ui.button("Refresh Titles").clicked() {
@@ -481,6 +491,18 @@ pub(crate) fn refresh_live_titles_throttled_with(
     }
     *last_refresh = Some(now);
     bindings::refresh_live_titles_with(workspaces, is_valid, window_title)
+}
+
+fn reconnect_button_text(active: bool) -> &'static str {
+    if active {
+        "Reconnecting…"
+    } else {
+        "Reconnect Windows"
+    }
+}
+
+fn reconnect_button_enabled(active: bool) -> bool {
+    !active
 }
 
 fn capture_banner_text(action: &PendingCaptureAction) -> &'static str {
@@ -938,6 +960,22 @@ mod tests {
             capture_banner_text(&action),
             "Recapture active: focus the replacement window and press Enter. Press S to skip this item. Escape cancels the queue."
         );
+    }
+
+    #[test]
+    fn reconnect_button_text_reflects_idle_state() {
+        assert_eq!(reconnect_button_text(false), "Reconnect Windows");
+    }
+
+    #[test]
+    fn reconnect_button_text_reflects_active_state() {
+        assert_eq!(reconnect_button_text(true), "Reconnecting…");
+    }
+
+    #[test]
+    fn reconnect_button_is_disabled_while_active() {
+        assert!(reconnect_button_enabled(false));
+        assert!(!reconnect_button_enabled(true));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve user feedback during MultiManager reconnect runs by showing an active label and keeping only the reconnect control disabled while the job runs.
- Ensure the GUI stays responsive and processes reconnect worker terminal events while reconnect is active by requesting periodic repaints.
- Make reconnect completion/failure handling explicit: bindings get marked dirty when needed, manual completions produce a categorized toast summary, manual failures report under `multi_manager.reconnect`, and automatic failures are logged.

### Description
- Added two UI helpers in `src/multi_manager/ui.rs`: `reconnect_button_text(active: bool)` returning `"Reconnecting…"` or `"Reconnect Windows"`, and `reconnect_button_enabled(active: bool)` returning a boolean used to disable only the reconnect button while reconnect is active.
- Wired the MultiManager toolbar button to use `add_enabled(...)` with the new helpers so unrelated controls remain enabled during reconnect; added three unit tests for `reconnect_button_text` and `reconnect_button_enabled` in `src/multi_manager/ui.rs`.
- During GUI updates in `src/gui/render.rs`, when `self.multi_manager.reconnect_in_progress` is true the code calls `ctx.request_repaint_after(Duration::from_millis(150))` to request periodic repaint (interval chosen inside ~100–250 ms range).
- Ensured runtime event draining/reaping continues during GUI updates via `multi_manager_drain_runtime_events()` and `reap_reconnect_worker()` usage (in `src/gui/multi_manager_actions.rs` / `src/gui/render.rs`).
- Clarified reconnect summary formatting and terminal-event handling in `src/gui/multi_manager_actions.rs`: manual completion marks bindings dirty when the summary indicates, manual completion shows a categorized summary toast via `format_reconnect_summary`, manual failures are reported under `multi_manager.reconnect`, and automatic failures are logged only; adjusted test expectations to match the new summary text.

### Testing
- Ran formatting checks with `rustfmt --edition 2024 --check src/multi_manager/ui.rs src/gui/multi_manager_actions.rs`, which succeeded for the modified files.
- Ran `git diff --check` which reported no conflicts for the change set.
- Attempted `cargo test multi_manager --lib`, but the run could not complete in this Linux environment because of platform-specific dependencies (Windows `windows::Win32` imports) despite installing several system packages, so the full test suite did not finish here.
- Ran `cargo fmt --check`, which flagged unrelated repository-wide formatting differences outside this change (pre-existing diffs), so a full repo-wide format check did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cf3f199748332ae99fec65f93e8c4)