### PR TITLE
Extend Clipboard Modify navigation sections

### DIFF
--- a/src/clipboard_modify/actions.rs
+++ b/src/clipboard_modify/actions.rs
@@ -32,6 +32,9 @@ pub enum ClipboardModifySectionPayload {
     Modify,
     Templates,
     SavedPipelines,
+    ManageTemplates,
+    ManagePipelines,
+    Help,
 }
 
 impl From<ModifySection> for ClipboardModifySectionPayload {
@@ -40,6 +43,9 @@ impl From<ModifySection> for ClipboardModifySectionPayload {
             ModifySection::Modify => Self::Modify,
             ModifySection::Templates => Self::Templates,
             ModifySection::SavedPipelines => Self::SavedPipelines,
+            ModifySection::ManageTemplates => Self::ManageTemplates,
+            ModifySection::ManagePipelines => Self::ManagePipelines,
+            ModifySection::Help => Self::Help,
         }
     }
 }
@@ -101,7 +107,16 @@ mod tests {
 
     #[test]
     fn encoded_payload_round_trips_for_every_variant() {
-        round_trip(open_dialog_payload(ModifySection::Modify));
+        for section in [
+            ModifySection::Modify,
+            ModifySection::Templates,
+            ModifySection::SavedPipelines,
+            ModifySection::ManageTemplates,
+            ModifySection::ManagePipelines,
+            ModifySection::Help,
+        ] {
+            round_trip(open_dialog_payload(section));
+        }
         round_trip(execute_stages_payload(vec![StageSpec {
             operation: OperationId::Uppercase,
             arguments: StageArguments::default(),

--- a/src/clipboard_modify/parser.rs
+++ b/src/clipboard_modify/parser.rs
@@ -15,6 +15,9 @@ pub enum ModifySection {
     Modify,
     Templates,
     SavedPipelines,
+    ManageTemplates,
+    ManagePipelines,
+    Help,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -290,10 +293,31 @@ fn parse_special(
 ) -> Option<ClipboardModifyParseResult> {
     let first = stage.tokens.first()?;
     let n = normalize_name(&first.text);
-    if n == "undo" && stage.tokens.len() == 1 {
-        return Some(ClipboardModifyParseResult::CompleteExecution(
-            ClipboardModifyIntent::Undo,
-        ));
+    if stage.tokens.len() == 1 {
+        match n.as_str() {
+            "modify" => {
+                return Some(ClipboardModifyParseResult::OpenSection(
+                    ModifySection::Modify,
+                ));
+            }
+            "manage-templates" => {
+                return Some(ClipboardModifyParseResult::OpenSection(
+                    ModifySection::ManageTemplates,
+                ));
+            }
+            "manage-pipelines" => {
+                return Some(ClipboardModifyParseResult::OpenSection(
+                    ModifySection::ManagePipelines,
+                ));
+            }
+            "help" => return Some(ClipboardModifyParseResult::OpenSection(ModifySection::Help)),
+            "undo" => {
+                return Some(ClipboardModifyParseResult::CompleteExecution(
+                    ClipboardModifyIntent::Undo,
+                ));
+            }
+            _ => {}
+        }
     }
     if n == "template" {
         return Some(if stage.tokens.len() == 1 {
@@ -719,6 +743,52 @@ mod tests {
             p("cm apply no-such"),
             ClipboardModifyParseResult::Partial(_)
         ));
+    }
+
+    #[test]
+    fn navigation_commands_open_sections_case_insensitively() {
+        for (query, section) in [
+            ("cm modify", ModifySection::Modify),
+            ("CM MODIFY", ModifySection::Modify),
+            ("cm template", ModifySection::Templates),
+            ("CM TEMPLATE", ModifySection::Templates),
+            ("cm apply", ModifySection::SavedPipelines),
+            ("CM APPLY", ModifySection::SavedPipelines),
+            ("cm manage-templates", ModifySection::ManageTemplates),
+            ("CM MANAGE_TEMPLATES", ModifySection::ManageTemplates),
+            ("cm manage-pipelines", ModifySection::ManagePipelines),
+            ("CM MANAGE-PIPELINES", ModifySection::ManagePipelines),
+            ("cm help", ModifySection::Help),
+            ("CM HELP", ModifySection::Help),
+        ] {
+            assert_eq!(
+                p(query),
+                ClipboardModifyParseResult::OpenSection(section),
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn template_apply_execution_and_undo_keep_existing_meanings() {
+        assert_eq!(
+            p("cm template prompt context"),
+            ClipboardModifyParseResult::CompleteExecution(ClipboardModifyIntent::ApplyTemplate {
+                name: "prompt context".into()
+            })
+        );
+        assert_eq!(
+            p("CM APPLY clean lines"),
+            ClipboardModifyParseResult::CompleteExecution(
+                ClipboardModifyIntent::ApplySavedPipeline {
+                    name: "clean lines".into()
+                }
+            )
+        );
+        assert_eq!(
+            p("Cm UnDo"),
+            ClipboardModifyParseResult::CompleteExecution(ClipboardModifyIntent::Undo)
+        );
     }
     #[test]
     fn incomplete_categories() {

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -863,7 +863,7 @@ impl LauncherApp {
             .as_deref()
             .and_then(|args| decode_action_payload::<ClipboardModifyActionPayload>(args).ok());
 
-        if action.action.starts_with(OPEN_PREFIX) {
+        if action.action.starts_with(OPEN_PREFIX) || action.action == "clipboard_modify:open" {
             let section = match payload {
                 Some(ClipboardModifyActionPayload::OpenDialogSection { section }) => section,
                 _ if action.action.ends_with(":templates") => {

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -872,6 +872,13 @@ impl LauncherApp {
                 _ if action.action.ends_with(":saved-pipelines") => {
                     ClipboardModifySectionPayload::SavedPipelines
                 }
+                _ if action.action.ends_with(":manage-templates") => {
+                    ClipboardModifySectionPayload::ManageTemplates
+                }
+                _ if action.action.ends_with(":manage-pipelines") => {
+                    ClipboardModifySectionPayload::ManagePipelines
+                }
+                _ if action.action.ends_with(":help") => ClipboardModifySectionPayload::Help,
                 _ => ClipboardModifySectionPayload::Modify,
             };
             let section = match section {
@@ -880,6 +887,13 @@ impl LauncherApp {
                 ClipboardModifySectionPayload::SavedPipelines => {
                     ClipboardModifyDialogSection::SavedPipelines
                 }
+                ClipboardModifySectionPayload::ManageTemplates => {
+                    ClipboardModifyDialogSection::ManageTemplates
+                }
+                ClipboardModifySectionPayload::ManagePipelines => {
+                    ClipboardModifyDialogSection::ManagePipelines
+                }
+                ClipboardModifySectionPayload::Help => ClipboardModifyDialogSection::Help,
             };
             self.clipboard_modify_dialog.open_section(
                 section,
@@ -1382,6 +1396,62 @@ mod clipboard_modify_gui_action_tests {
             app.clipboard_modify_dialog.section,
             ClipboardModifyDialogSection::Templates
         );
+    }
+
+    #[test]
+    fn dialog_open_payload_routes_all_clipboard_modify_sections() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        for (modify_section, dialog_section) in [
+            (ModifySection::Modify, ClipboardModifyDialogSection::Modify),
+            (
+                ModifySection::Templates,
+                ClipboardModifyDialogSection::Templates,
+            ),
+            (
+                ModifySection::SavedPipelines,
+                ClipboardModifyDialogSection::SavedPipelines,
+            ),
+            (
+                ModifySection::ManageTemplates,
+                ClipboardModifyDialogSection::ManageTemplates,
+            ),
+            (
+                ModifySection::ManagePipelines,
+                ClipboardModifyDialogSection::ManagePipelines,
+            ),
+            (ModifySection::Help, ClipboardModifyDialogSection::Help),
+        ] {
+            let args = encode_action_payload(&open_dialog_payload(modify_section)).unwrap();
+            assert!(app.handle_clipboard_modify_action(
+                &action("clipboard_modify:open", Some(args)),
+                ActivationSource::Click
+            ));
+            assert_eq!(app.clipboard_modify_dialog.section, dialog_section);
+        }
+    }
+
+    #[test]
+    fn dialog_open_legacy_suffix_routes_new_sections() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        for (suffix, dialog_section) in [
+            (
+                "manage-templates",
+                ClipboardModifyDialogSection::ManageTemplates,
+            ),
+            (
+                "manage-pipelines",
+                ClipboardModifyDialogSection::ManagePipelines,
+            ),
+            ("help", ClipboardModifyDialogSection::Help),
+        ] {
+            assert!(app.handle_clipboard_modify_action(
+                &action(&format!("clipboard_modify:open:{suffix}"), None),
+                ActivationSource::Click
+            ));
+            assert_eq!(app.clipboard_modify_dialog.section, dialog_section);
+        }
     }
 
     #[test]

--- a/src/plugins/clipboard_modify.rs
+++ b/src/plugins/clipboard_modify.rs
@@ -104,8 +104,15 @@ impl Plugin for ClipboardModifyPlugin {
     fn commands(&self) -> Vec<Action> {
         vec![
             command_action("cm", "Clipboard Modify"),
+            command_action("cm modify", "Open Clipboard Modify"),
             command_action("cm template", "Open Clipboard Modify templates"),
             command_action("cm apply", "Open Clipboard Modify saved pipelines"),
+            command_action("cm manage-templates", "Manage Clipboard Modify templates"),
+            command_action(
+                "cm manage-pipelines",
+                "Manage Clipboard Modify saved pipelines",
+            ),
+            command_action("cm help", "Open Clipboard Modify help"),
             command_action("cm undo", "Undo last Clipboard Modify"),
             command_action("cm upper", "Clipboard Modify uppercase text"),
             command_action("cm trim", "Clipboard Modify trim text"),
@@ -199,8 +206,13 @@ fn section_action(section: ModifySection) -> Action {
     let section_name = section_name(section);
     let payload = open_dialog_payload(section);
     let encoded = encode_action_payload(&payload).ok();
+    let label = if section == ModifySection::Modify {
+        "Open Clipboard Modify".into()
+    } else {
+        format!("Open Clipboard Modify {section_name}")
+    };
     Action {
-        label: format!("Open Clipboard Modify {section_name}"),
+        label,
         desc: format!("Open the Clipboard Modify {section_name} dialog section"),
         action: format!("clipboard_modify:open:{section_slug}"),
         args: encoded,
@@ -231,6 +243,9 @@ fn suggestion_query(section: ModifySection, suggestion: &str) -> String {
         ModifySection::Modify => format!("cm {suggestion}"),
         ModifySection::Templates => format!("cm template {suggestion}"),
         ModifySection::SavedPipelines => format!("cm apply {suggestion}"),
+        ModifySection::ManageTemplates => "cm manage-templates".into(),
+        ModifySection::ManagePipelines => "cm manage-pipelines".into(),
+        ModifySection::Help => "cm help".into(),
     }
 }
 
@@ -241,6 +256,9 @@ fn suggestion_label(section: ModifySection, suggestion: &str) -> String {
             .unwrap_or_else(|| suggestion.to_string()),
         ModifySection::Templates => format!("Use template {suggestion}"),
         ModifySection::SavedPipelines => format!("Apply pipeline {suggestion}"),
+        ModifySection::ManageTemplates => "Manage templates".into(),
+        ModifySection::ManagePipelines => "Manage pipelines".into(),
+        ModifySection::Help => "Open help".into(),
     }
 }
 
@@ -322,6 +340,9 @@ fn section_name(section: ModifySection) -> &'static str {
         ModifySection::Modify => "Modify",
         ModifySection::Templates => "Templates",
         ModifySection::SavedPipelines => "Saved Pipelines",
+        ModifySection::ManageTemplates => "Manage Templates",
+        ModifySection::ManagePipelines => "Manage Pipelines",
+        ModifySection::Help => "Help",
     }
 }
 
@@ -330,6 +351,9 @@ fn section_slug(section: ModifySection) -> &'static str {
         ModifySection::Modify => "modify",
         ModifySection::Templates => "templates",
         ModifySection::SavedPipelines => "saved-pipelines",
+        ModifySection::ManageTemplates => "manage-templates",
+        ModifySection::ManagePipelines => "manage-pipelines",
+        ModifySection::Help => "help",
     }
 }
 
@@ -413,6 +437,33 @@ mod tests {
             ClipboardModifyActionPayload::OpenDialogSection {
                 section: ClipboardModifySectionPayload::SavedPipelines
             }
+        );
+        assert_eq!(
+            payload(&plugin().search("cm manage-templates").remove(0)),
+            ClipboardModifyActionPayload::OpenDialogSection {
+                section: ClipboardModifySectionPayload::ManageTemplates
+            }
+        );
+        assert_eq!(
+            payload(&plugin().search("cm manage-pipelines").remove(0)),
+            ClipboardModifyActionPayload::OpenDialogSection {
+                section: ClipboardModifySectionPayload::ManagePipelines
+            }
+        );
+        assert_eq!(
+            payload(&plugin().search("cm help").remove(0)),
+            ClipboardModifyActionPayload::OpenDialogSection {
+                section: ClipboardModifySectionPayload::Help
+            }
+        );
+    }
+
+    #[test]
+    fn modify_direct_action_label_does_not_repeat_section_name() {
+        assert_eq!(plugin().search("cm")[0].label, "Open Clipboard Modify");
+        assert_eq!(
+            plugin().search("cm modify")[0].label,
+            "Open Clipboard Modify"
         );
     }
 


### PR DESCRIPTION
### Motivation

- Add new Clipboard Modify navigation targets for managing templates, managing pipelines, and help so users can open those dialog sections directly (e.g. `cm manage-templates`, `cm manage-pipelines`, `cm help`).
- Make navigation matching case-insensitive and preserve existing execution semantics for `cm template <name>`, `cm apply <pipeline>`, and `cm undo`.
- Ensure GUI routing and action payloads include the new sections and legacy suffix-form actions continue to route correctly.

### Description

- Extended `ModifySection` with `ManageTemplates`, `ManagePipelines`, and `Help` in `src/clipboard_modify/parser.rs` and updated `parse_special()` to recognize single-token navigation commands case-insensitively while preserving template/apply/undo execution semantics.
- Added corresponding variants to `ClipboardModifySectionPayload` and updated `From<ModifySection>` and payload round-trip tests in `src/clipboard_modify/actions.rs`, including a test to ensure encoded payloads do not contain clipboard source text.
- Updated GUI action routing in `src/gui/actions.rs` to map typed `OpenDialogSection` payloads and legacy `clipboard_modify:open:<suffix>` suffixes (`:manage-templates`, `:manage-pipelines`, `:help`) into `ClipboardModifyDialogSection` values, and added tests that route both typed and legacy suffix opens.
- Updated plugin exposure in `src/plugins/clipboard_modify.rs` to advertise the new `cm` commands, provide suggestion labels/queries for the new sections, add section slugs/names, and fix the direct `cm`/`cm modify` action label to be `Open Clipboard Modify`; added plugin search tests for the new sections.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `git diff --check` which succeeded (no whitespace errors).
- Ran `cargo test clipboard_modify --all-targets`; the test run compiled many crates but did not complete due to platform/build issues unrelated to these changes (missing system libs for ALSA/X11 were installed during the run, and remaining failures are caused by unresolved Windows-specific APIs when compiling cross-platform targets), so the full test suite could not finish in this environment.
- New unit tests added: parser tests for new navigation commands and case-insensitive forms, parser tests confirming `cm template <name>`, `cm apply <pipeline>`, and `cm undo` behaviors, action payload round-trip tests for every section variant (including source-text safety), and GUI routing tests for typed and legacy suffix open actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fedd6e5c88332a9ac0318f8525e50)