### PR TITLE
Add clipboard modify launcher search tests

### DIFF
--- a/src/gui/search.rs
+++ b/src/gui/search.rs
@@ -511,8 +511,7 @@ mod tests {
     use super::*;
     use crate::{
         clipboard_modify::actions::{
-            ClipboardModifyActionPayload, ClipboardModifySectionPayload, OPEN_PREFIX,
-            decode_action_payload,
+            ClipboardModifyActionPayload, ClipboardModifySectionPayload, decode_action_payload,
         },
         plugin::PluginManager,
         plugins::clipboard_modify::ClipboardModifyPlugin,
@@ -570,13 +569,12 @@ mod tests {
             .expect("clipboard modify result from launcher search path");
         assert_eq!(first.label, "cm: Open Clipboard Modify");
         assert_eq!(first.desc, "Opens the Clipboard Modify dialog section");
-        assert!(
-            first.action.starts_with(OPEN_PREFIX),
-            "expected direct Clipboard Modify open action, got {}",
-            first.action
-        );
+        assert_eq!(first.action, "clipboard_modify:open:modify");
 
-        let encoded = first.action.strip_prefix(OPEN_PREFIX).unwrap();
+        let encoded = first
+            .args
+            .as_deref()
+            .expect("direct Clipboard Modify open action carries encoded section payload");
         let payload: ClipboardModifyActionPayload = decode_action_payload(encoded).unwrap();
         assert_eq!(
             payload,

--- a/src/gui/search.rs
+++ b/src/gui/search.rs
@@ -509,7 +509,15 @@ impl LauncherApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{plugin::PluginManager, settings::Settings};
+    use crate::{
+        clipboard_modify::actions::{
+            ClipboardModifyActionPayload, ClipboardModifySectionPayload, OPEN_PREFIX,
+            decode_action_payload,
+        },
+        plugin::PluginManager,
+        plugins::clipboard_modify::ClipboardModifyPlugin,
+        settings::Settings,
+    };
     use eframe::egui;
     use std::sync::{Arc, atomic::AtomicBool};
 
@@ -530,6 +538,78 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
         )
+    }
+
+    fn new_app_with_clipboard_modify(ctx: &egui::Context) -> LauncherApp {
+        let mut plugin_manager = PluginManager::new();
+        let catalog = plugin_manager.clipboard_modifier_catalog();
+        plugin_manager.register(Box::new(ClipboardModifyPlugin::new(catalog)));
+
+        LauncherApp::new(
+            ctx,
+            Arc::new(Vec::new()),
+            0,
+            plugin_manager,
+            "actions.json".into(),
+            "settings.json".into(),
+            Settings::default(),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    fn assert_first_result_is_clipboard_modify_open_modify(app: &LauncherApp) {
+        let first = app
+            .results
+            .first()
+            .expect("clipboard modify result from launcher search path");
+        assert_eq!(first.label, "cm: Open Clipboard Modify");
+        assert_eq!(first.desc, "Opens the Clipboard Modify dialog section");
+        assert!(
+            first.action.starts_with(OPEN_PREFIX),
+            "expected direct Clipboard Modify open action, got {}",
+            first.action
+        );
+
+        let encoded = first.action.strip_prefix(OPEN_PREFIX).unwrap();
+        let payload: ClipboardModifyActionPayload = decode_action_payload(encoded).unwrap();
+        assert_eq!(
+            payload,
+            ClipboardModifyActionPayload::OpenDialogSection {
+                section: ClipboardModifySectionPayload::Modify,
+            }
+        );
+    }
+
+    #[test]
+    fn clipboard_modify_root_query_returns_direct_open_modify_first_in_fuzzy_mode() {
+        let ctx = egui::Context::default();
+        let mut app = new_app_with_clipboard_modify(&ctx);
+        app.query = "cm".into();
+        app.match_exact = false;
+        app.fuzzy_weight = 1.0;
+
+        app.search();
+
+        assert_first_result_is_clipboard_modify_open_modify(&app);
+    }
+
+    #[test]
+    fn clipboard_modify_root_query_returns_direct_open_modify_first_in_exact_mode() {
+        let ctx = egui::Context::default();
+        let mut app = new_app_with_clipboard_modify(&ctx);
+        app.query = "cm".into();
+        app.match_exact = true;
+        app.fuzzy_weight = 1.0;
+
+        app.search();
+
+        assert_first_result_is_clipboard_modify_open_modify(&app);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure the launcher search path returns the direct Clipboard Modify open action for the root `cm` query and that the action encodes the `Modify` section payload. 
- Exercise both fuzzy and exact matching modes through the normal `LauncherApp::search()` path rather than calling the plugin search in isolation. 
- Avoid reading the system clipboard during tests by registering only `ClipboardModifyPlugin` in the test `PluginManager` instance.

### Description
- Add `new_app_with_clipboard_modify` test helper that creates a `LauncherApp` with a `PluginManager` that has only `ClipboardModifyPlugin` registered. 
- Add `assert_first_result_is_clipboard_modify_open_modify` helper that asserts the first launcher result label/desc, verifies the action starts with `OPEN_PREFIX`, and decodes the base64 payload to `OpenDialogSection { section: Modify }`. 
- Add two tests: `clipboard_modify_root_query_returns_direct_open_modify_first_in_fuzzy_mode` and `clipboard_modify_root_query_returns_direct_open_modify_first_in_exact_mode` which set `app.query = "cm"` and exercise normal `app.search()` in fuzzy and exact modes respectively.

### Testing
- Ran `cargo fmt` successfully. 
- Ran `git diff --check` successfully. 
- Attempted to run `cargo test` for the new test (`cargo test clipboard_modify_root_query_returns_direct_open_modify_first -- --nocapture`) but the build is blocked/failing in this Linux environment due to platform-specific `windows::Win32` imports in the codebase, so the new tests could not complete in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ff883681c833294f685f4afa7e247)