### PR TITLE
Defer launcher result activation

### DIFF
--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1,5 +1,24 @@
 use super::*;
 
+#[derive(Clone, Debug)]
+pub(crate) struct DeferredActivation {
+    pub(crate) action: Action,
+    pub(crate) query_override: Option<String>,
+    pub(crate) source: ActivationSource,
+}
+
+pub(crate) fn deferred_activation_from_results(
+    results: &[Action],
+    idx: usize,
+    source: ActivationSource,
+) -> Option<DeferredActivation> {
+    results.get(idx).cloned().map(|action| DeferredActivation {
+        action,
+        query_override: None,
+        source,
+    })
+}
+
 impl LauncherApp {
     pub(crate) fn launcher_query_keyboard_enabled(query_has_focus: bool) -> bool {
         query_has_focus
@@ -992,6 +1011,7 @@ impl eframe::App for LauncherApp {
                     });
                 }
 
+                let mut deferred_activation: Option<DeferredActivation> = None;
                 let mut launch_idx: Option<usize> = None;
                 if !accepted_suggestion
                     && enter
@@ -1012,11 +1032,10 @@ impl eframe::App for LauncherApp {
                     launch_idx = self.handle_key(egui::Key::Enter);
                 }
 
-                if let Some(i) = launch_idx
-                    && let Some(a) = self.results.get(i) {
-                        let a = a.clone();
-                        self.activate_action(a, None, ActivationSource::Enter);
-                    }
+                if let Some(i) = launch_idx {
+                    deferred_activation =
+                        deferred_activation_from_results(&self.results, i, ActivationSource::Enter);
+                }
             });
 
             if use_dashboard {
@@ -1107,11 +1126,11 @@ impl eframe::App for LauncherApp {
                                             }
                                             if menu_resp.clicked() {
                                                 self.selected = Some(idx);
-                                                self.activate_action(
+                                                deferred_activation = Some(DeferredActivation {
                                                     action,
-                                                    None,
-                                                    ActivationSource::Click,
-                                                );
+                                                    query_override: None,
+                                                    source: ActivationSource::Click,
+                                                });
                                             }
                                             if (idx + 1) % cols == 0 {
                                                 ui.end_row();
@@ -1153,7 +1172,11 @@ impl eframe::App for LauncherApp {
                                     }
                                     if menu_resp.clicked() {
                                         self.selected = Some(idx);
-                                        self.activate_action(a.clone(), None, ActivationSource::Click);
+                                        deferred_activation = Some(DeferredActivation {
+                                            action: a.clone(),
+                                            query_override: None,
+                                            source: ActivationSource::Click,
+                                        });
                                     }
                                 }
                             }
@@ -1169,6 +1192,13 @@ impl eframe::App for LauncherApp {
                             }
                         });
                     });
+            }
+            if let Some(deferred) = deferred_activation.take() {
+                self.activate_action(
+                    deferred.action,
+                    deferred.query_override,
+                    deferred.source,
+                );
             }
         });
         let show_editor = self.show_editor;
@@ -1523,6 +1553,51 @@ mod tests {
         assert_eq!(app.selected, Some(1));
         app.handle_key(egui::Key::ArrowDown);
         assert_eq!(app.selected, Some(4));
+    }
+
+    #[test]
+    fn deferred_activation_from_results_clones_action_without_retaining_index() {
+        let original = vec![
+            Action {
+                label: "First".into(),
+                desc: "Command".into(),
+                action: "query:first".into(),
+                args: None,
+            },
+            Action {
+                label: "cm camel-case".into(),
+                desc: "Completion".into(),
+                action: "query:cm camel-case".into(),
+                args: Some("{\"query\":\"camel-case\"}".into()),
+            },
+        ];
+
+        let deferred = deferred_activation_from_results(&original, 1, ActivationSource::Enter)
+            .expect("selected result should resolve to a deferred activation");
+        let mut refreshed = original.clone();
+        refreshed[1] = Action {
+            label: "Refreshed".into(),
+            desc: "New list".into(),
+            action: "refreshed:action".into(),
+            args: None,
+        };
+
+        assert_eq!(deferred.action.label, "cm camel-case");
+        assert_eq!(deferred.action.action, "query:cm camel-case");
+        assert_eq!(deferred.source, ActivationSource::Enter);
+        assert_eq!(refreshed[1].action, "refreshed:action");
+    }
+
+    #[test]
+    fn deferred_activation_from_results_ignores_out_of_bounds_index() {
+        let results = vec![Action {
+            label: "Only".into(),
+            desc: "Command".into(),
+            action: "only".into(),
+            args: None,
+        }];
+
+        assert!(deferred_activation_from_results(&results, 3, ActivationSource::Click).is_none());
     }
 
     #[test]

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -892,6 +892,7 @@ impl eframe::App for LauncherApp {
         }
 
         CentralPanel::default().show(ctx, |ui| {
+            let mut deferred_activation: Option<DeferredActivation> = None;
             ui.heading("🚀 Multi Lnchr");
             if self.should_render_inline_error()
                 && let Some(err) = &self.error {
@@ -1011,7 +1012,6 @@ impl eframe::App for LauncherApp {
                     });
                 }
 
-                let mut deferred_activation: Option<DeferredActivation> = None;
                 let mut launch_idx: Option<usize> = None;
                 if !accepted_suggestion
                     && enter

--- a/src/gui/search.rs
+++ b/src/gui/search.rs
@@ -256,9 +256,13 @@ impl LauncherApp {
         }
     }
 
+    pub(crate) fn clear_selected_after_results_replaced(&mut self) {
+        self.selected = None;
+    }
+
     pub fn search(&mut self) {
         if self.last_results_valid && self.query == self.last_search_query {
-            self.selected = None;
+            self.clear_selected_after_results_replaced();
             return;
         }
 
@@ -280,7 +284,7 @@ impl LauncherApp {
                 });
             }
             self.results = res;
-            self.selected = None;
+            self.clear_selected_after_results_replaced();
             self.recompute_query_results_layout();
             return;
         }
@@ -318,7 +322,7 @@ impl LauncherApp {
         res.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         self.results = res.into_iter().map(|(a, _)| a).collect();
-        self.selected = None;
+        self.clear_selected_after_results_replaced();
         self.last_search_query = self.query.clone();
         self.last_results_valid = true;
         self.update_suggestions();
@@ -582,6 +586,46 @@ mod tests {
                 section: ClipboardModifySectionPayload::Modify,
             }
         );
+    }
+
+    #[test]
+    fn search_replacement_clears_selected_index() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.actions = vec![Action {
+            label: "Calculator".into(),
+            desc: "App".into(),
+            action: "calc".into(),
+            args: None,
+        }];
+        app.update_action_cache();
+        app.selected = Some(0);
+        app.query = "app calc".into();
+
+        app.search();
+
+        assert_eq!(app.results.len(), 1);
+        assert_eq!(app.selected, None);
+    }
+
+    #[test]
+    fn repeated_search_clears_stale_out_of_bounds_selected_index() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        app.results = vec![Action {
+            label: "Only".into(),
+            desc: "Result".into(),
+            action: "only".into(),
+            args: None,
+        }];
+        app.query = "same".into();
+        app.last_search_query = "same".into();
+        app.last_results_valid = true;
+        app.selected = Some(5);
+
+        app.search();
+
+        assert_eq!(app.selected, None);
     }
 
     #[test]

--- a/src/gui/search.rs
+++ b/src/gui/search.rs
@@ -592,12 +592,12 @@ mod tests {
     fn search_replacement_clears_selected_index() {
         let ctx = egui::Context::default();
         let mut app = new_app(&ctx);
-        app.actions = vec![Action {
+        app.actions = Arc::new(vec![Action {
             label: "Calculator".into(),
             desc: "App".into(),
             action: "calc".into(),
             args: None,
-        }];
+        }]);
         app.update_action_cache();
         app.selected = Some(0);
         app.query = "app calc".into();


### PR DESCRIPTION
### Motivation
- Prevent activating an action that may be replaced by a later `search()` call during the same frame by cloning the selected `Action` immediately and deferring the actual activation until after result traversal and context-menu handling.

### Description
- Add a GUI-local `DeferredActivation` type and helper `deferred_activation_from_results` to resolve+clone an `Action` from `results` by index (`src/gui/render.rs`).
- Replace immediate `self.activate_action(...)` calls for result clicks and Enter-key activation with capture of a cloned `Action` into a `DeferredActivation`, then call `self.activate_action(...)` once after the results `ScrollArea` and related refresh/focus handling completes (`src/gui/render.rs`).
- Preserve dashboard activation semantics by keeping dashboard widget activations on their direct `activate_action` path (`src/gui/render.rs`).
- Add `clear_selected_after_results_replaced` and use it from `search()` to clamp/clear `self.selected` whenever `self.results` is replaced, covering the cached-results early-return path (`src/gui/search.rs`).
- Add unit tests for the deferred helper (clone/no-index retention and out-of-bounds) and for selection clearing after search replacement (`src/gui/render.rs` and `src/gui/search.rs`).

### Testing
- Ran `cargo fmt` (success) and `git diff --check` (success).
- Attempted to run unit tests, but test execution/build was blocked by a missing system dependency: the `alsa` development package (`alsa.pc`) required by `alsa-sys` caused the build to fail, so the new tests could not be executed in this environment.
- The changes were committed on the current branch with the message `Defer launcher result activation`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61476703ac833283c529c1fe39486f)