### PR TITLE
Add reusable note mutation coordinator

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -22,6 +22,7 @@ mod mouse_gesture_settings_dialog;
 mod mouse_gestures_dialog;
 mod multi_manager_actions;
 mod note_graph_dialog;
+pub(crate) mod note_mutation;
 mod note_panel;
 mod notes_dialog;
 mod render;
@@ -437,6 +438,8 @@ pub struct LauncherApp {
     note_graph_dialog: NoteGraphDialog,
     unused_assets_dialog: UnusedAssetsDialog,
     note_panels: Vec<NotePanel>,
+    #[cfg(test)]
+    pub(crate) note_mutation_refresh_count: usize,
     image_panels: Vec<ImagePanel>,
     screenshot_editors: Vec<ScreenshotEditor>,
     todo_dialog: TodoDialog,
@@ -1377,6 +1380,8 @@ impl LauncherApp {
             note_graph_dialog: NoteGraphDialog::default(),
             unused_assets_dialog: UnusedAssetsDialog::default(),
             note_panels: Vec::new(),
+            #[cfg(test)]
+            note_mutation_refresh_count: 0,
             image_panels: Vec::new(),
             screenshot_editors: Vec::new(),
             todo_dialog: TodoDialog::default(),

--- a/src/gui/note_mutation.rs
+++ b/src/gui/note_mutation.rs
@@ -1,0 +1,292 @@
+use crate::gui::LauncherApp;
+use crate::plugins::note::{load_notes, save_note};
+use anyhow::{Context, anyhow};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NoteMutationOutcome<R> {
+    Changed(R),
+    Unchanged(R),
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NoteMutationResult {
+    pub wrapped_links: usize,
+    pub skipped_existing_links: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoteMutationOutput {
+    pub content: String,
+    pub result: NoteMutationResult,
+}
+
+impl NoteMutationOutput {
+    pub(crate) fn changed(content: impl Into<String>, result: NoteMutationResult) -> Self {
+        Self {
+            content: content.into(),
+            result,
+        }
+    }
+
+    pub(crate) fn unchanged(content: impl Into<String>, result: NoteMutationResult) -> Self {
+        Self {
+            content: content.into(),
+            result,
+        }
+    }
+
+    fn into_outcome(self, source: &str) -> NoteMutationOutcome<Self> {
+        if self.content == source {
+            NoteMutationOutcome::Unchanged(self)
+        } else {
+            NoteMutationOutcome::Changed(self)
+        }
+    }
+}
+
+impl LauncherApp {
+    pub(crate) fn mutate_note_by_slug(
+        &mut self,
+        slug: &str,
+        mutation: impl FnOnce(&str) -> NoteMutationOutput,
+    ) -> anyhow::Result<NoteMutationResult> {
+        match self.try_mutate_note_by_slug(slug, mutation) {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                self.report_error_message("note.mutation", err.to_string());
+                Err(err)
+            }
+        }
+    }
+
+    fn try_mutate_note_by_slug(
+        &mut self,
+        slug: &str,
+        mutation: impl FnOnce(&str) -> NoteMutationOutput,
+    ) -> anyhow::Result<NoteMutationResult> {
+        if let Some(index) = self
+            .note_panels
+            .iter()
+            .position(|panel| panel.note_slug() == slug)
+        {
+            let mut panel = self.note_panels.remove(index);
+            let source = panel.note_content().to_owned();
+            let outcome = mutation(&source).into_outcome(&source);
+            let result = match outcome {
+                NoteMutationOutcome::Unchanged(output) => output.result,
+                NoteMutationOutcome::Changed(output) => {
+                    let mut note = panel.note_content_clone_for_mutation();
+                    note.content = output.content;
+                    let save_result = save_note(&mut note, true).context("save mutated open note");
+                    if let Err(err) = save_result {
+                        self.note_panels.insert(index, panel);
+                        return Err(err);
+                    }
+                    panel.replace_note_after_external_mutation(note);
+                    let result = output.result;
+                    self.note_panels.insert(index, panel);
+                    self.refresh_after_note_mutation();
+                    return Ok(result);
+                }
+            };
+            self.note_panels.insert(index, panel);
+            return Ok(result);
+        }
+
+        let mut note = load_notes()
+            .context("load notes for mutation")?
+            .into_iter()
+            .find(|note| note.slug == slug)
+            .ok_or_else(|| anyhow!("Note not found: {slug}"))?;
+        let source = note.content.clone();
+        match mutation(&source).into_outcome(&source) {
+            NoteMutationOutcome::Unchanged(output) => Ok(output.result),
+            NoteMutationOutcome::Changed(output) => {
+                note.content = output.content;
+                save_note(&mut note, true).context("save mutated closed note")?;
+                self.refresh_after_note_mutation();
+                Ok(output.result)
+            }
+        }
+    }
+
+    fn refresh_after_note_mutation(&mut self) {
+        #[cfg(test)]
+        {
+            self.note_mutation_refresh_count += 1;
+        }
+        self.dashboard_data_cache.refresh_notes();
+        if self.notes_dialog.open {
+            self.notes_dialog.refresh_entries_from_notes();
+        }
+        for panel in &mut self.note_panels {
+            panel.invalidate_note_derived_data_after_external_mutation();
+        }
+        self.last_results_valid = false;
+        self.search();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::NotePanel;
+    use crate::plugins::note::{Note, load_notes, save_note, save_notes};
+    use crate::{plugin::PluginManager, settings::Settings};
+    use eframe::egui;
+    use once_cell::sync::Lazy;
+    use std::sync::{Arc, Mutex, atomic::AtomicBool};
+    use tempfile::tempdir;
+
+    static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn new_app(ctx: &egui::Context) -> LauncherApp {
+        LauncherApp::new(
+            ctx,
+            Arc::new(Vec::new()),
+            0,
+            PluginManager::new(),
+            "actions.json".into(),
+            "settings.json".into(),
+            Settings::default(),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    fn note(title: &str, slug: &str, content: &str) -> Note {
+        Note {
+            title: title.into(),
+            path: Default::default(),
+            content: content.into(),
+            tags: Vec::new(),
+            links: Vec::new(),
+            slug: slug.into(),
+            alias: None,
+            aliases: Vec::new(),
+            entity_refs: Vec::new(),
+        }
+    }
+
+    fn setup() -> (tempfile::TempDir, egui::Context, LauncherApp) {
+        let dir = tempdir().unwrap();
+        let notes_dir = dir.path().join("notes");
+        std::fs::create_dir_all(&notes_dir).unwrap();
+        unsafe { std::env::set_var("ML_NOTES_DIR", &notes_dir) };
+        unsafe { std::env::set_var("HOME", dir.path()) };
+        save_notes(&[]).unwrap();
+        let ctx = egui::Context::default();
+        let app = new_app(&ctx);
+        (dir, ctx, app)
+    }
+
+    #[test]
+    fn open_note_mutation_uses_unsaved_panel_content_and_saves_it() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _ctx, mut app) = setup();
+        let mut disk_note = note("Alpha", "alpha", "disk");
+        save_note(&mut disk_note, true).unwrap();
+        let mut panel = NotePanel::from_note(disk_note);
+        panel.replace_content_after_external_mutation("unsaved".into());
+        app.note_panels.push(panel);
+
+        app.mutate_note_by_slug("alpha", |content| {
+            assert_eq!(content, "unsaved");
+            NoteMutationOutput::changed(
+                format!("{content} changed"),
+                NoteMutationResult {
+                    wrapped_links: 1,
+                    skipped_existing_links: 0,
+                },
+            )
+        })
+        .unwrap();
+
+        assert_eq!(app.note_panels[0].note_content(), "unsaved changed");
+        let saved = load_notes().unwrap().remove(0);
+        assert_eq!(saved.content, "unsaved changed");
+    }
+
+    #[test]
+    fn closed_note_mutation_uses_persisted_content() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _ctx, mut app) = setup();
+        let mut disk_note = note("Alpha", "alpha", "persisted");
+        save_note(&mut disk_note, true).unwrap();
+
+        app.mutate_note_by_slug("alpha", |content| {
+            assert_eq!(content, "persisted");
+            NoteMutationOutput::changed(format!("{content} updated"), NoteMutationResult::default())
+        })
+        .unwrap();
+
+        assert_eq!(load_notes().unwrap()[0].content, "persisted updated");
+    }
+
+    #[test]
+    fn unchanged_mutation_does_not_rewrite_file_or_refresh() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _ctx, mut app) = setup();
+        let mut disk_note = note("Alpha", "alpha", "same");
+        save_note(&mut disk_note, true).unwrap();
+        let path = load_notes().unwrap()[0].path.clone();
+        let before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        app.mutate_note_by_slug("alpha", |content| {
+            NoteMutationOutput::unchanged(content, NoteMutationResult::default())
+        })
+        .unwrap();
+
+        let after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(before, after);
+        assert_eq!(app.note_mutation_refresh_count, 0);
+    }
+
+    #[test]
+    fn changed_mutation_refreshes_note_derived_state_once() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _ctx, mut app) = setup();
+        app.notes_dialog.open();
+        let mut disk_note = note("Alpha", "alpha", "old");
+        save_note(&mut disk_note, true).unwrap();
+
+        app.mutate_note_by_slug("alpha", |_| {
+            NoteMutationOutput::changed("new", NoteMutationResult::default())
+        })
+        .unwrap();
+
+        assert_eq!(app.note_mutation_refresh_count, 1);
+    }
+
+    #[test]
+    fn failed_open_note_save_reports_error_and_preserves_unsaved_edits() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _ctx, mut app) = setup();
+        let mut disk_note = note("Alpha", "alpha", "disk");
+        save_note(&mut disk_note, true).unwrap();
+        let mut panel = NotePanel::from_note(disk_note);
+        panel.replace_content_after_external_mutation("unsaved".into());
+        app.note_panels.push(panel);
+        unsafe { std::env::set_var("ML_NOTES_DIR", "/dev/null/not-a-dir") };
+
+        let err = app
+            .mutate_note_by_slug("alpha", |_| {
+                NoteMutationOutput::changed("changed", NoteMutationResult::default())
+            })
+            .unwrap_err();
+
+        assert!(err.to_string().contains("save mutated open note"));
+        assert!(
+            app.error
+                .as_ref()
+                .unwrap()
+                .contains("save mutated open note")
+        );
+        assert_eq!(app.note_panels[0].note_content(), "unsaved");
+    }
+}

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1155,6 +1155,28 @@ impl NotePanel {
         &self.note.content
     }
 
+    pub(crate) fn note_content_clone_for_mutation(&self) -> Note {
+        self.note.clone()
+    }
+
+    pub(crate) fn replace_content_after_external_mutation(&mut self, content: String) {
+        self.note.content = content;
+        self.mark_content_changed(0.0);
+    }
+
+    pub(crate) fn replace_note_after_external_mutation(&mut self, note: Note) {
+        self.note = note;
+        self.mark_content_changed(0.0);
+    }
+
+    pub(crate) fn invalidate_note_derived_data_after_external_mutation(&mut self) {
+        self.invalidate_markdown_analysis();
+        self.invalidate_link_menu_results();
+        self.link_menu_targets_version = None;
+        self.fast_derived_dirty = true;
+        self.heavy_recompute_requested = true;
+    }
+
     pub fn ui(&mut self, ctx: &egui::Context, app: &mut LauncherApp) {
         if !self.open {
             return;

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -280,6 +280,11 @@ impl NotesDialog {
         }
     }
 
+    pub(crate) fn refresh_entries_from_notes(&mut self) {
+        self.entries = cached_notes_or_load();
+        self.rebuild_index();
+    }
+
     pub fn open_edit(&mut self, idx: usize) {
         self.entries = cached_notes_or_load();
         self.rebuild_index();


### PR DESCRIPTION
### Motivation
- Provide a single, reusable GUI coordinator for applying content-transforming mutations to notes so later link-wrapping/refactoring phases can call a consistent API that preserves open-panel edits and centralizes save/refresh/error behavior.
- Avoid duplicating save/refresh logic across Quick Notes, note commands, and other UI handlers by exposing a single `LauncherApp` mutation entrypoint.
- Allow tests to validate open/closed/unchanged/changed/failure mutation semantics before implementing the concrete wrapping behavior.

### Description
- Added a new module `src/gui/note_mutation.rs` with generic mutation types: `NoteMutationOutcome`, `NoteMutationResult`, and `NoteMutationOutput`, plus the coordinator methods `LauncherApp::mutate_note_by_slug` and an internal `try_mutate_note_by_slug` that implement the mutation flow and error reporting via `report_error_message`.
- Registered the module in `src/gui/mod.rs` with `pub(crate) mod note_mutation;` and added a test-only counter `note_mutation_refresh_count` to observe refresh semantics from tests.
- Implemented logic to prefer open `NotePanel` in-memory content for mutations and to persist changes using existing `save_note`; on save failure the open-panel unsaved edits are preserved and the error is reported.
- Added panel-local helpers in `src/gui/note_panel.rs`: `note_content_clone_for_mutation`, `replace_content_after_external_mutation`, `replace_note_after_external_mutation`, and `invalidate_note_derived_data_after_external_mutation` to safely apply external mutations and reuse the panel content invalidation paths.
- Added `NotesDialog::refresh_entries_from_notes` in `src/gui/notes_dialog.rs` so Quick Notes refresh can reuse the centralized refresh path.
- Centralized post-mutation refresh into `refresh_after_note_mutation`, which refreshes dashboard note cache, Quick Notes when open, invalidates derived data for open panels, and triggers a single search refresh.
- Added unit tests inside `src/gui/note_mutation.rs` covering: open-note mutation uses unsaved panel content and saves it, closed-note mutation uses persisted disk content, unchanged mutation does not rewrite the file, changed mutation refreshes note-derived state exactly once, and failed open-note save reports an error while preserving unsaved edits.

### Testing
- Ran formatting with `cargo fmt --all` successfully.
- Attempted to run the focused unit tests with `cargo test -q note_mutation`; the test invocation encountered platform-specific build issues in this Linux environment: initial runs failed due to missing ALSA (`alsa-sys`) and X11 (`x11`) native packages which were then installed, but the build still fails to compile Windows-only bindings (`windows::Win32` / `windows::core`) present elsewhere in the crate, preventing the test binary from being produced; as a result the new unit tests could not be executed to completion here.
- The new tests are included and should run successfully in CI or on developer machines where platform-native dependencies and platform-gated features are available (or when tests are run with appropriate feature flags isolating platform-specific modules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a601632f8e48332acfa0313da98f17f)