### PR TITLE
Add Quick Notes 'Wrap links in note' Meta context action

### DIFF
--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -1215,7 +1215,7 @@ impl LauncherApp {
         *count += 1;
     }
 
-    fn wrap_note_plain_links(&mut self, slug: &str) {
+    pub(crate) fn wrap_note_plain_links(&mut self, slug: &str) {
         let outcome = self.mutate_note_by_slug(slug, |content| {
             let report = crate::notes_markdown::links::wrap_plain_urls(content);
             NoteMutationOutput::changed(

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -1159,6 +1159,21 @@ impl NotePanel {
         self.note.clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_view_mode(&self) -> NoteViewMode {
+        self.view_mode
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_set_view_mode(&mut self, view_mode: NoteViewMode) {
+        self.view_mode = view_mode;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_last_edit_at_secs(&self) -> Option<f64> {
+        self.last_edit_at_secs
+    }
+
     pub(crate) fn replace_content_from_mutation(&mut self, content: String, now_secs: f64) {
         if self.note.content == content {
             return;

--- a/src/gui/notes_dialog.rs
+++ b/src/gui/notes_dialog.rs
@@ -86,6 +86,10 @@ fn note_action(label: impl Into<String>, action: impl Into<String>) -> Action {
     }
 }
 
+fn wrap_links_note_action(slug: &str) -> Action {
+    note_action("Wrap links in note", format!("note:meta:wrap-links:{slug}"))
+}
+
 #[derive(Default)]
 pub struct NotesDialog {
     pub open: bool,
@@ -339,6 +343,7 @@ impl NotesDialog {
         let mut save_now = false;
         let mut rebuild_idx = false;
         let mut refresh_entries = false;
+        let mut wrap_links_slug: Option<String> = None;
         egui::Window::new("Quick Notes")
             .open(&mut self.open)
             .resizable(true)
@@ -543,6 +548,12 @@ impl NotesDialog {
                                             );
                                             ui.close_menu();
                                         }
+                                        ui.menu_button("Meta", |ui| {
+                                            if ui.button("Wrap links in note").clicked() {
+                                                wrap_links_slug = Some(entry.slug.clone());
+                                                ui.close_menu();
+                                            }
+                                        });
                                         if ui.button("Remove Note").clicked() {
                                             if entry.slug.is_empty() {
                                                 remove = Some(idx_copy);
@@ -600,6 +611,9 @@ impl NotesDialog {
                     }
                 }
             });
+        if let Some(slug) = wrap_links_slug {
+            app.activate_action(wrap_links_note_action(&slug), None, ActivationSource::Click);
+        }
         if refresh_entries {
             self.entries = cached_notes_or_load();
             rebuild_idx = true;
@@ -626,7 +640,188 @@ mod tests {
     use super::{
         checkbox_count, format_note_timestamp, insert_at_char_boundary, note_action, short_preview,
     };
+    use crate::gui::{LauncherApp, NotePanel};
+    use crate::plugins::note::{Note, load_notes, save_note, save_notes};
+    use crate::{
+        plugin::PluginManager,
+        settings::{NoteViewMode, Settings},
+    };
     use chrono::{Local, TimeZone};
+    use eframe::egui;
+    use once_cell::sync::Lazy;
+    use std::sync::{Arc, Mutex, atomic::AtomicBool};
+    use tempfile::tempdir;
+
+    static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn new_app(ctx: &egui::Context) -> LauncherApp {
+        LauncherApp::new(
+            ctx,
+            Arc::new(Vec::new()),
+            0,
+            PluginManager::new(),
+            "actions.json".into(),
+            "settings.json".into(),
+            Settings::default(),
+            None,
+            None,
+            None,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    fn note(title: &str, slug: &str, content: &str) -> Note {
+        Note {
+            title: title.into(),
+            path: Default::default(),
+            content: content.into(),
+            tags: Vec::new(),
+            links: Vec::new(),
+            slug: slug.into(),
+            alias: None,
+            aliases: Vec::new(),
+            entity_refs: Vec::new(),
+        }
+    }
+
+    fn setup() -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        egui::Context,
+        LauncherApp,
+    ) {
+        let dir = tempdir().unwrap();
+        let notes_dir = dir.path().join("notes");
+        std::fs::create_dir_all(&notes_dir).unwrap();
+        unsafe { std::env::set_var("ML_NOTES_DIR", &notes_dir) };
+        unsafe { std::env::set_var("HOME", dir.path()) };
+        save_notes(&[]).unwrap();
+        let ctx = egui::Context::default();
+        let app = new_app(&ctx);
+        (dir, notes_dir, ctx, app)
+    }
+
+    #[test]
+    fn wrap_links_context_action_uses_expected_meta_route_for_selected_slug() {
+        let action = super::wrap_links_note_action("alpha");
+
+        assert_eq!(action.label, "Wrap links in note");
+        assert_eq!(action.desc, "Note");
+        assert_eq!(action.action, "note:meta:wrap-links:alpha");
+    }
+
+    #[test]
+    fn quick_notes_wrap_links_saves_closed_note_and_refreshes_entries() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _notes_dir, _ctx, mut app) = setup();
+        let mut alpha = note("Alpha", "alpha", "visit https://example.com");
+        save_note(&mut alpha, true).unwrap();
+        app.notes_dialog.open();
+        app.notes_dialog.search = "example".into();
+
+        app.wrap_note_plain_links("alpha");
+
+        let saved = load_notes().unwrap().remove(0);
+        assert!(
+            saved
+                .content
+                .contains("[https://example.com](https://example.com)")
+        );
+        assert!(
+            app.notes_dialog.entries[0]
+                .content
+                .contains("[https://example.com](https://example.com)")
+        );
+        assert_eq!(app.notes_dialog.search, "example");
+        assert_eq!(app.note_mutation_quick_notes_refresh_count, 1);
+    }
+
+    #[test]
+    fn quick_notes_wrap_links_mutates_open_unsaved_content_from_memory() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _notes_dir, _ctx, mut app) = setup();
+        let mut alpha = note("Alpha", "alpha", "disk https://disk.example");
+        save_note(&mut alpha, true).unwrap();
+        let mut panel = NotePanel::from_note(alpha);
+        panel.replace_content_after_external_mutation("memory https://memory.example".into());
+        app.note_panels.push(panel);
+
+        app.wrap_note_plain_links("alpha");
+
+        assert!(
+            app.note_panels[0]
+                .note_content()
+                .contains("[https://memory.example](https://memory.example)")
+        );
+        assert!(!app.note_panels[0].note_content().contains("disk.example"));
+        assert!(
+            load_notes().unwrap()[0]
+                .content
+                .contains("[https://memory.example](https://memory.example)")
+        );
+    }
+
+    #[test]
+    fn quick_notes_wrap_links_noop_preserves_content_and_modification_state() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _notes_dir, _ctx, mut app) = setup();
+        let mut alpha = note("Alpha", "alpha", "already [link](https://example.com)");
+        save_note(&mut alpha, true).unwrap();
+        let mut panel = NotePanel::from_note(alpha);
+        panel.replace_content_after_external_mutation("already [link](https://example.com)".into());
+        let modified_before = panel.test_last_edit_at_secs();
+        app.note_panels.push(panel);
+
+        app.wrap_note_plain_links("alpha");
+
+        assert_eq!(
+            app.note_panels[0].note_content(),
+            "already [link](https://example.com)"
+        );
+        assert_eq!(app.note_panels[0].test_last_edit_at_secs(), modified_before);
+        assert_eq!(app.note_mutation_quick_notes_refresh_count, 0);
+    }
+
+    #[test]
+    fn quick_notes_wrap_links_preserves_open_panel_and_view_mode() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let (_dir, _notes_dir, _ctx, mut app) = setup();
+        let mut alpha = note("Alpha", "alpha", "visit https://example.com");
+        save_note(&mut alpha, true).unwrap();
+        let mut panel = NotePanel::from_note(alpha);
+        panel.open = true;
+        panel.test_set_view_mode(NoteViewMode::Split);
+        app.note_panels.push(panel);
+
+        app.wrap_note_plain_links("alpha");
+
+        assert_eq!(app.note_panels.len(), 1);
+        assert!(app.note_panels[0].open);
+        assert_eq!(app.note_panels[0].test_view_mode(), NoteViewMode::Split);
+    }
+
+    #[test]
+    fn existing_context_action_routes_are_unchanged() {
+        assert_eq!(
+            note_action("Open note", "note:open:alpha").action,
+            "note:open:alpha"
+        );
+        assert_eq!(
+            note_action("Edit note", "note:edit:alpha").action,
+            "note:edit:alpha"
+        );
+        assert_eq!(
+            note_action("Remove note", "note:remove:alpha").action,
+            "note:remove:alpha"
+        );
+        assert_eq!(
+            format!("@todo:{} {}", "todo-1", "Ship it"),
+            "@todo:todo-1 Ship it"
+        );
+    }
 
     #[test]
     fn insert_in_middle() {


### PR DESCRIPTION
### Motivation
- Add a Quick Notes note-row context-menu entry that reuses the existing note meta mutation for wrapping plain links so UI and command behavior are identical.
- Avoid mutable-borrow conflicts by deferring the mutation until after the row/UI closure and preserve Quick Notes UI/search/panel state when the operation runs.

### Description
- Added a `Meta` submenu to the Quick Notes row context menu that contains `Wrap links in note` implemented with `ui.menu_button("Meta", |ui| { ... })` and which captures the selected note slug (deferred via an `Option<String>` recorded during the menu callback). 
- Deferred the actual mutation until after the UI closure and routed the operation through the existing shared app mutation path via `app.activate_action(wrap_links_note_action(&slug), None, ActivationSource::Click)` so the same toast/mutation behavior is used as the command route. 
- Exported the existing `wrap_note_plain_links` helper (changed to `pub(crate)`) in `src/gui/actions.rs` so UI and actions share the same implementation and user feedback. 
- Preserved Quick Notes state: the search text is kept, `self.entries` are refreshed via existing `refresh_entries_from_notes` flow after a successful mutation, the note panel open state and view mode are preserved, and no panel is opened just to perform the operation. 
- For open-but-dirty notes the mutation updates the in-memory `NotePanel` content and saves using the shared mutation coordinator, avoiding mutating stale disk content; no-op behavior shows the same toast `No unwrapped links found.` and leaves content/modification state unchanged. 
- Added small test-only accessors in `src/gui/note_panel.rs` to inspect `view_mode` and `last_edit_at_secs` for assertions in unit tests without changing production logic. 
- Added unit/UI tests in `src/gui/notes_dialog.rs` covering routing and behavior: action build, closed-note save+refresh, open-note in-memory mutation, no-op preservation, Quick Notes refresh/search preservation, open panel/view preservation, and existing context-action routes remaining unchanged.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran repository checks (`git diff --check`) which produced no issues for the changed files.
- Ran `cargo test notes_dialog::tests:: -- --nocapture` to exercise the new Quick Notes tests but the build failed in this Linux environment due to unrelated platform/native dependency compilation/resolution errors (Windows/X11/alsa pkg-config and `windows::Win32` resolution) outside the scope of these changes; the failure prevented the test suite from finishing here.  The added tests are present and intended to pass in CI where platform toolchain/deps are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62bab63e6c833283d5c6f18588cba7)