### PR TITLE
Add 'Insert Timestamp' menu item and unit tests for timestamp insertion

### DIFF
--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -5575,7 +5575,7 @@ More text.
         assert_eq!(panel.note.content, "Hello 20260808-202512.347world");
         let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
         let range = state.cursor.char_range().unwrap();
-        assert!(range.is_empty());
+        assert_eq!(range.primary.index, range.secondary.index);
         assert_eq!(range.primary.index, 6 + TIMESTAMP.chars().count());
         assert!(panel.fast_derived_dirty);
         assert!(panel.heavy_recompute_requested);
@@ -5596,7 +5596,7 @@ More text.
         assert_eq!(panel.note.content, "Before 20260808-202512.347 after");
         let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
         let range = state.cursor.char_range().unwrap();
-        assert!(range.is_empty());
+        assert_eq!(range.primary.index, range.secondary.index);
         assert_eq!(range.primary.index, 7 + TIMESTAMP.chars().count());
         assert!(panel.pending_selection.is_none());
     }
@@ -5614,7 +5614,7 @@ More text.
         assert_eq!(panel.note.content, "alpha 20260808-202512.347eta");
         let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
         let range = state.cursor.char_range().unwrap();
-        assert!(range.is_empty());
+        assert_eq!(range.primary.index, range.secondary.index);
         assert_eq!(range.primary.index, 6 + TIMESTAMP.chars().count());
         assert!(panel.pending_selection.is_none());
     }

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -3252,6 +3252,11 @@ impl NotePanel {
                 state.store(ctx, id);
                 ui.close_menu();
             }
+            if ui.button("Insert Timestamp").clicked() {
+                let timestamp = format_note_editor_timestamp_now();
+                self.insert_text_at_cursor_or_selection(ctx, id, &timestamp);
+                ui.close_menu();
+            }
             if ui.button("Insert Link...").clicked() {
                 if let Some((start, end)) = self.resolve_selection(ctx, id) {
                     let (start, end) = char_range_to_byte_range(&self.note.content, start, end);
@@ -5545,6 +5550,72 @@ More text.
         panel.insert_text_at_cursor_or_selection(&ctx, id, "replacement");
 
         assert_eq!(panel.note.content, "alpha\nreplacement");
+        assert!(panel.pending_selection.is_none());
+    }
+
+    #[test]
+    fn timestamp_insertion_at_caret_preserves_surrounding_text_and_collapses_cursor() {
+        const TIMESTAMP: &str = "20260808-202512.347";
+        let ctx = egui::Context::default();
+        ctx.begin_frame(egui::RawInput {
+            time: Some(42.25),
+            ..Default::default()
+        });
+        let id = egui::Id::new("timestamp_at_caret");
+        let mut panel = NotePanel::from_note(empty_note("Hello world"));
+        let mut state = egui::widgets::text_edit::TextEditState::default();
+        collapse_cursor(&mut state, 6);
+        state.store(&ctx, id);
+        assert!(!panel.fast_derived_dirty);
+        assert!(!panel.heavy_recompute_requested);
+        assert_eq!(panel.last_edit_at_secs, None);
+
+        panel.insert_text_at_cursor_or_selection(&ctx, id, TIMESTAMP);
+
+        assert_eq!(panel.note.content, "Hello 20260808-202512.347world");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let range = state.cursor.char_range().unwrap();
+        assert!(range.is_empty());
+        assert_eq!(range.primary.index, 6 + TIMESTAMP.chars().count());
+        assert!(panel.fast_derived_dirty);
+        assert!(panel.heavy_recompute_requested);
+        assert_eq!(panel.last_edit_at_secs, Some(42.25));
+        let _ = ctx.end_frame();
+    }
+
+    #[test]
+    fn timestamp_replaces_pending_selection_and_clears_it() {
+        const TIMESTAMP: &str = "20260808-202512.347";
+        let ctx = egui::Context::default();
+        let id = egui::Id::new("timestamp_selection");
+        let mut panel = NotePanel::from_note(empty_note("Before selected text after"));
+        panel.pending_selection = Some((7, 20));
+
+        panel.insert_text_at_cursor_or_selection(&ctx, id, TIMESTAMP);
+
+        assert_eq!(panel.note.content, "Before 20260808-202512.347 after");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let range = state.cursor.char_range().unwrap();
+        assert!(range.is_empty());
+        assert_eq!(range.primary.index, 7 + TIMESTAMP.chars().count());
+        assert!(panel.pending_selection.is_none());
+    }
+
+    #[test]
+    fn timestamp_replacement_uses_character_indices_for_unicode_content() {
+        const TIMESTAMP: &str = "20260808-202512.347";
+        let ctx = egui::Context::default();
+        let id = egui::Id::new("timestamp_unicode_selection");
+        let mut panel = NotePanel::from_note(empty_note("alpha 😀 βeta"));
+        panel.pending_selection = Some((6, 9));
+
+        panel.insert_text_at_cursor_or_selection(&ctx, id, TIMESTAMP);
+
+        assert_eq!(panel.note.content, "alpha 20260808-202512.347eta");
+        let state = egui::widgets::text_edit::TextEditState::load(&ctx, id).unwrap();
+        let range = state.cursor.char_range().unwrap();
+        assert!(range.is_empty());
+        assert_eq!(range.primary.index, 6 + TIMESTAMP.chars().count());
         assert!(panel.pending_selection.is_none());
     }
 


### PR DESCRIPTION
### Motivation

- Provide a convenient, deterministic "Insert Timestamp" action in the shared Markdown context menu that routes through the existing insertion helper so all editor invalidation and derived-data flows remain unchanged. 
- Prove correct integration with the generic insertion helpers by adding deterministic unit tests that exercise caret insertion, selection replacement, Unicode character-index handling, cursor collapse, and dirty-state signaling. 

### Description

- Add an `Insert Timestamp` button immediately after `Add Checkbox` inside `NotePanel::build_textedit_menu`, call `format_note_editor_timestamp_now()` only when the button branch executes, and pass its result to `self.insert_text_at_cursor_or_selection(ctx, id, &timestamp)` followed by `ui.close_menu()`. 
- Preserve the existing shared menu architecture and insertion semantics so `NoteViewMode::Edit` and the editable pane of `NoteViewMode::Split` continue to reach the command through `handle_editor_response` and `build_textedit_menu`, and `Preview`/render-only code is unchanged. 
- Add fixed-payload unit tests adjacent to the existing insertion tests covering: a caret insertion case (inserting `20260808-202512.347` into `Hello world`), a selection-replacement case, a Unicode-regression case that verifies character-index→byte-index correctness, and a dirty-state assertion that `fast_derived_dirty`, `heavy_recompute_requested`, and `last_edit_at_secs` are updated. 
- Keep the timestamp text fixed in tests and do not alter unrelated features, schema, plugins, shortcuts, or existing formatter expectations. 

### Testing

- `cargo fmt --check` completed successfully. 
- Confirmed the formatter test expectation in `src/gui/notes_dialog.rs` still asserts `2024-01-02 03:04:05`. 
- `git diff --check` returned no whitespace/format issues after the change. 
- `cargo test note_panel --lib` and `cargo test` were attempted but the full test runs are blocked by pre-existing, platform-specific build errors on this Linux environment (unresolved Windows-only APIs and native build dependencies), so the new unit tests could not be exercised by the entire workspace test run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77ce0fa2e88332aab2e91c39d39652)