### PR TITLE
docs: clarify MultiManager reconnect behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,14 +461,14 @@ Layouts let you capture and restore a **window arrangement** (great for “work 
 
 MultiManager is a **Windows-oriented embedded window workspace manager** for keeping groups of real application windows organized inside named workspaces. It is designed for day-to-day window orchestration: capture the windows you care about, define where they should live, assign shortcuts, and quickly move or recover them later.
 
-MultiManager is separate from saved `layout` commands. A saved `layout` is a named window arrangement that can be loaded from `layouts.json`; a MultiManager workspace tracks windows as workspace members, including their current Win32 window bindings and per-window home/target rectangles. Use `layout ...` for simple saved arrangements, and use `mm ...` when you want an interactive workspace manager that can keep reconnecting and recapturing tracked windows.
+MultiManager is separate from saved `layout` commands. A saved `layout` is a named window arrangement that can be loaded from `layouts.json`; a MultiManager workspace tracks windows as workspace members, including their current Win32 window bindings and per-window home/target rectangles. Use `layout ...` for simple saved arrangements, and use `mm ...` when you want an interactive workspace manager for explicitly reconnecting or recapturing tracked windows.
 
 Because MultiManager works with live Windows desktop windows, it uses Win32 concepts such as:
 
 - **HWNDs** as the native identifiers for tracked windows.
 - **Foreground-window capture** to add the currently active window to a workspace.
 - **Top-level window enumeration** to find candidate windows and recover missing entries.
-- **Reconnecting stale window handles** when a previously captured window was closed, relaunched, or received a new HWND.
+- **Explicitly reconnecting stale window handles** when a previously captured window was closed, relaunched, or received a new HWND.
 
 ### Commands
 
@@ -489,7 +489,19 @@ Because MultiManager works with live Windows desktop windows, it uses Win32 conc
 3. Capture windows into that workspace.
 4. Set each window's home and target rectangles.
 5. Assign a hotkey for quick workspace actions.
-6. Toggle, send home, send target, rotate, reconnect, or recapture windows as your session changes.
+6. Toggle, send home, send target, rotate, reconnect, or recapture windows explicitly as your session changes.
+
+
+### Reconnect behavior
+
+MultiManager reconnect is intentionally explicit and bounded:
+
+- When workspaces load or reload, MultiManager can perform **one optional reconnect pass** if `auto_reconnect_on_load` is enabled. This pass enumerates visible top-level windows once and tries to match missing or stale entries.
+- Failed automatic matches remain disconnected. MultiManager does not retry after that pass.
+- Applications opened after the load/reload reconnect pass require manual reconnect. Use **Reconnect Windows** in the UI or run `mm reconnect`.
+- **Reconnect Windows** and `mm reconnect` explicitly enumerate current windows and apply the same matching rules used by the load/reload reconnect pass.
+- Toggle, home, target, and rotate actions validate existing HWNDs and clear invalid HWNDs before acting, but they do not search for replacement windows.
+- Exact-title and stable-metadata matching rules are unchanged: exact-title candidates still need compatible stable metadata, duplicate exact-title candidates are ambiguous, and incompatible metadata remains a mismatch.
 
 ### Capture and recapture controls
 
@@ -657,7 +669,7 @@ MultiManager paths can be customized under the `multi_manager` settings object:
 }
 ```
 
-`workspaces_path` controls where MultiManager stores workspace state, and `bindings_path` controls the optional live-window binding snapshot location. `ignore_launcher_window_on_capture` is a safety setting that helps prevent capture flows from saving the launcher window instead of the intended target window.
+`workspaces_path` controls where MultiManager stores workspace state, and `bindings_path` controls the optional live-window binding snapshot location. `auto_reconnect_on_load` enables the single load/reload reconnect pass described above. `ignore_launcher_window_on_capture` is a safety setting that helps prevent capture flows from saving the launcher window instead of the intended target window.
 
 Disable the default hotkey entirely (useful if you bind your own trigger elsewhere):
 
@@ -755,7 +767,7 @@ cargo run
 
 ### MultiManager cannot find or move a window
 
-* Run `mm reconnect` after restarting apps or the launcher so MultiManager can refresh stale window handles.
+* Run `mm reconnect` after restarting apps or the launcher so MultiManager can explicitly enumerate windows and refresh stale window handles. Apps opened after workspace load/reload remain disconnected until this manual reconnect succeeds.
 * Use `mm recapture all` when a window is missing, closed and reopened, or ambiguous.
 * Ensure the target app is not running elevated while Multi Launcher is running non-elevated.
 * Check whether the workspace or window is disabled before sending, restoring, or moving it.

--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -9,10 +9,17 @@ This checklist covers behavior that depends on a real Windows desktop session, W
 3. Use **Capture Active Window** and press **Enter** while the target app is foregrounded.
 4. Confirm the captured row shows the expected title and executable metadata.
 5. Set home and target rectangles, then verify **Send Home** and **Move Target** move the real window.
-6. Close and reopen one captured app, then run `mm reconnect` and confirm stale handles are refreshed when a matching window exists.
-7. Run `mm recapture all`, use **S** to skip at least one candidate, and use **Escape** to cancel a remaining recapture flow.
-8. Use **Save HWND Snapshot** and **Restore HWND Snapshot** after moving/reopening windows to confirm bindings round-trip.
-9. Keep `ignore_launcher_window_on_capture` enabled and verify capture does not save the launcher window when the launcher had focus immediately before capture.
+6. Close one tracked application and leave Multi Launcher running for several minutes. Confirm the GUI remains responsive and the closed application does not automatically reconnect while the launcher continues running.
+7. Reopen the closed application and confirm it remains disconnected until a manual reconnect is requested.
+8. Run `mm reconnect` or click **Reconnect Windows**. Confirm the UI shows **Reconnecting…**, remains responsive during the operation, and reconnects the reopened application when a matching window exists.
+9. Force or observe a failed manual reconnect, then fix the matching condition or reopen the application and confirm a later manual reconnect attempt can succeed.
+10. In a workspace with three tracked windows, close one window and confirm **Send Home**, **Move Target**, toggle, and rotate still move the other two tracked windows.
+11. Create two candidate windows with the same exact title for one disconnected entry, then run manual reconnect and confirm the result is reported as `Ambiguous`.
+12. Create an exact-title candidate whose stable metadata is incompatible with the disconnected entry, then run manual reconnect and confirm the result is reported as `MetadataMismatch`.
+13. Start reconnect, recapture the same entry before stale reconnect results can apply, and confirm the recaptured HWND is not overwritten by stale reconnect results.
+14. Run `mm recapture all`, use **S** to skip at least one candidate, and use **Escape** to cancel a remaining recapture flow.
+15. Use **Save HWND Snapshot** and **Restore HWND Snapshot** after moving/reopening windows to confirm bindings round-trip.
+16. Keep `ignore_launcher_window_on_capture` enabled and verify capture does not save the launcher window when the launcher had focus immediately before capture.
 
 ## Browser tabs and UI Automation
 


### PR DESCRIPTION
### Motivation

- Clarify that MultiManager does not perform continuous or background reconnects and that reconnecting is an explicit, bounded operation. 
- Update user-facing documentation and smoke tests to accurately describe the single optional reconnect pass on workspace load/reload and manual reconnect expectations. 

### Description

- Update `README.md` to remove language implying continual/automatic reconnect and add a `Reconnect behavior` section describing the single optional load/reload reconnect pass and that `auto_reconnect_on_load` toggles it. 
- Document that failed automatic matches remain disconnected, applications opened after the load/reload pass require manual reconnect, and `Reconnect Windows` / `mm reconnect` explicitly enumerate and match windows. 
- Note that toggle/home/target/rotate actions validate and clear invalid HWNDs but do not search for replacement windows, and that exact-title and stable-metadata matching rules remain unchanged. 
- Extend `docs/manual-smoke-tests.md` with scenarios covering no automatic reconnect while running, manual reconnect responsiveness and retry behavior, partial-workspace movement when one window is closed, ambiguous/metadata-mismatch outcomes, and recapture-vs-stale-reconnect race handling. 

### Testing

- Ran targeted text searches with `rg -n` to confirm occurrences of reconnect-related terms were updated or present as intended, and the searches returned expected results. 
- Ran `git diff --check` to validate there are no whitespace or diff errors and it completed successfully. 
- Committed the changes and verified the working tree shows only the two documentation files modified (`README.md` and `docs/manual-smoke-tests.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cfac3c0488332bf075fa4b7056563)