### PR TITLE
Add native diff feature foundation (plugin, parser, model, GUI, persistence, tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +635,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -634,6 +652,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -1825,6 +1849,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1910,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -3244,15 +3285,18 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shlex",
+ "similar",
  "siphasher 0.3.11",
  "slab",
  "slug",
+ "syntect",
  "sysinfo",
  "tempfile",
  "time",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "trash",
  "url",
  "urlencoding",
  "walkdir",
@@ -3266,7 +3310,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.9.3",
  "codespan-reporting",
  "hexf-parse",
@@ -4745,6 +4789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4960,6 +5010,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.18",
+ "walkdir",
 ]
 
 [[package]]
@@ -5344,6 +5412,23 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trash"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0102cfb632fbe1adefa067036d4f383045091ae8d4fc4c2c14d3c0f92d878972"
+dependencies = [
+ "libc",
+ "log",
+ "objc2 0.6.2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -5946,7 +6031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.9.3",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
@@ -6097,6 +6182,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -6157,6 +6252,18 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
@@ -6205,6 +6312,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -6234,6 +6352,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,10 @@ dirs-next = "2"
 shlex = "1.3"
 similar = "2.7"
 syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "regex-fancy"] }
-trash = { version = "5.2", default-features = false }
+# `trash` deliberately fails its Windows build unless one COM apartment model
+# is selected. Keep the optional chrono integration disabled while matching
+# the crate's default, UI-friendly apartment-threaded initialization.
+trash = { version = "5.2", default-features = false, features = ["coinit_apartmentthreaded"] }
 sysinfo = "0.35"
 chrono = "0.4"
 screenshots = "0.8.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ egui_extras = "0.27"
 figlet-rs = "0.1"
 dirs-next = "2"
 shlex = "1.3"
+similar = "2.7"
+syntect = { version = "5.2", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "regex-fancy"] }
+trash = { version = "5.2", default-features = false }
 sysinfo = "0.35"
 chrono = "0.4"
 screenshots = "0.8.10"
@@ -93,4 +96,3 @@ harness = false
 [[bench]]
 name = "todo_widget_filtering"
 harness = false
-

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -1,0 +1,11 @@
+//! Native two-way file and folder comparison.
+//!
+//! Deliberately out of scope: three-way merge, synchronization, archive virtual
+//! folders, Git-specific UI, media/image comparison, cloud protocols, fuzzy
+//! filename pairing, and a hex editor.
+
+pub mod model;
+pub mod persistence;
+pub mod query;
+pub mod settings;
+pub mod worker;

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -1,0 +1,272 @@
+use crate::diff::settings::DiffConfigV1;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+fn id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffStatus {
+    Identical,
+    Modified,
+    LeftOnly,
+    RightOnly,
+    Error,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FolderDisplayFilter {
+    #[default]
+    All,
+    Changed,
+    Identical,
+    OneSided,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FolderSortState {
+    pub column: String,
+    pub descending: bool,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderCompareState {
+    pub selected_relative_path: Option<PathBuf>,
+    pub expanded_nodes: BTreeSet<PathBuf>,
+    pub scroll_anchor: Option<PathBuf>,
+    pub display_filter: FolderDisplayFilter,
+    pub path_filter: String,
+    pub sort: FolderSortState,
+    pub content_statuses: BTreeMap<PathBuf, DiffStatus>,
+}
+impl Default for FolderCompareState {
+    fn default() -> Self {
+        Self {
+            selected_relative_path: None,
+            expanded_nodes: BTreeSet::new(),
+            scroll_anchor: None,
+            display_filter: FolderDisplayFilter::All,
+            path_filter: String::new(),
+            sort: FolderSortState {
+                column: "path".into(),
+                descending: false,
+            },
+            content_statuses: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FileComparisonKind {
+    Text,
+    Binary,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextCompareState {
+    pub left: Option<PathBuf>,
+    pub right: Option<PathBuf>,
+    pub relative_path: Option<PathBuf>,
+    pub kind: FileComparisonKind,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiffView {
+    Start,
+    TextCompare(TextCompareState),
+    FolderCompare(FolderCompareState),
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetainedView {
+    pub id: u64,
+    pub view: DiffView,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiffWorkspace {
+    pub left_visible: String,
+    pub right_visible: String,
+    pub left_normalized: Option<PathBuf>,
+    pub right_normalized: Option<PathBuf>,
+    pub workspace_id: u64,
+    pub current_view: RetainedView,
+    pub navigation_stack: Vec<RetainedView>,
+    pub settings: DiffConfigV1,
+    pub current_job_generation: u64,
+    pub progress: Option<crate::diff::worker::DiffProgress>,
+    pub status: Option<String>,
+    pub error: Option<String>,
+    pub focus_left_requested: bool,
+}
+
+impl Default for DiffWorkspace {
+    fn default() -> Self {
+        Self::new(DiffConfigV1::default())
+    }
+}
+impl DiffWorkspace {
+    pub fn new(settings: DiffConfigV1) -> Self {
+        Self {
+            left_visible: String::new(),
+            right_visible: String::new(),
+            left_normalized: None,
+            right_normalized: None,
+            workspace_id: id(),
+            current_view: RetainedView {
+                id: id(),
+                view: DiffView::Start,
+            },
+            navigation_stack: vec![],
+            settings,
+            current_job_generation: 0,
+            progress: None,
+            status: None,
+            error: None,
+            focus_left_requested: true,
+        }
+    }
+    pub fn open_invocation(
+        &mut self,
+        left: Option<String>,
+        right: Option<String>,
+    ) -> Result<(), String> {
+        match (left, right) {
+            (None, None) => {
+                self.focus_left_requested = true;
+                Ok(())
+            }
+            (Some(l), None) => {
+                self.left_visible = l.clone();
+                self.left_normalized = Some(crate::diff::query::normalize_path(&l));
+                self.focus_left_requested = false;
+                Ok(())
+            }
+            (l, r) => self.open_paths(l.unwrap_or_default(), r.unwrap_or_default()),
+        }
+    }
+    pub fn open_paths(&mut self, left: String, right: String) -> Result<(), String> {
+        self.left_visible = left;
+        self.right_visible = right;
+        self.focus_left_requested = false;
+        let lp = crate::diff::query::normalize_path(&self.left_visible);
+        let rp = crate::diff::query::normalize_path(&self.right_visible);
+        self.left_normalized = Some(lp.clone());
+        self.right_normalized = Some(rp.clone());
+        let lm = metadata(&lp, "Left");
+        let rm = metadata(&rp, "Right");
+        let (lm, rm) = match (lm, rm) {
+            (Ok(l), Ok(r)) => (l, r),
+            (l, r) => {
+                let msg = [l.err(), r.err()]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                self.error = Some(msg.clone());
+                return Err(msg);
+            }
+        };
+        let view = if lm.is_file() && rm.is_file() {
+            DiffView::TextCompare(TextCompareState {
+                left: Some(lp.clone()),
+                right: Some(rp.clone()),
+                relative_path: None,
+                kind: detect_kind(&lp, &rp),
+            })
+        } else if lm.is_dir() && rm.is_dir() {
+            DiffView::FolderCompare(FolderCompareState::default())
+        } else {
+            let msg = "Left and right paths must both be files or both be directories".to_string();
+            self.error = Some(msg.clone());
+            return Err(msg);
+        };
+        self.navigation_stack.clear();
+        self.current_view = RetainedView { id: id(), view };
+        self.current_job_generation += 1;
+        self.error = None;
+        self.status = Some("Comparison ready".into());
+        Ok(())
+    }
+    /// Opens a folder child; either side may be absent without weakening root validation.
+    pub fn push_file_compare(
+        &mut self,
+        relative_path: PathBuf,
+        left: Option<PathBuf>,
+        right: Option<PathBuf>,
+    ) -> Result<(), String> {
+        if left.is_none() && right.is_none() {
+            return Err("A folder child must exist on at least one side".into());
+        }
+        let kind = match (&left, &right) {
+            (Some(l), Some(r)) => detect_kind(l, r),
+            _ => FileComparisonKind::Text,
+        };
+        let next = RetainedView {
+            id: id(),
+            view: DiffView::TextCompare(TextCompareState {
+                left,
+                right,
+                relative_path: Some(relative_path),
+                kind,
+            }),
+        };
+        let old = std::mem::replace(&mut self.current_view, next);
+        self.navigation_stack.push(old);
+        Ok(())
+    }
+    pub fn back(&mut self) -> bool {
+        if let Some(previous) = self.navigation_stack.pop() {
+            self.current_view = previous;
+            true
+        } else {
+            false
+        }
+    }
+}
+fn metadata(path: &Path, side: &str) -> Result<fs::Metadata, String> {
+    fs::metadata(path).map_err(|e| format!("{side} path '{}': {e}", path.display()))
+}
+fn detect_kind(left: &Path, right: &Path) -> FileComparisonKind {
+    let binary = |p: &Path| {
+        fs::read(p)
+            .ok()
+            .is_some_and(|b| b.iter().take(8192).any(|v| *v == 0))
+    };
+    if binary(left) || binary(right) {
+        FileComparisonKind::Binary
+    } else {
+        FileComparisonKind::Text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn validates_and_retains_inputs() {
+        let d = tempfile::tempdir().unwrap();
+        let f = d.path().join("f");
+        fs::write(&f, "x").unwrap();
+        let mut w = DiffWorkspace::default();
+        assert!(
+            w.open_paths(f.display().to_string(), d.path().display().to_string())
+                .is_err()
+        );
+        assert_eq!(w.left_visible, f.display().to_string());
+    }
+    #[test]
+    fn push_back_restores_same_folder_state() {
+        let mut w = DiffWorkspace::default();
+        w.current_view = RetainedView {
+            id: 99,
+            view: DiffView::FolderCompare(FolderCompareState {
+                path_filter: "rs".into(),
+                ..Default::default()
+            }),
+        };
+        w.push_file_compare("a".into(), Some("a".into()), None)
+            .unwrap();
+        assert!(w.back());
+        assert_eq!(w.current_view.id, 99);
+        assert!(matches!(&w.current_view.view,DiffView::FolderCompare(s) if s.path_filter=="rs"));
+    }
+}

--- a/src/diff/persistence.rs
+++ b/src/diff/persistence.rs
@@ -1,0 +1,157 @@
+//! Versioned persistence for durable diff preferences and named sessions only.
+//! Runtime workers, cancellation/undo state, buffers, progress, selections, and
+//! computed output are intentionally never serialized.
+
+use crate::common::atomic_file::save_atomic;
+use crate::diff::query::normalize_path;
+use crate::diff::settings::{
+    DIFF_CONFIG_VERSION, DiffConfigV1, ReplacementRuleV1, UnimportantSectionRuleV1,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io::ErrorKind;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DisplayPathPairV1 {
+    pub left: String,
+    pub right: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SavedDiffSessionV1 {
+    pub id: String,
+    pub name: String,
+    pub left: String,
+    pub right: String,
+    pub pane_split: f32,
+    pub wrap_text: bool,
+    pub syntax_highlighting: bool,
+    pub syntax_theme: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiffPersistenceV1 {
+    pub version: u32,
+    pub config: DiffConfigV1,
+    pub recent_comparisons: Vec<DisplayPathPairV1>,
+    pub named_sessions: Vec<SavedDiffSessionV1>,
+    pub replacement_rules: Vec<ReplacementRuleV1>,
+    pub unimportant_section_rules: Vec<UnimportantSectionRuleV1>,
+    pub window_size: Option<[f32; 2]>,
+    pub window_position: Option<[f32; 2]>,
+}
+impl Default for DiffPersistenceV1 {
+    fn default() -> Self {
+        Self {
+            version: DIFF_CONFIG_VERSION,
+            config: Default::default(),
+            recent_comparisons: vec![],
+            named_sessions: vec![],
+            replacement_rules: vec![],
+            unimportant_section_rules: vec![],
+            window_size: None,
+            window_position: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    Io(std::io::Error),
+    Malformed(serde_json::Error),
+    UnsupportedVersion(u64),
+}
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "read diff settings: {e}"),
+            Self::Malformed(e) => write!(f, "malformed diff settings: {e}"),
+            Self::UnsupportedVersion(v) => write!(f, "unsupported diff settings version {v}"),
+        }
+    }
+}
+impl std::error::Error for LoadError {}
+
+pub fn load(path: &Path) -> Result<Option<DiffPersistenceV1>, LoadError> {
+    let bytes = match std::fs::read(path) {
+        Ok(v) => v,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(LoadError::Io(e)),
+    };
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(LoadError::Malformed)?;
+    let version = value.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
+    if version != DIFF_CONFIG_VERSION as u64 {
+        return Err(LoadError::UnsupportedVersion(version));
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(LoadError::Malformed)
+}
+pub fn save(path: &Path, value: &DiffPersistenceV1) -> anyhow::Result<()> {
+    let data = serde_json::to_vec_pretty(value)?;
+    save_atomic(path, &data)
+}
+
+pub fn record_recent(state: &mut DiffPersistenceV1, left: String, right: String) {
+    let identity = pair_identity(&left, &right);
+    state
+        .recent_comparisons
+        .retain(|p| pair_identity(&p.left, &p.right) != identity);
+    state
+        .recent_comparisons
+        .insert(0, DisplayPathPairV1 { left, right });
+    state
+        .recent_comparisons
+        .truncate(state.config.max_recent_comparisons);
+}
+pub fn deduplicate_rule_ids(state: &mut DiffPersistenceV1) {
+    fn retain_unique<T>(values: &mut Vec<T>, id: impl Fn(&T) -> &str) {
+        let mut seen = HashSet::new();
+        values.retain(|v| seen.insert(id(v).to_owned()));
+    }
+    retain_unique(&mut state.replacement_rules, |r| &r.id);
+    retain_unique(&mut state.unimportant_section_rules, |r| &r.id);
+}
+fn pair_identity(left: &str, right: &str) -> (String, String) {
+    (
+        normalize_path(left).to_string_lossy().to_lowercase(),
+        normalize_path(right).to_string_lossy().to_lowercase(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn roundtrip_and_unknown_fields() {
+        let d = tempfile::tempdir().unwrap();
+        let p = d.path().join("d.json");
+        let s = DiffPersistenceV1::default();
+        save(&p, &s).unwrap();
+        assert_eq!(load(&p).unwrap(), Some(s));
+        let mut v: serde_json::Value = serde_json::from_slice(&std::fs::read(&p).unwrap()).unwrap();
+        v["future"] = true.into();
+        std::fs::write(&p, serde_json::to_vec(&v).unwrap()).unwrap();
+        assert!(load(&p).unwrap().is_some());
+    }
+    #[test]
+    fn missing_and_malformed() {
+        let d = tempfile::tempdir().unwrap();
+        let p = d.path().join("x");
+        assert!(load(&p).unwrap().is_none());
+        std::fs::write(&p, "{").unwrap();
+        assert!(matches!(load(&p), Err(LoadError::Malformed(_))));
+        assert_eq!(std::fs::read_to_string(p).unwrap(), "{");
+    }
+    #[test]
+    fn recent_is_bounded_and_deduped() {
+        let mut s = DiffPersistenceV1::default();
+        s.config.max_recent_comparisons = 1;
+        record_recent(&mut s, "a".into(), "b".into());
+        record_recent(&mut s, "./a".into(), "./b".into());
+        assert_eq!(s.recent_comparisons.len(), 1);
+        assert_eq!(s.recent_comparisons[0].left, "./a");
+    }
+}

--- a/src/diff/query.rs
+++ b/src/diff/query.rs
@@ -1,0 +1,130 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub const OPEN_PREFIX: &str = "diff:open:";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffOpenPayload {
+    pub left: Option<String>,
+    pub right: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffCommand {
+    Open,
+    OpenWithLeft {
+        visible: String,
+        normalized: PathBuf,
+    },
+    Compare {
+        left_visible: String,
+        right_visible: String,
+        left_normalized: PathBuf,
+        right_normalized: PathBuf,
+    },
+    Error(String),
+}
+
+pub fn parse_diff_query(query: &str) -> Option<DiffCommand> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let tokens = match shlex::split(trimmed) {
+        Some(tokens) => tokens,
+        None if trimmed
+            .split_whitespace()
+            .next()
+            .is_some_and(|h| h.eq_ignore_ascii_case("diff")) =>
+        {
+            return Some(DiffCommand::Error(
+                "Malformed quoting in diff command".into(),
+            ));
+        }
+        None => return None,
+    };
+    if !tokens
+        .first()
+        .is_some_and(|head| head.eq_ignore_ascii_case("diff"))
+    {
+        return None;
+    }
+    match tokens.as_slice() {
+        [_] => Some(DiffCommand::Open),
+        [_, left] => Some(DiffCommand::OpenWithLeft {
+            visible: left.clone(),
+            normalized: normalize_path(left),
+        }),
+        [_, left, right] => Some(DiffCommand::Compare {
+            left_visible: left.clone(),
+            right_visible: right.clone(),
+            left_normalized: normalize_path(left),
+            right_normalized: normalize_path(right),
+        }),
+        _ => Some(DiffCommand::Error(
+            "Usage: diff [<left-path> [<right-path>]]".into(),
+        )),
+    }
+}
+
+pub fn normalize_path(value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if let Ok(canonical) = std::fs::canonicalize(&path) {
+        return canonical;
+    }
+    // Missing paths still need a stable identity. Making them absolute also
+    // collapses harmless `./` components without changing the visible value.
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    absolute.components().collect()
+}
+
+pub fn encode_payload(payload: &DiffOpenPayload) -> Result<String, String> {
+    let bytes = serde_json::to_vec(payload).map_err(|e| e.to_string())?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+pub fn decode_payload(value: &str) -> Result<DiffOpenPayload, String> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|e| format!("invalid diff payload: {e}"))?;
+    serde_json::from_slice(&bytes).map_err(|e| format!("invalid diff payload JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn preserves_visible_paths() {
+        let command = parse_diff_query(r#"diff "./left file" "right file""#).unwrap();
+        let DiffCommand::Compare {
+            left_visible,
+            right_visible,
+            ..
+        } = command
+        else {
+            panic!()
+        };
+        assert_eq!(left_visible, "./left file");
+        assert_eq!(right_visible, "right file");
+    }
+    #[test]
+    fn escaped_spaces_are_tokenized() {
+        assert!(
+            matches!(parse_diff_query(r#"diff left\ file right"#), Some(DiffCommand::Compare { left_visible, .. }) if left_visible == "left file")
+        );
+    }
+    #[test]
+    fn malformed_quote_is_error() {
+        assert!(matches!(
+            parse_diff_query("diff \"oops"),
+            Some(DiffCommand::Error(_))
+        ));
+    }
+}

--- a/src/diff/settings.rs
+++ b/src/diff/settings.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+pub const DIFF_CONFIG_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiffConfigV1 {
+    pub version: u32,
+    pub pane_split: f32,
+    pub wrap_text: bool,
+    pub syntax_highlighting: bool,
+    pub syntax_theme: String,
+    pub ignore_whitespace: bool,
+    pub case_sensitive: bool,
+    pub max_recent_comparisons: usize,
+}
+
+impl Default for DiffConfigV1 {
+    fn default() -> Self {
+        Self {
+            version: DIFF_CONFIG_VERSION,
+            pane_split: 0.5,
+            wrap_text: false,
+            syntax_highlighting: true,
+            syntax_theme: "InspiredGitHub".into(),
+            ignore_whitespace: false,
+            case_sensitive: true,
+            max_recent_comparisons: 20,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplacementRuleV1 {
+    pub id: String,
+    pub pattern: String,
+    pub replacement: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnimportantSectionRuleV1 {
+    pub id: String,
+    pub pattern: String,
+    pub enabled: bool,
+}

--- a/src/diff/worker.rs
+++ b/src/diff/worker.rs
@@ -1,0 +1,7 @@
+//! Background comparison job primitives. Actual jobs are introduced separately.
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DiffProgress {
+    pub completed: u64,
+    pub total: Option<u64>,
+}

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -71,6 +71,9 @@ impl LauncherApp {
         if self.handle_file_search_action(&a.action) {
             return;
         }
+        if self.handle_diff_action(&a.action) {
+            return;
+        }
         if let Some(new_query) = query_override {
             self.query = new_query;
             self.last_timer_query =
@@ -1194,6 +1197,21 @@ impl LauncherApp {
             return true;
         }
         false
+    }
+
+    fn handle_diff_action(&mut self, action: &str) -> bool {
+        let Some(encoded) = action.strip_prefix(crate::diff::query::OPEN_PREFIX) else {
+            return false;
+        };
+        match crate::diff::query::decode_payload(encoded) {
+            Ok(payload) => {
+                if let Err(error) = self.diff_dialog.open_payload(payload) {
+                    self.report_error_message("diff", error);
+                }
+            }
+            Err(error) => self.report_error_message("diff", error),
+        }
+        true
     }
 
     fn report_file_search_action_error(&mut self, err: String) {

--- a/src/gui/diff_dialog.rs
+++ b/src/gui/diff_dialog.rs
@@ -1,0 +1,97 @@
+use crate::diff::model::{DiffView, DiffWorkspace};
+use crate::diff::query::DiffOpenPayload;
+use eframe::egui;
+
+#[derive(Debug, Default)]
+pub struct DiffDialogState {
+    pub open: bool,
+    pub workspace: DiffWorkspace,
+}
+
+impl DiffDialogState {
+    pub fn open_payload(&mut self, payload: DiffOpenPayload) -> Result<(), String> {
+        self.open = true;
+        self.workspace = DiffWorkspace::default();
+        self.workspace.open_invocation(payload.left, payload.right)
+    }
+    pub fn ui(&mut self, ctx: &egui::Context) {
+        if !self.open {
+            return;
+        }
+        let mut open = self.open;
+        egui::Window::new("Diff")
+            .id(egui::Id::new(("diff_window", self.workspace.workspace_id)))
+            .open(&mut open)
+            .default_size([900.0, 650.0])
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    let left = ui.add(
+                        egui::TextEdit::singleline(&mut self.workspace.left_visible)
+                            .id(egui::Id::new((self.workspace.workspace_id, "left")))
+                            .hint_text("Left file or folder"),
+                    );
+                    if self.workspace.focus_left_requested {
+                        left.request_focus();
+                        self.workspace.focus_left_requested = false;
+                    }
+                    if ui.button("Browse…").clicked() {
+                        if let Some(p) = rfd::FileDialog::new().pick_file() {
+                            self.workspace.left_visible = p.display().to_string();
+                        }
+                    }
+                    ui.label("↔");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut self.workspace.right_visible)
+                            .id(egui::Id::new((self.workspace.workspace_id, "right")))
+                            .hint_text("Right file or folder"),
+                    );
+                    if ui.button("Browse…").clicked() {
+                        if let Some(p) = rfd::FileDialog::new().pick_file() {
+                            self.workspace.right_visible = p.display().to_string();
+                        }
+                    }
+                    if ui.button("Compare").clicked() {
+                        let _ = self.workspace.open_paths(
+                            self.workspace.left_visible.clone(),
+                            self.workspace.right_visible.clone(),
+                        );
+                    }
+                });
+                if let Some(error) = &self.workspace.error {
+                    ui.colored_label(egui::Color32::RED, error);
+                }
+                if self.workspace.navigation_stack.len() > 0 && ui.button("← Back").clicked() {
+                    self.workspace.back();
+                }
+                ui.separator();
+                match &self.workspace.current_view.view {
+                    DiffView::Start => {
+                        ui.label("Choose two files or two folders to compare.");
+                    }
+                    DiffView::TextCompare(s) => {
+                        ui.heading(match s.kind {
+                            crate::diff::model::FileComparisonKind::Text => "Text comparison",
+                            crate::diff::model::FileComparisonKind::Binary => "Binary files",
+                        });
+                        ui.label(format!(
+                            "Left: {}",
+                            s.left
+                                .as_ref()
+                                .map_or("(missing)".into(), |p| p.display().to_string())
+                        ));
+                        ui.label(format!(
+                            "Right: {}",
+                            s.right
+                                .as_ref()
+                                .map_or("(missing)".into(), |p| p.display().to_string())
+                        ));
+                    }
+                    DiffView::FolderCompare(s) => {
+                        ui.heading("Folder comparison");
+                        ui.label(format!("{} computed entries", s.content_statuses.len()));
+                    }
+                }
+            });
+        self.open = open;
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -13,6 +13,7 @@ mod confirmation_modal;
 mod convert_panel;
 mod cpu_list_dialog;
 mod dashboard_editor_dialog;
+mod diff_dialog;
 mod fav_dialog;
 mod file_search_dialog;
 pub mod file_search_preview_dialog;
@@ -57,6 +58,7 @@ pub use clipboard_dialog::ClipboardDialog;
 pub use clipboard_modify_dialog::{ClipboardModifyDialogSection, ClipboardModifyDialogState};
 pub use convert_panel::ConvertPanel;
 pub use cpu_list_dialog::CpuListDialog;
+pub use diff_dialog::DiffDialogState;
 pub use fav_dialog::FavDialog;
 pub use file_search_dialog::{
     FileSearchDialogState, FileSearchMode, FileSearchScopeMode, FileSearchUiCommand,
@@ -433,6 +435,7 @@ pub struct LauncherApp {
     theme_settings_dialog: ThemeSettingsDialogState,
     fav_dialog: FavDialog,
     file_search_dialog: FileSearchDialogState,
+    pub diff_dialog: DiffDialogState,
     file_search_coordinator: SearchCoordinator,
     notes_dialog: NotesDialog,
     note_graph_dialog: NoteGraphDialog,
@@ -1394,6 +1397,7 @@ impl LauncherApp {
                 ..FileSearchDialogState::default()
             },
             file_search_coordinator: SearchCoordinator::from_settings(file_search_settings),
+            diff_dialog: DiffDialogState::default(),
             notes_dialog: NotesDialog::default(),
             note_graph_dialog: NoteGraphDialog::default(),
             unused_assets_dialog: UnusedAssetsDialog::default(),

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1329,6 +1329,7 @@ impl eframe::App for LauncherApp {
         self.file_search_dialog
             .preview_dialog
             .ui(ctx, &self.file_search_dialog.settings);
+        self.diff_dialog.ui(ctx);
         let mut notes_dlg = std::mem::take(&mut self.notes_dialog);
         notes_dlg.ui(ctx, self);
         self.notes_dialog = notes_dlg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod actions_editor;
 pub mod clipboard_modify;
 pub mod common;
 pub mod dashboard;
+pub mod diff;
 pub mod file_search;
 pub mod help_window;
 pub mod history;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -11,6 +11,7 @@ use crate::plugins::clipboard::ClipboardPlugin;
 use crate::plugins::clipboard_modify::ClipboardModifyPlugin;
 use crate::plugins::color_picker::ColorPickerPlugin;
 use crate::plugins::convert_panel::ConvertPanelPlugin;
+use crate::plugins::diff::DiffPlugin;
 use crate::plugins::dropcalc::DropCalcPlugin;
 use crate::plugins::emoji::EmojiPlugin;
 use crate::plugins::fav::FavPlugin;
@@ -204,6 +205,7 @@ impl PluginManager {
         self.register_with_settings(BookmarksPlugin::default(), plugin_settings);
         self.register_with_settings(FoldersPlugin::default(), plugin_settings);
         self.register_with_settings(FileSearchPlugin::default(), plugin_settings);
+        self.register_with_settings(DiffPlugin::default(), plugin_settings);
         self.register_with_settings(OmniSearchPlugin::new(actions.clone()), plugin_settings);
         self.register_with_settings(SystemPlugin, plugin_settings);
         self.register_with_settings(ProcessesPlugin, plugin_settings);

--- a/src/plugins/diff.rs
+++ b/src/plugins/diff.rs
@@ -1,0 +1,95 @@
+use crate::actions::Action;
+use crate::diff::query::{
+    DiffCommand, DiffOpenPayload, OPEN_PREFIX, encode_payload, parse_diff_query,
+};
+use crate::diff::settings::DiffConfigV1;
+use crate::plugin::Plugin;
+use eframe::egui;
+
+#[derive(Debug, Clone, Default)]
+pub struct DiffPlugin {
+    settings: DiffConfigV1,
+}
+impl Plugin for DiffPlugin {
+    fn search(&self, query: &str) -> Vec<Action> {
+        match parse_diff_query(query) {
+            None => vec![],
+            Some(DiffCommand::Open) => vec![open_action(None, None)],
+            Some(DiffCommand::OpenWithLeft { visible, .. }) => {
+                vec![open_action(Some(visible), None)]
+            }
+            Some(DiffCommand::Compare {
+                left_visible,
+                right_visible,
+                ..
+            }) => vec![open_action(Some(left_visible), Some(right_visible))],
+            Some(DiffCommand::Error(e)) => vec![Action {
+                label: "Invalid diff command".into(),
+                desc: e,
+                action: "error".into(),
+                args: None,
+            }],
+        }
+    }
+    fn name(&self) -> &str {
+        "diff"
+    }
+    fn description(&self) -> &str {
+        "Compare two files or folders"
+    }
+    fn capabilities(&self) -> &[&str] {
+        &["search"]
+    }
+    fn commands(&self) -> Vec<Action> {
+        vec![Action {
+            label: "diff".into(),
+            desc: "Open file and folder comparison".into(),
+            action: format!(
+                "{OPEN_PREFIX}{}",
+                encode_payload(&DiffOpenPayload {
+                    left: None,
+                    right: None
+                })
+                .unwrap()
+            ),
+            args: None,
+        }]
+    }
+    fn query_prefixes(&self) -> &[&str] {
+        &["diff"]
+    }
+    fn default_settings(&self) -> Option<serde_json::Value> {
+        serde_json::to_value(DiffConfigV1::default()).ok()
+    }
+    fn apply_settings(&mut self, value: &serde_json::Value) {
+        self.settings = serde_json::from_value(value.clone()).unwrap_or_default();
+    }
+    fn settings_ui(&mut self, ui: &mut egui::Ui, value: &mut serde_json::Value) {
+        let mut c: DiffConfigV1 = serde_json::from_value(value.clone()).unwrap_or_default();
+        ui.heading("Diff");
+        ui.checkbox(&mut c.wrap_text, "Wrap text");
+        ui.checkbox(&mut c.syntax_highlighting, "Syntax highlighting");
+        ui.checkbox(&mut c.ignore_whitespace, "Ignore whitespace by default");
+        ui.checkbox(&mut c.case_sensitive, "Case sensitive");
+        ui.add(egui::Slider::new(&mut c.pane_split, 0.1..=0.9).text("Pane split"));
+        self.settings = c.clone();
+        *value = serde_json::to_value(c).unwrap();
+    }
+}
+fn open_action(left: Option<String>, right: Option<String>) -> Action {
+    let payload = encode_payload(&DiffOpenPayload {
+        left: left.clone(),
+        right: right.clone(),
+    })
+    .unwrap();
+    Action {
+        label: match (&left, &right) {
+            (Some(l), Some(r)) => format!("Compare {l} ↔ {r}"),
+            (Some(l), None) => format!("Open Diff with {l}"),
+            _ => "Open Diff".into(),
+        },
+        desc: "Open native file and folder comparison".into(),
+        action: format!("{OPEN_PREFIX}{payload}"),
+        args: None,
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -9,6 +9,7 @@ pub mod clipboard;
 pub mod clipboard_modify;
 pub mod color_picker;
 pub mod convert_panel;
+pub mod diff;
 pub mod dropcalc;
 pub mod emoji;
 pub mod fav;

--- a/tests/diff_plugin.rs
+++ b/tests/diff_plugin.rs
@@ -1,0 +1,63 @@
+use multi_launcher::diff::query::{DiffOpenPayload, OPEN_PREFIX, decode_payload};
+use multi_launcher::plugin::Plugin;
+use multi_launcher::plugins::diff::DiffPlugin;
+
+fn payload(query: &str) -> DiffOpenPayload {
+    let action = DiffPlugin::default().search(query).remove(0).action;
+    decode_payload(
+        action
+            .strip_prefix(OPEN_PREFIX)
+            .expect("structured diff action"),
+    )
+    .unwrap()
+}
+
+#[test]
+fn exposes_name_command_and_prefix() {
+    let plugin = DiffPlugin::default();
+    assert_eq!(plugin.name(), "diff");
+    assert_eq!(plugin.query_prefixes(), &["diff"]);
+    assert_eq!(plugin.commands().len(), 1);
+}
+
+#[test]
+fn empty_one_and_two_argument_commands_are_encoded() {
+    assert_eq!(
+        payload("diff"),
+        DiffOpenPayload {
+            left: None,
+            right: None
+        }
+    );
+    assert_eq!(
+        payload("diff left"),
+        DiffOpenPayload {
+            left: Some("left".into()),
+            right: None
+        }
+    );
+    assert_eq!(
+        payload("diff left right"),
+        DiffOpenPayload {
+            left: Some("left".into()),
+            right: Some("right".into())
+        }
+    );
+}
+
+#[test]
+fn quotes_windows_paths_and_rejects_malformed_quote() {
+    let parsed = payload(r#"diff "C:\Users\A B\left.txt" "D:\right.txt""#);
+    assert_eq!(parsed.left.as_deref(), Some(r"C:\Users\A B\left.txt"));
+    assert_eq!(parsed.right.as_deref(), Some(r"D:\right.txt"));
+    assert_eq!(
+        DiffPlugin::default().search("diff \"unfinished")[0].action,
+        "error"
+    );
+}
+
+#[test]
+fn does_not_interfere_with_other_prefixes() {
+    assert!(DiffPlugin::default().search("fs file query").is_empty());
+    assert!(DiffPlugin::default().search("folder docs").is_empty());
+}

--- a/tests/plugin_routing.rs
+++ b/tests/plugin_routing.rs
@@ -228,6 +228,30 @@ fn builtin_search_filtered_routes_file_omni_and_folder_prefixes() {
 }
 
 #[test]
+fn diff_prefix_routes_only_to_diff_among_native_file_plugins() {
+    use multi_launcher::plugins::diff::DiffPlugin;
+    use multi_launcher::plugins::file_search::FileSearchPlugin;
+    use multi_launcher::plugins::folders::FoldersPlugin;
+    let mut pm = PluginManager::new();
+    pm.register(Box::new(DiffPlugin::default()));
+    pm.register(Box::new(FileSearchPlugin::default()));
+    pm.register(Box::new(FoldersPlugin::default()));
+    let results = pm.search_filtered("diff left right", None, None);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].action.starts_with("diff:open:"));
+    assert!(
+        pm.search_filtered("fs", None, None)
+            .iter()
+            .all(|a| !a.action.starts_with("diff:"))
+    );
+    assert!(
+        pm.search_filtered("folder", None, None)
+            .iter()
+            .all(|a| !a.action.starts_with("diff:"))
+    );
+}
+
+#[test]
 fn file_search_plugin_prefix_is_only_fs() {
     use multi_launcher::plugin::Plugin;
     use multi_launcher::plugins::file_search::FileSearchPlugin;


### PR DESCRIPTION
### Motivation

- Provide a native, lightweight two-way file/folder comparison feature with proper plugin routing, structured command payloads, and a retained model to preserve navigation and UI state.
- Avoid ad-hoc path parsing in egui code by implementing a dedicated, shlex-based command parser that preserves visible user input while using normalized identities for validation and persistence.
- Add stable, versioned settings and persistence DTOs so UI preferences and named sessions can be stored and migrated safely without serializing transient runtime state.

### Description

- Added a new `diff` feature tree under `src/diff/` (`mod.rs`, `query.rs`, `model.rs`, `settings.rs`, `persistence.rs`, `worker.rs`) implementing a `DiffCommand` parser, `DiffWorkspace` model with retained views/navigation, and versioned `DiffConfigV1`/`DiffPersistenceV1` DTOs.
- Implemented `DiffPlugin` in `src/plugins/diff.rs` that exposes the `diff` prefix and command, returns structured `diff:open:` actions carrying a Base64/JSON payload, and provides `default_settings`/`apply_settings`/`settings_ui` hooks.
- Integrated the dialog and routing into the shell by adding `src/gui/diff_dialog.rs`, registering `DiffDialogState` in the main `LauncherApp` state, routing `diff:open` actions in `src/gui/actions.rs`, and rendering the dialog in `src/gui/render.rs` using stable egui IDs and `rfd::FileDialog` file pickers.
- Added persistence helpers in `src/diff/persistence.rs` with safe `save_atomic` writes, recent-comparison deduplication, stable rule-ID deduplication, and tests for round-trip/malformed/missing-file behavior.
- Added focused unit and integration tests: `tests/diff_plugin.rs` for plugin/query behavior and extensions to `tests/plugin_routing.rs` to verify routing, plus small unit tests inside `src/diff/query.rs`, `src/diff/model.rs`, and `src/diff/persistence.rs`.
- Updated `src/lib.rs`, `src/plugins/mod.rs`, and `src/plugin.rs` to export and register the `diff` feature; appended `similar`, a reduced `syntect` feature set, and `trash` to `Cargo.toml` for future diff functionality.

### Testing

- Ran `cargo fmt --check` which succeeded, and ran `git diff --check` which reported no spacing errors in the changes; both checks passed.
- Executed targeted test runs (e.g. `cargo test --test diff_plugin --test plugin_routing`), and the new tests and compilation progressed, but the full test run could not complete in this Linux environment due to pre-existing platform-specific `windows` crate usages and native pkg-config dependencies; several compile steps ran and native packages (`libasound2-dev`, `libxi-dev`, `libxtst-dev`) were installed to resolve some build-time checks, but unresolved `windows::Win32` platform imports prevented completion of the test suite here.
- The new `diff` unit tests (parser/model/persistence) are present and exercise visible-path preservation, tokenization, input validation, navigation push/back behavior, persistence round-trip and deduplication, and command/action encoding; these tests are expected to run in CI environments that build with the appropriate platform toolchain or target filtering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77d9bc127c8332be53f0e2f9288092)