### PR TITLE
Add text case and plugin routing regression tests

### DIFF
--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -175,3 +175,46 @@ fn command_collection_keeps_existing_folder_and_omni_commands_and_adds_file_sear
         );
     }
 }
+
+#[test]
+fn default_command_collection_keeps_clipboard_modify_baseline_plugins_registered() {
+    let actions = Arc::new(Vec::new());
+    let mut plugins = PluginManager::new();
+    plugins.reload_from_dirs(
+        &[],
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        Arc::clone(&actions),
+    );
+
+    let plugin_names: std::collections::HashSet<_> = plugins.plugin_names().into_iter().collect();
+    for name in [
+        "clipboard",
+        "snippets",
+        "text_case",
+        "file_search",
+        "omni_search",
+    ] {
+        assert!(plugin_names.contains(name), "missing plugin {name}");
+    }
+
+    let commands: std::collections::HashSet<_> = plugins
+        .commands()
+        .into_iter()
+        .map(|a| (a.label, a.desc, a.action))
+        .collect();
+    for expected in [
+        ("cb", "Clipboard", "query:cb"),
+        ("cs", "Snippet", "query:cs"),
+        ("case <text>", "Text Case", "query:case "),
+        ("fs", "Open local file search", "query:fs"),
+        ("o", "Omni", "query:o "),
+    ] {
+        assert!(
+            commands.contains(&(expected.0.into(), expected.1.into(), expected.2.into())),
+            "missing command {expected:?}"
+        );
+    }
+}

--- a/tests/plugin_routing.rs
+++ b/tests/plugin_routing.rs
@@ -316,7 +316,11 @@ fn clipboard_modify_baseline_builtin_queries_keep_current_routing_results() {
         ("cb clear", "clipboard:clear", "Clipboard"),
         ("cs", "snippet:dialog", "Snippet"),
         ("case Rust", "clipboard:RUST", "Text Case-Uppercase"),
-        ("fs", "file_search:open", "File Search"),
+        (
+            "fs",
+            "file_search:open",
+            "Open local filename/content search",
+        ),
         ("o plan", "app:plan", "launcher"),
     ];
 

--- a/tests/plugin_routing.rs
+++ b/tests/plugin_routing.rs
@@ -290,3 +290,53 @@ fn constructing_manager_with_file_search_settings_preserves_omni_and_indexer_beh
     };
     assert_eq!(action_view(indexed_before), action_view(indexed_after));
 }
+
+#[test]
+fn clipboard_modify_baseline_builtin_queries_keep_current_routing_results() {
+    use multi_launcher::plugins::clipboard::ClipboardPlugin;
+    use multi_launcher::plugins::file_search::FileSearchPlugin;
+    use multi_launcher::plugins::omni_search::OmniSearchPlugin;
+    use multi_launcher::plugins::snippets::SnippetsPlugin;
+    use multi_launcher::plugins::text_case::TextCasePlugin;
+
+    let actions = Arc::new(vec![Action {
+        label: "plan app".into(),
+        desc: "launcher".into(),
+        action: "app:plan".into(),
+        args: None,
+    }]);
+    let mut pm = PluginManager::new();
+    pm.register(Box::new(ClipboardPlugin::new(10)));
+    pm.register(Box::new(SnippetsPlugin::default()));
+    pm.register(Box::new(TextCasePlugin));
+    pm.register(Box::new(FileSearchPlugin::default()));
+    pm.register(Box::new(OmniSearchPlugin::new(Arc::clone(&actions))));
+
+    let cases = [
+        ("cb clear", "clipboard:clear", "Clipboard"),
+        ("cs", "snippet:dialog", "Snippet"),
+        ("case Rust", "clipboard:RUST", "Text Case-Uppercase"),
+        ("fs", "file_search:open", "File Search"),
+        ("o plan", "app:plan", "launcher"),
+    ];
+
+    for (query, action, desc) in cases {
+        let results = pm.search_filtered(query, None, None);
+        assert!(
+            results
+                .iter()
+                .any(|result| result.action == action && result.desc == desc),
+            "missing routed result {action:?} for {query:?}: {results:?}"
+        );
+    }
+
+    let file_search_unrelated = pm.search_filtered("plain query", None, None);
+    assert!(!file_search_unrelated
+        .iter()
+        .any(|result| result.action.starts_with("file_search:")));
+
+    let omni_unrelated = pm.search_filtered("plan", None, None);
+    assert!(!omni_unrelated
+        .iter()
+        .any(|result| result.action == "app:plan"));
+}

--- a/tests/text_case_plugin.rs
+++ b/tests/text_case_plugin.rs
@@ -1,47 +1,142 @@
+use multi_launcher::actions::Action;
 use multi_launcher::plugin::Plugin;
 use multi_launcher::plugins::text_case::TextCasePlugin;
 
-#[test]
-fn converts_text_cases() {
-    let plugin = TextCasePlugin;
-    let results = plugin.search("case Rust Test");
-    assert_eq!(results.len(), 26);
-    // original cases
-    assert_eq!(results[0].label, "RUST TEST");
-    assert_eq!(results[0].action, "clipboard:RUST TEST");
-    assert_eq!(results[1].label, "rust test");
-    assert_eq!(results[1].action, "clipboard:rust test");
-    assert_eq!(results[2].label, "Rust Test");
-    assert_eq!(results[2].action, "clipboard:Rust Test");
-    assert_eq!(results[5].label, "rust_test");
-    assert_eq!(results[5].action, "clipboard:rust_test");
-    assert_eq!(results[3].label, "rustTest"); // camelCase
-    assert_eq!(results[4].label, "RustTest"); // PascalCase
-    assert_eq!(results[6].label, "RUST_TEST"); // SCREAMING_SNAKE_CASE
-    assert_eq!(results[7].label, "rust-test"); // kebab-case
-    assert_eq!(results[9].label, "rust.test"); // dot.case
-    assert_eq!(results[10].label, "RuSt TeSt"); // Alternating case
-    assert_eq!(results[11].label, "rUsT tEsT"); // Mocking SpongeBob
-    assert_eq!(results[12].label, "rUST tEST"); // Inverse case
-    assert_eq!(results[13].label, "tseT tsuR"); // Backwards case
-    assert_eq!(results[14].label, "RT"); // Acronym
-    assert_eq!(results[15].label, "R. T."); // Initial Caps
-    assert_eq!(results[17].label, "Rust test"); // Sentence case
-    assert_eq!(results[18].label, "UnVzdCBUZXN0"); // Base64
-    assert_eq!(results[19].label, "527573742054657374"); // Hex
-    assert_eq!(results[21].label, "Ehfg Grfg"); // ROT13
-    assert_eq!(results[22].label, "rust 👏 test"); // Clap case
-    assert_eq!(results[24].label, "R-u-s-t T-e-s-t"); // Custom delimiter
+fn action_view(action: &Action) -> (&str, &str, &str) {
+    (&action.label, &action.desc, &action.action)
 }
 
 #[test]
-fn converts_specific_cases() {
+fn default_case_rust_test_results_are_frozen_in_order() {
     let plugin = TextCasePlugin;
-    let hex = plugin.search("case hex Rust");
-    assert_eq!(hex.len(), 1);
-    assert_eq!(hex[0].label, "52757374");
+    let results = plugin.search("case Rust Test");
 
-    let bin = plugin.search("case binary A");
-    assert_eq!(bin.len(), 1);
-    assert_eq!(bin[0].label, "01000001");
+    let expected = [
+        ("RUST TEST", "Text Case-Uppercase", "clipboard:RUST TEST"),
+        ("rust test", "Text Case-Lowercase", "clipboard:rust test"),
+        ("Rust Test", "Text Case-Capitalized", "clipboard:Rust Test"),
+        ("rustTest", "Text Case-Camel", "clipboard:rustTest"),
+        ("RustTest", "Text Case-Pascal", "clipboard:RustTest"),
+        ("rust_test", "Text Case-Snake", "clipboard:rust_test"),
+        ("RUST_TEST", "Text Case-Screaming", "clipboard:RUST_TEST"),
+        ("rust-test", "Text Case-Kebab", "clipboard:rust-test"),
+        ("Rust-Test", "Text Case-Train", "clipboard:Rust-Test"),
+        ("rust.test", "Text Case-Dot", "clipboard:rust.test"),
+        ("RuSt TeSt", "Text Case-Alternating", "clipboard:RuSt TeSt"),
+        ("rUsT tEsT", "Text Case-Mocking", "clipboard:rUsT tEsT"),
+        ("rUST tEST", "Text Case-Inverse", "clipboard:rUST tEST"),
+        ("tseT tsuR", "Text Case-Backwards", "clipboard:tseT tsuR"),
+        ("RT", "Text Case-Acronym", "clipboard:RT"),
+        ("R. T.", "Text Case-Initials", "clipboard:R. T."),
+        ("Rust Test", "Text Case-Title", "clipboard:Rust Test"),
+        ("Rust test", "Text Case-Sentence", "clipboard:Rust test"),
+        ("UnVzdCBUZXN0", "Text Case-Base64", "clipboard:UnVzdCBUZXN0"),
+        (
+            "527573742054657374",
+            "Text Case-Hex",
+            "clipboard:527573742054657374",
+        ),
+        (
+            "01010010 01110101 01110011 01110100 00100000 01010100 01100101 01110011 01110100",
+            "Text Case-Binary",
+            "clipboard:01010010 01110101 01110011 01110100 00100000 01010100 01100101 01110011 01110100",
+        ),
+        ("Ehfg Grfg", "Text Case-ROT13", "clipboard:Ehfg Grfg"),
+        ("rust 👏 test", "Text Case-Clap", "clipboard:rust 👏 test"),
+        ("Rust Test", "Text Case-Emoji", "clipboard:Rust Test"),
+        ("R-u-s-t T-e-s-t", "Text Case-Custom", "clipboard:R-u-s-t T-e-s-t"),
+        (
+            ".-. ..- ... - / - . ... -",
+            "Text Case-Morse",
+            "clipboard:.-. ..- ... - / - . ... -",
+        ),
+    ];
+
+    assert_eq!(results.len(), 26);
+    for (index, expected_action) in expected.iter().enumerate() {
+        assert_eq!(
+            action_view(&results[index]),
+            *expected_action,
+            "unexpected result at index {index}"
+        );
+    }
+}
+
+#[test]
+fn specific_operation_queries_return_only_requested_operation() {
+    let plugin = TextCasePlugin;
+    let cases = [
+        (
+            "case upper Rust Test",
+            ("RUST TEST", "Text Case-Uppercase", "clipboard:RUST TEST"),
+        ),
+        (
+            "case title use the following API",
+            (
+                "Use the Following Api",
+                "Text Case-Title",
+                "clipboard:Use the Following Api",
+            ),
+        ),
+        (
+            "case screaming Rust Test",
+            ("RUST_TEST", "Text Case-Screaming", "clipboard:RUST_TEST"),
+        ),
+        (
+            "case base64 Rust",
+            ("UnVzdA==", "Text Case-Base64", "clipboard:UnVzdA=="),
+        ),
+        (
+            "case hex Rust",
+            ("52757374", "Text Case-Hex", "clipboard:52757374"),
+        ),
+        (
+            "case binary A",
+            ("01000001", "Text Case-Binary", "clipboard:01000001"),
+        ),
+    ];
+
+    for (query, expected) in cases {
+        let results = plugin.search(query);
+        assert_eq!(results.len(), 1, "{query}");
+        assert_eq!(action_view(&results[0]), expected, "{query}");
+    }
+}
+
+#[test]
+fn text_case_behavior_regressions() {
+    let plugin = TextCasePlugin;
+    let cases = [
+        ("case", Vec::<(&str, &str)>::new()),
+        (
+            "case     Rust     Test  ",
+            vec![("Text Case-Snake", "rust_test")],
+        ),
+        (
+            "case hello, world!",
+            vec![("Text Case-Title", "Hello, World!")],
+        ),
+        ("case rUsT TeSt", vec![("Text Case-Inverse", "RuSt tEsT")]),
+        ("case café мир", vec![("Text Case-Uppercase", "CAFÉ МИР")]),
+        (
+            "case title the lord of the rings and to mars",
+            vec![("Text Case-Title", "The Lord of the Rings and to Mars")],
+        ),
+    ];
+
+    for (query, expected_matches) in cases {
+        let results = plugin.search(query);
+        if expected_matches.is_empty() {
+            assert!(results.is_empty(), "{query}");
+            continue;
+        }
+        for (desc, label) in expected_matches {
+            let result = results
+                .iter()
+                .find(|action| action.desc == desc)
+                .unwrap_or_else(|| panic!("missing {desc} for {query}"));
+            assert_eq!(result.label, label, "{query}");
+            assert_eq!(result.action, format!("clipboard:{label}"), "{query}");
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve and freeze regression coverage for the `TextCasePlugin` to prevent accidental reordering or behavioral regressions. 
- Add focused tests that exercise single-case queries and edge cases (spacing, punctuation, unicode, small-title words). 
- Add baseline assertions that core plugin commands remain registered and that prefix-based routing behavior is unchanged.

### Description
- Expanded `tests/text_case_plugin.rs` with a table-driven frozen expectation for the default `case Rust Test` output (exactly 26 results) asserting index, label, description, and `clipboard:` action for each entry. 
- Added focused single-operation tests in `tests/text_case_plugin.rs` for `case upper`, `case title`, `case screaming`, `case base64`, `case hex`, and `case binary`. 
- Added behavior regression cases in `tests/text_case_plugin.rs` for empty input after `case`, multiple spaces, punctuation, mixed case, Unicode input, and English title-case small words. 
- Added a new test in `tests/plugin_commands.rs` to assert that baseline plugins/commands (`clipboard`, `snippets`, `text_case`, `file_search`, `omni_search`) remain registered and their command shortcuts exist. 
- Added a new routing baseline test in `tests/plugin_routing.rs` asserting current query-prefix routing behavior for the same plugin set and negative checks for unrelated queries. 
- No production code or runtime behavior was changed.

### Testing
- Ran `cargo fmt --check` which reported pre-existing repository-wide formatting diffs (failure unrelated to these test changes). 
- Ran `cargo clippy --all-targets --all-features -- -D warnings` which failed due to pre-existing platform/all-features compile issues (Windows API imports unresolved) and an existing `unused_mut` warning; these failures existed before the Clipboard Modify work. 
- Attempted `cargo nextest run --no-fail-fast` but `cargo-nextest` was not available in the environment (tooling not installed). 
- Ran `cargo test --test text_case_plugin --test plugin_commands --test plugin_routing`; the test run did not complete because the workspace fails to compile under the current platform/all-features configuration (pre-existing native dependency and platform API compile errors). 

All automated test/format/lint failures observed are recorded as pre-existing baseline issues and not introduced by these test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d14be77888332b12b59ed9be67ba8)