### PR TITLE
Add clipboard_modify domain catalog with operations, templates, and validation

### DIFF
--- a/src/clipboard_modify.rs
+++ b/src/clipboard_modify.rs
@@ -1,0 +1,9 @@
+pub mod catalog;
+pub mod defaults;
+pub mod error;
+pub mod model;
+
+pub use catalog::*;
+pub use defaults::*;
+pub use error::*;
+pub use model::*;

--- a/src/clipboard_modify/catalog.rs
+++ b/src/clipboard_modify/catalog.rs
@@ -1,0 +1,462 @@
+use once_cell::sync::Lazy;
+use std::collections::{BTreeSet, HashMap};
+
+use super::error::ClipboardModifyError;
+use super::model::{OperationId, StageArguments};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationCategory {
+    Wrap,
+    Lines,
+    Format,
+    Encoding,
+    Case,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgumentRequirements {
+    None,
+    CustomWrap,
+    NamedWrap,
+    CodeBlock,
+    Template,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationInfo {
+    pub id: OperationId,
+    pub command: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+    pub category: OperationCategory,
+    pub aliases: &'static [&'static str],
+    pub argument_requirements: ArgumentRequirements,
+    pub pipeline_available: bool,
+    pub synchronous_small_input: bool,
+    pub help_examples: &'static [&'static str],
+}
+
+impl ArgumentRequirements {
+    pub fn validate(
+        self,
+        id: OperationId,
+        args: &StageArguments,
+    ) -> Result<(), ClipboardModifyError> {
+        let op = canonical_command(id);
+        match self {
+            Self::None => {
+                for (name, supplied) in [
+                    ("prefix", args.prefix.is_some()),
+                    ("suffix", args.suffix.is_some()),
+                    ("name", args.name.is_some()),
+                    ("language", args.language.is_some()),
+                ] {
+                    if supplied {
+                        return Err(ClipboardModifyError::UnexpectedArgument {
+                            operation: op.into(),
+                            argument: name,
+                        });
+                    }
+                }
+            }
+            Self::CustomWrap => {
+                if args.prefix.is_none() {
+                    return Err(ClipboardModifyError::MissingArgument {
+                        operation: op.into(),
+                        argument: "prefix",
+                    });
+                }
+                if args.suffix.is_none() {
+                    return Err(ClipboardModifyError::MissingArgument {
+                        operation: op.into(),
+                        argument: "suffix",
+                    });
+                }
+                reject(args.name.is_some(), op, "name")?;
+                reject(args.language.is_some(), op, "language")?;
+            }
+            Self::NamedWrap | Self::Template => {
+                if args.name.is_none() {
+                    return Err(ClipboardModifyError::MissingArgument {
+                        operation: op.into(),
+                        argument: "name",
+                    });
+                }
+                reject(args.prefix.is_some(), op, "prefix")?;
+                reject(args.suffix.is_some(), op, "suffix")?;
+                reject(args.language.is_some(), op, "language")?;
+            }
+            Self::CodeBlock => {
+                reject(args.prefix.is_some(), op, "prefix")?;
+                reject(args.suffix.is_some(), op, "suffix")?;
+                reject(args.name.is_some(), op, "name")?;
+            }
+        }
+        Ok(())
+    }
+}
+fn reject(v: bool, op: &str, a: &'static str) -> Result<(), ClipboardModifyError> {
+    if v {
+        Err(ClipboardModifyError::UnexpectedArgument {
+            operation: op.into(),
+            argument: a,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+pub static OPERATIONS: Lazy<Vec<OperationInfo>> = Lazy::new(|| {
+    vec![
+        op(
+            OperationId::SingleQuote,
+            "single-quote",
+            "Single quote",
+            "Wrap in single quotes",
+            OperationCategory::Wrap,
+            &["sq", "quote-single"],
+            ArgumentRequirements::None,
+            &["single-quote"],
+        ),
+        op(
+            OperationId::DoubleQuote,
+            "double-quote",
+            "Double quote",
+            "Wrap in double quotes",
+            OperationCategory::Wrap,
+            &["dq"],
+            ArgumentRequirements::None,
+            &["double-quote"],
+        ),
+        op(
+            OperationId::Backticks,
+            "backticks",
+            "Backticks",
+            "Wrap in backticks",
+            OperationCategory::Wrap,
+            &["tick"],
+            ArgumentRequirements::None,
+            &["backticks"],
+        ),
+        op(
+            OperationId::CustomWrap,
+            "custom-wrap",
+            "Custom wrap",
+            "Wrap with a supplied prefix and suffix",
+            OperationCategory::Wrap,
+            &["wrap-custom"],
+            ArgumentRequirements::CustomWrap,
+            &["custom-wrap --prefix '<' --suffix '>'"],
+        ),
+        op(
+            OperationId::NamedWrap,
+            "named-wrap",
+            "Named wrap",
+            "Apply a named wrapper",
+            OperationCategory::Wrap,
+            &["wrap"],
+            ArgumentRequirements::NamedWrap,
+            &["named-wrap markdown-quote"],
+        ),
+        op(
+            OperationId::Template,
+            "template",
+            "Template",
+            "Apply a saved template",
+            OperationCategory::Wrap,
+            &["tpl"],
+            ArgumentRequirements::Template,
+            &["template prompt-context"],
+        ),
+        op(
+            OperationId::CodeBlock,
+            "code-block",
+            "Code block",
+            "Wrap in a Markdown code block",
+            OperationCategory::Wrap,
+            &["code", "fence"],
+            ArgumentRequirements::CodeBlock,
+            &["code-block rust"],
+        ),
+        op(
+            OperationId::SortAscending,
+            "sort-ascending",
+            "Sort ascending",
+            "Sort lines ascending",
+            OperationCategory::Lines,
+            &["sort", "sort-asc"],
+            ArgumentRequirements::None,
+            &["sort-ascending"],
+        ),
+        op(
+            OperationId::SortDescending,
+            "sort-descending",
+            "Sort descending",
+            "Sort lines descending",
+            OperationCategory::Lines,
+            &["sort-desc"],
+            ArgumentRequirements::None,
+            &["sort-descending"],
+        ),
+        op(
+            OperationId::UniqueLines,
+            "unique-lines",
+            "Unique lines",
+            "Remove duplicate lines",
+            OperationCategory::Lines,
+            &["uniq"],
+            ArgumentRequirements::None,
+            &["unique-lines"],
+        ),
+        op(
+            OperationId::Trim,
+            "trim",
+            "Trim",
+            "Trim surrounding whitespace",
+            OperationCategory::Lines,
+            &[],
+            ArgumentRequirements::None,
+            &["trim"],
+        ),
+        op(
+            OperationId::TrimLines,
+            "trim-lines",
+            "Trim lines",
+            "Trim each line",
+            OperationCategory::Lines,
+            &["strip-lines"],
+            ArgumentRequirements::None,
+            &["trim-lines"],
+        ),
+        op(
+            OperationId::JsonPretty,
+            "json-pretty",
+            "JSON pretty",
+            "Pretty-print JSON",
+            OperationCategory::Format,
+            &["pretty-json"],
+            ArgumentRequirements::None,
+            &["json-pretty"],
+        ),
+        op(
+            OperationId::JsonMinify,
+            "json-minify",
+            "JSON minify",
+            "Minify JSON",
+            OperationCategory::Format,
+            &["compact-json"],
+            ArgumentRequirements::None,
+            &["json-minify"],
+        ),
+        op(
+            OperationId::Base64Encode,
+            "base64-encode",
+            "Base64 encode",
+            "Encode as Base64",
+            OperationCategory::Encoding,
+            &["b64enc"],
+            ArgumentRequirements::None,
+            &["base64-encode"],
+        ),
+        op(
+            OperationId::Base64Decode,
+            "base64-decode",
+            "Base64 decode",
+            "Decode Base64",
+            OperationCategory::Encoding,
+            &["b64dec"],
+            ArgumentRequirements::None,
+            &["base64-decode"],
+        ),
+        op(
+            OperationId::UrlEncode,
+            "url-encode",
+            "URL encode",
+            "Percent-encode text",
+            OperationCategory::Encoding,
+            &[],
+            ArgumentRequirements::None,
+            &["url-encode"],
+        ),
+        op(
+            OperationId::UrlDecode,
+            "url-decode",
+            "URL decode",
+            "Decode percent-encoded text",
+            OperationCategory::Encoding,
+            &[],
+            ArgumentRequirements::None,
+            &["url-decode"],
+        ),
+        op(
+            OperationId::Lowercase,
+            "lowercase",
+            "Lowercase",
+            "Convert to lowercase",
+            OperationCategory::Case,
+            &["lower"],
+            ArgumentRequirements::None,
+            &["lowercase"],
+        ),
+        op(
+            OperationId::Uppercase,
+            "uppercase",
+            "Uppercase",
+            "Convert to uppercase",
+            OperationCategory::Case,
+            &["upper"],
+            ArgumentRequirements::None,
+            &["uppercase"],
+        ),
+        op(
+            OperationId::TitleCase,
+            "title-case",
+            "Title case",
+            "Convert to title case",
+            OperationCategory::Case,
+            &["title"],
+            ArgumentRequirements::None,
+            &["title-case"],
+        ),
+        op(
+            OperationId::CamelCase,
+            "camel-case",
+            "Camel case",
+            "Convert to camelCase",
+            OperationCategory::Case,
+            &["camel"],
+            ArgumentRequirements::None,
+            &["camel-case"],
+        ),
+        op(
+            OperationId::PascalCase,
+            "pascal-case",
+            "Pascal case",
+            "Convert to PascalCase",
+            OperationCategory::Case,
+            &["pascal"],
+            ArgumentRequirements::None,
+            &["pascal-case"],
+        ),
+        op(
+            OperationId::SnakeCase,
+            "snake-case",
+            "Snake case",
+            "Convert to snake_case",
+            OperationCategory::Case,
+            &["snake"],
+            ArgumentRequirements::None,
+            &["snake-case"],
+        ),
+        op(
+            OperationId::ScreamingSnake,
+            "screaming-snake",
+            "Screaming snake",
+            "Convert to SCREAMING_SNAKE_CASE",
+            OperationCategory::Case,
+            &["constant-case", "screaming-snake-case"],
+            ArgumentRequirements::None,
+            &["screaming-snake"],
+        ),
+        op(
+            OperationId::KebabCase,
+            "kebab-case",
+            "Kebab case",
+            "Convert to kebab-case",
+            OperationCategory::Case,
+            &["kebab"],
+            ArgumentRequirements::None,
+            &["kebab-case"],
+        ),
+    ]
+});
+fn op(
+    id: OperationId,
+    command: &'static str,
+    label: &'static str,
+    description: &'static str,
+    category: OperationCategory,
+    aliases: &'static [&'static str],
+    argument_requirements: ArgumentRequirements,
+    help_examples: &'static [&'static str],
+) -> OperationInfo {
+    OperationInfo {
+        id,
+        command,
+        label,
+        description,
+        category,
+        aliases,
+        argument_requirements,
+        pipeline_available: true,
+        synchronous_small_input: true,
+        help_examples,
+    }
+}
+
+pub fn operations() -> &'static [OperationInfo] {
+    &OPERATIONS
+}
+pub fn operation_by_id(id: OperationId) -> Option<&'static OperationInfo> {
+    operations().iter().find(|o| o.id == id)
+}
+pub fn canonical_command(id: OperationId) -> &'static str {
+    operation_by_id(id).map(|o| o.command).unwrap_or("unknown")
+}
+pub fn operation_lookup(name: &str) -> Option<&'static OperationInfo> {
+    LOOKUP
+        .get(&normalize_name(name))
+        .and_then(|i| operations().get(*i))
+}
+static LOOKUP: Lazy<HashMap<String, usize>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    for (i, o) in operations().iter().enumerate() {
+        m.insert(normalize_name(o.command), i);
+        for a in o.aliases {
+            m.insert(normalize_name(a), i);
+        }
+    }
+    m
+});
+
+pub fn normalize_name(input: &str) -> String {
+    let mut out = String::new();
+    let mut hyphen = false;
+    for c in input.trim().chars().flat_map(char::to_lowercase) {
+        if c == '_' || c.is_whitespace() || c == '-' {
+            if !hyphen && !out.is_empty() {
+                out.push('-');
+                hyphen = true;
+            }
+        } else {
+            out.push(c);
+            hyphen = false;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+pub fn reserved_names() -> BTreeSet<String> {
+    let mut s = BTreeSet::new();
+    for w in [
+        "clipboard",
+        "cb",
+        "modify",
+        "template",
+        "apply",
+        "undo",
+        "wrap",
+    ] {
+        s.insert(normalize_name(w));
+    }
+    for o in operations() {
+        s.insert(normalize_name(o.command));
+        for a in o.aliases {
+            s.insert(normalize_name(a));
+        }
+    }
+    s
+}

--- a/src/clipboard_modify/defaults.rs
+++ b/src/clipboard_modify/defaults.rs
@@ -1,0 +1,120 @@
+use super::model::*;
+
+pub fn default_templates() -> Vec<ClipboardTemplate> {
+    vec![
+        ClipboardTemplate {
+            id: "markdown-quote".into(),
+            label: "Markdown quote".into(),
+            aliases: vec!["md-quote".into()],
+            template: "> {{clipboard}}".into(),
+            processor: Some(TemplateProcessor::Literal),
+        },
+        ClipboardTemplate {
+            id: "prompt-context".into(),
+            label: "Prompt context".into(),
+            aliases: vec!["context".into()],
+            template: "Context:\n{{clipboard}}".into(),
+            processor: Some(TemplateProcessor::Literal),
+        },
+        ClipboardTemplate {
+            id: "xml-block".into(),
+            label: "XML block".into(),
+            aliases: vec!["xml".into()],
+            template: "<clipboard>\n{{clipboard}}\n</clipboard>".into(),
+            processor: Some(TemplateProcessor::Literal),
+        },
+        ClipboardTemplate {
+            id: "rust-raw-string".into(),
+            label: "Rust raw string".into(),
+            aliases: vec!["raw-string".into()],
+            template: "{{clipboard}}".into(),
+            processor: Some(TemplateProcessor::RustRawString),
+        },
+        ClipboardTemplate {
+            id: "sql-diagnostic".into(),
+            label: "SQL diagnostic".into(),
+            aliases: vec!["sql-diag".into()],
+            template: "-- Diagnostic SQL\n{{clipboard}}".into(),
+            processor: Some(TemplateProcessor::Literal),
+        },
+    ]
+}
+
+pub fn default_pipelines() -> Vec<SavedPipeline> {
+    use OperationId::*;
+    vec![
+        pipeline(
+            "clean-lines",
+            "Clean lines",
+            &["tidy-lines"],
+            vec![stage(TrimLines), stage(UniqueLines)],
+        ),
+        pipeline(
+            "sorted-unique-lines",
+            "Sorted unique lines",
+            &["sort-uniq"],
+            vec![stage(TrimLines), stage(UniqueLines), stage(SortAscending)],
+        ),
+        pipeline(
+            "rust-code",
+            "Rust code",
+            &["rs-code"],
+            vec![StageSpec {
+                operation: CodeBlock,
+                arguments: StageArguments {
+                    language: Some("rust".into()),
+                    ..Default::default()
+                },
+            }],
+        ),
+        pipeline(
+            "json-code",
+            "JSON code",
+            &["json-fence"],
+            vec![
+                stage(JsonPretty),
+                StageSpec {
+                    operation: CodeBlock,
+                    arguments: StageArguments {
+                        language: Some("json".into()),
+                        ..Default::default()
+                    },
+                },
+            ],
+        ),
+        pipeline(
+            "prompt-context",
+            "Prompt context",
+            &["prompt"],
+            vec![StageSpec {
+                operation: Template,
+                arguments: StageArguments {
+                    name: Some("prompt-context".into()),
+                    ..Default::default()
+                },
+            }],
+        ),
+    ]
+}
+
+pub fn default_catalog() -> ClipboardModifierCatalog {
+    ClipboardModifierCatalog {
+        templates: default_templates(),
+        pipelines: default_pipelines(),
+    }
+}
+
+fn stage(operation: OperationId) -> StageSpec {
+    StageSpec {
+        operation,
+        arguments: StageArguments::default(),
+    }
+}
+fn pipeline(id: &str, label: &str, aliases: &[&str], stages: Vec<StageSpec>) -> SavedPipeline {
+    SavedPipeline {
+        id: id.into(),
+        label: label.into(),
+        aliases: aliases.iter().map(|s| s.to_string()).collect(),
+        stages,
+    }
+}

--- a/src/clipboard_modify/error.rs
+++ b/src/clipboard_modify/error.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardModifyError {
+    MissingArgument {
+        operation: String,
+        argument: &'static str,
+    },
+    UnexpectedArgument {
+        operation: String,
+        argument: &'static str,
+    },
+    MissingPlaceholder {
+        template: String,
+    },
+    ReservedName {
+        name: String,
+    },
+    DuplicateName {
+        name: String,
+    },
+    UnknownOperation {
+        operation: String,
+    },
+}
+
+impl fmt::Display for ClipboardModifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingArgument {
+                operation,
+                argument,
+            } => write!(f, "{operation} requires {argument}"),
+            Self::UnexpectedArgument {
+                operation,
+                argument,
+            } => write!(f, "{operation} does not accept {argument}"),
+            Self::MissingPlaceholder { template } => {
+                write!(f, "template {template} must contain {{{{clipboard}}}}")
+            }
+            Self::ReservedName { name } => write!(f, "{name} is reserved"),
+            Self::DuplicateName { name } => write!(f, "{name} is duplicated"),
+            Self::UnknownOperation { operation } => write!(f, "unknown operation {operation}"),
+        }
+    }
+}
+
+impl std::error::Error for ClipboardModifyError {}

--- a/src/clipboard_modify/model.rs
+++ b/src/clipboard_modify/model.rs
@@ -1,0 +1,356 @@
+use serde::{Deserialize, Serialize};
+
+use super::catalog::{normalize_name, operation_by_id, reserved_names};
+use super::error::ClipboardModifyError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OperationId {
+    SingleQuote,
+    DoubleQuote,
+    Backticks,
+    CustomWrap,
+    NamedWrap,
+    Template,
+    CodeBlock,
+    SortAscending,
+    SortDescending,
+    UniqueLines,
+    Trim,
+    TrimLines,
+    JsonPretty,
+    JsonMinify,
+    Base64Encode,
+    Base64Decode,
+    UrlEncode,
+    UrlDecode,
+    Lowercase,
+    Uppercase,
+    TitleCase,
+    CamelCase,
+    PascalCase,
+    SnakeCase,
+    ScreamingSnake,
+    KebabCase,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StageArguments {
+    pub prefix: Option<String>,
+    pub suffix: Option<String>,
+    pub name: Option<String>,
+    pub language: Option<String>,
+}
+
+impl StageArguments {
+    pub fn any_supplied(&self) -> bool {
+        self.prefix.is_some()
+            || self.suffix.is_some()
+            || self.name.is_some()
+            || self.language.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StageSpec {
+    pub operation: OperationId,
+    #[serde(default)]
+    pub arguments: StageArguments,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TemplateProcessor {
+    Literal,
+    RustRawString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClipboardTemplate {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub template: String,
+    #[serde(default)]
+    pub processor: Option<TemplateProcessor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SavedPipeline {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub stages: Vec<StageSpec>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ClipboardModifiersFile {
+    pub templates: Vec<ClipboardTemplate>,
+    pub pipelines: Vec<SavedPipeline>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClipboardModifierCatalog {
+    pub templates: Vec<ClipboardTemplate>,
+    pub pipelines: Vec<SavedPipeline>,
+}
+
+impl StageSpec {
+    pub fn validate(&self) -> Result<(), ClipboardModifyError> {
+        let op = operation_by_id(self.operation).ok_or_else(|| {
+            ClipboardModifyError::UnknownOperation {
+                operation: format!("{:?}", self.operation),
+            }
+        })?;
+        op.argument_requirements
+            .validate(self.operation, &self.arguments)
+    }
+}
+
+impl ClipboardTemplate {
+    pub fn validate(&self) -> Result<(), ClipboardModifyError> {
+        if !self.template.contains("{{clipboard}}") {
+            return Err(ClipboardModifyError::MissingPlaceholder {
+                template: self.id.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn render(&self, clipboard: &str) -> String {
+        let processed = match self.processor.unwrap_or(TemplateProcessor::Literal) {
+            TemplateProcessor::Literal => clipboard.to_string(),
+            TemplateProcessor::RustRawString => rust_raw_string_literal(clipboard),
+        };
+        self.template.replace("{{clipboard}}", &processed)
+    }
+}
+
+pub fn rust_raw_string_literal(text: &str) -> String {
+    let mut hashes = 0usize;
+    loop {
+        let fence = format!("\"{}", "#".repeat(hashes));
+        if !text.contains(&fence) {
+            return format!("r{}\"{}\"{}", "#".repeat(hashes), text, "#".repeat(hashes));
+        }
+        hashes += 1;
+    }
+}
+
+impl SavedPipeline {
+    pub fn validate(&self) -> Result<(), ClipboardModifyError> {
+        for stage in &self.stages {
+            stage.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl ClipboardModifierCatalog {
+    pub fn new(
+        templates: Vec<ClipboardTemplate>,
+        pipelines: Vec<SavedPipeline>,
+    ) -> Result<Self, ClipboardModifyError> {
+        validate_namespace(&templates, &pipelines)?;
+        for t in &templates {
+            t.validate()?;
+        }
+        for p in &pipelines {
+            p.validate()?;
+        }
+        Ok(Self {
+            templates,
+            pipelines,
+        })
+    }
+}
+
+pub fn validate_namespace(
+    templates: &[ClipboardTemplate],
+    pipelines: &[SavedPipeline],
+) -> Result<(), ClipboardModifyError> {
+    let reserved = reserved_names();
+    let mut seen = std::collections::BTreeSet::new();
+    for name in templates
+        .iter()
+        .flat_map(|t| std::iter::once(&t.id).chain(t.aliases.iter()))
+        .chain(
+            pipelines
+                .iter()
+                .flat_map(|p| std::iter::once(&p.id).chain(p.aliases.iter())),
+        )
+    {
+        let n = normalize_name(name);
+        if reserved.contains(&n) {
+            return Err(ClipboardModifyError::ReservedName { name: n });
+        }
+        if !seen.insert(n.clone()) {
+            return Err(ClipboardModifyError::DuplicateName { name: n });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clipboard_modify::catalog::*;
+
+    #[test]
+    fn operation_id_serialization_names() {
+        assert_eq!(
+            serde_json::to_string(&OperationId::SingleQuote).unwrap(),
+            "\"single-quote\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::CodeBlock).unwrap(),
+            "\"code-block\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::SortDescending).unwrap(),
+            "\"sort-descending\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::TrimLines).unwrap(),
+            "\"trim-lines\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::JsonPretty).unwrap(),
+            "\"json-pretty\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::Base64Decode).unwrap(),
+            "\"base64-decode\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OperationId::ScreamingSnake).unwrap(),
+            "\"screaming-snake\""
+        );
+    }
+
+    #[test]
+    fn registry_uniqueness() {
+        let mut names = std::collections::BTreeSet::new();
+        let mut ids = std::collections::BTreeSet::new();
+        for op in operations() {
+            assert!(ids.insert(format!("{:?}", op.id)));
+            assert!(
+                names.insert(normalize_name(op.command)),
+                "duplicate {}",
+                op.command
+            );
+            for alias in op.aliases {
+                assert!(
+                    names.insert(normalize_name(alias)),
+                    "duplicate alias {alias}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn alias_normalization_and_lookup() {
+        assert_eq!(normalize_name("  Foo__ Bar---Baz  "), "foo-bar-baz");
+        assert_eq!(
+            operation_lookup("SORT DESC").unwrap().id,
+            OperationId::SortDescending
+        );
+    }
+
+    #[test]
+    fn reserved_name_rejection() {
+        let t = ClipboardTemplate {
+            id: "template".into(),
+            label: "Bad".into(),
+            aliases: vec![],
+            template: "{{clipboard}}".into(),
+            processor: None,
+        };
+        assert!(matches!(
+            ClipboardModifierCatalog::new(vec![t], vec![]),
+            Err(ClipboardModifyError::ReservedName { .. })
+        ));
+    }
+
+    #[test]
+    fn template_placeholder_validation() {
+        let t = ClipboardTemplate {
+            id: "x".into(),
+            label: "X".into(),
+            aliases: vec![],
+            template: "missing".into(),
+            processor: None,
+        };
+        assert!(matches!(
+            t.validate(),
+            Err(ClipboardModifyError::MissingPlaceholder { .. })
+        ));
+    }
+
+    #[test]
+    fn pipeline_validation() {
+        let good = StageSpec {
+            operation: OperationId::CodeBlock,
+            arguments: StageArguments {
+                language: Some("rust".into()),
+                ..Default::default()
+            },
+        };
+        assert!(good.validate().is_ok());
+        let bad = StageSpec {
+            operation: OperationId::CustomWrap,
+            arguments: StageArguments {
+                prefix: Some("(".into()),
+                ..Default::default()
+            },
+        };
+        assert!(matches!(
+            bad.validate(),
+            Err(ClipboardModifyError::MissingArgument {
+                argument: "suffix",
+                ..
+            })
+        ));
+        let no_args = StageSpec {
+            operation: OperationId::TrimLines,
+            arguments: StageArguments {
+                name: Some("x".into()),
+                ..Default::default()
+            },
+        };
+        assert!(matches!(
+            no_args.validate(),
+            Err(ClipboardModifyError::UnexpectedArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_field_rejection_through_serde() {
+        let json = r#"{"operation":"trim-lines","arguments":{"extra":"nope"}}"#;
+        assert!(serde_json::from_str::<StageSpec>(json).is_err());
+    }
+
+    #[test]
+    fn raw_string_processor_collision_safety() {
+        let text = "contains \"# and \"## fences";
+        let literal = rust_raw_string_literal(text);
+        assert!(literal.starts_with("r###\""));
+        assert!(literal.ends_with("\"###"));
+        let t = ClipboardTemplate {
+            id: "raw".into(),
+            label: "Raw".into(),
+            aliases: vec![],
+            template: "{{clipboard}}".into(),
+            processor: Some(TemplateProcessor::RustRawString),
+        };
+        assert_eq!(t.render(text), literal);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod actions;
 pub mod actions_editor;
 
+pub mod clipboard_modify;
 pub mod common;
 pub mod dashboard;
 pub mod file_search;


### PR DESCRIPTION
### Motivation
- Centralize clipboard transformation metadata and behavior behind a single registry so parser, launcher suggestions, GUI stage selection, validation and help can read one source of truth.
- Provide strict, serializable stage and argument models with denial of unknown serde fields to prevent drift and accidental configuration mistakes.
- Offer typed templates, saved pipelines and a catalog with deterministic normalization and reserved-name checks to avoid namespace collisions.

### Description
- Add the `clipboard_modify` domain module and export it from the crate root via `src/clipboard_modify.rs` and `pub mod clipboard_modify;` in `src/lib.rs` and create the files `catalog.rs`, `model.rs`, `defaults.rs`, and `error.rs` under `src/clipboard_modify`.
- Define `OperationId` as a serializable enum using canonical kebab-case names and implement a single operation registry (`OPERATIONS`) in `src/clipboard_modify/catalog.rs` that includes canonical command, label, description, category, aliases, argument requirements, pipeline availability, sync suitability, and help examples.
- Add strict stage and argument types: `StageSpec { operation: OperationId, arguments: StageArguments }` and `StageArguments` with optional `prefix`, `suffix`, `name`, and `language`, and annotate with `#[serde(deny_unknown_fields)]`/`#[serde(default, deny_unknown_fields)]` to reject unknown fields.
- Implement operation-specific argument validation (custom wrap, named wrap, code block, template, and argument-free transforms), operation lookup, a global `normalize_name` function with the specified normalization rules, and a `reserved_names` generator built from commands/aliases and control words.
- Add typed models `ClipboardTemplate`, `SavedPipeline`, `ClipboardModifiersFile`, and `ClipboardModifierCatalog`, including `TemplateProcessor` (with `literal` and `rust_raw_string`) and a collision-safe `rust_raw_string_literal` generator used by the `rust-raw-string` starter template.
- Provide typed default templates and pipelines in `defaults.rs` (no manual JSON string) and add namespace/template/pipeline validation functions to detect reserved or duplicate names and missing `{{clipboard}}` placeholders.
- Add unit tests for `OperationId` serialization, registry uniqueness, alias normalization and lookup, reserved-name rejection, template placeholder validation, pipeline/argument validation, serde unknown-field rejection, and raw-string processor collision safety in `model.rs` test module.

### Testing
- Ran `rustfmt --check` against the new `src/clipboard_modify` files and it succeeded.
- Attempted `cargo test clipboard_modify --lib`; the test run was blocked from completing in this workspace due to unrelated build issues in other parts of the workspace (missing system dev packages were installed during the run, then the build failed due to platform-specific Windows API code and platform-dependent crates in unrelated modules), so the full test suite could not complete here.
- The new unit tests for the `clipboard_modify` module are present and exercise serialization names, registry uniqueness, normalization/lookup, validation rules, serde unknown-field denial, and raw-string collision safety; they should pass when run in a build environment where the workspace compiles end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d22b3e1608332a949e7717c7d9f9c)