### PR TITLE
Document Clipboard Modify command browser behavior and add manual layout/completions smoke tests

### DIFF
--- a/docs/clipboard_modify.md
+++ b/docs/clipboard_modify.md
@@ -33,14 +33,43 @@ Clipboard Modify is launched with the `cm` prefix. It reads the current text cli
 | `screaming-snake` | `constant-case`, `screaming-snake-case` | `cm screaming-snake` | yes |
 | `kebab-case` | `kebab` | `cm kebab-case` | yes |
 
-## Commands and pipeline syntax
+## Command browser behavior
 
-- `cm` opens the Modify section.
+Typing bare `cm` opens the launcher command browser instead of immediately applying a transformation. The root browser is ordered for discovery:
+
+1. **Open Clipboard Modify** appears first and opens the full Clipboard Modify dialog.
+2. Navigation completions are listed for the major Clipboard Modify sections and management views.
+3. Canonical operation suggestions are listed for built-in transformations.
+4. Template completions and saved-pipeline completions are listed from the current catalog.
+
+Aliases are intentionally omitted from the bare-`cm` root list so the browser remains focused on canonical, discoverable commands. Aliases remain available when typed directly in contexts where they are currently supported, such as operation aliases, template aliases, and pipeline aliases. `cm undo` also remains available when typed directly, but it is not shown in the bare-`cm` root list.
+
+Completion rows use a two-Enter flow. Pressing **Enter** the first time on a completion row fills the query with that completed command while keeping launcher focus active. Pressing **Enter** again opens the completed view or executes the completed command.
+
+## Navigation commands
+
+- `cm` shows the command browser with **Open Clipboard Modify** selected first.
+- `cm modify` opens the Modify section.
 - `cm template` opens Templates; `cm template <name-or-alias>` applies that template immediately.
 - `cm apply` opens Saved Pipelines; `cm apply <name-or-alias>` runs that saved pipeline immediately.
-- `cm undo` restores the clipboard text captured before the last Clipboard Modify write.
+- `cm manage-templates` opens template management.
+- `cm manage-pipelines` opens saved-pipeline management.
+- `cm help` opens Clipboard Modify help.
+
+## Commands and pipeline syntax
+
+- `cm undo` restores the clipboard text captured before the last Clipboard Modify write when typed directly.
 - Pipeline stages are separated with `|`, for example `cm trim-lines | unique-lines | sort-ascending`.
 - Custom wrapper values can be quoted with single or double quotes when they contain spaces, pipes, or quote characters: `cm wrap "<!-- " " -->"`.
+
+## Dialog layout and resizing
+
+The Clipboard Modify dialog keeps large content usable without letting the window grow without bound:
+
+- Source, editor, and preview controls display ten rows and scroll internally for larger content.
+- Tabs are scrollable, and tab navigation stays fixed so tab switching remains reachable while tab content scrolls.
+- Important actions, such as add/filter controls and save/apply buttons where applicable, stay fixed and visible while long lists or content panes scroll.
+- Dialog resizing is session-only. Runtime resize changes are retained while the application session is running, but runtime resize is not persisted to settings; after restart, the configured or default startup size is used.
 
 ## Template file schema
 

--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -21,6 +21,81 @@ This checklist covers behavior that depends on a real Windows desktop session, W
 15. Use **Save HWND Snapshot** and **Restore HWND Snapshot** after moving/reopening windows to confirm bindings round-trip.
 16. Keep `ignore_launcher_window_on_capture` enabled and verify capture does not save the launcher window when the launcher had focus immediately before capture.
 
+## Clipboard Modify layout matrix
+
+Run these checks in a real desktop session because they depend on launcher focus, dialog sizing, clipboard behavior, and native text-control scrolling.
+
+| Scenario | Setup | Verify |
+|---|---|---|
+| Large Clipboard | Copy text containing at least 1,000 short lines, one extremely long line, Unicode characters, and blank lines. Open Clipboard Modify with `cm`. | Window remains bounded; source field displays ten rows; source scrolls internally; preview displays ten rows; wrapping defaults to enabled; applying a transformation produces complete output, not only the visible preview. |
+| Tab Growth | Create enough templates and saved pipelines to exceed window height, then open template and pipeline management. | Every tab scrolls; add/filter controls remain visible; Save remains visible; tab navigation remains fixed. |
+| Help | Open `cm help`, clear the Help filter, and scroll the command list. | Complete command list is reachable; window does not grow; filtering still works while scrolled. |
+| Narrow Dialog | Open Clipboard Modify and reduce the dialog width until the tab bar no longer fits. | Tab row scrolls horizontally; tab labels do not wrap; no tab becomes unreachable. |
+| Session Resize | Resize the dialog, close it, reopen it, then restart the application and open it again. | Size is retained after close/reopen within the same session; after restart, the configured or default startup size is used. |
+| Launcher Completions | Type `cm` in the launcher. | Open Clipboard Modify is selected first; navigation commands are listed; canonical transformations are listed; pipelines are listed; templates are listed; undo and aliases are not listed; selecting rows fills the query and keeps focus active; pressing Enter a second time opens or executes the completed command. |
+
+### Clipboard Modify scenario details
+
+#### Large Clipboard
+
+1. Copy a large sample that includes:
+   - At least 1,000 short lines.
+   - One extremely long line.
+   - Unicode characters.
+   - Blank lines.
+2. Type `cm` and open **Open Clipboard Modify**.
+3. Confirm the window remains bounded instead of growing to fit the whole clipboard.
+4. Confirm the Source field displays ten rows and scrolls internally.
+5. Run a previewable transformation and confirm the Preview field displays ten rows.
+6. Confirm wrapping defaults to enabled.
+7. Apply the transformation and paste the clipboard into an editor. Confirm the output contains the complete transformed clipboard, not only the visible preview text.
+
+#### Tab Growth
+
+1. Create enough templates and saved pipelines to exceed the dialog height.
+2. Open template management and saved-pipeline management.
+3. Confirm every tab can scroll through its full content.
+4. Confirm add/filter controls remain visible while content scrolls.
+5. Confirm Save remains visible.
+6. Confirm tab navigation remains fixed while tab content scrolls.
+
+#### Help
+
+1. Open `cm help`.
+2. Clear the Help filter.
+3. Scroll through the Help list.
+4. Confirm the complete command list is reachable.
+5. Confirm the window does not grow to fit the list.
+6. Confirm filtering still works after scrolling.
+
+#### Narrow Dialog
+
+1. Open Clipboard Modify.
+2. Reduce the width until the tab bar no longer fits.
+3. Confirm the tab row scrolls horizontally.
+4. Confirm tab labels do not wrap.
+5. Confirm every tab remains reachable.
+
+#### Session Resize
+
+1. Open Clipboard Modify and resize the dialog.
+2. Close the dialog.
+3. Reopen Clipboard Modify and confirm the resized dimensions are retained.
+4. Restart Multi Launcher.
+5. Open Clipboard Modify and confirm the configured or default startup size is used instead of the previous runtime resize.
+
+#### Launcher Completions
+
+1. Type `cm` in the launcher.
+2. Confirm **Open Clipboard Modify** is selected first.
+3. Confirm navigation commands are listed.
+4. Confirm canonical transformations are listed.
+5. Confirm saved pipelines are listed.
+6. Confirm templates are listed.
+7. Confirm `cm undo` and aliases are not listed.
+8. Select completion rows and confirm the first **Enter** fills the query while keeping focus active.
+9. Press **Enter** again and confirm the completed command opens or executes.
+
 ## Browser tabs and UI Automation
 
 1. Open a Chromium-based browser with several tabs.


### PR DESCRIPTION
### Motivation

- Clarify the exact user-facing behavior of the bare `cm` launcher flow, including discovery order, completion semantics, and alias/undo visibility.
- Record UI layout and resizing expectations so manual testers can verify large-input and tab-growth edge cases. 
- Provide a compact manual smoke-test matrix to ensure consistent behavior for launcher completions and session resize semantics.

### Description

- Updated `docs/clipboard_modify.md` to describe bare-`cm` command browser behavior, the two-Enter completion flow, omission of aliases from the root list, and that `cm undo` remains available when typed directly. 
- Added a concise `cm` navigation command list including `cm`, `cm modify`, `cm template`, `cm apply`, `cm manage-templates`, `cm manage-pipelines`, and `cm help`. 
- Documented dialog layout and resizing rules: ten-row source/editor/preview controls, scrollable tabs with fixed tab navigation and important actions, and session-only runtime resize that is not persisted. 
- Extended `docs/manual-smoke-tests.md` with a Clipboard Modify layout matrix and detailed scenarios for Large Clipboard, Tab Growth, Help, Narrow Dialog, Session Resize, and Launcher Completions.

### Testing

- Ran `git diff --check` which completed with no issues. 
- Verified repository status with `git status --short` and committed the documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6004dd1bd88332a0563112f629bb0b)