### PR TITLE
Expand Clipboard Modify configuration and runtime test coverage

### DIFF
--- a/tests/clipboard_modify_config.rs
+++ b/tests/clipboard_modify_config.rs
@@ -1,0 +1,177 @@
+use multi_launcher::clipboard_modify::config::{
+    CURRENT_SCHEMA_VERSION, LoadError, LoadState, MAX_CONFIG_BYTES,
+    VersionedClipboardModifiersFile, default_model, load_current_or_migrate, load_startup,
+    reset_to_defaults_with_backup, save_model_atomic, validate_model,
+};
+use multi_launcher::clipboard_modify::model::{ClipboardTemplate, SavedPipeline};
+
+fn minimal() -> VersionedClipboardModifiersFile {
+    VersionedClipboardModifiersFile {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        templates: vec![ClipboardTemplate {
+            id: "my template".into(),
+            label: "My template".into(),
+            aliases: vec!["mt".into()],
+            template: "[{{clipboard}}]".into(),
+            processor: None,
+        }],
+        pipelines: Vec::new(),
+    }
+}
+
+#[test]
+fn startup_creates_defaults_next_to_explicit_settings_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let settings = dir.path().join("profile/settings.json");
+    let loaded = load_startup(&settings);
+    assert_eq!(
+        loaded.path,
+        dir.path().join("profile/clipboard_modifiers.json")
+    );
+    assert!(matches!(loaded.state, LoadState::DefaultsCreated));
+    assert!(loaded.path.is_file());
+    assert_eq!(
+        load_current_or_migrate(&loaded.path).unwrap().0,
+        loaded.model
+    );
+}
+
+#[test]
+fn size_limit_is_checked_before_json_parsing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("clipboard_modifiers.json");
+    std::fs::File::create(&path)
+        .unwrap()
+        .set_len(MAX_CONFIG_BYTES + 1)
+        .unwrap();
+    assert!(
+        matches!(load_current_or_migrate(&path), Err(LoadError::Oversized(n)) if n == MAX_CONFIG_BYTES + 1)
+    );
+}
+
+#[test]
+fn validation_normalizes_and_rejects_colliding_identities() {
+    let mut model = minimal();
+    model.templates[0].id = "  My__Template ".into();
+    model.templates.push(ClipboardTemplate {
+        id: "other".into(),
+        label: "Other".into(),
+        aliases: vec!["my-template".into()],
+        template: "{{clipboard}}".into(),
+        processor: None,
+    });
+    assert!(
+        validate_model(&model)
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate identity")
+    );
+}
+
+#[test]
+fn placeholder_is_exact_and_reserved_and_cross_kind_names_are_rejected() {
+    let mut model = minimal();
+    model.templates[0].template = "{{ clipboard }}".into();
+    assert!(validate_model(&model).is_err());
+
+    let mut model = minimal();
+    model.templates[0].id = "template".into();
+    assert!(validate_model(&model).is_err());
+
+    let mut model = minimal();
+    model.pipelines.push(SavedPipeline {
+        id: "mt".into(),
+        label: "Conflict".into(),
+        aliases: vec![],
+        stages: vec![],
+    });
+    assert!(validate_model(&model).is_err());
+}
+
+#[test]
+fn unknown_fields_future_versions_and_invalid_startup_are_safe() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("clipboard_modifiers.json");
+    std::fs::write(
+        &path,
+        r#"{"schema_version":1,"templates":[],"pipelines":[],"surprise":true}"#,
+    )
+    .unwrap();
+    assert!(matches!(
+        load_current_or_migrate(&path),
+        Err(LoadError::Json(_))
+    ));
+    std::fs::write(
+        &path,
+        r#"{"schema_version":99,"templates":[],"pipelines":[]}"#,
+    )
+    .unwrap();
+    assert!(matches!(
+        load_current_or_migrate(&path),
+        Err(LoadError::Future(99))
+    ));
+    std::fs::write(&path, "not json").unwrap();
+    let loaded = load_startup(&dir.path().join("settings.json"));
+    assert!(matches!(
+        loaded.state,
+        LoadState::InvalidStartupInMemoryDefaults { .. }
+    ));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "not json");
+}
+
+#[test]
+fn migration_and_factory_reset_create_backups() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("clipboard_modifiers.json");
+    std::fs::write(
+        &path,
+        r#"{"schema_version":0,"templates":[],"pipelines":[]}"#,
+    )
+    .unwrap();
+    load_current_or_migrate(&path).unwrap();
+    assert!(std::fs::read_dir(dir.path()).unwrap().any(|e| {
+        e.unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("schema-migration")
+    }));
+
+    std::fs::write(&path, serde_json::to_vec(&minimal()).unwrap()).unwrap();
+    reset_to_defaults_with_backup(&path).unwrap();
+    assert!(std::fs::read_dir(dir.path()).unwrap().any(|e| {
+        e.unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("factory-reset")
+    }));
+    assert_eq!(load_current_or_migrate(&path).unwrap().0, default_model());
+}
+
+#[test]
+fn atomic_save_replaces_content_without_leaving_temporary_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("clipboard_modifiers.json");
+    std::fs::write(&path, b"old").unwrap();
+    save_model_atomic(&path, &minimal()).unwrap();
+    assert_eq!(load_current_or_migrate(&path).unwrap().0, minimal());
+    let names = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        vec![std::ffi::OsString::from("clipboard_modifiers.json")]
+    );
+}
+
+#[test]
+fn defaults_are_not_merged_into_valid_user_catalogs() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("clipboard_modifiers.json");
+    save_model_atomic(&path, &minimal()).unwrap();
+    let loaded = load_startup(&dir.path().join("settings.json"));
+    assert_eq!(loaded.model.templates.len(), 1);
+    assert_eq!(loaded.model.templates[0].id, "my template");
+    assert_eq!(loaded.catalog.templates[0].id, "my-template");
+    assert!(loaded.model.pipelines.is_empty());
+}

--- a/tests/clipboard_modify_runtime.rs
+++ b/tests/clipboard_modify_runtime.rs
@@ -1,0 +1,121 @@
+use multi_launcher::clipboard_modify::clipboard::{
+    ClipboardBackend, ClipboardError, ClipboardService,
+};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct Fake {
+    text: Mutex<Option<String>>,
+    reads: Mutex<VecDeque<Result<String, ClipboardError>>>,
+    writes: Mutex<VecDeque<Result<(), ClipboardError>>>,
+    committed: Mutex<Vec<String>>,
+}
+impl Fake {
+    fn text(value: &str) -> Self {
+        Self {
+            text: Mutex::new(Some(value.into())),
+            ..Default::default()
+        }
+    }
+}
+impl ClipboardBackend for Arc<Fake> {
+    fn read_text(&self) -> Result<String, ClipboardError> {
+        if let Some(result) = self.reads.lock().unwrap().pop_front() {
+            return result;
+        }
+        self.text
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or(ClipboardError::NonText)
+    }
+    fn write_text(&self, text: &str) -> Result<(), ClipboardError> {
+        if let Some(result) = self.writes.lock().unwrap().pop_front() {
+            result?;
+        }
+        *self.text.lock().unwrap() = Some(text.into());
+        self.committed.lock().unwrap().push(text.into());
+        Ok(())
+    }
+}
+
+#[test]
+fn retries_transient_reads_and_writes_and_succeeds() {
+    let fake = Arc::new(Fake::text("old"));
+    fake.reads
+        .lock()
+        .unwrap()
+        .extend([Err(ClipboardError::Busy("read".into())), Ok("old".into())]);
+    fake.writes
+        .lock()
+        .unwrap()
+        .extend([Err(ClipboardError::Transient("write".into())), Ok(())]);
+    let service = ClipboardService::new(fake.clone());
+    let record = service.commit_output("new".into(), "test").unwrap();
+    assert_eq!(record.original_text, "old");
+    assert_eq!(&*fake.text.lock().unwrap(), &Some("new".into()));
+}
+
+#[test]
+fn retry_exhaustion_non_text_and_empty_text_are_distinct() {
+    let fake = Arc::new(Fake::text("x"));
+    fake.reads
+        .lock()
+        .unwrap()
+        .extend((0..4).map(|_| Err(ClipboardError::Busy("busy".into()))));
+    assert!(matches!(
+        ClipboardService::new(fake).read_text_for_modify(),
+        Err(ClipboardError::Busy(_))
+    ));
+    assert!(matches!(
+        ClipboardService::new(Arc::new(Fake::default())).read_text_for_modify(),
+        Err(ClipboardError::NonText)
+    ));
+    assert_eq!(
+        ClipboardService::new(Arc::new(Fake::text("")))
+            .read_text_for_modify()
+            .unwrap(),
+        ""
+    );
+}
+
+#[test]
+fn immediate_noop_replaces_undo_and_successful_undo_clears_it() {
+    let service = ClipboardService::new(Arc::new(Fake::text("same")));
+    service.commit_output("first".into(), "first").unwrap();
+    let record = service.commit_output("first".into(), "noop").unwrap();
+    assert_eq!(record.operation_label, "noop");
+    assert_eq!(record.original_text, "first");
+    service.undo().unwrap();
+    assert!(service.undo_record().is_none());
+}
+
+#[test]
+fn external_change_requires_dialog_confirmation_and_becomes_undo_source() {
+    let fake = Arc::new(Fake::text("baseline"));
+    let service = ClipboardService::new(fake.clone());
+    *fake.text.lock().unwrap() = Some("external".into());
+    assert!(matches!(
+        service.commit_dialog("baseline", "working", "out", false, "dialog"),
+        Err(ClipboardError::ConfirmationRequired(_))
+    ));
+    let record = service
+        .commit_dialog("baseline", "working", "out", true, "dialog")
+        .unwrap();
+    assert_eq!(record.original_text, "external");
+    assert_eq!(&*fake.text.lock().unwrap(), &Some("out".into()));
+}
+
+#[test]
+fn failed_undo_retains_the_record() {
+    let fake = Arc::new(Fake::text("a"));
+    let service = ClipboardService::new(fake.clone());
+    service.commit_output("b".into(), "change").unwrap();
+    fake.writes
+        .lock()
+        .unwrap()
+        .push_back(Err(ClipboardError::Permanent("denied".into())));
+    assert!(service.undo().is_err());
+    assert!(service.undo_record().is_some());
+}

--- a/tests/clipboard_modify_runtime.rs
+++ b/tests/clipboard_modify_runtime.rs
@@ -5,62 +5,71 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 #[derive(Default)]
-struct Fake {
+struct FakeState {
     text: Mutex<Option<String>>,
     reads: Mutex<VecDeque<Result<String, ClipboardError>>>,
     writes: Mutex<VecDeque<Result<(), ClipboardError>>>,
     committed: Mutex<Vec<String>>,
 }
+
+#[derive(Clone, Default)]
+struct Fake(Arc<FakeState>);
+
 impl Fake {
     fn text(value: &str) -> Self {
-        Self {
+        Self(Arc::new(FakeState {
             text: Mutex::new(Some(value.into())),
             ..Default::default()
-        }
+        }))
     }
 }
-impl ClipboardBackend for Arc<Fake> {
+
+impl ClipboardBackend for Fake {
     fn read_text(&self) -> Result<String, ClipboardError> {
-        if let Some(result) = self.reads.lock().unwrap().pop_front() {
+        if let Some(result) = self.0.reads.lock().unwrap().pop_front() {
             return result;
         }
-        self.text
+        self.0
+            .text
             .lock()
             .unwrap()
             .clone()
             .ok_or(ClipboardError::NonText)
     }
     fn write_text(&self, text: &str) -> Result<(), ClipboardError> {
-        if let Some(result) = self.writes.lock().unwrap().pop_front() {
+        if let Some(result) = self.0.writes.lock().unwrap().pop_front() {
             result?;
         }
-        *self.text.lock().unwrap() = Some(text.into());
-        self.committed.lock().unwrap().push(text.into());
+        *self.0.text.lock().unwrap() = Some(text.into());
+        self.0.committed.lock().unwrap().push(text.into());
         Ok(())
     }
 }
 
 #[test]
 fn retries_transient_reads_and_writes_and_succeeds() {
-    let fake = Arc::new(Fake::text("old"));
-    fake.reads
+    let fake = Fake::text("old");
+    fake.0
+        .reads
         .lock()
         .unwrap()
         .extend([Err(ClipboardError::Busy("read".into())), Ok("old".into())]);
-    fake.writes
+    fake.0
+        .writes
         .lock()
         .unwrap()
         .extend([Err(ClipboardError::Transient("write".into())), Ok(())]);
     let service = ClipboardService::new(fake.clone());
     let record = service.commit_output("new".into(), "test").unwrap();
     assert_eq!(record.original_text, "old");
-    assert_eq!(&*fake.text.lock().unwrap(), &Some("new".into()));
+    assert_eq!(&*fake.0.text.lock().unwrap(), &Some("new".into()));
 }
 
 #[test]
 fn retry_exhaustion_non_text_and_empty_text_are_distinct() {
-    let fake = Arc::new(Fake::text("x"));
-    fake.reads
+    let fake = Fake::text("x");
+    fake.0
+        .reads
         .lock()
         .unwrap()
         .extend((0..4).map(|_| Err(ClipboardError::Busy("busy".into()))));
@@ -69,11 +78,11 @@ fn retry_exhaustion_non_text_and_empty_text_are_distinct() {
         Err(ClipboardError::Busy(_))
     ));
     assert!(matches!(
-        ClipboardService::new(Arc::new(Fake::default())).read_text_for_modify(),
+        ClipboardService::new(Fake::default()).read_text_for_modify(),
         Err(ClipboardError::NonText)
     ));
     assert_eq!(
-        ClipboardService::new(Arc::new(Fake::text("")))
+        ClipboardService::new(Fake::text(""))
             .read_text_for_modify()
             .unwrap(),
         ""
@@ -82,7 +91,7 @@ fn retry_exhaustion_non_text_and_empty_text_are_distinct() {
 
 #[test]
 fn immediate_noop_replaces_undo_and_successful_undo_clears_it() {
-    let service = ClipboardService::new(Arc::new(Fake::text("same")));
+    let service = ClipboardService::new(Fake::text("same"));
     service.commit_output("first".into(), "first").unwrap();
     let record = service.commit_output("first".into(), "noop").unwrap();
     assert_eq!(record.operation_label, "noop");
@@ -93,9 +102,9 @@ fn immediate_noop_replaces_undo_and_successful_undo_clears_it() {
 
 #[test]
 fn external_change_requires_dialog_confirmation_and_becomes_undo_source() {
-    let fake = Arc::new(Fake::text("baseline"));
+    let fake = Fake::text("baseline");
     let service = ClipboardService::new(fake.clone());
-    *fake.text.lock().unwrap() = Some("external".into());
+    *fake.0.text.lock().unwrap() = Some("external".into());
     assert!(matches!(
         service.commit_dialog("baseline", "working", "out", false, "dialog"),
         Err(ClipboardError::ConfirmationRequired(_))
@@ -104,15 +113,16 @@ fn external_change_requires_dialog_confirmation_and_becomes_undo_source() {
         .commit_dialog("baseline", "working", "out", true, "dialog")
         .unwrap();
     assert_eq!(record.original_text, "external");
-    assert_eq!(&*fake.text.lock().unwrap(), &Some("out".into()));
+    assert_eq!(&*fake.0.text.lock().unwrap(), &Some("out".into()));
 }
 
 #[test]
 fn failed_undo_retains_the_record() {
-    let fake = Arc::new(Fake::text("a"));
+    let fake = Fake::text("a");
     let service = ClipboardService::new(fake.clone());
     service.commit_output("b".into(), "change").unwrap();
-    fake.writes
+    fake.0
+        .writes
         .lock()
         .unwrap()
         .push_back(Err(ClipboardError::Permanent("denied".into())));


### PR DESCRIPTION
### Motivation

- Add isolated integration tests for Clipboard Modify configuration handling to exercise startup, validation, migration, backups, and atomic saves.
- Add runtime tests that exercise clipboard operations (retries, undo, external changes) without touching the global OS clipboard.
- Ensure tests avoid process-wide state by using temporary directories and a local fake clipboard backend so they can run in parallel where possible.

### Description

- Add `tests/clipboard_modify_config.rs` which covers default creation, five‑MiB config rejection, exact placeholder validation, identity normalization/duplicates, reserved and cross-kind name rejection, unknown‑field rejection, unsupported future schema handling, recognized migration with backup, factory‑reset backup, atomic save behavior, invalid startup fallback, and preservation of user catalogs without merging defaults. 
- Add `tests/clipboard_modify_runtime.rs` which implements a thread‑safe fake clipboard backend and tests transient read/write retries, retry exhaustion, non‑text and empty clipboard cases, immediate no‑op/undo behavior, external clipboard confirmation behavior, and failed undo retention. 
- Tests use `tempfile::tempdir()` and explicit config/settings paths and rely on `Arc`/`Mutex` to keep runtime state local and testable without `serial_test`. 
- Formatting and minor whitespace adjustments applied to new test files to satisfy `rustfmt` style checks.

### Testing

- Ran `cargo fmt --all -- --check` and `git diff --check` successfully to ensure formatting and basic repository hygiene. 
- Attempted `cargo test --test clipboard_modify_config --test clipboard_modify_runtime --test clipboard_modify_parser --test clipboard_modify_plugin`, but a full build/test run could not be completed in this Linux environment due to unconditional Windows API imports and missing system libraries in other parts of the workspace; the added tests are self‑contained and should pass on supported targets when the workspace builds successfully. 
- All new tests are isolated (no global clipboard access) and designed to avoid serial execution requirements except where unavoidable by the runtime environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63eb69f9fc8332b7086bca44a227a0)