### PR TITLE
Integrate Clipboard Modify runtime events into the GUI loop

### DIFF
--- a/src/clipboard_modify/watch.rs
+++ b/src/clipboard_modify/watch.rs
@@ -1,25 +1,32 @@
 use super::config::{LoadError, load_current_or_migrate};
 use super::store::ClipboardModifierStore;
+use crate::gui::ClipboardModifyGuiEvent;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+/// A UI-owned configuration watcher.
+///
+/// Filesystem callbacks only enqueue notifications. Debouncing and loading are
+/// deliberately performed by [`poll`](Self::poll), so the regular GUI update
+/// pass is the single place that mutates the live catalog and diagnostics.
 pub struct ClipboardModifyWatcher {
-    _watcher: RecommendedWatcher,
+    watcher: RecommendedWatcher,
+    path: PathBuf,
+    store: ClipboardModifierStore,
+    debounce: Duration,
+    rx: mpsc::Receiver<notify::Result<notify::Event>>,
+    reload_deadline: Option<Instant>,
 }
 
 impl ClipboardModifyWatcher {
     pub fn start(store: ClipboardModifierStore, debounce: Duration) -> notify::Result<Self> {
         let path = store.path.clone();
-        let watch_path = if path.exists() {
-            path.clone()
-        } else {
-            path.parent()
-                .unwrap_or_else(|| std::path::Path::new("."))
-                .to_path_buf()
-        };
+        let watch_path = path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf();
         let (tx, rx) = mpsc::channel();
         let mut watcher = RecommendedWatcher::new(
             move |res| {
@@ -28,38 +35,70 @@ impl ClipboardModifyWatcher {
             Config::default(),
         )?;
         watcher.watch(&watch_path, RecursiveMode::NonRecursive)?;
-        std::thread::spawn(move || event_loop(path, store, debounce, rx));
-        Ok(Self { _watcher: watcher })
+        Ok(Self {
+            watcher,
+            path,
+            store,
+            debounce,
+            rx,
+            reload_deadline: None,
+        })
+    }
+
+    /// Drain notifications, advance the debounce deadline, and perform at most
+    /// one reload. Returned events contain status/diagnostics only, never file
+    /// or clipboard-derived text.
+    pub fn poll(&mut self, now: Instant) -> Vec<ClipboardModifyGuiEvent> {
+        while let Ok(result) = self.rx.try_recv() {
+            match result {
+                Ok(event)
+                    if matches!(
+                        event.kind,
+                        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                    ) && (event.paths.is_empty()
+                        || event.paths.iter().any(|p| p == &self.path)) =>
+                {
+                    self.reload_deadline = Some(now + self.debounce);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    return vec![ClipboardModifyGuiEvent::ConfigurationReloadFailure(
+                        err.to_string(),
+                    )];
+                }
+            }
+        }
+        if !self.reload_deadline.is_some_and(|deadline| now >= deadline) {
+            return Vec::new();
+        }
+        self.reload_deadline = None;
+        let event = match load_current_or_migrate(&self.path) {
+            Ok((_model, catalog)) => {
+                self.store.replace_valid(catalog);
+                ClipboardModifyGuiEvent::ConfigurationReloadSuccess
+            }
+            Err(LoadError::Future(version)) => {
+                let error = format!("unsupported future schema {version}");
+                self.store.retain_with_error(error.clone());
+                ClipboardModifyGuiEvent::ConfigurationReloadFailure(error)
+            }
+            Err(error) => {
+                let error = error.to_string();
+                self.store.retain_with_error(error.clone());
+                ClipboardModifyGuiEvent::ConfigurationReloadFailure(error)
+            }
+        };
+        vec![event]
+    }
+
+    pub fn has_pending_reload(&self) -> bool {
+        self.reload_deadline.is_some()
     }
 }
 
-fn event_loop(
-    path: PathBuf,
-    store: ClipboardModifierStore,
-    debounce: Duration,
-    rx: mpsc::Receiver<notify::Result<notify::Event>>,
-) {
-    let seq = AtomicU64::new(0);
-    while let Ok(res) = rx.recv() {
-        if let Ok(ev) = res {
-            if !matches!(
-                ev.kind,
-                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
-            ) {
-                continue;
-            }
-            let my = seq.fetch_add(1, Ordering::SeqCst) + 1;
-            std::thread::sleep(debounce);
-            if seq.load(Ordering::SeqCst) != my {
-                continue;
-            }
-            match load_current_or_migrate(&path) {
-                Ok((_m, c)) => store.replace_valid(c),
-                Err(LoadError::Future(v)) => {
-                    store.retain_with_error(format!("unsupported future schema {v}"))
-                }
-                Err(e) => store.retain_with_error(e.to_string()),
-            }
-        }
+impl Drop for ClipboardModifyWatcher {
+    fn drop(&mut self) {
+        // Explicitly touch the handle: dropping it unregisters the OS watcher.
+        let _ = &self.watcher;
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -456,6 +456,7 @@ pub struct LauncherApp {
     pub clipboard_modify_runtime: ClipboardModifyRuntime,
     pub clipboard_modify_dialog: ClipboardModifyDialogState,
     pub clipboard_modify_config_diagnostic: Option<String>,
+    clipboard_modify_watcher: Option<crate::clipboard_modify::watch::ClipboardModifyWatcher>,
     pending_clipboard_modify_immediate: HashMap<u64, ImmediateRequestMetadata>,
     clipboard_modify_immediate: ImmediateExecutionCoordinator<
         crate::clipboard_modify::clipboard::ProductionClipboardService,
@@ -1040,6 +1041,15 @@ impl LauncherApp {
         let (clipboard_modify_runtime, loaded_clipboard_modify) =
             ClipboardModifyRuntime::new(Path::new(&settings_path), clipboard_modify_catalog);
         let clipboard_modify_config_diagnostic = loaded_clipboard_modify.state.startup_diagnostic();
+        let clipboard_modify_watcher =
+            crate::clipboard_modify::watch::ClipboardModifyWatcher::start(
+                clipboard_modify_runtime.store.clone(),
+                Duration::from_millis(150),
+            )
+            .map_err(
+                |error| tracing::warn!(%error, "failed to watch Clipboard Modify configuration"),
+            )
+            .ok();
 
         #[cfg(not(test))]
         match watch_file(Path::new(&actions_path), tx.clone(), WatchEvent::Actions) {
@@ -1409,6 +1419,7 @@ impl LauncherApp {
                 clipboard_modify_settings.dialog_height,
             ),
             clipboard_modify_config_diagnostic,
+            clipboard_modify_watcher,
             pending_clipboard_modify_immediate: HashMap::new(),
             clipboard_modify_immediate: ImmediateExecutionCoordinator::new(clipboard_service()),
             clipboard_modify_events: Vec::new(),
@@ -1533,6 +1544,9 @@ impl LauncherApp {
         app.update_command_cache();
         app.rebuild_completion_index_now();
         app.search();
+        let repaint_context = ctx.clone();
+        app.clipboard_modify_immediate
+            .set_repaint_callback(Arc::new(move || repaint_context.request_repaint()));
         crate::plugins::mouse_gestures::sync_enabled_plugins(app.enabled_plugins.as_ref());
         app.recompute_query_results_layout();
         app
@@ -2922,10 +2936,10 @@ pub fn recv_test_event(rx: &Receiver<WatchEvent>) -> Option<TestWatchEvent> {
             | WatchEvent::Todos
             | WatchEvent::Favorites
             | WatchEvent::Gestures
-            | WatchEvent::ExecuteAction(_)
-            | WatchEvent::ClipboardModify(_) => {
+            | WatchEvent::ExecuteAction(_) => {
                 continue;
             }
+            WatchEvent::ClipboardModify(_) => return Some(ev.into()),
             WatchEvent::Recycle(_) => return Some(ev.into()),
         }
     }

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -663,6 +663,15 @@ impl LauncherApp {
 
 impl LauncherApp {
     pub(crate) fn poll_clipboard_modify_runtime(&mut self, ctx: &egui::Context) {
+        let reload_events = self
+            .clipboard_modify_watcher
+            .as_mut()
+            .map(|watcher| watcher.poll(Instant::now()))
+            .unwrap_or_default();
+        for event in reload_events {
+            self.handle_clipboard_modify_gui_event(event);
+            ctx.request_repaint();
+        }
         let preview_finished = self.clipboard_modify_dialog.preview.tick();
         if preview_finished {
             ctx.request_repaint();
@@ -674,6 +683,10 @@ impl LauncherApp {
         }
         if self.clipboard_modify_dialog.preview.is_active()
             || self.clipboard_modify_immediate.has_pending()
+            || self
+                .clipboard_modify_watcher
+                .as_ref()
+                .is_some_and(|watcher| watcher.has_pending_reload())
         {
             ctx.request_repaint_after(Duration::from_millis(150));
         }
@@ -1422,6 +1435,7 @@ impl eframe::App for LauncherApp {
         self.clipboard_modify_immediate.cancel_pending();
         self.pending_clipboard_modify_immediate.clear();
         self.clipboard_modify_events.clear();
+        self.clipboard_modify_watcher = None;
         self.multi_manager.shutdown();
         let multi_manager_save_on_exit = crate::settings::Settings::load(&self.settings_path)
             .map(|settings| settings.multi_manager.save_on_exit)
@@ -1439,6 +1453,24 @@ impl eframe::App for LauncherApp {
         if let Ok(mut settings) = crate::settings::Settings::load(&self.settings_path) {
             settings.window_size = Some(self.window_size);
             settings.pinned_panels = self.pinned_panels.clone();
+            // Persist only the explicitly approved, non-sensitive Clipboard
+            // Modify UI geometry. Runtime source/preview/undo data is held only
+            // by the dialog/service and is never serialized into Settings.
+            let mut clipboard_modify_preferences: ClipboardModifyPluginSettings = settings
+                .plugin_settings
+                .get("clipboard_modify")
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok())
+                .unwrap_or_default();
+            clipboard_modify_preferences.dialog_width =
+                self.clipboard_modify_dialog.persisted_window_size.x;
+            clipboard_modify_preferences.dialog_height =
+                self.clipboard_modify_dialog.persisted_window_size.y;
+            if let Ok(value) = serde_json::to_value(clipboard_modify_preferences) {
+                settings
+                    .plugin_settings
+                    .insert("clipboard_modify".into(), value);
+            }
             let _ = settings.save(&self.settings_path);
         }
         let _ = usage::save_usage(USAGE_FILE, &self.usage);

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -83,11 +83,12 @@ pub(crate) struct PendingConfirmAction {
     pub(crate) source: ActivationSource,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TestWatchEvent {
     Actions,
     Folders,
     Bookmarks,
+    ClipboardModify(ClipboardModifyGuiEvent),
 }
 
 impl From<WatchEvent> for TestWatchEvent {
@@ -105,7 +106,7 @@ impl From<WatchEvent> for TestWatchEvent {
             WatchEvent::Dashboard(_) => TestWatchEvent::Actions,
             WatchEvent::Recycle(_) => unreachable!(),
             WatchEvent::ExecuteAction(_) => TestWatchEvent::Actions,
-            WatchEvent::ClipboardModify(_) => TestWatchEvent::Actions,
+            WatchEvent::ClipboardModify(event) => TestWatchEvent::ClipboardModify(event),
         }
     }
 }

--- a/src/gui/watch.rs
+++ b/src/gui/watch.rs
@@ -171,18 +171,20 @@ mod tests {
     }
 
     #[test]
-    fn clipboard_modify_watch_events_map_to_action_refresh_for_tests() {
+    fn clipboard_modify_watch_events_keep_their_content_free_type_for_tests() {
         assert_eq!(
             TestWatchEvent::from(WatchEvent::ClipboardModify(
                 ClipboardModifyGuiEvent::ImmediateOperationComplete
             )),
-            TestWatchEvent::Actions
+            TestWatchEvent::ClipboardModify(ClipboardModifyGuiEvent::ImmediateOperationComplete)
         );
         assert_eq!(
             TestWatchEvent::from(WatchEvent::ClipboardModify(
                 ClipboardModifyGuiEvent::ConfigurationReloadFailure("bad".into())
             )),
-            TestWatchEvent::Actions
+            TestWatchEvent::ClipboardModify(ClipboardModifyGuiEvent::ConfigurationReloadFailure(
+                "bad".into()
+            ))
         );
     }
 


### PR DESCRIPTION
### Motivation

- Prevent clipboard or preview content from leaking through watcher events and centralize configuration reload logic in the UI runtime pass. 
- Ensure preview and immediate execution work are polled/drained every frame, that repaints are requested while work is active, and that stale results cannot overwrite current state. 
- Harden shutdown and persistence so only approved UI preferences (dialog geometry) are saved and no clipboard-derived data is persisted.

### Description

- Added a UI-owned `ClipboardModifyWatcher` that enqueues filesystem notifications and exposes `poll(now: Instant) -> Vec<ClipboardModifyGuiEvent>` to perform debounced reloads and return content-free status/diagnostic events. 
- Plumbed the watcher into `LauncherApp` (new `clipboard_modify_watcher` field), call `poll_clipboard_modify_runtime` each frame to drain preview completions, immediate completions, and pending reloads, and request repaints while work is active. 
- Extended the test adapter mapping so `WatchEvent::ClipboardModify` preserves a typed `ClipboardModifyGuiEvent` for tests (`TestWatchEvent::ClipboardModify`) and updated the related tests to expect typed, content-free events. 
- Set a repaint callback on the `ImmediateExecutionCoordinator`, cancel/invalidate dialog preview state when the dialog closes, cancel immediate pending work on exit, drop the configuration watcher during shutdown, and persist only the non-sensitive Clipboard Modify dialog geometry into `plugin_settings`.

### Testing

- Ran `cargo fmt --all -- --check` and formatting checks passed. 
- Ran `git diff --check` to ensure no whitespace/diff issues and the diff check passed. 
- Attempted `cargo test --test watchers --test clipboard_modify_plugin` (targeted tests were updated to expect typed clipboard-modify events), but the full test run was blocked by missing system pkg-config metadata for `alsa` during compilation in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63e63baa748332b430a8814d60ffd3)