### PR TITLE
Add deterministic atomic note persistence failure tests

### DIFF
--- a/src/common/atomic_file.rs
+++ b/src/common/atomic_file.rs
@@ -5,6 +5,14 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn save_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    save_atomic_with_replace(path, bytes, replace_existing)
+}
+
+fn save_atomic_with_replace(
+    path: &Path,
+    bytes: &[u8],
+    replace: impl FnOnce(&Path, &Path) -> Result<()>,
+) -> Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)?;
     let name = path
@@ -18,7 +26,7 @@ pub fn save_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
         file.flush()?;
         file.sync_all()?;
         drop(file);
-        replace_existing(&tmp, path)?;
+        replace(&tmp, path)?;
         Ok(())
     })();
     if res.is_err() {
@@ -81,6 +89,42 @@ fn timestamp() -> String {
 #[cfg(not(windows))]
 fn replace_existing(src: &Path, dst: &Path) -> Result<()> {
     fs::rename(src, dst).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_atomic_failed_replace_preserves_existing_destination_and_removes_temp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("note.md");
+        fs::write(&dest, b"original markdown").expect("write existing destination");
+
+        let result = save_atomic_with_replace(&dest, b"updated markdown", |_tmp, _dst| {
+            anyhow::bail!("deterministic replace failure")
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read(&dest).expect("read destination"),
+            b"original markdown"
+        );
+        let temp_entries: Vec<_> = fs::read_dir(dir.path())
+            .expect("read notes dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".note.md.tmp."))
+            })
+            .collect();
+        assert!(
+            temp_entries.is_empty(),
+            "temporary files should be removed after a failed replace: {temp_entries:?}"
+        );
+    }
 }
 
 #[cfg(windows)]

--- a/src/plugins/note.rs
+++ b/src/plugins/note.rs
@@ -280,6 +280,25 @@ static NOTE_VERSION: AtomicU64 = AtomicU64::new(0);
 static LAST_NOTE_REINDEX_MS: AtomicU64 = AtomicU64::new(0);
 const NOTE_REINDEX_DEBOUNCE_MS: u64 = 250;
 
+#[cfg(test)]
+type NoteSaveHook = dyn Fn(&std::path::Path, &[u8]) -> anyhow::Result<()> + Send + Sync;
+
+#[cfg(test)]
+static NOTE_SAVE_HOOK: Lazy<Mutex<Option<Box<NoteSaveHook>>>> = Lazy::new(|| Mutex::new(None));
+
+fn persist_note_file(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
+    #[cfg(test)]
+    if let Some(hook) = NOTE_SAVE_HOOK
+        .lock()
+        .expect("note save hook lock poisoned")
+        .as_ref()
+    {
+        return hook(path, bytes);
+    }
+
+    crate::common::atomic_file::save_atomic(path, bytes)
+}
+
 fn extract_tags(content: &str) -> Vec<String> {
     let mut tags: Vec<String> = Vec::new();
     let mut in_code = false;
@@ -966,7 +985,7 @@ pub fn save_note(note: &mut Note, overwrite: bool) -> anyhow::Result<bool> {
     note.alias = note.aliases.first().cloned();
     note.tags = extract_tags(&content);
     note.entity_refs = extract_entity_refs(&content);
-    crate::common::atomic_file::save_atomic(&path, content.as_bytes())
+    persist_note_file(&path, content.as_bytes())
         .with_context(|| format!("save note {}", path.display()))?;
     if !note.path.as_os_str().is_empty() && note.path != path {
         let _ = std::fs::remove_file(&note.path);
@@ -1008,7 +1027,7 @@ pub fn save_notes(notes: &[Note]) -> anyhow::Result<()> {
             let rest = lines.collect::<Vec<_>>().join("\n");
             content = format!("{first}\nAlias: {a}\n{rest}");
         }
-        crate::common::atomic_file::save_atomic(&path, content.as_bytes())
+        persist_note_file(&path, content.as_bytes())
             .with_context(|| format!("save note {}", path.display()))?;
     }
     for entry in std::fs::read_dir(&dir)? {
@@ -2003,6 +2022,27 @@ mod tests {
     }
 
     static TEMPLATE_ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    static NOTES_ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn set_note_save_hook(
+        hook: impl Fn(&std::path::Path, &[u8]) -> anyhow::Result<()> + Send + Sync + 'static,
+    ) {
+        *NOTE_SAVE_HOOK.lock().expect("note save hook lock poisoned") = Some(Box::new(hook));
+    }
+
+    fn clear_note_save_hook() {
+        *NOTE_SAVE_HOOK.lock().expect("note save hook lock poisoned") = None;
+    }
+
+    fn assert_no_bak_files(dir: &std::path::Path) {
+        assert!(std::fs::read_dir(dir).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .path()
+                .extension()
+                .is_some_and(|ext| ext == "bak")
+        }));
+    }
 
     fn with_template_dir<T>(test: impl FnOnce(&std::path::Path) -> T) -> T {
         let _lock = TEMPLATE_ENV_LOCK
@@ -3363,49 +3403,39 @@ Body",
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn save_note_failed_atomic_write_preserves_existing_note_without_backup() {
         use std::fs;
         use tempfile::tempdir;
 
+        let _lock = NOTES_ENV_LOCK.lock().expect("notes env lock poisoned");
         let dir = tempdir().unwrap();
         let prev = std::env::var("ML_NOTES_DIR").ok();
         unsafe { std::env::set_var("ML_NOTES_DIR", dir.path()) };
 
-        let old_path = dir.path().join("alpha.md");
-        let blocked_path = dir.path().join("alpha-renamed.md");
-        fs::write(&old_path, "# Alpha\n\noriginal").unwrap();
-        fs::create_dir(&blocked_path).unwrap();
+        let path = dir.path().join("alpha.md");
+        fs::write(&path, "# Alpha\n\noriginal").unwrap();
         refresh_cache().unwrap();
+        set_note_save_hook(|_path, _bytes| anyhow::bail!("deterministic save failure"));
 
         let mut note = Note {
-            title: "Alpha renamed".into(),
-            path: old_path.clone(),
-            content: "# Alpha renamed\n\nupdated".into(),
+            title: "Alpha".into(),
+            path: path.clone(),
+            content: "# Alpha\n\nupdated".into(),
             tags: Vec::new(),
             links: Vec::new(),
-            slug: "alpha-renamed".into(),
+            slug: "alpha".into(),
             alias: None,
             aliases: Vec::new(),
             entity_refs: Vec::new(),
         };
 
         let result = save_note(&mut note, true);
+        clear_note_save_hook();
 
         assert!(result.is_err());
-        assert_eq!(
-            fs::read_to_string(&old_path).unwrap(),
-            "# Alpha\n\noriginal"
-        );
-        assert!(blocked_path.is_dir());
-        assert!(fs::read_dir(dir.path()).unwrap().all(|entry| {
-            !entry
-                .unwrap()
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == "bak")
-        }));
+        assert_eq!(fs::read_to_string(&path).unwrap(), "# Alpha\n\noriginal");
+        assert_no_bak_files(dir.path());
 
         if let Some(p) = prev {
             unsafe { std::env::set_var("ML_NOTES_DIR", p) };
@@ -3414,12 +3444,12 @@ Body",
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn save_note_rename_keeps_old_file_when_new_atomic_write_fails() {
         use std::fs;
         use tempfile::tempdir;
 
+        let _lock = NOTES_ENV_LOCK.lock().expect("notes env lock poisoned");
         let dir = tempdir().unwrap();
         let prev = std::env::var("ML_NOTES_DIR").ok();
         unsafe { std::env::set_var("ML_NOTES_DIR", dir.path()) };
@@ -3427,8 +3457,8 @@ Body",
         let old_path = dir.path().join("alpha.md");
         let new_path = dir.path().join("alpha-renamed.md");
         fs::write(&old_path, "# Alpha\n\noriginal").unwrap();
-        fs::create_dir(&new_path).unwrap();
         refresh_cache().unwrap();
+        set_note_save_hook(|_path, _bytes| anyhow::bail!("deterministic save failure"));
 
         let mut note = Note {
             title: "Alpha renamed".into(),
@@ -3443,6 +3473,7 @@ Body",
         };
 
         let result = save_note(&mut note, true);
+        clear_note_save_hook();
 
         assert!(result.is_err());
         assert_eq!(note.path, old_path);
@@ -3450,14 +3481,8 @@ Body",
             fs::read_to_string(&old_path).unwrap(),
             "# Alpha\n\noriginal"
         );
-        assert!(new_path.is_dir());
-        assert!(fs::read_dir(dir.path()).unwrap().all(|entry| {
-            !entry
-                .unwrap()
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == "bak")
-        }));
+        assert!(!new_path.exists());
+        assert_no_bak_files(dir.path());
 
         if let Some(p) = prev {
             unsafe { std::env::set_var("ML_NOTES_DIR", p) };
@@ -3466,49 +3491,71 @@ Body",
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn save_notes_failed_write_does_not_delete_unrelated_old_notes_or_create_backups() {
         use std::fs;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use tempfile::tempdir;
 
+        let _lock = NOTES_ENV_LOCK.lock().expect("notes env lock poisoned");
         let dir = tempdir().unwrap();
         let prev = std::env::var("ML_NOTES_DIR").ok();
         unsafe { std::env::set_var("ML_NOTES_DIR", dir.path()) };
 
         let stale_path = dir.path().join("stale.md");
-        let blocked_path = dir.path().join("alpha.md");
         fs::write(&stale_path, "# Stale\n\nkeep me").unwrap();
-        fs::create_dir(&blocked_path).unwrap();
         refresh_cache().unwrap();
+        let writes = Arc::new(AtomicUsize::new(0));
+        let hook_writes = writes.clone();
+        set_note_save_hook(move |path, bytes| {
+            let write_number = hook_writes.fetch_add(1, Ordering::SeqCst);
+            if write_number == 0 {
+                crate::common::atomic_file::save_atomic(path, bytes)
+            } else {
+                anyhow::bail!("deterministic save failure")
+            }
+        });
 
-        let notes = vec![Note {
-            title: "Alpha".into(),
-            path: PathBuf::new(),
-            content: "# Alpha\n\nnew".into(),
-            tags: Vec::new(),
-            links: Vec::new(),
-            slug: "alpha".into(),
-            alias: None,
-            aliases: Vec::new(),
-            entity_refs: Vec::new(),
-        }];
+        let notes = vec![
+            Note {
+                title: "Alpha".into(),
+                path: PathBuf::new(),
+                content: "# Alpha\n\nnew".into(),
+                tags: Vec::new(),
+                links: Vec::new(),
+                slug: "alpha".into(),
+                alias: None,
+                aliases: Vec::new(),
+                entity_refs: Vec::new(),
+            },
+            Note {
+                title: "Beta".into(),
+                path: PathBuf::new(),
+                content: "# Beta\n\nnew".into(),
+                tags: Vec::new(),
+                links: Vec::new(),
+                slug: "beta".into(),
+                alias: None,
+                aliases: Vec::new(),
+                entity_refs: Vec::new(),
+            },
+        ];
 
         let result = save_notes(&notes);
+        clear_note_save_hook();
 
         assert!(result.is_err());
+        assert_eq!(writes.load(Ordering::SeqCst), 2);
         assert_eq!(
             fs::read_to_string(&stale_path).unwrap(),
             "# Stale\n\nkeep me"
         );
-        assert!(blocked_path.is_dir());
-        assert!(fs::read_dir(dir.path()).unwrap().all(|entry| {
-            !entry
-                .unwrap()
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == "bak")
-        }));
+        assert_eq!(
+            fs::read_to_string(dir.path().join("alpha.md")).unwrap(),
+            "# Alpha\n\nnew"
+        );
+        assert!(!dir.path().join("beta.md").exists());
+        assert_no_bak_files(dir.path());
 
         if let Some(p) = prev {
             unsafe { std::env::set_var("ML_NOTES_DIR", p) };


### PR DESCRIPTION
### Motivation
- Enable deterministic, low-level testing of atomic file persistence and note save failure paths without changing production behavior or relying on timing.
- Verify that failed atomic writes preserve existing files, do not create `.bak` backups, and do not delete unrelated files during batched saves.

### Description
- Factor `save_atomic` through a private helper `save_atomic_with_replace` so the replace step can be injected for deterministic failure tests while keeping the public `save_atomic` behavior unchanged.
- Add a unit test in `src/common/atomic_file.rs` that forces a replacement failure and asserts the destination retains the original bytes and temporary files are removed.
- Add a test-only in-memory seam in `src/plugins/note.rs`: a `NOTE_SAVE_HOOK` and `persist_note_file` helper used by `save_note` and `save_notes` during tests while the production path still calls `crate::common::atomic_file::save_atomic` through the helper.
- Update and add deterministic tests in the notes test module to use the hook and helpers for three failure scenarios and include assertions that no `.bak` files are created and that existing files are preserved.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran `git diff --check`, which succeeded.
- Attempted to run the new unit tests via `cargo test` targeting the new test names, but the test runs could not complete due to unrelated native build dependencies and platform-specific code in the repository: an initial `pkg-config`/`alsa` error was resolved by installing system packages, but subsequent compilation still failed while building other platform-specific/native crates (Windows API bindings and X11-related native deps) unrelated to these changes, so the new tests were not able to complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a613cfa6b248332bf399f06d06af2ee)