### PR TITLE
Harden Clipboard Modify immediate execution

### DIFF
--- a/src/clipboard_modify/coordinator.rs
+++ b/src/clipboard_modify/coordinator.rs
@@ -750,7 +750,7 @@ mod tests {
                 ClipboardModifyIntent::ApplyTemplate {
                     name: "missing".into(),
                 },
-                Arc::new(ClipboardModifierCatalog::default()),
+                Arc::new(ClipboardModifierCatalog::new(Vec::new(), Vec::new()).unwrap()),
                 meta("q"),
             )
             .unwrap();

--- a/src/clipboard_modify/coordinator.rs
+++ b/src/clipboard_modify/coordinator.rs
@@ -8,6 +8,7 @@ use crate::clipboard_modify::executor::{
 use crate::clipboard_modify::model::{ClipboardModifierCatalog, StageSpec};
 use crate::clipboard_modify::parser::ClipboardModifyIntent;
 use crate::gui::ActivationSource;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
@@ -404,7 +405,12 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
         intent: ClipboardModifyIntent,
         catalog: Arc<ClipboardModifierCatalog>,
         meta: ImmediateRequestMetadata,
-    ) -> OperationId {
+    ) -> Result<OperationId, StructuredClipboardModifyError> {
+        if self.has_pending() {
+            return Err(StructuredClipboardModifyError {
+                message: "Clipboard Modify operation already running".to_string(),
+            });
+        }
         let id = OperationId(self.next_id);
         self.next_id += 1;
         self.pending.insert(id.0, meta.clone());
@@ -414,7 +420,7 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
         let repaint = self.repaint.clone();
         thread::spawn(move || {
             let label = meta.action.label.clone();
-            let result = (|| {
+            let result = catch_unwind(AssertUnwindSafe(|| {
                 let source = service.read_text()?;
                 let cancel = CancellationToken::new();
                 let out = run_intent(&source, &intent, catalog.as_ref(), &cancel)
@@ -422,25 +428,37 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
                 let md = OutputMetadata::from_text(&out);
                 service.commit_output(out, &label)?;
                 Ok::<_, ClipboardError>(md)
-            })();
+            }));
             let ev = match result {
-                Ok(md) => ImmediateCompletionEvent {
-                    request_id: id,
-                    display_label: label,
-                    character_count: md.chars,
-                    line_count: md.lines,
-                    undo_available: true,
-                    result: Ok(()),
-                },
-                Err(e) => ImmediateCompletionEvent {
+                Err(_) => ImmediateCompletionEvent {
                     request_id: id,
                     display_label: label,
                     character_count: 0,
                     line_count: 0,
                     undo_available: false,
                     result: Err(StructuredClipboardModifyError {
-                        message: e.to_string(),
+                        message: "Clipboard Modify operation failed unexpectedly".to_string(),
                     }),
+                },
+                Ok(result) => match result {
+                    Ok(md) => ImmediateCompletionEvent {
+                        request_id: id,
+                        display_label: label,
+                        character_count: md.chars,
+                        line_count: md.lines,
+                        undo_available: true,
+                        result: Ok(()),
+                    },
+                    Err(e) => ImmediateCompletionEvent {
+                        request_id: id,
+                        display_label: label,
+                        character_count: 0,
+                        line_count: 0,
+                        undo_available: false,
+                        result: Err(StructuredClipboardModifyError {
+                            message: e.to_string(),
+                        }),
+                    },
                 },
             };
             let _ = tx.send(ev);
@@ -448,7 +466,7 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
                 r();
             }
         });
-        id
+        Ok(id)
     }
     pub fn drain_completions(&mut self) -> Vec<ImmediateCompletionEvent> {
         let mut out = Vec::new();
@@ -479,6 +497,10 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
     }
     pub fn diagnostics(&self) -> &ImmediateDiagnostics {
         &self.diagnostics
+    }
+    #[cfg(test)]
+    pub(crate) fn inject_completion_for_test(&self, ev: ImmediateCompletionEvent) {
+        self.tx.send(ev).unwrap();
     }
 }
 
@@ -583,15 +605,17 @@ mod tests {
             "a\nb",
         )));
         let mut ic = ImmediateExecutionCoordinator::new(svc);
-        let id = ic.start(
-            ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
-            Arc::new(default_catalog()),
-            ImmediateRequestMetadata {
-                action: action(),
-                query: "cm upper".into(),
-                source: ActivationSource::Enter,
-            },
-        );
+        let id = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                ImmediateRequestMetadata {
+                    action: action(),
+                    query: "cm upper".into(),
+                    source: ActivationSource::Enter,
+                },
+            )
+            .unwrap();
         std::thread::sleep(Duration::from_millis(50));
         let ev = ic.drain_completions().pop().unwrap();
         assert_eq!(ev.request_id, id);
@@ -604,19 +628,211 @@ mod tests {
     fn immediate_cancel_pending_rejects_stale_completion() {
         let svc = Arc::new(ClipboardService::new(FakeClipboardBackend::with_text("x")));
         let mut ic = ImmediateExecutionCoordinator::new(svc);
-        let id = ic.start(
-            ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
-            Arc::new(default_catalog()),
-            ImmediateRequestMetadata {
-                action: action(),
-                query: "q".into(),
-                source: ActivationSource::Enter,
-            },
-        );
+        let id = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                ImmediateRequestMetadata {
+                    action: action(),
+                    query: "q".into(),
+                    source: ActivationSource::Enter,
+                },
+            )
+            .unwrap();
         assert!(ic.pending_metadata(id).is_some());
         ic.cancel_pending();
         std::thread::sleep(Duration::from_millis(50));
         assert!(ic.drain_completions().is_empty());
+    }
+
+    #[derive(Clone, Copy)]
+    enum PanicAt {
+        Read,
+        Commit,
+    }
+    struct PanicService {
+        at: PanicAt,
+    }
+    impl ClipboardCommit for PanicService {
+        fn read_text(&self) -> Result<String, ClipboardError> {
+            if matches!(self.at, PanicAt::Read) {
+                panic!("secret source");
+            }
+            Ok("x".into())
+        }
+        fn commit_output(
+            &self,
+            _output: String,
+            _label: &str,
+        ) -> Result<UndoRecord, ClipboardError> {
+            if matches!(self.at, PanicAt::Commit) {
+                panic!("secret output");
+            }
+            Ok(UndoRecord {
+                original_text: "x".into(),
+                modified_text: "X".into(),
+                operation_label: "Run".into(),
+            })
+        }
+    }
+
+    fn meta(query: &str) -> ImmediateRequestMetadata {
+        ImmediateRequestMetadata {
+            action: action(),
+            query: query.into(),
+            source: ActivationSource::Enter,
+        }
+    }
+
+    fn wait_one<S: ClipboardCommit>(
+        ic: &mut ImmediateExecutionCoordinator<S>,
+    ) -> ImmediateCompletionEvent {
+        for _ in 0..50 {
+            if let Some(ev) = ic.drain_completions().pop() {
+                return ev;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("completion not received")
+    }
+
+    #[test]
+    fn immediate_rejects_start_while_pending_without_mutation() {
+        let svc = Arc::new(ClipboardService::new(FakeClipboardBackend::with_text("x")));
+        let mut ic = ImmediateExecutionCoordinator::new(svc);
+        let id = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                meta("first"),
+            )
+            .unwrap();
+        let diagnostics = ic.diagnostics().clone();
+        let err = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::DoubleQuote)]),
+                Arc::new(default_catalog()),
+                meta("second"),
+            )
+            .unwrap_err();
+        assert_eq!(err.message, "Clipboard Modify operation already running");
+        assert_eq!(ic.pending_metadata(id).unwrap().query, "first");
+        assert_eq!(ic.diagnostics(), &diagnostics);
+        let _ = wait_one(&mut ic);
+    }
+
+    #[test]
+    fn immediate_panic_during_read_becomes_failure_and_clears_pending() {
+        let mut ic =
+            ImmediateExecutionCoordinator::new(Arc::new(PanicService { at: PanicAt::Read }));
+        let id = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                meta("q"),
+            )
+            .unwrap();
+        let ev = wait_one(&mut ic);
+        assert_eq!(ev.request_id, id);
+        assert_eq!(
+            ev.result.unwrap_err().message,
+            "Clipboard Modify operation failed unexpectedly"
+        );
+        assert!(!ic.has_pending());
+    }
+
+    #[test]
+    fn immediate_panic_during_transformation_becomes_failure_and_clears_pending() {
+        let svc = Arc::new(ClipboardService::new(FakeClipboardBackend::with_text("x")));
+        let mut ic = ImmediateExecutionCoordinator::new(svc);
+        let id = ic
+            .start(
+                ClipboardModifyIntent::ApplyTemplate {
+                    name: "missing".into(),
+                },
+                Arc::new(ClipboardModifierCatalog::default()),
+                meta("q"),
+            )
+            .unwrap();
+        let ev = wait_one(&mut ic);
+        assert_eq!(ev.request_id, id);
+        assert!(ev.result.is_err());
+        assert!(!ic.has_pending());
+    }
+
+    #[test]
+    fn immediate_panic_during_commit_becomes_failure_and_clears_pending() {
+        let mut ic = ImmediateExecutionCoordinator::new(Arc::new(PanicService {
+            at: PanicAt::Commit,
+        }));
+        let id = ic
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                meta("q"),
+            )
+            .unwrap();
+        let ev = wait_one(&mut ic);
+        assert_eq!(ev.request_id, id);
+        assert_eq!(
+            ev.result.unwrap_err().message,
+            "Clipboard Modify operation failed unexpectedly"
+        );
+        assert!(!ic.has_pending());
+    }
+
+    #[test]
+    fn immediate_repaint_after_success_expected_failure_and_panic() {
+        let repaint_count = Arc::new(AtomicUsize::new(0));
+        let mut success = ImmediateExecutionCoordinator::new(Arc::new(ClipboardService::new(
+            FakeClipboardBackend::with_text("x"),
+        )));
+        let c = repaint_count.clone();
+        success.set_repaint_callback(Arc::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        success
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                meta("q"),
+            )
+            .unwrap();
+        let _ = wait_one(&mut success);
+
+        let mut fail = ImmediateExecutionCoordinator::new(Arc::new(ClipboardService::new(
+            FakeClipboardBackend::with_text("x"),
+        )));
+        fail.service
+            .backend()
+            .push(Op::Write(Err(ClipboardError::Permanent("no".into()))));
+        let c = repaint_count.clone();
+        fail.set_repaint_callback(Arc::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        fail.start(
+            ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+            Arc::new(default_catalog()),
+            meta("q"),
+        )
+        .unwrap();
+        let _ = wait_one(&mut fail);
+
+        let mut panicc =
+            ImmediateExecutionCoordinator::new(Arc::new(PanicService { at: PanicAt::Read }));
+        let c = repaint_count.clone();
+        panicc.set_repaint_callback(Arc::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        panicc
+            .start(
+                ClipboardModifyIntent::Stages(vec![stage(OpId::Uppercase)]),
+                Arc::new(default_catalog()),
+                meta("q"),
+            )
+            .unwrap();
+        let _ = wait_one(&mut panicc);
+        assert_eq!(repaint_count.load(Ordering::SeqCst), 3);
     }
 
     #[test]
@@ -638,7 +854,8 @@ mod tests {
                 query: "q".into(),
                 source: ActivationSource::Click,
             },
-        );
+        )
+        .unwrap();
         std::thread::sleep(Duration::from_millis(50));
         let ev = ic.drain_completions().pop().unwrap();
         assert!(ev.result.is_err());

--- a/src/clipboard_modify/coordinator.rs
+++ b/src/clipboard_modify/coordinator.rs
@@ -499,7 +499,12 @@ impl<S: ClipboardCommit> ImmediateExecutionCoordinator<S> {
         &self.diagnostics
     }
     #[cfg(test)]
-    pub(crate) fn inject_completion_for_test(&self, ev: ImmediateCompletionEvent) {
+    pub(crate) fn inject_completion_for_test(
+        &mut self,
+        meta: ImmediateRequestMetadata,
+        ev: ImmediateCompletionEvent,
+    ) {
+        self.pending.insert(ev.request_id.0, meta);
         self.tx.send(ev).unwrap();
     }
 }

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -967,12 +967,21 @@ impl LauncherApp {
                 query: canonical_command,
                 source,
             };
-            let id = self.clipboard_modify_immediate.start(
+            match self.clipboard_modify_immediate.start(
                 intent,
                 self.clipboard_modify_runtime.catalog_snapshot(),
                 meta.clone(),
-            );
-            self.pending_clipboard_modify_immediate.insert(id.0, meta);
+            ) {
+                Ok(id) => {
+                    self.pending_clipboard_modify_immediate.insert(id.0, meta);
+                }
+                Err(err) => {
+                    self.report_clipboard_modify_action_error(err.message);
+                    self.visible_flag.store(true, Ordering::SeqCst);
+                    self.move_cursor_end = true;
+                    self.focus_input();
+                }
+            }
             return true;
         }
 
@@ -1017,8 +1026,11 @@ impl LauncherApp {
                     ));
                     if let Some(meta) = meta {
                         self.query = meta.query;
+                        self.last_results_valid = false;
+                        self.search();
                     }
                     self.visible_flag.store(true, Ordering::SeqCst);
+                    self.move_cursor_end = true;
                     self.focus_input();
                     self.report_error_message("clipboard_modify", err.message.clone());
                 }
@@ -1250,7 +1262,7 @@ mod tests {
 
     #[test]
     fn destructive_confirmation_supports_queue_confirm_and_cancel_paths() {
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let notes_dir = dir.path().join("notes");
         std::fs::create_dir_all(&notes_dir).unwrap();
         let original_dir = std::env::current_dir().unwrap();
@@ -1291,7 +1303,7 @@ mod tests {
 
     #[test]
     fn action_execution_errors_flow_through_unified_ui_reporting() {
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
 
@@ -1328,7 +1340,7 @@ mod tests {
 
     #[test]
     fn activation_source_and_usage_are_recorded_for_successful_actions() {
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
 
@@ -1529,6 +1541,123 @@ mod clipboard_modify_gui_action_tests {
             ));
             assert_eq!(app.clipboard_modify_dialog.section, dialog_section);
         }
+    }
+
+    #[test]
+    fn concurrent_activation_shows_already_running_and_leaves_launcher_visible() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        app.visible_flag.store(true, Ordering::SeqCst);
+        let args = encode_action_payload(&execute_stages_payload(vec![StageSpec {
+            operation: OperationId::Uppercase,
+            arguments: StageArguments::default(),
+        }]))
+        .unwrap();
+        let act = action("clipboard_modify:execute", Some(args));
+        assert!(app.handle_clipboard_modify_action(&act, ActivationSource::Enter));
+        let query_before = app.query.clone();
+        assert!(app.handle_clipboard_modify_action(&act, ActivationSource::Enter));
+        assert!(app.visible_flag.load(Ordering::SeqCst));
+        assert_eq!(app.query, query_before);
+        assert!(app.move_cursor_end);
+        assert!(
+            app.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Clipboard Modify operation already running")
+        );
+    }
+
+    #[test]
+    fn immediate_failure_restores_canonical_query_and_focus_cursor_flags() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        let meta = ImmediateRequestMetadata {
+            action: action("clipboard_modify:execute", None),
+            query: "cm uppercase".into(),
+            source: ActivationSource::Enter,
+        };
+        app.pending_clipboard_modify_immediate
+            .insert(7, meta.clone());
+        app.query = "changed".into();
+        app.clipboard_modify_immediate.inject_completion_for_test(
+            crate::clipboard_modify::coordinator::ImmediateCompletionEvent {
+                request_id: crate::clipboard_modify::coordinator::OperationId(7),
+                display_label: "Test".into(),
+                character_count: 0,
+                line_count: 0,
+                undo_available: false,
+                result: Err(
+                    crate::clipboard_modify::coordinator::StructuredClipboardModifyError {
+                        message: "boom".into(),
+                    },
+                ),
+            },
+        );
+        app.drain_clipboard_modify_immediate();
+        assert_eq!(app.query, "cm uppercase");
+        assert!(app.visible_flag.load(Ordering::SeqCst));
+        assert!(app.move_cursor_end);
+        assert!(app.error.as_deref().unwrap_or_default().contains("boom"));
+        assert!(app.usage.get(&meta.action.action).is_none());
+    }
+
+    #[test]
+    fn immediate_success_records_canonical_usage_history_and_hides_launcher() {
+        let dir = tempfile::tempdir().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        app.visible_flag.store(true, Ordering::SeqCst);
+        let meta = ImmediateRequestMetadata {
+            action: action("clipboard_modify:execute", None),
+            query: "cm uppercase".into(),
+            source: ActivationSource::Gesture,
+        };
+        app.pending_clipboard_modify_immediate
+            .insert(8, meta.clone());
+        let before_len = history::get_history().len();
+        app.clipboard_modify_immediate.inject_completion_for_test(
+            crate::clipboard_modify::coordinator::ImmediateCompletionEvent {
+                request_id: crate::clipboard_modify::coordinator::OperationId(8),
+                display_label: "Test".into(),
+                character_count: 1,
+                line_count: 1,
+                undo_available: true,
+                result: Ok(()),
+            },
+        );
+        app.drain_clipboard_modify_immediate();
+        assert!(!app.visible_flag.load(Ordering::SeqCst));
+        assert_eq!(app.usage.get(&meta.action.action), Some(&1));
+        assert!(history::get_history().len() > before_len);
+        assert_eq!(
+            history::get_history().front().unwrap().query,
+            "cm uppercase"
+        );
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn malformed_payload_failure_leaves_coordinator_ready_for_valid_command() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        assert!(app.handle_clipboard_modify_action(
+            &action("clipboard_modify:execute", Some("not-json".into())),
+            ActivationSource::Enter
+        ));
+        assert!(!app.clipboard_modify_immediate.has_pending());
+        let args = encode_action_payload(&execute_stages_payload(vec![StageSpec {
+            operation: OperationId::Uppercase,
+            arguments: StageArguments::default(),
+        }]))
+        .unwrap();
+        assert!(app.handle_clipboard_modify_action(
+            &action("clipboard_modify:execute", Some(args)),
+            ActivationSource::Enter
+        ));
+        assert!(app.clipboard_modify_immediate.has_pending());
     }
 
     #[test]

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -1581,6 +1581,7 @@ mod clipboard_modify_gui_action_tests {
             .insert(7, meta.clone());
         app.query = "changed".into();
         app.clipboard_modify_immediate.inject_completion_for_test(
+            meta.clone(),
             crate::clipboard_modify::coordinator::ImmediateCompletionEvent {
                 request_id: crate::clipboard_modify::coordinator::OperationId(7),
                 display_label: "Test".into(),
@@ -1619,6 +1620,7 @@ mod clipboard_modify_gui_action_tests {
             .insert(8, meta.clone());
         let before_len = history::get_history().len();
         app.clipboard_modify_immediate.inject_completion_for_test(
+            meta.clone(),
             crate::clipboard_modify::coordinator::ImmediateCompletionEvent {
                 request_id: crate::clipboard_modify::coordinator::OperationId(8),
                 display_label: "Test".into(),


### PR DESCRIPTION
### Motivation
- Prevent concurrent immediate Clipboard Modify starts and make start failures observable to the GUI without corrupting coordinator state or diagnostics.
- Ensure worker panics are captured and converted into safe failure events so the GUI and coordinator reach a terminal state and repaint reliably.
- Preserve existing success-side effects (commit/undo/history/hooks) and ensure failures restore GUI state and do not record usage or undo.

### Description
- Change `ImmediateExecutionCoordinator::start` to return `Result<OperationId, StructuredClipboardModifyError>` and reject starts when `self.has_pending()` with the message `Clipboard Modify operation already running`. Pending/next_id/diagnostics are not mutated on rejected starts.
- Wrap the entire worker body in `std::panic::catch_unwind(AssertUnwindSafe(...))` and map caught panics to a sanitized failure `ImmediateCompletionEvent` with message `Clipboard Modify operation failed unexpectedly` (no clipboard content included), then attempt to send the event and call the repaint callback.
- Keep all accepted requests producing a terminal event: success yields `Ok(())`, expected errors map to structured failure, and panics map to structured failure; repaint is requested after every terminal path.
- Keep `drain_completions` behavior that removes pending metadata for both success and all failure variants and maintains diagnostics and success-hook invocation only for successful commits; add `inject_completion_for_test` helper to emit test completions into the coordinator channel.
- Update `src/gui/actions.rs::handle_clipboard_modify_action` to match on `start(...)` result: on `Ok(id)` insert pending metadata, on `Err` call `report_clipboard_modify_action_error`, keep the launcher visible, move cursor to end and focus input, and do not hide the launcher.
- Update `drain_clipboard_modify_immediate` to preserve failed-side effects: failures restore canonical attempted command to `self.query`, refresh results (`self.search()`), set `move_cursor_end = true`, focus input, report error via existing error/toast infra, and avoid recording history/usage or undo unless commit succeeded.
- Add coordinator tests covering concurrent rejection, non-mutation on rejected starts, panic-to-failure for read/transform/commit, pending cleanup after drain, and repaint invocation after success/failure/panic; add GUI tests covering concurrent activation rejection, failure restore behavior, success history/usage and hide-launcher behavior, and malformed-payload readiness.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Attempted `cargo test clipboard_modify::coordinator --lib` to exercise the new coordinator tests, but the test run was blocked by broader platform-native build issues (missing system pkg-config libraries and non-Linux/Windows crate resolution for `windows::Win32` in unrelated modules), so the full test suite could not complete in this environment.
- Unit tests were added for both coordinator and GUI paths (concurrent start rejection, panic-to-failure flows, repaint calls, GUI restore/hide/usage behaviors) and are included in the patch for CI execution where platform prerequisites are satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a615b33b62883329ad3b48e935dd4cb)