### PR TITLE
Add clipboard_modify launcher plugin (cm prefix)

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,6 +8,7 @@ use crate::plugins::brightness::BrightnessPlugin;
 use crate::plugins::browser_tabs::BrowserTabsPlugin;
 use crate::plugins::calendar::CalendarPlugin;
 use crate::plugins::clipboard::ClipboardPlugin;
+use crate::plugins::clipboard_modify::ClipboardModifyPlugin;
 use crate::plugins::color_picker::ColorPickerPlugin;
 use crate::plugins::convert_panel::ConvertPanelPlugin;
 use crate::plugins::dropcalc::DropCalcPlugin;
@@ -184,6 +185,11 @@ impl PluginManager {
         self.register_with_settings(RedditPlugin, plugin_settings);
         self.register_with_settings(WikipediaPlugin, plugin_settings);
         self.register_with_settings(ClipboardPlugin::new(clipboard_limit), plugin_settings);
+        let clipboard_modifier_catalog = Arc::clone(&self.services.clipboard_modifier_catalog);
+        self.register_with_settings(
+            ClipboardModifyPlugin::new(clipboard_modifier_catalog),
+            plugin_settings,
+        );
         self.register_with_settings(BookmarksPlugin::default(), plugin_settings);
         self.register_with_settings(FoldersPlugin::default(), plugin_settings);
         self.register_with_settings(FileSearchPlugin::default(), plugin_settings);

--- a/src/plugins/clipboard_modify.rs
+++ b/src/plugins/clipboard_modify.rs
@@ -1,0 +1,141 @@
+use crate::actions::Action;
+use crate::clipboard_modify::catalog::{canonical_command, operation_lookup};
+use crate::clipboard_modify::parser::{
+    parse, ClipboardModifyIntent, ClipboardModifyParseResult, ModifySection, PartialQuery,
+};
+use crate::clipboard_modify::store::SharedClipboardModifierCatalog;
+use crate::plugin::Plugin;
+
+pub struct ClipboardModifyPlugin {
+    catalog: SharedClipboardModifierCatalog,
+}
+
+impl ClipboardModifyPlugin {
+    pub fn new(catalog: SharedClipboardModifierCatalog) -> Self {
+        Self { catalog }
+    }
+
+    fn catalog_snapshot(
+        &self,
+    ) -> std::sync::Arc<crate::clipboard_modify::model::ClipboardModifierCatalog> {
+        self.catalog.read().unwrap().clone()
+    }
+}
+
+impl Plugin for ClipboardModifyPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        let catalog = self.catalog_snapshot();
+        match parse(query, catalog.as_ref()) {
+            ClipboardModifyParseResult::NotClipboardModify => Vec::new(),
+            ClipboardModifyParseResult::OpenSection(section) => vec![section_action(section)],
+            ClipboardModifyParseResult::Partial(partial) => partial_actions(partial),
+            ClipboardModifyParseResult::CompleteExecution(intent) => vec![execution_action(intent)],
+            ClipboardModifyParseResult::Invalid(error) => vec![Action {
+                label: "Invalid clipboard modify query".into(),
+                desc: format!("Clipboard Modify: {:?}", error.kind),
+                action: "clipboard_modify:error".into(),
+                args: None,
+            }],
+        }
+    }
+
+    fn name(&self) -> &str {
+        "clipboard_modify"
+    }
+
+    fn description(&self) -> &str {
+        "Builds clipboard modification pipelines with prefix `cm`"
+    }
+
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "cm".into(),
+            desc: "Clipboard Modify".into(),
+            action: "query:cm".into(),
+            args: None,
+        }]
+    }
+
+    fn query_prefixes(&self) -> &[&str] {
+        &["cm"]
+    }
+}
+
+fn section_action(section: ModifySection) -> Action {
+    let section_name = section_name(section);
+    Action {
+        label: format!("Open Clipboard Modify {section_name}"),
+        desc: "Clipboard Modify".into(),
+        action: format!("clipboard_modify:open:{section_name}"),
+        args: serde_json::to_string(&serde_json::json!({ "section": section_name })).ok(),
+    }
+}
+
+fn partial_actions(partial: PartialQuery) -> Vec<Action> {
+    partial
+        .suggestions
+        .into_iter()
+        .map(|suggestion| {
+            let label = suggestion_label(partial.section, &suggestion);
+            Action {
+                label,
+                desc: format!("Clipboard Modify stage {}", partial.stage_index + 1),
+                action: format!("query:{}", suggestion_query(partial.section, &suggestion)),
+                args: None,
+            }
+        })
+        .collect()
+}
+
+fn suggestion_query(section: ModifySection, suggestion: &str) -> String {
+    match section {
+        ModifySection::Modify => format!("cm {suggestion}"),
+        ModifySection::Templates => format!("cm template {suggestion}"),
+        ModifySection::SavedPipelines => format!("cm apply {suggestion}"),
+    }
+}
+
+fn suggestion_label(section: ModifySection, suggestion: &str) -> String {
+    match section {
+        ModifySection::Modify => operation_lookup(suggestion)
+            .map(|op| format!("{}: {}", canonical_command(op.id), op.description))
+            .unwrap_or_else(|| suggestion.to_string()),
+        ModifySection::Templates => format!("Use template {suggestion}"),
+        ModifySection::SavedPipelines => format!("Apply pipeline {suggestion}"),
+    }
+}
+
+fn execution_action(intent: ClipboardModifyIntent) -> Action {
+    match intent {
+        ClipboardModifyIntent::Stages(stages) => Action {
+            label: "Run Clipboard Modify pipeline".into(),
+            desc: format!("Clipboard Modify: {} stage(s)", stages.len()),
+            action: "clipboard_modify:execute".into(),
+            args: serde_json::to_string(
+                &serde_json::json!({ "intent": "stages", "stages": stages }),
+            )
+            .ok(),
+        },
+        ClipboardModifyIntent::ApplySavedPipeline { name } => Action {
+            label: format!("Run Clipboard Modify pipeline {name}"),
+            desc: "Clipboard Modify".into(),
+            action: "clipboard_modify:execute".into(),
+            args: serde_json::to_string(
+                &serde_json::json!({ "intent": "saved-pipeline", "name": name }),
+            )
+            .ok(),
+        },
+    }
+}
+
+fn section_name(section: ModifySection) -> &'static str {
+    match section {
+        ModifySection::Modify => "modify",
+        ModifySection::Templates => "templates",
+        ModifySection::SavedPipelines => "saved-pipelines",
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,6 +6,7 @@ pub mod browser_tabs;
 pub mod calc_history;
 pub mod calendar;
 pub mod clipboard;
+pub mod clipboard_modify;
 pub mod color_picker;
 pub mod convert_panel;
 pub mod dropcalc;

--- a/tests/plugin_commands.rs
+++ b/tests/plugin_commands.rs
@@ -218,3 +218,36 @@ fn default_command_collection_keeps_clipboard_modify_baseline_plugins_registered
         );
     }
 }
+
+#[test]
+fn cm_command_is_visible_without_hiding_existing_commands() {
+    let actions = Arc::new(Vec::new());
+    let mut plugins = PluginManager::new();
+    plugins.reload_from_dirs(
+        &[],
+        Settings::default().clipboard_limit,
+        Settings::default().net_unit,
+        false,
+        &std::collections::HashMap::new(),
+        Arc::clone(&actions),
+    );
+
+    let commands: std::collections::HashSet<_> = plugins
+        .commands()
+        .into_iter()
+        .map(|a| (a.label, a.desc, a.action))
+        .collect();
+
+    for expected in [
+        ("cm", "Clipboard Modify", "query:cm"),
+        ("cb", "Clipboard", "query:cb"),
+        ("cs", "Snippet", "query:cs"),
+        ("fs", "Open local file search", "query:fs"),
+        ("o", "Omni", "query:o "),
+    ] {
+        assert!(
+            commands.contains(&(expected.0.into(), expected.1.into(), expected.2.into())),
+            "missing command {expected:?}"
+        );
+    }
+}

--- a/tests/plugin_routing.rs
+++ b/tests/plugin_routing.rs
@@ -344,3 +344,117 @@ fn clipboard_modify_baseline_builtin_queries_keep_current_routing_results() {
         .iter()
         .any(|result| result.action == "app:plan"));
 }
+
+fn clipboard_modify_manager_with_catalog(
+    catalog: multi_launcher::clipboard_modify::model::ClipboardModifierCatalog,
+) -> PluginManager {
+    use multi_launcher::clipboard_modify::store::shared_default_catalog;
+    use multi_launcher::plugins::clipboard_modify::ClipboardModifyPlugin;
+
+    let shared = shared_default_catalog();
+    *shared.write().unwrap() = Arc::new(catalog);
+    let mut pm = PluginManager::with_clipboard_modifier_catalog(Arc::clone(&shared));
+    pm.register(Box::new(ClipboardModifyPlugin::new(shared)));
+    pm
+}
+
+#[test]
+fn cm_prefix_routes_only_clipboard_modify_plugin() {
+    use multi_launcher::plugins::clipboard_modify::ClipboardModifyPlugin;
+    use multi_launcher::plugins::file_search::FileSearchPlugin;
+    use multi_launcher::plugins::omni_search::OmniSearchPlugin;
+
+    let actions = Arc::new(vec![Action {
+        label: "plan app".into(),
+        desc: "launcher".into(),
+        action: "app:plan".into(),
+        args: None,
+    }]);
+    let mut pm = PluginManager::new();
+    let catalog = Arc::clone(&pm.internal_services().clipboard_modifier_catalog);
+    pm.register(Box::new(FileSearchPlugin::default()));
+    pm.register(Box::new(OmniSearchPlugin::new(Arc::clone(&actions))));
+    pm.register(Box::new(ClipboardModifyPlugin::new(catalog)));
+
+    let results = pm.search_filtered("cm", None, None);
+    assert!(results
+        .iter()
+        .any(|a| a.action == "clipboard_modify:open:modify"));
+    assert!(!results.iter().any(|a| a.action == "app:plan"));
+    assert!(!results.iter().any(|a| a.action.starts_with("file_search:")));
+}
+
+#[test]
+fn cm_wrap_and_json_queries_return_contextual_suggestions() {
+    let pm = clipboard_modify_manager_with_catalog(
+        multi_launcher::clipboard_modify::defaults::default_catalog(),
+    );
+
+    let wrap = pm.search_filtered("cm wrap", None, None);
+    assert!(wrap.iter().any(|a| a.label.contains("wrap quotes")));
+    assert!(wrap.iter().any(|a| a.action == "query:cm wrap quotes"));
+
+    let json = pm.search_filtered("cm json", None, None);
+    assert!(json.iter().any(|a| a.label.contains("json-pretty")));
+    assert!(json.iter().any(|a| a.label.contains("json-minify")));
+}
+
+#[test]
+fn cm_template_and_apply_suggestions_come_from_current_catalog() {
+    use multi_launcher::clipboard_modify::model::{
+        ClipboardModifierCatalog, ClipboardTemplate, OperationId, SavedPipeline, StageArguments,
+        StageSpec,
+    };
+
+    let catalog = ClipboardModifierCatalog::new(
+        vec![ClipboardTemplate {
+            id: "prompt-context".into(),
+            label: "Prompt context".into(),
+            aliases: vec!["pc".into()],
+            template: "{{clipboard}}".into(),
+            processor: None,
+        }],
+        vec![SavedPipeline {
+            id: "cleanup-code".into(),
+            label: "Cleanup code".into(),
+            aliases: vec!["cc".into()],
+            stages: vec![StageSpec {
+                operation: OperationId::Trim,
+                arguments: StageArguments::default(),
+            }],
+        }],
+    )
+    .unwrap();
+    let pm = clipboard_modify_manager_with_catalog(catalog);
+
+    let templates = pm.search_filtered("cm template p", None, None);
+    assert!(templates
+        .iter()
+        .any(|a| a.label == "Use template prompt-context"));
+    assert!(templates
+        .iter()
+        .any(|a| a.action == "query:cm template prompt-context"));
+
+    let pipelines = pm.search_filtered("cm apply c", None, None);
+    assert!(pipelines
+        .iter()
+        .any(|a| a.label == "Apply pipeline cleanup-code"));
+    assert!(pipelines
+        .iter()
+        .any(|a| a.action == "query:cm apply cleanup-code"));
+}
+
+#[test]
+fn cm_complete_query_encodes_stages_without_touching_clipboard() {
+    let pm = clipboard_modify_manager_with_catalog(
+        multi_launcher::clipboard_modify::defaults::default_catalog(),
+    );
+    let results = pm.search_filtered("cm trim | json-pretty", None, None);
+    let action = results
+        .iter()
+        .find(|a| a.action == "clipboard_modify:execute")
+        .expect("execute action");
+    let args = action.args.as_deref().expect("encoded args");
+    assert!(args.contains("trim"));
+    assert!(args.contains("json-pretty"));
+}


### PR DESCRIPTION
### Motivation
- Introduce an interactive launcher plugin to build clipboard-modification pipelines with a short `cm` prefix, surface contextual suggestions from the modifiers catalog, and encode intents for later execution without touching the real clipboard.

### Description
- Add `src/plugins/clipboard_modify.rs` implementing `ClipboardModifyPlugin` that snapshots the shared `SharedClipboardModifierCatalog` and uses `src/clipboard_modify/parser.rs` to classify queries into `OpenSection`, `Partial`, `CompleteExecution`, `Invalid`, or `NotClipboardModify` outcomes.
- Register the new module in `src/plugins/mod.rs` and register `ClipboardModifyPlugin` from `PluginManager::reload_from_dirs` immediately after the existing `ClipboardPlugin` using `Arc::clone(&self.services.clipboard_modifier_catalog)`.
- Expose a `cm` command shortcut and prefix routing, return section-opening actions for `OpenSection`, contextual `query:` suggestion actions for `Partial` parser results, and `clipboard_modify:execute` actions encoding structured stage lists or saved-pipeline names for `CompleteExecution` results while not reading/writing the OS clipboard.
- Resolve template and saved-pipeline suggestions from the current catalog snapshot and preserve existing plugin command and routing behavior expected by existing tests.

### Testing
- Added unit tests exercising command visibility (`cm_command_is_visible_without_hiding_existing_commands`) and routing/suggestions (`cm` prefix routing, `cm wrap`, `cm json`, catalog-backed `cm template p`, catalog-backed `cm apply c`, and complete-query stage encoding) under `tests/plugin_commands.rs` and `tests/plugin_routing.rs`.
- Ran `cargo fmt` and attempted `cargo test -q --test plugin_commands --test plugin_routing`, but test execution was blocked in this environment due to missing system libraries and unresolved Windows API bindings during full crate compilation, so the test run could not complete here.
- Also attempted `cargo test -q --no-default-features --test plugin_routing cm_wrap_and_json_queries_return_contextual_suggestions`, which was likewise blocked by the same environment-related compilation issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d46c1dc348332bea2430a42ae1e64)