### PR TITLE
Add robust diff watching and durable session persistence

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -14,4 +14,5 @@ pub mod settings;
 pub mod syntax;
 pub mod text_compare;
 pub mod text_file;
+pub mod watch;
 pub mod worker;

--- a/src/diff/persistence.rs
+++ b/src/diff/persistence.rs
@@ -11,11 +11,31 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonModeV1 {
+    #[default]
+    Text,
+    Folder,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentComparisonModeV1 {
+    Metadata,
+    #[default]
+    OnDemand,
+    Always,
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DisplayPathPairV1 {
     pub left: String,
     pub right: String,
+    #[serde(default)]
+    pub mode: ComparisonModeV1,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -28,6 +48,50 @@ pub struct SavedDiffSessionV1 {
     pub wrap_text: bool,
     pub syntax_highlighting: bool,
     pub syntax_theme: String,
+    #[serde(default)]
+    pub comparison_mode: ComparisonModeV1,
+    #[serde(default)]
+    pub ignore_whitespace: bool,
+    #[serde(default = "default_true")]
+    pub case_sensitive: bool,
+    #[serde(default)]
+    pub replacement_rules: Vec<ReplacementRuleV1>,
+    #[serde(default)]
+    pub unimportant_section_rules: Vec<UnimportantSectionRuleV1>,
+    #[serde(default)]
+    pub folder_includes: Vec<String>,
+    #[serde(default)]
+    pub folder_excludes: Vec<String>,
+    #[serde(default)]
+    pub folder_display_filter: String,
+    #[serde(default)]
+    pub content_comparison: ContentComparisonModeV1,
+}
+impl Default for SavedDiffSessionV1 {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            left: String::new(),
+            right: String::new(),
+            pane_split: 0.5,
+            wrap_text: false,
+            syntax_highlighting: true,
+            syntax_theme: "InspiredGitHub".into(),
+            comparison_mode: Default::default(),
+            ignore_whitespace: false,
+            case_sensitive: true,
+            replacement_rules: vec![],
+            unimportant_section_rules: vec![],
+            folder_includes: vec![],
+            folder_excludes: vec![],
+            folder_display_filter: "all".into(),
+            content_comparison: Default::default(),
+        }
+    }
+}
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -95,16 +159,28 @@ pub fn save(path: &Path, value: &DiffPersistenceV1) -> anyhow::Result<()> {
 }
 
 pub fn record_recent(state: &mut DiffPersistenceV1, left: String, right: String) {
-    let identity = pair_identity(&left, &right);
+    record_recent_mode(state, left, right, ComparisonModeV1::Text)
+}
+/// Call only after `DiffWorkspace::open_paths` succeeds.
+pub fn record_recent_mode(
+    state: &mut DiffPersistenceV1,
+    left: String,
+    right: String,
+    mode: ComparisonModeV1,
+) {
+    let identity = pair_identity(&left, &right, mode);
     state
         .recent_comparisons
-        .retain(|p| pair_identity(&p.left, &p.right) != identity);
+        .retain(|p| pair_identity(&p.left, &p.right, p.mode) != identity);
     state
         .recent_comparisons
-        .insert(0, DisplayPathPairV1 { left, right });
+        .insert(0, DisplayPathPairV1 { left, right, mode });
     state
         .recent_comparisons
         .truncate(state.config.max_recent_comparisons);
+}
+pub fn clear_recents(state: &mut DiffPersistenceV1) {
+    state.recent_comparisons.clear();
 }
 pub fn deduplicate_rule_ids(state: &mut DiffPersistenceV1) {
     fn retain_unique<T>(values: &mut Vec<T>, id: impl Fn(&T) -> &str) {
@@ -114,11 +190,158 @@ pub fn deduplicate_rule_ids(state: &mut DiffPersistenceV1) {
     retain_unique(&mut state.replacement_rules, |r| &r.id);
     retain_unique(&mut state.unimportant_section_rules, |r| &r.id);
 }
-fn pair_identity(left: &str, right: &str) -> (String, String) {
+fn pair_identity(
+    left: &str,
+    right: &str,
+    mode: ComparisonModeV1,
+) -> (String, String, ComparisonModeV1) {
     (
         normalize_path(left).to_string_lossy().to_lowercase(),
         normalize_path(right).to_string_lossy().to_lowercase(),
+        mode,
     )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionError {
+    DuplicateName(String),
+    NotFound(String),
+    InvalidRule(String),
+    InvalidPath(String),
+}
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateName(n) => write!(f, "a session named '{n}' already exists"),
+            Self::NotFound(id) => write!(f, "session '{id}' was not found"),
+            Self::InvalidRule(e) => write!(f, "invalid rule: {e}"),
+            Self::InvalidPath(e) => write!(f, "cannot reopen session: {e}"),
+        }
+    }
+}
+impl std::error::Error for SessionError {}
+
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(1);
+pub fn new_session_id() -> String {
+    let n = NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("session-{nanos:032x}-{n:016x}")
+}
+pub fn validate_rules(
+    replacements: &[ReplacementRuleV1],
+    sections: &[UnimportantSectionRuleV1],
+) -> Result<(), SessionError> {
+    let mut ids = HashSet::new();
+    for r in replacements {
+        if !ids.insert(r.id.as_str()) {
+            return Err(SessionError::InvalidRule(format!(
+                "duplicate rule id '{}'",
+                r.id
+            )));
+        }
+        regex::Regex::new(&r.pattern)
+            .map_err(|e| SessionError::InvalidRule(format!("{}: {e}", r.pattern)))?;
+    }
+    for r in sections {
+        if !ids.insert(r.id.as_str()) {
+            return Err(SessionError::InvalidRule(format!(
+                "duplicate rule id '{}'",
+                r.id
+            )));
+        }
+        regex::Regex::new(&r.pattern)
+            .map_err(|e| SessionError::InvalidRule(format!("{}: {e}", r.pattern)))?;
+    }
+    Ok(())
+}
+pub fn insert_session(
+    state: &mut DiffPersistenceV1,
+    mut session: SavedDiffSessionV1,
+) -> Result<String, SessionError> {
+    validate_rules(
+        &session.replacement_rules,
+        &session.unimportant_section_rules,
+    )?;
+    if state
+        .named_sessions
+        .iter()
+        .any(|s| s.name.eq_ignore_ascii_case(&session.name))
+    {
+        return Err(SessionError::DuplicateName(session.name));
+    }
+    if session.id.is_empty() {
+        session.id = new_session_id();
+    }
+    let id = session.id.clone();
+    state.named_sessions.push(session);
+    Ok(id)
+}
+pub fn rename_session(
+    state: &mut DiffPersistenceV1,
+    id: &str,
+    name: String,
+) -> Result<(), SessionError> {
+    if state
+        .named_sessions
+        .iter()
+        .any(|s| s.id != id && s.name.eq_ignore_ascii_case(&name))
+    {
+        return Err(SessionError::DuplicateName(name));
+    }
+    let s = state
+        .named_sessions
+        .iter_mut()
+        .find(|s| s.id == id)
+        .ok_or_else(|| SessionError::NotFound(id.into()))?;
+    s.name = name;
+    Ok(())
+}
+pub fn delete_session(
+    state: &mut DiffPersistenceV1,
+    id: &str,
+) -> Result<SavedDiffSessionV1, SessionError> {
+    let i = state
+        .named_sessions
+        .iter()
+        .position(|s| s.id == id)
+        .ok_or_else(|| SessionError::NotFound(id.into()))?;
+    Ok(state.named_sessions.remove(i))
+}
+/// Apply and persist as one logical operation. The caller's state is replaced
+/// only after the atomic file write succeeds.
+pub fn update_atomic(
+    path: &Path,
+    state: &mut DiffPersistenceV1,
+    change: impl FnOnce(&mut DiffPersistenceV1) -> Result<(), SessionError>,
+) -> anyhow::Result<()> {
+    let mut candidate = state.clone();
+    change(&mut candidate).map_err(anyhow::Error::new)?;
+    save(path, &candidate)?;
+    *state = candidate;
+    Ok(())
+}
+/// Validate sources at reopen time. Contents/results are absent from the
+/// persisted type and therefore necessarily recomputed by the workspace.
+pub fn reopen_session(session: &SavedDiffSessionV1) -> Result<(String, String), SessionError> {
+    let l = normalize_path(&session.left);
+    let r = normalize_path(&session.right);
+    let lm = std::fs::metadata(&l)
+        .map_err(|e| SessionError::InvalidPath(format!("{}: {e}", l.display())))?;
+    let rm = std::fs::metadata(&r)
+        .map_err(|e| SessionError::InvalidPath(format!("{}: {e}", r.display())))?;
+    let valid = match session.comparison_mode {
+        ComparisonModeV1::Text => lm.is_file() && rm.is_file(),
+        ComparisonModeV1::Folder => lm.is_dir() && rm.is_dir(),
+    };
+    if !valid {
+        return Err(SessionError::InvalidPath(
+            "saved comparison mode no longer matches its paths".into(),
+        ));
+    }
+    Ok((session.left.clone(), session.right.clone()))
 }
 
 #[cfg(test)]

--- a/src/diff/watch.rs
+++ b/src/diff/watch.rs
@@ -1,0 +1,344 @@
+//! Filesystem watching and external-change arbitration for diff views.
+//!
+//! The types in this module deliberately do not depend on egui.  `WatchSet`
+//! adapts `notify`, while `EventCoalescer` and `ExternalDocument` can be driven
+//! by fake events in deterministic tests.
+
+use crate::diff::text_file::{FileIdentity, LoadedTextFile, load_text_file};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WatchTag {
+    pub workspace: u64,
+    pub view: u64,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchScope {
+    File,
+    Root,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchEvent {
+    pub tag: WatchTag,
+    /// The watched file, or the recursive root (never a transient spelling
+    /// supplied by a backend).
+    pub identity_path: PathBuf,
+    pub paths: Vec<PathBuf>,
+    pub scope: WatchScope,
+}
+
+/// Owns exactly one backend watcher for a view. Dropping or replacing it tears
+/// down all registrations, preventing old sessions from delivering events.
+pub struct WatchSet {
+    watcher: RecommendedWatcher,
+    receiver: Receiver<notify::Result<Event>>,
+    tag: WatchTag,
+    registrations: Vec<(PathBuf, WatchScope)>,
+}
+impl WatchSet {
+    pub fn files(tag: WatchTag, paths: impl IntoIterator<Item = PathBuf>) -> notify::Result<Self> {
+        Self::new(tag, paths.into_iter().map(|p| (p, WatchScope::File)))
+    }
+    pub fn roots(tag: WatchTag, roots: impl IntoIterator<Item = PathBuf>) -> notify::Result<Self> {
+        Self::new(tag, roots.into_iter().map(|p| (p, WatchScope::Root)))
+    }
+    fn new(
+        tag: WatchTag,
+        values: impl IntoIterator<Item = (PathBuf, WatchScope)>,
+    ) -> notify::Result<Self> {
+        let (tx, receiver) = mpsc::channel();
+        let mut watcher = notify::recommended_watcher(move |e| {
+            let _ = tx.send(e);
+        })?;
+        let mut registrations = Vec::new();
+        for (path, scope) in values {
+            let path = normalize_absolute(&path);
+            watcher.watch(
+                &path,
+                if scope == WatchScope::Root {
+                    RecursiveMode::Recursive
+                } else {
+                    RecursiveMode::NonRecursive
+                },
+            )?;
+            registrations.push((path, scope));
+        }
+        Ok(Self {
+            watcher,
+            receiver,
+            tag,
+            registrations,
+        })
+    }
+    pub fn tag(&self) -> WatchTag {
+        self.tag
+    }
+    pub fn try_events(&self) -> Vec<notify::Result<WatchEvent>> {
+        self.receiver
+            .try_iter()
+            .map(|result| result.map(|event| self.map_event(event)))
+            .collect()
+    }
+    fn map_event(&self, event: Event) -> WatchEvent {
+        let normalized: Vec<_> = event.paths.iter().map(|p| normalize_absolute(p)).collect();
+        let registration = self
+            .registrations
+            .iter()
+            .find(|(watched, scope)| match scope {
+                WatchScope::File => normalized
+                    .iter()
+                    .any(|p| p == watched || p.parent() == watched.parent()),
+                WatchScope::Root => normalized.iter().any(|p| p.starts_with(watched)),
+            })
+            .or_else(|| self.registrations.first());
+        let (identity_path, scope) = registration
+            .cloned()
+            .unwrap_or((PathBuf::new(), WatchScope::File));
+        let paths = normalized
+            .into_iter()
+            .filter(|p| match scope {
+                WatchScope::File => p == &identity_path,
+                WatchScope::Root => p.starts_with(&identity_path),
+            })
+            .collect();
+        WatchEvent {
+            tag: self.tag,
+            identity_path,
+            paths,
+            scope,
+        }
+    }
+}
+impl Drop for WatchSet {
+    fn drop(&mut self) {
+        for (p, _) in &self.registrations {
+            let _ = self.watcher.unwatch(p);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EventCoalescer {
+    delay: Duration,
+    pending: HashMap<(WatchTag, PathBuf), Pending>,
+}
+#[derive(Debug)]
+struct Pending {
+    deadline: Instant,
+    scope: WatchScope,
+    paths: BTreeSet<PathBuf>,
+}
+impl EventCoalescer {
+    pub fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            pending: HashMap::new(),
+        }
+    }
+    pub fn push(&mut self, now: Instant, event: WatchEvent) {
+        let p = self
+            .pending
+            .entry((event.tag, event.identity_path))
+            .or_insert_with(|| Pending {
+                deadline: now + self.delay,
+                scope: event.scope,
+                paths: BTreeSet::new(),
+            });
+        p.deadline = now + self.delay;
+        p.paths.extend(event.paths);
+    }
+    pub fn drain_ready(&mut self, now: Instant, current: WatchTag) -> Vec<WatchEvent> {
+        let keys: Vec<_> = self
+            .pending
+            .iter()
+            .filter(|((tag, _), p)| *tag != current || p.deadline <= now)
+            .map(|(k, _)| k.clone())
+            .collect();
+        keys.into_iter()
+            .filter_map(|key| {
+                let pending = self.pending.remove(&key)?;
+                if key.0 != current {
+                    return None;
+                }
+                Some(WatchEvent {
+                    tag: key.0,
+                    identity_path: key.1,
+                    paths: pending.paths.into_iter().collect(),
+                    scope: pending.scope,
+                })
+            })
+            .collect()
+    }
+    pub fn clear(&mut self) {
+        self.pending.clear();
+    }
+}
+
+/// Returns the smallest relative subtree containing all affected paths.
+pub fn affected_subtree(root: &Path, paths: &[PathBuf]) -> Option<PathBuf> {
+    let mut rels = paths
+        .iter()
+        .filter_map(|p| p.strip_prefix(root).ok())
+        .map(|p| {
+            if p.extension().is_some() {
+                p.parent().unwrap_or(Path::new(""))
+            } else {
+                p
+            }
+        })
+        .map(Path::to_path_buf);
+    let first = rels.next()?;
+    Some(rels.fold(first, common_ancestor))
+}
+fn common_ancestor(a: PathBuf, b: PathBuf) -> PathBuf {
+    a.components()
+        .zip(b.components())
+        .take_while(|(x, y)| x == y)
+        .fold(PathBuf::new(), |mut p, (c, _)| {
+            p.push(c.as_os_str());
+            p
+        })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalState {
+    Current,
+    Reloading,
+    Conflict,
+    Missing(String),
+}
+#[derive(Debug, Clone)]
+pub struct ReloadTicket {
+    pub revision: u64,
+    pub path: PathBuf,
+    pub tag: WatchTag,
+}
+#[derive(Debug, Clone)]
+pub struct ExternalDocument {
+    pub path: PathBuf,
+    pub identity: Option<FileIdentity>,
+    pub revision: u64,
+    pub dirty: bool,
+    pub state: ExternalState,
+    own_save: Option<FileIdentity>,
+    pub tag: WatchTag,
+}
+impl ExternalDocument {
+    pub fn new(
+        path: PathBuf,
+        identity: Option<FileIdentity>,
+        revision: u64,
+        tag: WatchTag,
+    ) -> Self {
+        Self {
+            path: normalize_absolute(&path),
+            identity,
+            revision,
+            dirty: false,
+            state: ExternalState::Current,
+            own_save: None,
+            tag,
+        }
+    }
+    pub fn record_save(&mut self, identity: FileIdentity) {
+        self.identity = Some(identity.clone());
+        self.own_save = Some(identity);
+        self.dirty = false;
+        self.state = ExternalState::Current;
+    }
+    /// Re-stats after every event. Only the exact identity produced by our save
+    /// is suppressed; elapsed time is intentionally irrelevant.
+    pub fn observe(&mut self) -> Option<ReloadTicket> {
+        match stat_identity(&self.path) {
+            Ok(now) if self.own_save.as_ref() == Some(&now) => {
+                self.own_save = None;
+                self.identity = Some(now);
+                None
+            }
+            Ok(now) if self.identity.as_ref() == Some(&now) => None,
+            Ok(_) if self.dirty => {
+                self.state = ExternalState::Conflict;
+                None
+            }
+            Ok(_) => {
+                self.state = ExternalState::Reloading;
+                Some(self.ticket())
+            }
+            Err(e) => {
+                self.state = ExternalState::Missing(e.to_string());
+                None
+            }
+        }
+    }
+    pub fn ticket(&self) -> ReloadTicket {
+        ReloadTicket {
+            revision: self.revision,
+            path: self.path.clone(),
+            tag: self.tag,
+        }
+    }
+    pub fn accept_reload(&mut self, ticket: &ReloadTicket, loaded: &LoadedTextFile) -> bool {
+        if ticket.revision != self.revision
+            || ticket.path != self.path
+            || ticket.tag != self.tag
+            || self.dirty
+        {
+            return false;
+        }
+        self.identity = Some(loaded.identity.clone());
+        self.state = ExternalState::Current;
+        true
+    }
+    pub fn keep_buffer(&mut self) {
+        self.state = ExternalState::Conflict;
+    }
+    pub fn change_context(&mut self, path: PathBuf, tag: WatchTag) {
+        self.path = normalize_absolute(&path);
+        self.tag = tag;
+        self.own_save = None;
+        self.state = ExternalState::Current;
+    }
+    pub fn load(ticket: &ReloadTicket) -> io::Result<LoadedTextFile> {
+        load_text_file(&ticket.path)
+    }
+}
+pub fn stat_identity(path: &Path) -> io::Result<FileIdentity> {
+    let m = fs::metadata(path)?;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+    Ok(FileIdentity {
+        size: m.len(),
+        modified: m.modified().ok(),
+        #[cfg(unix)]
+        device: m.dev(),
+        #[cfg(unix)]
+        inode: m.ino(),
+    })
+}
+fn normalize_absolute(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(path)
+    };
+    let mut out = PathBuf::new();
+    for c in absolute.components() {
+        match c {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            _ => out.push(c.as_os_str()),
+        }
+    }
+    out
+}

--- a/tests/diff_sessions.rs
+++ b/tests/diff_sessions.rs
@@ -1,0 +1,93 @@
+use multi_launcher::diff::persistence::*;
+
+fn session(name: &str) -> SavedDiffSessionV1 {
+    SavedDiffSessionV1 {
+        name: name.into(),
+        left: "left".into(),
+        right: "right".into(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn sessions_have_stable_ids_and_explicit_duplicate_names() {
+    let mut p = DiffPersistenceV1::default();
+    let id = insert_session(&mut p, session("Work")).unwrap();
+    assert!(!id.is_empty());
+    assert!(matches!(
+        insert_session(&mut p, session("work")),
+        Err(SessionError::DuplicateName(_))
+    ));
+    rename_session(&mut p, &id, "Renamed".into()).unwrap();
+    assert_eq!(p.named_sessions[0].id, id);
+    assert_eq!(delete_session(&mut p, &id).unwrap().name, "Renamed");
+}
+
+#[test]
+fn session_roundtrip_rules_and_unsupported_data() {
+    let d = tempfile::tempdir().unwrap();
+    let path = d.path().join("sessions.json");
+    let mut p = DiffPersistenceV1::default();
+    let mut s = session("rules");
+    s.replacement_rules = vec![crate_rule("b"), crate_rule("a")];
+    insert_session(&mut p, s).unwrap();
+    save(&path, &p).unwrap();
+    let loaded = load(&path).unwrap().unwrap();
+    assert_eq!(
+        loaded.named_sessions[0]
+            .replacement_rules
+            .iter()
+            .map(|r| r.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b", "a"]
+    );
+    std::fs::write(&path, r#"{"version":999,"future":"preserve me"}"#).unwrap();
+    assert!(matches!(
+        load(&path),
+        Err(LoadError::UnsupportedVersion(999))
+    ));
+    assert!(
+        std::fs::read_to_string(path)
+            .unwrap()
+            .contains("preserve me")
+    );
+}
+fn crate_rule(id: &str) -> multi_launcher::diff::settings::ReplacementRuleV1 {
+    multi_launcher::diff::settings::ReplacementRuleV1 {
+        id: id.into(),
+        pattern: "(x)".into(),
+        replacement: "$1".into(),
+        enabled: true,
+    }
+}
+
+#[test]
+fn recents_are_mode_aware_bounded_clearable_and_separate() {
+    let mut p = DiffPersistenceV1::default();
+    p.config.max_recent_comparisons = 2;
+    insert_session(&mut p, session("named")).unwrap();
+    record_recent_mode(&mut p, "a".into(), "b".into(), ComparisonModeV1::Text);
+    record_recent_mode(&mut p, "c".into(), "d".into(), ComparisonModeV1::Text);
+    record_recent_mode(&mut p, "./a".into(), "./b".into(), ComparisonModeV1::Text);
+    assert_eq!(p.recent_comparisons.len(), 2);
+    assert_eq!(p.recent_comparisons[0].left, "./a");
+    clear_recents(&mut p);
+    assert_eq!(p.named_sessions.len(), 1);
+}
+
+#[test]
+fn failed_atomic_update_preserves_memory_and_file() {
+    let d = tempfile::tempdir().unwrap();
+    let target = d.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    let mut p = DiffPersistenceV1::default();
+    assert!(
+        update_atomic(&target, &mut p, |state| {
+            state.named_sessions.push(session("not committed"));
+            Ok(())
+        })
+        .is_err()
+    );
+    assert!(p.named_sessions.is_empty());
+    assert!(target.is_dir());
+}

--- a/tests/diff_watch.rs
+++ b/tests/diff_watch.rs
@@ -1,0 +1,99 @@
+use multi_launcher::diff::watch::*;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+fn tag(generation: u64) -> WatchTag {
+    WatchTag {
+        workspace: 1,
+        view: 2,
+        generation,
+    }
+}
+
+#[test]
+fn coalesces_bursts_and_rejects_stale_generations() {
+    let now = Instant::now();
+    let mut c = EventCoalescer::new(Duration::from_millis(50));
+    for path in ["/root/a.tmp", "/root/a"] {
+        c.push(
+            now,
+            WatchEvent {
+                tag: tag(1),
+                identity_path: "/root".into(),
+                paths: vec![path.into()],
+                scope: WatchScope::Root,
+            },
+        );
+    }
+    assert!(
+        c.drain_ready(now + Duration::from_millis(49), tag(1))
+            .is_empty()
+    );
+    let ready = c.drain_ready(now + Duration::from_millis(50), tag(1));
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].paths.len(), 2);
+    c.push(
+        now,
+        WatchEvent {
+            tag: tag(1),
+            identity_path: "/root".into(),
+            paths: vec!["/root/a".into()],
+            scope: WatchScope::Root,
+        },
+    );
+    assert!(
+        c.drain_ready(now + Duration::from_secs(1), tag(2))
+            .is_empty()
+    );
+}
+
+#[test]
+fn exact_own_save_is_suppressed_but_later_change_is_not() {
+    let d = tempfile::tempdir().unwrap();
+    let p = d.path().join("a");
+    std::fs::write(&p, "one").unwrap();
+    let first = stat_identity(&p).unwrap();
+    let mut doc = ExternalDocument::new(p.clone(), Some(first), 1, tag(1));
+    std::fs::write(&p, "saved-content").unwrap();
+    let saved = stat_identity(&p).unwrap();
+    doc.record_save(saved);
+    assert!(doc.observe().is_none());
+    std::fs::write(&p, "external content with distinct size").unwrap();
+    assert!(doc.observe().is_some());
+    assert_eq!(doc.state, ExternalState::Reloading);
+}
+
+#[test]
+fn dirty_and_removed_files_retain_buffer_state() {
+    let d = tempfile::tempdir().unwrap();
+    let p = d.path().join("a");
+    std::fs::write(&p, "one").unwrap();
+    let mut doc = ExternalDocument::new(p.clone(), Some(stat_identity(&p).unwrap()), 7, tag(1));
+    doc.dirty = true;
+    std::fs::write(&p, "different longer").unwrap();
+    assert!(doc.observe().is_none());
+    assert_eq!(doc.state, ExternalState::Conflict);
+    std::fs::remove_file(&p).unwrap();
+    assert!(doc.observe().is_none());
+    assert!(matches!(doc.state, ExternalState::Missing(_)));
+    assert!(doc.dirty);
+}
+
+#[test]
+fn stale_reload_and_smallest_subtree() {
+    let d = tempfile::tempdir().unwrap();
+    let p = d.path().join("a");
+    std::fs::write(&p, "one").unwrap();
+    let mut doc = ExternalDocument::new(p.clone(), None, 3, tag(1));
+    let ticket = doc.ticket();
+    let loaded = ExternalDocument::load(&ticket).unwrap();
+    doc.revision = 4;
+    assert!(!doc.accept_reload(&ticket, &loaded));
+    assert_eq!(
+        affected_subtree(
+            PathBuf::from("/r").as_path(),
+            &["/r/a/x.txt".into(), "/r/a/y/z.txt".into()]
+        ),
+        Some("a".into())
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide reliable filesystem-watching for diff views that coalesces noisy backend events, maps recursive root events to the smallest affected subtree, and tags events with workspace/view/generation so stale listeners are ignored.
- Track file identity beyond path text so self-saves are suppressed only for the exact produced identity and external changes cause correct reload/conflict state transitions.
- Persist named diff sessions and recents with stable IDs, validation, and atomic updates while avoiding serializing runtime buffers or computed results.

### Description
- Add a notify-backed watcher module `src/diff/watch.rs` implementing `WatchSet` (per-view watcher ownership), `EventCoalescer` (debounce/coalescing by tag+root), `ExternalDocument` (identity-aware external-change state machine), `ReloadTicket`, `affected_subtree` (smallest subtree computation), and helpers for stat/normalization.\
- Expand `src/diff/persistence.rs` with `ComparisonModeV1`/`ContentComparisonModeV1`, extend `SavedDiffSessionV1` to store comparison mode, rule lists, folder filters, content-comparison mode, wrap/syntax/pane settings, and provide `Default`.\
- Add session management APIs: `validate_rules`, `insert_session`, `rename_session`, `delete_session`, stable `new_session_id`, `reopen_session` (validate paths on reopen), and `update_atomic` to apply-and-persist atomically.\
- Make recents mode-aware with `record_recent_mode`/`record_recent`, `clear_recents`, and deduplicated/normalized identity handling.\
- Add deterministic unit tests: `tests/diff_watch.rs` (coalescing, stale-generation rejection, own-save suppression, dirty/missing handling, subtree mapping) and `tests/diff_sessions.rs` (stable IDs, duplicate-name handling, rule round-trip/validation, recents behavior, atomic-update preservation).

### Testing
- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran `git diff --check` (style/whitespace checks) which succeeded. 
- Attempted `cargo test --test diff_watch --test diff_sessions` but the run was blocked by unrelated platform-specific build failures in other parts of the repository (unconditional Windows-only APIs and system library requirements), so the new tests could not be executed to completion in this environment. 
- The added unit tests are deterministic and designed to be runnable with the provided fake-event entrypoints; they should pass once platform/unconditional-API compilation blockers are resolved on the CI runner or a matching host.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a788643e2b083329c1a9867499106de)