### PR TITLE
Route Clipboard Modify completions through GUI lifecycle

### DIFF
--- a/src/clipboard_modify/coordinator.rs
+++ b/src/clipboard_modify/coordinator.rs
@@ -183,13 +183,25 @@ impl PreviewCoordinator {
             t.cancel();
         }
     }
-    pub fn tick(&mut self) {
+    pub fn cancel_and_invalidate(&mut self) {
+        self.cancel_active();
+        self.active = None;
+        self.pending = None;
+        self.full_output = None;
+        self.state = PreviewState::IdleMissing;
+    }
+    pub fn is_active(&self) -> bool {
+        self.active.is_some() || self.pending.is_some()
+    }
+    pub fn tick(&mut self) -> bool {
+        let before = self.is_active();
         self.drain();
         if self.pending.as_ref().is_some_and(|p| Instant::now() >= p.1) {
             let (id, _, source, intent, catalog) = self.pending.take().unwrap();
             self.start(id, source, intent, catalog);
         }
         self.drain();
+        before && !self.is_active()
     }
     pub fn force_start_pending(&mut self) {
         if let Some((id, _, s, i, c)) = self.pending.take() {
@@ -459,6 +471,12 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
     pub fn pending_metadata(&self, id: OperationId) -> Option<&ImmediateRequestMetadata> {
         self.pending.get(&id.0)
     }
+    pub fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+    pub fn cancel_pending(&mut self) {
+        self.pending.clear();
+    }
     pub fn diagnostics(&self) -> &ImmediateDiagnostics {
         &self.diagnostics
     }
@@ -582,6 +600,25 @@ mod tests {
         assert!(ev.undo_available);
         assert!(ev.result.is_ok());
     }
+    #[test]
+    fn immediate_cancel_pending_rejects_stale_completion() {
+        let svc = Arc::new(ClipboardService::new(FakeClipboardBackend::with_text("x")));
+        let mut ic = ImmediateExecutionCoordinator::new(svc);
+        let id = ic.start(
+            ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+            Arc::new(default_catalog()),
+            ImmediateRequestMetadata {
+                action: action(),
+                query: "q".into(),
+                source: ActivationSource::Enter,
+            },
+        );
+        assert!(ic.pending_metadata(id).is_some());
+        ic.cancel_pending();
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(ic.drain_completions().is_empty());
+    }
+
     #[test]
     fn hooks_only_after_successful_commits() {
         let svc = Arc::new(ClipboardService::new(FakeClipboardBackend::with_text("x")));

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -893,6 +893,9 @@ impl LauncherApp {
         {
             match crate::clipboard_modify::runtime::undo() {
                 Ok(()) => {
+                    self.handle_clipboard_modify_gui_event(
+                        ClipboardModifyGuiEvent::ImmediateOperationComplete,
+                    );
                     self.visible_flag.store(false, Ordering::SeqCst);
                     if self.enable_toasts {
                         push_toast(
@@ -962,12 +965,16 @@ impl LauncherApp {
     }
 
     pub(crate) fn drain_clipboard_modify_immediate(&mut self) {
+        let mut typed_events = Vec::new();
         for ev in self.clipboard_modify_immediate.drain_completions() {
             let meta = self
                 .pending_clipboard_modify_immediate
                 .remove(&ev.request_id.0);
             match ev.result {
                 Ok(()) => {
+                    typed_events.push(WatchEvent::ClipboardModify(
+                        ClipboardModifyGuiEvent::ImmediateOperationComplete,
+                    ));
                     if let Some(meta) = meta.as_ref() {
                         self.record_history_usage(&meta.action, &meta.query, meta.source);
                     }
@@ -985,6 +992,9 @@ impl LauncherApp {
                     }
                 }
                 Err(ref err) => {
+                    typed_events.push(WatchEvent::ClipboardModify(
+                        ClipboardModifyGuiEvent::ImmediateOperationFailed,
+                    ));
                     if let Some(meta) = meta {
                         self.query = meta.query;
                     }
@@ -994,6 +1004,44 @@ impl LauncherApp {
                 }
             }
             self.clipboard_modify_events.push(ev);
+        }
+        for ev in typed_events {
+            self.handle_clipboard_modify_gui_event(match ev {
+                WatchEvent::ClipboardModify(e) => e,
+                _ => unreachable!(),
+            });
+        }
+    }
+
+    pub(crate) fn handle_clipboard_modify_gui_event(&mut self, ev: ClipboardModifyGuiEvent) {
+        match ev {
+            ClipboardModifyGuiEvent::ImmediateOperationComplete
+            | ClipboardModifyGuiEvent::ImmediateOperationFailed => {}
+            ClipboardModifyGuiEvent::ConfigurationReloadSuccess => {
+                self.clipboard_modify_config_diagnostic = self
+                    .clipboard_modify_runtime
+                    .diagnostic
+                    .read()
+                    .unwrap()
+                    .clone();
+                self.last_results_valid = false;
+                if self
+                    .query
+                    .trim_start()
+                    .to_ascii_lowercase()
+                    .starts_with("cm")
+                {
+                    self.search();
+                }
+                self.update_command_cache();
+            }
+            ClipboardModifyGuiEvent::ConfigurationReloadFailure(err) => {
+                self.clipboard_modify_config_diagnostic = Some(err.clone());
+                self.report_error_message("clipboard_modify.config.reload", err);
+            }
+            ClipboardModifyGuiEvent::StartupDiagnosticChanged(diagnostic) => {
+                self.clipboard_modify_config_diagnostic = diagnostic;
+            }
         }
     }
 

--- a/src/gui/clipboard_modify_dialog.rs
+++ b/src/gui/clipboard_modify_dialog.rs
@@ -147,7 +147,7 @@ impl ClipboardModifyDialogState {
     }
     pub fn cleanup_after_close(&mut self) {
         let wrap = self.wrap_preview;
-        self.preview.cancel_active();
+        self.preview.cancel_and_invalidate();
         self.source.clear();
         self.baseline.clear();
         self.reset_source.clear();
@@ -155,6 +155,7 @@ impl ClipboardModifyDialogState {
         self.source_error = None;
         self.stages.clear();
         self.preview = PreviewCoordinator::default();
+        self.acknowledged_large_sources.clear();
         self.external_change = None;
         self.pending_action = None;
         self.unsaved_template_draft = false;
@@ -233,7 +234,6 @@ impl ClipboardModifyDialogState {
         if !self.open {
             return;
         }
-        self.preview.tick();
         let mut open = self.open;
         egui::Window::new("Clipboard Modify")
             .open(&mut open)
@@ -1138,6 +1138,34 @@ mod tests {
         let d = ClipboardModifyDialogState::default();
         assert!(!d.can_apply());
     }
+    #[test]
+    fn cleanup_after_close_clears_content_bearing_fields() {
+        let mut dlg = ClipboardModifyDialogState::default();
+        dlg.open = true;
+        dlg.source = "secret source".into();
+        dlg.baseline = "secret baseline".into();
+        dlg.reset_source = "secret reset".into();
+        dlg.source_fingerprint = 99;
+        dlg.source_error = Some("secret error".into());
+        dlg.external_change = Some(ClipboardSummary {
+            fingerprint: 1,
+            bytes: 2,
+            chars: 3,
+        });
+        dlg.pending_action = Some(PendingDialogAction::Apply);
+        dlg.wrap_preview = false;
+        dlg.cleanup_after_close();
+        assert!(dlg.source.is_empty());
+        assert!(dlg.baseline.is_empty());
+        assert!(dlg.reset_source.is_empty());
+        assert_eq!(dlg.source_fingerprint, 0);
+        assert!(dlg.source_error.is_none());
+        assert!(dlg.external_change.is_none());
+        assert!(dlg.pending_action.is_none());
+        assert!(!dlg.wrap_preview);
+        assert!(matches!(dlg.preview.state(), PreviewState::IdleMissing));
+    }
+
     #[test]
     fn ctrl_z_not_global_clipboard_modify_undo() {
         assert_ne!("Ctrl+Z", "cm undo");

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -144,7 +144,7 @@ use std::time::{Duration, Instant};
 use url::Url;
 use watch::watch_file;
 
-pub use state::{ActivationSource, TestWatchEvent, WatchEvent};
+pub use state::{ActivationSource, ClipboardModifyGuiEvent, TestWatchEvent, WatchEvent};
 pub(crate) use state::{PendingConfirmAction, ResultContextMenuKind, UiErrorEvent};
 
 const SUBCOMMANDS: &[&str] = &[
@@ -654,10 +654,16 @@ impl LauncherApp {
 
     pub fn reload_clipboard_modify_config(&mut self) {
         match self.clipboard_modify_runtime.reload_now() {
-            Ok(catalog) => self.refresh_clipboard_modify_catalog(catalog, true),
+            Ok(catalog) => {
+                self.refresh_clipboard_modify_catalog(catalog, true);
+                self.handle_clipboard_modify_gui_event(
+                    ClipboardModifyGuiEvent::ConfigurationReloadSuccess,
+                );
+            }
             Err(err) => {
-                self.clipboard_modify_config_diagnostic = Some(err.to_string());
-                self.report_error_message("clipboard_modify.config.reload", err.to_string());
+                self.handle_clipboard_modify_gui_event(
+                    ClipboardModifyGuiEvent::ConfigurationReloadFailure(err.to_string()),
+                );
             }
         }
     }
@@ -2879,7 +2885,8 @@ pub fn recv_test_event(rx: &Receiver<WatchEvent>) -> Option<TestWatchEvent> {
             | WatchEvent::Todos
             | WatchEvent::Favorites
             | WatchEvent::Gestures
-            | WatchEvent::ExecuteAction(_) => {
+            | WatchEvent::ExecuteAction(_)
+            | WatchEvent::ClipboardModify(_) => {
                 continue;
             }
             WatchEvent::Recycle(_) => return Some(ev.into()),

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -642,6 +642,25 @@ impl LauncherApp {
     }
 }
 
+impl LauncherApp {
+    pub(crate) fn poll_clipboard_modify_runtime(&mut self, ctx: &egui::Context) {
+        let preview_finished = self.clipboard_modify_dialog.preview.tick();
+        if preview_finished {
+            ctx.request_repaint();
+        }
+        let had_immediate = self.clipboard_modify_immediate.has_pending();
+        self.drain_clipboard_modify_immediate();
+        if preview_finished || (had_immediate && !self.clipboard_modify_immediate.has_pending()) {
+            ctx.request_repaint();
+        }
+        if self.clipboard_modify_dialog.preview.is_active()
+            || self.clipboard_modify_immediate.has_pending()
+        {
+            ctx.request_repaint_after(Duration::from_millis(150));
+        }
+    }
+}
+
 impl eframe::App for LauncherApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         use egui::*;
@@ -651,7 +670,7 @@ impl eframe::App for LauncherApp {
             self.launcher_hwnd = Some(hwnd.0 as usize);
         }
         self.multi_manager_drain_runtime_events();
-        self.drain_clipboard_modify_immediate();
+        self.poll_clipboard_modify_runtime(ctx);
         let _ = self.multi_manager.start_pending_automatic_reconnect();
         if self
             .multi_manager
@@ -1369,6 +1388,10 @@ impl eframe::App for LauncherApp {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        self.clipboard_modify_dialog.cleanup_after_close();
+        self.clipboard_modify_immediate.cancel_pending();
+        self.pending_clipboard_modify_immediate.clear();
+        self.clipboard_modify_events.clear();
         self.multi_manager.shutdown();
         let multi_manager_save_on_exit = crate::settings::Settings::load(&self.settings_path)
             .map(|settings| settings.multi_manager.save_on_exit)

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -2,6 +2,15 @@ use crate::actions::Action;
 use crate::dashboard::DashboardEvent;
 use std::fmt::Display;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClipboardModifyGuiEvent {
+    ImmediateOperationComplete,
+    ImmediateOperationFailed,
+    ConfigurationReloadSuccess,
+    ConfigurationReloadFailure(String),
+    StartupDiagnosticChanged(Option<String>),
+}
+
 #[derive(Clone)]
 pub enum WatchEvent {
     Actions,
@@ -16,6 +25,7 @@ pub enum WatchEvent {
     Dashboard(DashboardEvent),
     Recycle(Result<(), String>),
     ExecuteAction(Action),
+    ClipboardModify(ClipboardModifyGuiEvent),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -95,6 +105,7 @@ impl From<WatchEvent> for TestWatchEvent {
             WatchEvent::Dashboard(_) => TestWatchEvent::Actions,
             WatchEvent::Recycle(_) => unreachable!(),
             WatchEvent::ExecuteAction(_) => TestWatchEvent::Actions,
+            WatchEvent::ClipboardModify(_) => TestWatchEvent::Actions,
         }
     }
 }

--- a/src/gui/watch.rs
+++ b/src/gui/watch.rs
@@ -134,6 +134,9 @@ impl LauncherApp {
                 WatchEvent::ExecuteAction(action) => {
                     self.activate_action(action, None, ActivationSource::Gesture);
                 }
+                WatchEvent::ClipboardModify(ev) => {
+                    self.handle_clipboard_modify_gui_event(ev);
+                }
             }
         }
         self.maybe_rebuild_completion_index(Instant::now());
@@ -165,6 +168,22 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
         )
+    }
+
+    #[test]
+    fn clipboard_modify_watch_events_map_to_action_refresh_for_tests() {
+        assert_eq!(
+            TestWatchEvent::from(WatchEvent::ClipboardModify(
+                ClipboardModifyGuiEvent::ImmediateOperationComplete
+            )),
+            TestWatchEvent::Actions
+        );
+        assert_eq!(
+            TestWatchEvent::from(WatchEvent::ClipboardModify(
+                ClipboardModifyGuiEvent::ConfigurationReloadFailure("bad".into())
+            )),
+            TestWatchEvent::Actions
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Surface Clipboard Modify background work (preview/immediate) and configuration lifecycle as typed GUI events so the UI can react deterministically without embedding clipboard text in events.
- Centralize per-frame polling of Clipboard Modify runtime state to request repaints for active work and finished completions.
- Ensure closing the dialog and exiting the app cancels and invalidates background work and does not persist content-bearing state.

### Description
- Added a typed `ClipboardModifyGuiEvent` enum and a `WatchEvent::ClipboardModify` variant and mapped it into `TestWatchEvent` for tests in `src/gui/state.rs` and `src/gui/watch.rs`.
- Routed configuration reload outcomes to the typed GUI handler (`ClipboardModifyGuiEvent::ConfigurationReloadSuccess/Failure`) in `src/gui/mod.rs`.
- Centralized runtime polling in `LauncherApp::poll_clipboard_modify_runtime(ctx)` (added in `src/gui/render.rs`) which: ticks the preview coordinator, drains immediate completions, calls `ctx.request_repaint()` on completion events, and calls `ctx.request_repaint_after(...)` while work is active.
- Preserved existing immediate completion behavior but made `drain_clipboard_modify_immediate()` emit typed events and call a new `handle_clipboard_modify_gui_event()` helper in `src/gui/actions.rs` to update diagnostics/search/cache state.
- Added non-blocking lifecycle helpers: `PreviewCoordinator::cancel_and_invalidate`, `PreviewCoordinator::is_active`, `PreviewCoordinator::tick` returning a finished-while-active bool, and `ImmediateExecutionCoordinator::has_pending`/`cancel_pending` in `src/clipboard_modify/coordinator.rs`.
- Hardened dialog close cleanup in `src/gui/clipboard_modify_dialog.rs` to cancel+invalidate preview work, clear source/baseline/reset source/preview/external-change/pending-action/errors/content-bearing fields, and preserve non-sensitive UI preferences; also clear acknowledged-large-source tracking.
- On application exit (`on_exit` in `src/gui/render.rs`) cancel pending immediate work and dialog state and clear related pending maps without blocking on transform threads.
- Added unit tests: event mapping test, dialog cleanup test, and coordinator test that stale immediate completions are rejected after cancellation.

### Testing
- Ran `cargo fmt` successfully and ensured `git diff --check` produced no whitespace errors.
- Added and committed code changes and unit tests; new tests are `clipboard_modify_watch_events_map_to_action_refresh_for_tests`, `cleanup_after_close_clears_content_bearing_fields`, and `immediate_cancel_pending_rejects_stale_completion` in the clipboard-modify modules.
- Attempted `cargo check -q` and `cargo test -q clipboard_modify --lib`; CI-local `cargo check` was blocked by platform-specific native dependency and Windows-target crate resolution issues in this environment (installed some Linux dev packages to satisfy `alsa`/X11 but unresolved `windows::Win32` imports remain), and the targeted `cargo test` run did not complete within the available command window; no new clipboard-modify-specific test failures were observed before the run was stopped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e8efd3c5c8332b4d81ebffd2a8f4a)