### PR TITLE
Add Clipboard Modify root suggestions

### DIFF
--- a/src/plugins/clipboard_modify.rs
+++ b/src/plugins/clipboard_modify.rs
@@ -702,7 +702,7 @@ mod tests {
 
     #[test]
     fn modify_direct_action_label_does_not_repeat_section_name() {
-        assert_eq!(plugin().search("cm")[0].label, "Open Clipboard Modify");
+        assert_eq!(plugin().search("cm")[0].label, "cm: Open Clipboard Modify");
         assert_eq!(
             plugin().search("cm modify")[0].label,
             "Open Clipboard Modify"

--- a/src/plugins/clipboard_modify.rs
+++ b/src/plugins/clipboard_modify.rs
@@ -3,7 +3,10 @@ use crate::clipboard_modify::actions::{
     OPEN_PREFIX, encode_action_payload, execute_saved_pipeline_payload, execute_stages_payload,
     execute_template_payload, open_dialog_payload, undo_payload,
 };
-use crate::clipboard_modify::catalog::{canonical_command, normalize_name, operation_lookup};
+use crate::clipboard_modify::catalog::{
+    ArgumentRequirements, canonical_command, normalize_name, operation_lookup, operations,
+};
+use crate::clipboard_modify::model::{ClipboardModifierCatalog, OperationId};
 use crate::clipboard_modify::parser::{
     ClipboardModifyIntent, ClipboardModifyParseResult, ModifySection, PartialQuery, parse,
 };
@@ -72,6 +75,9 @@ impl ClipboardModifyPlugin {
 impl Plugin for ClipboardModifyPlugin {
     fn search(&self, query: &str) -> Vec<Action> {
         let catalog = self.catalog_snapshot();
+        if is_exact_cm_root_query(query) {
+            return cm_root_actions(catalog.as_ref());
+        }
         match parse(query, catalog.as_ref()) {
             ClipboardModifyParseResult::NotClipboardModify => Vec::new(),
             ClipboardModifyParseResult::OpenSection(section) => vec![section_action(section)],
@@ -102,23 +108,7 @@ impl Plugin for ClipboardModifyPlugin {
     }
 
     fn commands(&self) -> Vec<Action> {
-        vec![
-            command_action("cm", "Clipboard Modify"),
-            command_action("cm modify", "Open Clipboard Modify"),
-            command_action("cm template", "Open Clipboard Modify templates"),
-            command_action("cm apply", "Open Clipboard Modify saved pipelines"),
-            command_action("cm manage-templates", "Manage Clipboard Modify templates"),
-            command_action(
-                "cm manage-pipelines",
-                "Manage Clipboard Modify saved pipelines",
-            ),
-            command_action("cm help", "Open Clipboard Modify help"),
-            command_action("cm undo", "Undo last Clipboard Modify"),
-            command_action("cm upper", "Clipboard Modify uppercase text"),
-            command_action("cm trim", "Clipboard Modify trim text"),
-            command_action("cm wrap", "Clipboard Modify wrap text"),
-            command_action("cm sort", "Clipboard Modify sort lines"),
-        ]
+        cm_static_commands()
     }
 
     fn query_prefixes(&self) -> &[&str] {
@@ -167,6 +157,96 @@ impl Plugin for ClipboardModifyPlugin {
         });
         ui.checkbox(&mut cfg.management_sort_ascending, "Sort ascending");
         *value = serde_json::to_value(cfg).unwrap_or(serde_json::Value::Null);
+    }
+}
+
+fn is_exact_cm_root_query(query: &str) -> bool {
+    query.trim().eq_ignore_ascii_case("cm")
+}
+
+fn cm_root_actions(catalog: &ClipboardModifierCatalog) -> Vec<Action> {
+    let mut actions = vec![root_open_modify_action()];
+    actions.extend(cm_root_suggestions(catalog));
+    actions
+}
+
+fn root_open_modify_action() -> Action {
+    let mut action = section_action(ModifySection::Modify);
+    action.label = "cm: Open Clipboard Modify".into();
+    action.desc = "Opens the Clipboard Modify dialog section".into();
+    action
+}
+
+fn cm_root_suggestions(catalog: &ClipboardModifierCatalog) -> Vec<Action> {
+    let mut actions = Vec::new();
+    actions.extend(cm_navigation_suggestions());
+    actions.extend(cm_operation_suggestions());
+    actions.extend(catalog.pipelines.iter().map(|pipeline| {
+        query_action(
+            &format!("cm apply {}", pipeline.id),
+            &format!("Pipeline: {} ({})", pipeline.label, pipeline.id),
+            &format!("Replace the launcher query with `cm apply {}`", pipeline.id),
+        )
+    }));
+    actions.extend(catalog.templates.iter().map(|template| {
+        query_action(
+            &format!("cm template {}", template.id),
+            &format!("Template: {} ({})", template.label, template.id),
+            &format!(
+                "Replace the launcher query with `cm template {}`",
+                template.id
+            ),
+        )
+    }));
+    actions
+}
+
+fn cm_navigation_suggestions() -> Vec<Action> {
+    [
+        ("cm modify", "Open Modify section"),
+        ("cm template", "Open Templates section"),
+        ("cm apply", "Open Saved Pipelines section"),
+        ("cm manage-templates", "Open Manage Templates section"),
+        ("cm manage-pipelines", "Open Manage Pipelines section"),
+        ("cm help", "Open Help section"),
+    ]
+    .into_iter()
+    .map(|(query, desc)| query_action(query, query, desc))
+    .collect()
+}
+
+fn cm_operation_suggestions() -> Vec<Action> {
+    operations()
+        .iter()
+        .filter(|op| op.id != OperationId::Template)
+        .map(|op| {
+            let query = match op.argument_requirements {
+                ArgumentRequirements::None => format!("cm {}", op.command),
+                _ => format!("cm {} ", op.command),
+            };
+            query_action(
+                &query,
+                &format!("{}: {}", op.command, op.label),
+                op.description,
+            )
+        })
+        .collect()
+}
+
+fn cm_static_commands() -> Vec<Action> {
+    let mut actions = vec![command_action("cm", "Clipboard Modify")];
+    actions.extend(cm_navigation_suggestions());
+    actions.push(command_action("cm undo", "Undo last Clipboard Modify"));
+    actions.extend(cm_operation_suggestions());
+    actions
+}
+
+fn query_action(query: &str, label: &str, desc: &str) -> Action {
+    Action {
+        label: label.into(),
+        desc: desc.into(),
+        action: format!("query:{query}"),
+        args: None,
     }
 }
 
@@ -363,11 +443,173 @@ mod tests {
     use crate::clipboard_modify::actions::{
         ClipboardModifyActionPayload, ClipboardModifySectionPayload, decode_action_payload,
     };
+    use crate::clipboard_modify::model::{
+        ClipboardModifierCatalog, ClipboardTemplate, SavedPipeline,
+    };
     use crate::clipboard_modify::store::shared_default_catalog;
     use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
 
     fn plugin() -> ClipboardModifyPlugin {
         ClipboardModifyPlugin::new(shared_default_catalog())
+    }
+
+    fn plugin_with_test_catalog() -> ClipboardModifyPlugin {
+        let catalog = ClipboardModifierCatalog::new(
+            vec![
+                ClipboardTemplate {
+                    id: "alpha-template".into(),
+                    label: "Alpha Template".into(),
+                    aliases: vec!["at".into()],
+                    template: "A {{clipboard}}".into(),
+                    processor: None,
+                },
+                ClipboardTemplate {
+                    id: "beta-template".into(),
+                    label: "Beta Template".into(),
+                    aliases: vec!["bt".into()],
+                    template: "B {{clipboard}}".into(),
+                    processor: None,
+                },
+            ],
+            vec![
+                SavedPipeline {
+                    id: "alpha-pipeline".into(),
+                    label: "Alpha Pipeline".into(),
+                    aliases: vec!["ap".into()],
+                    stages: vec![],
+                },
+                SavedPipeline {
+                    id: "beta-pipeline".into(),
+                    label: "Beta Pipeline".into(),
+                    aliases: vec!["bp".into()],
+                    stages: vec![],
+                },
+            ],
+        )
+        .unwrap();
+        ClipboardModifyPlugin::new(Arc::new(RwLock::new(Arc::new(catalog))))
+    }
+
+    #[test]
+    fn bare_cm_root_lists_direct_open_and_non_executing_completions() {
+        let results = plugin_with_test_catalog().search("  CM  ");
+        assert!(!results.is_empty());
+        assert_eq!(results[0].label, "cm: Open Clipboard Modify");
+        assert_eq!(results[0].action, "clipboard_modify:open:modify");
+        assert_eq!(
+            payload(&results[0]),
+            ClipboardModifyActionPayload::OpenDialogSection {
+                section: ClipboardModifySectionPayload::Modify
+            }
+        );
+        assert!(results[0].desc.contains("opens") || results[0].desc.contains("Open"));
+        assert!(
+            results[1..]
+                .iter()
+                .all(|action| action.action.starts_with("query:"))
+        );
+
+        let queries: Vec<_> = results
+            .iter()
+            .filter_map(|action| action.action.strip_prefix("query:"))
+            .collect();
+
+        for nav in [
+            "cm modify",
+            "cm template",
+            "cm apply",
+            "cm manage-templates",
+            "cm manage-pipelines",
+            "cm help",
+        ] {
+            assert!(queries.contains(&nav), "missing navigation query {nav}");
+        }
+
+        for op in operations()
+            .iter()
+            .filter(|op| op.id != OperationId::Template)
+        {
+            let expected = match op.argument_requirements {
+                ArgumentRequirements::None => format!("cm {}", op.command),
+                _ => format!("cm {} ", op.command),
+            };
+            assert!(
+                queries.contains(&expected.as_str()),
+                "missing operation query {expected}"
+            );
+            assert!(
+                results
+                    .iter()
+                    .any(|action| action.action == format!("query:{expected}")
+                        && action.label.contains(op.label)
+                        && action.desc.contains(op.description)),
+                "missing label/description for {expected}"
+            );
+        }
+
+        assert!(queries.contains(&"cm uppercase"));
+        assert!(!queries.contains(&"cm upper"));
+        assert!(queries.contains(&"cm apply alpha-pipeline"));
+        assert!(queries.contains(&"cm apply beta-pipeline"));
+        assert!(!queries.contains(&"cm apply ap"));
+        assert!(!queries.contains(&"cm apply bp"));
+        assert!(queries.contains(&"cm template alpha-template"));
+        assert!(queries.contains(&"cm template beta-template"));
+        assert!(!queries.contains(&"cm template at"));
+        assert!(!queries.contains(&"cm template bt"));
+        assert!(!queries.contains(&"cm undo"));
+        assert_eq!(
+            queries
+                .iter()
+                .filter(|query| **query == "cm template")
+                .count(),
+            1
+        );
+
+        let nav_start = 1;
+        let ops_start = nav_start + 6;
+        let pipeline_start = ops_start
+            + operations()
+                .iter()
+                .filter(|op| op.id != OperationId::Template)
+                .count();
+        let template_start = pipeline_start + 2;
+        assert_eq!(results[nav_start].action, "query:cm modify");
+        assert_eq!(results[ops_start].action, "query:cm single-quote");
+        assert_eq!(
+            results[pipeline_start].action,
+            "query:cm apply alpha-pipeline"
+        );
+        assert_eq!(
+            results[template_start].action,
+            "query:cm template alpha-template"
+        );
+
+        for query in [
+            "cm modify",
+            "cm uppercase",
+            "cm apply alpha-pipeline",
+            "cm template alpha-template",
+        ] {
+            let action = results
+                .iter()
+                .find(|action| action.action == format!("query:{query}"))
+                .expect("completion action");
+            assert!(action.args.is_none());
+        }
+    }
+
+    #[test]
+    fn root_detection_does_not_swallow_subcommands_or_undo() {
+        assert_eq!(
+            plugin_with_test_catalog().search("cm modify")[0].label,
+            "Open Clipboard Modify"
+        );
+        assert_eq!(
+            payload(&plugin_with_test_catalog().search("cm undo").remove(0)),
+            ClipboardModifyActionPayload::Undo
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a dedicated, user-friendly root experience when users enter the bare `cm` launcher query by detecting exact root queries and presenting a curated list instead of routing only to the parser.
- Surface non-executing navigation and canonical completions (operations, saved pipelines, templates) that replace the launcher query for a follow-up Enter rather than executing immediately.
- Ensure canonical-only completions (no aliases) and a fixed ordering to make the root list predictable and maintainable.

### Description
- Detect exact bare `cm` before parser dispatch with `is_exact_cm_root_query` (trimmed, case-insensitive, subcommands remain on parser path). 
- Add `cm_root_actions` that returns a first typed open action (`cm: Open Clipboard Modify`) followed by navigation, canonical operation, saved-pipeline, and template `query:` suggestions using shared helpers (`cm_root_suggestions`, `cm_navigation_suggestions`, `cm_operation_suggestions`, `query_action`).
- Canonical operation suggestions are built from `operations()`, exclude the `template` operation, omit aliases, include operation labels/descriptions, and append a trailing space when arguments are required.
- Refactor static command list into `cm_static_commands()` to reuse navigation and operation suggestion logic while keeping `cm undo` in the global command list.
- Add unit tests that construct a small test catalog (two templates, two pipelines, aliases for both) and verify root behavior, ordering (navigation -> operations -> pipelines -> templates), canonical-only completions, alias exclusion, undo omission from the bare `cm` list, and that suggestion `query:` actions replace the launcher query (no immediate execution).

### Testing
- Ran `cargo fmt` to format the code and it completed successfully.
- Ran `git diff --check` as part of validation and it reported no issues.
- Attempted `cargo test clipboard_modify --lib` but the build/test run failed on this host due to a missing system dependency required by `alsa-sys` (`alsa.pc` / pkg-config), preventing the test suite from completing in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ff3cc81d08332a73a524eed678b12)