### PR TITLE
Complete Diff worker coordination and large-file policy

### DIFF
--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -2,6 +2,39 @@
 
 This checklist covers behavior that depends on a real Windows desktop session, Win32 window handles, UI Automation, global hooks, or foreground-window focus. Keep these checks manual instead of forcing them into CI.
 
+## Diff acceptance matrix (25 criteria)
+
+Use two temporary roots containing text, binary, Unicode, read-only, missing,
+and deliberately large files. Repeat filesystem cases on Windows and Linux.
+
+| # | Scenario | Verify |
+|---:|---|---|
+| 1 | Run `diff`, `diff <left>`, and `diff <left> <right>`. | Start focus and visible path validation are correct; invalid/mixed paths show recoverable errors. |
+| 2 | Press Ctrl+O and choose another pair. | The replacement invalidates the old scan/compare immediately and receives focus. |
+| 3 | Compare equal and changed text. | Raw/rules equality, aligned rows, status, and progress are correct. |
+| 4 | Use F7 and F8. | Previous/next differences wrap and focus the active pane. |
+| 5 | Use both copy-direction actions, then undo. | The selected hunk copies in the requested direction, recomputes, and undo restores it. |
+| 6 | Press Ctrl+S and Ctrl+Shift+S. | Active/all dirty sides save; failures remain dirty with a visible error. |
+| 7 | Press Alt+Left from a folder child. | The exact parent selection, expansion, filter, sort, and scroll state return. |
+| 8 | Use focus-left and focus-right commands. | Keyboard editing moves to the requested pane after every invocation. |
+| 9 | Open a changed file from a folder and use Previous/Next Different File. | Navigation skips identical/filter-hidden files without losing the folder parent. |
+| 10 | Change status/display filters repeatedly. | Retained scan data is filtered without starting another scan. |
+| 11 | Compare roots with repeated directory and filenames. | Expansion, selection, scrolling, and row widgets never share state. |
+| 12 | Scroll very large text and folder results. | Only visible rows plus overscan are created; navigation still spans all retained data. |
+| 13 | Edit while comparison is running. | An old text result never replaces the new document revisions. |
+| 14 | Change include/exclude rules during a scan. | Old batches and content refinements never enter the new root/filter generation. |
+| 15 | Change comparison rules. | Text/content caches invalidate and results report the active rules revision. |
+| 16 | Resize panes, toggle wrapping, font, or theme. | Wrapped/syntax caches update without changing comparison meaning. |
+| 17 | Externally edit a clean file. | The watcher reload is generation checked and comparison refreshes. |
+| 18 | Externally edit a dirty file. | A conflict prompt preserves edits; reload/overwrite/cancel each behaves as labelled. |
+| 19 | Delete or rename an open file externally. | Missing state is visible, recoverable, and stale reloads are rejected. |
+| 20 | Copy one/many folder items in both directions. | Confirmation, containment, per-item cancellation/errors, cache invalidation, and rescan are correct. |
+| 21 | Delete to Recycle Bin and permanently. | The chosen mode is explicit; failures do not claim success; Windows Recycle Bin receives recycled files. |
+| 22 | Open a normal, large, and extremely large text file. | Status explains the active tier; large reduces expensive decoration; extreme is bounded/read-only and never advertises hex editing. |
+| 23 | Compare equal/different binary files. | Byte equality remains available and no text/hex editor is implied. |
+| 24 | Close Diff during scan/read/hash/mutation, then reopen a session. | Senders/watchers release promptly, no old event updates the new view, and focus is restored. |
+| 25 | Exercise permission errors, locked destinations, invalid regex, malformed UTF-8, UTF-16 save, symlink/reparse escape, and disk-full simulation. | Each failure is scoped and actionable; data is retained, atomic overwrite is used, and unrelated launcher plugins/routing still work. |
+
 ## MultiManager Win32 workflow
 
 1. Start Multi Launcher on Windows with at least two normal desktop applications open, such as Notepad and Windows Terminal.

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -352,6 +352,7 @@ pub struct TextViewModel {
     pub current_row: Option<usize>,
     pub wrap: bool,
     pub syntax: bool,
+    pub large_file_tier: crate::diff::worker::LargeFileTier,
     pub splitter: f32,
     pub recalculate_at: Option<Instant>,
     pub recalculating: bool,
@@ -384,6 +385,15 @@ impl TextViewModel {
             } else {
                 settings.wrap_text
             };
+        let bytes = left.source().len().saturating_add(right.source().len()) as u64;
+        let estimated_rows =
+            left.source()
+                .bytes()
+                .filter(|b| *b == b'\n')
+                .count()
+                .max(right.source().bytes().filter(|b| *b == b'\n').count()) as u64
+                + 1;
+        let large_file_tier = settings.large_file_policy().tier(bytes, estimated_rows);
         let mut out = Self {
             left_path: state.left.clone(),
             right_path: state.right.clone(),
@@ -394,7 +404,8 @@ impl TextViewModel {
             active_side: DiffSide::Left,
             current_row: None,
             wrap,
-            syntax: settings.syntax_highlighting,
+            syntax: settings.syntax_highlighting && large_file_tier.syntax_enabled(),
+            large_file_tier,
             splitter: validated_splitter(settings.pane_split),
             recalculate_at: Some(Instant::now()),
             recalculating: true,
@@ -488,6 +499,9 @@ impl TextViewModel {
         changed
     }
     pub fn copy_hunk(&mut self, from: DiffSide) -> Result<(), String> {
+        if !self.large_file_tier.editable() {
+            return Err(self.large_file_tier.explanation().into());
+        }
         if self.external_conflict != [false, false] {
             return Err("Resolve external-change conflict before merging".into());
         }

--- a/src/diff/settings.rs
+++ b/src/diff/settings.rs
@@ -13,6 +13,12 @@ pub struct DiffConfigV1 {
     pub ignore_whitespace: bool,
     pub case_sensitive: bool,
     pub max_recent_comparisons: usize,
+    /// Files at or above either byte/estimated-row threshold use the reduced
+    /// large-file presentation. These are deliberately user configurable.
+    pub large_file_bytes: u64,
+    pub extreme_file_bytes: u64,
+    pub large_file_estimated_rows: u64,
+    pub extreme_file_estimated_rows: u64,
 }
 
 impl Default for DiffConfigV1 {
@@ -26,6 +32,23 @@ impl Default for DiffConfigV1 {
             ignore_whitespace: false,
             case_sensitive: true,
             max_recent_comparisons: 20,
+            large_file_bytes: 8 * 1024 * 1024,
+            extreme_file_bytes: 128 * 1024 * 1024,
+            large_file_estimated_rows: 200_000,
+            extreme_file_estimated_rows: 2_000_000,
+        }
+    }
+}
+
+impl DiffConfigV1 {
+    pub fn large_file_policy(&self) -> crate::diff::worker::LargeFilePolicy {
+        crate::diff::worker::LargeFilePolicy {
+            large_bytes: self.large_file_bytes,
+            extreme_bytes: self.extreme_file_bytes.max(self.large_file_bytes),
+            large_estimated_rows: self.large_file_estimated_rows,
+            extreme_estimated_rows: self
+                .extreme_file_estimated_rows
+                .max(self.large_file_estimated_rows),
         }
     }
 }

--- a/src/diff/worker.rs
+++ b/src/diff/worker.rs
@@ -1,7 +1,626 @@
-//! Background comparison job primitives. Actual jobs are introduced separately.
+//! Shared coordination primitives for every asynchronous Diff operation.
+//!
+//! Workers are deliberately unaware of egui.  [`ResultSender`] invokes the
+//! application's repaint callback after enqueueing an event, which keeps tests
+//! deterministic and avoids passing an `egui::Context` into filesystem code.
+
+use crate::diff::file_ops::{CopyDirection, DeleteMode};
+use crate::diff::folder_compare::{EntryMetadata, FolderStatus};
+use crate::diff::folder_scan::{DiscoveredEntry, RootIdentity, ScanRules};
+use crate::diff::model::DiffSide;
+use crate::diff::syntax::HighlightFragment;
+use crate::diff::text_compare::{TextComparisonResult, TextComparisonRules};
+use crate::diff::text_file::LoadedTextFile;
+use crate::diff::watch::WatchEvent;
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+use std::io::{self, Read};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+pub const DEFAULT_RESULT_CAPACITY: usize = 64;
+pub const DEFAULT_BATCH_ENTRIES: usize = 128;
+pub const IO_CANCELLATION_CHUNK: usize = 256 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DiffProgress {
     pub completed: u64,
     pub total: Option<u64>,
+}
+
+/// Identity shared by requests and results. Request ids never repeat within a
+/// coordinator; generations identify the model which is allowed to consume it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct JobTag {
+    pub request_id: u64,
+    pub workspace_id: u64,
+    pub view_id: u64,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LargeFileTier {
+    /// Editable alignment, syntax highlighting, and intraline comparison.
+    Normal,
+    /// Still editable/comparable, with syntax and intraline work reduced.
+    Large,
+    /// Bounded read-only comparison; this is not a hex editor.
+    Extreme,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LargeFilePolicy {
+    pub large_bytes: u64,
+    pub extreme_bytes: u64,
+    pub large_estimated_rows: u64,
+    pub extreme_estimated_rows: u64,
+}
+
+impl Default for LargeFilePolicy {
+    fn default() -> Self {
+        Self {
+            large_bytes: 8 * 1024 * 1024,
+            extreme_bytes: 128 * 1024 * 1024,
+            large_estimated_rows: 200_000,
+            extreme_estimated_rows: 2_000_000,
+        }
+    }
+}
+
+impl LargeFilePolicy {
+    pub fn tier(&self, bytes: u64, estimated_rows: u64) -> LargeFileTier {
+        if bytes >= self.extreme_bytes || estimated_rows >= self.extreme_estimated_rows {
+            LargeFileTier::Extreme
+        } else if bytes >= self.large_bytes || estimated_rows >= self.large_estimated_rows {
+            LargeFileTier::Large
+        } else {
+            LargeFileTier::Normal
+        }
+    }
+}
+
+impl LargeFileTier {
+    pub fn editable(self) -> bool {
+        self != Self::Extreme
+    }
+    pub fn syntax_enabled(self) -> bool {
+        self == Self::Normal
+    }
+    pub fn intraline_enabled(self) -> bool {
+        self == Self::Normal
+    }
+    pub fn explanation(self) -> &'static str {
+        match self {
+            Self::Normal => "Full editable comparison",
+            Self::Large => "Large file: syntax and intraline comparison are reduced",
+            Self::Extreme => "Extremely large file: bounded read-only comparison (no hex editing)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FilterIdentity {
+    pub revision: u64,
+    pub includes: Vec<String>,
+    pub excludes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum DiffRequest {
+    Load {
+        tag: JobTag,
+        side: DiffSide,
+        path: PathBuf,
+        tier_policy: LargeFilePolicy,
+    },
+    CompareText {
+        tag: JobTag,
+        left: Arc<str>,
+        right: Arc<str>,
+        key: TextResultKey,
+        rules: TextComparisonRules,
+    },
+    ScanFolder {
+        tag: JobTag,
+        root: RootIdentity,
+        filter: FilterIdentity,
+        rules: ScanRules,
+    },
+    RefineContent {
+        tag: JobTag,
+        key: FolderContentKey,
+        rules: TextComparisonRules,
+    },
+    Syntax {
+        tag: JobTag,
+        key: SyntaxKey,
+        source: Arc<str>,
+    },
+    Reload {
+        tag: JobTag,
+        event: WatchEvent,
+    },
+    Copy {
+        tag: JobTag,
+        direction: CopyDirection,
+        items: Vec<PathBuf>,
+    },
+    Delete {
+        tag: JobTag,
+        mode: DeleteMode,
+        items: Vec<PathBuf>,
+    },
+}
+
+impl DiffRequest {
+    pub fn tag(&self) -> JobTag {
+        match self {
+            Self::Load { tag, .. }
+            | Self::CompareText { tag, .. }
+            | Self::ScanFolder { tag, .. }
+            | Self::RefineContent { tag, .. }
+            | Self::Syntax { tag, .. }
+            | Self::Reload { tag, .. }
+            | Self::Copy { tag, .. }
+            | Self::Delete { tag, .. } => *tag,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DiffResult {
+    Loaded {
+        tag: JobTag,
+        side: DiffSide,
+        document_revision: u64,
+        tier: LargeFileTier,
+        file: Arc<LoadedTextFile>,
+    },
+    TextCompared {
+        tag: JobTag,
+        key: TextResultKey,
+        tier: LargeFileTier,
+        result: Arc<TextComparisonResult>,
+    },
+    FolderBatch {
+        tag: JobTag,
+        root: RootIdentity,
+        filter: FilterIdentity,
+        entries: Vec<DiscoveredEntry>,
+        complete: bool,
+    },
+    ContentRefined {
+        tag: JobTag,
+        key: FolderContentKey,
+        status: FolderStatus,
+    },
+    SyntaxReady {
+        tag: JobTag,
+        key: SyntaxKey,
+        fragments: Arc<[HighlightFragment]>,
+    },
+    Reloaded {
+        tag: JobTag,
+        event: WatchEvent,
+        document_revision: Option<u64>,
+    },
+    MutationItem {
+        tag: JobTag,
+        path: PathBuf,
+        operation: MutationKind,
+        result: Result<(), String>,
+    },
+    Progress {
+        tag: JobTag,
+        progress: DiffProgress,
+    },
+    Cancelled {
+        tag: JobTag,
+    },
+    Failed {
+        tag: JobTag,
+        message: String,
+    },
+}
+
+impl DiffResult {
+    pub fn tag(&self) -> JobTag {
+        match self {
+            Self::Loaded { tag, .. }
+            | Self::TextCompared { tag, .. }
+            | Self::FolderBatch { tag, .. }
+            | Self::ContentRefined { tag, .. }
+            | Self::SyntaxReady { tag, .. }
+            | Self::Reloaded { tag, .. }
+            | Self::MutationItem { tag, .. }
+            | Self::Progress { tag, .. }
+            | Self::Cancelled { tag }
+            | Self::Failed { tag, .. } => *tag,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutationKind {
+    Copy,
+    Delete,
+}
+
+/// The single stale-result predicate used by all consumers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Acceptance {
+    pub workspace_id: u64,
+    pub view_id: u64,
+    pub generation: u64,
+    pub text_key: Option<TextResultKey>,
+    pub root: Option<RootIdentity>,
+    pub filter: Option<FilterIdentity>,
+}
+
+impl Acceptance {
+    pub fn accepts_tag(&self, tag: JobTag) -> bool {
+        tag.workspace_id == self.workspace_id
+            && tag.view_id == self.view_id
+            && tag.generation == self.generation
+    }
+    pub fn accepts(&self, result: &DiffResult) -> bool {
+        if !self.accepts_tag(result.tag()) {
+            return false;
+        }
+        match result {
+            DiffResult::TextCompared { key, result, .. } => {
+                self.text_key.as_ref() == Some(key)
+                    && result.left_revision == key.left_revision
+                    && result.right_revision == key.right_revision
+                    && result.rules_revision == key.rules_revision
+            }
+            DiffResult::FolderBatch { root, filter, .. } => {
+                self.root.as_ref() == Some(root) && self.filter.as_ref() == Some(filter)
+            }
+            DiffResult::ContentRefined { key, .. } => {
+                self.root.as_ref().is_some_and(|r| key.belongs_to(r))
+            }
+            DiffResult::Reloaded { event, .. } => {
+                event.tag.workspace == self.workspace_id
+                    && event.tag.view == self.view_id
+                    && event.tag.generation == self.generation
+            }
+            _ => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TextResultKey {
+    pub left_revision: u64,
+    pub right_revision: u64,
+    pub rules_revision: u64,
+    pub algorithm: String,
+    pub tier: LargeFileTier,
+    pub intraline_limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SyntaxKey {
+    pub document_revision: u64,
+    pub language: String,
+    pub theme: String,
+    pub source_start_line: usize,
+    pub source_end_line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FolderContentKey {
+    pub root: RootIdentity,
+    pub left_path: PathBuf,
+    pub right_path: PathBuf,
+    pub left_metadata: EntryMetadata,
+    pub right_metadata: EntryMetadata,
+}
+impl FolderContentKey {
+    fn belongs_to(&self, root: &RootIdentity) -> bool {
+        &self.root == root
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WrappedLayoutKey {
+    pub comparison_revision: u64,
+    pub left_revision: u64,
+    pub right_revision: u64,
+    pub pane_width_bits: u32,
+    pub font_id: String,
+    pub theme: String,
+    pub wrap: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CancellationToken(Arc<AtomicBool>);
+impl CancellationToken {
+    fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+    /// Workers call this between directory visits, batches, read/hash chunks,
+    /// comparisons, and individual mutation items.
+    pub fn checkpoint(&self) -> Result<(), Cancelled> {
+        if self.is_cancelled() {
+            Err(Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cancelled;
+
+/// Read with cancellation checkpoints between bounded chunks. `max_bytes` is
+/// used by the extreme tier to retain only a bounded preview.
+pub fn read_cancellable(
+    mut reader: impl Read,
+    token: &CancellationToken,
+    max_bytes: Option<usize>,
+) -> io::Result<Vec<u8>> {
+    let limit = max_bytes.unwrap_or(usize::MAX);
+    let mut bytes = Vec::with_capacity(limit.min(IO_CANCELLATION_CHUNK));
+    let mut chunk = vec![0; IO_CANCELLATION_CHUNK.min(limit.max(1))];
+    while bytes.len() < limit {
+        token
+            .checkpoint()
+            .map_err(|_| io::Error::new(io::ErrorKind::Interrupted, "Diff job cancelled"))?;
+        let wanted = chunk.len().min(limit - bytes.len());
+        let n = reader.read(&mut chunk[..wanted])?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..n]);
+    }
+    Ok(bytes)
+}
+
+/// Deterministic chunked byte equality which never needs two complete copies.
+pub fn byte_equal_cancellable(
+    mut left: impl Read,
+    mut right: impl Read,
+    token: &CancellationToken,
+) -> io::Result<bool> {
+    let mut a = vec![0; IO_CANCELLATION_CHUNK];
+    let mut b = vec![0; IO_CANCELLATION_CHUNK];
+    loop {
+        token
+            .checkpoint()
+            .map_err(|_| io::Error::new(io::ErrorKind::Interrupted, "Diff job cancelled"))?;
+        let an = left.read(&mut a)?;
+        let bn = right.read(&mut b)?;
+        if an != bn || a[..an] != b[..bn] {
+            return Ok(false);
+        }
+        if an == 0 {
+            return Ok(true);
+        }
+    }
+}
+
+/// Splits high-volume results into a documented maximum without cloning the
+/// entries. Callers checkpoint between calls to `next`/emissions.
+pub fn bounded_batches<T>(items: Vec<T>, batch_size: usize) -> impl Iterator<Item = Vec<T>> {
+    let mut items: VecDeque<T> = items.into();
+    let size = batch_size.max(1);
+    std::iter::from_fn(move || {
+        if items.is_empty() {
+            return None;
+        }
+        Some(items.drain(..size.min(items.len())).collect())
+    })
+}
+
+/// Generates ids and invalidates replacement jobs synchronously.
+pub struct JobCoordinator {
+    next_request: AtomicU64,
+    generation: AtomicU64,
+    active: Mutex<Option<CancellationToken>>,
+}
+impl Default for JobCoordinator {
+    fn default() -> Self {
+        Self {
+            next_request: AtomicU64::new(1),
+            generation: AtomicU64::new(0),
+            active: Mutex::new(None),
+        }
+    }
+}
+impl JobCoordinator {
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+    pub fn start(&self, workspace_id: u64, view_id: u64) -> (JobTag, CancellationToken) {
+        let mut active = self.active.lock().unwrap();
+        if let Some(old) = active.take() {
+            old.cancel();
+        }
+        let generation = self.generation.fetch_add(1, Ordering::AcqRel) + 1;
+        let token = CancellationToken::new();
+        *active = Some(token.clone());
+        let request_id = self.next_request.fetch_add(1, Ordering::Relaxed);
+        (
+            JobTag {
+                request_id,
+                workspace_id,
+                view_id,
+                generation,
+            },
+            token,
+        )
+    }
+    pub fn cancel_and_invalidate(&self) {
+        if let Some(token) = self.active.lock().unwrap().take() {
+            token.cancel();
+        }
+        self.generation.fetch_add(1, Ordering::AcqRel);
+    }
+}
+impl Drop for JobCoordinator {
+    fn drop(&mut self) {
+        if let Ok(Some(t)) = self.active.get_mut() {
+            t.cancel();
+        }
+    }
+}
+
+/// Bounded result queue. Dropping the receiver makes producers release their
+/// payloads rather than retaining source buffers after Diff closes.
+pub struct ResultSender {
+    sender: mpsc::SyncSender<DiffResult>,
+    repaint: Arc<dyn Fn() + Send + Sync>,
+}
+pub struct ResultReceiver {
+    receiver: mpsc::Receiver<DiffResult>,
+}
+pub fn result_channel(
+    capacity: usize,
+    repaint: impl Fn() + Send + Sync + 'static,
+) -> (ResultSender, ResultReceiver) {
+    let (sender, receiver) = mpsc::sync_channel(capacity.max(1));
+    (
+        ResultSender {
+            sender,
+            repaint: Arc::new(repaint),
+        },
+        ResultReceiver { receiver },
+    )
+}
+impl Clone for ResultSender {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            repaint: self.repaint.clone(),
+        }
+    }
+}
+impl ResultSender {
+    pub fn send(&self, result: DiffResult, cancel: &CancellationToken) -> Result<(), DiffResult> {
+        if cancel.is_cancelled() {
+            return Err(result);
+        }
+        match self.sender.try_send(result) {
+            Ok(()) => {
+                (self.repaint)();
+                Ok(())
+            }
+            Err(mpsc::TrySendError::Full(v)) | Err(mpsc::TrySendError::Disconnected(v)) => Err(v),
+        }
+    }
+}
+impl ResultReceiver {
+    pub fn try_iter(&self) -> mpsc::TryIter<'_, DiffResult> {
+        self.receiver.try_iter()
+    }
+}
+
+/// Entry-and-byte bounded LRU cache used by text, syntax, content, and layout
+/// owners. `weight` lets callers account for retained rows/fragments/bytes.
+pub struct BoundedCache<K, V> {
+    values: HashMap<K, (V, usize)>,
+    order: VecDeque<K>,
+    max_entries: usize,
+    max_weight: usize,
+    weight: usize,
+}
+impl<K: Eq + Hash + Clone, V> BoundedCache<K, V> {
+    pub fn new(max_entries: usize, max_weight: usize) -> Self {
+        Self {
+            values: HashMap::new(),
+            order: VecDeque::new(),
+            max_entries: max_entries.max(1),
+            max_weight: max_weight.max(1),
+            weight: 0,
+        }
+    }
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        if self.values.contains_key(key) {
+            self.order.retain(|k| k != key);
+            self.order.push_back(key.clone());
+        }
+        self.values.get(key).map(|x| &x.0)
+    }
+    pub fn insert(&mut self, key: K, value: V, weight: usize) {
+        if let Some((_, old)) = self.values.remove(&key) {
+            self.weight = self.weight.saturating_sub(old);
+            self.order.retain(|k| k != &key);
+        }
+        self.weight = self.weight.saturating_add(weight);
+        self.order.push_back(key.clone());
+        self.values.insert(key, (value, weight));
+        while self.values.len() > self.max_entries || self.weight > self.max_weight {
+            if let Some(k) = self.order.pop_front() {
+                if let Some((_, w)) = self.values.remove(&k) {
+                    self.weight = self.weight.saturating_sub(w);
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    pub fn clear(&mut self) {
+        self.values.clear();
+        self.order.clear();
+        self.weight = 0;
+    }
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn replacement_cancels_and_changes_generation() {
+        let c = JobCoordinator::default();
+        let (a, ca) = c.start(1, 2);
+        let (b, _) = c.start(1, 2);
+        assert!(ca.is_cancelled());
+        assert!(b.request_id > a.request_id && b.generation > a.generation);
+    }
+    #[test]
+    fn tiers_consider_bytes_and_rows() {
+        let p = LargeFilePolicy::default();
+        assert_eq!(p.tier(1, p.large_estimated_rows), LargeFileTier::Large);
+        assert_eq!(p.tier(p.extreme_bytes, 1), LargeFileTier::Extreme);
+        assert!(!LargeFileTier::Extreme.editable());
+    }
+    #[test]
+    fn cache_is_bounded() {
+        let mut c = BoundedCache::new(2, 10);
+        c.insert(1, "a", 4);
+        c.insert(2, "b", 4);
+        let _ = c.get(&1);
+        c.insert(3, "c", 4);
+        assert!(c.get(&2).is_none());
+        assert_eq!(c.len(), 2);
+    }
+    #[test]
+    fn io_and_batches_are_cooperatively_bounded() {
+        let token = CancellationToken::new();
+        assert!(byte_equal_cancellable(&b"same"[..], &b"same"[..], &token).unwrap());
+        assert!(!byte_equal_cancellable(&b"left"[..], &b"right"[..], &token).unwrap());
+        let batches: Vec<_> = bounded_batches((0..1000).collect(), 128).collect();
+        assert_eq!(batches.iter().map(Vec::len).max(), Some(128));
+        token.cancel();
+        assert_eq!(
+            read_cancellable(&b"anything"[..], &token, None)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Interrupted
+        );
+    }
 }

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -29,6 +29,9 @@ impl DiffDialogState {
             .open(&mut open)
             .default_size([900.0, 650.0])
             .show(ctx, |ui| {
+                if ui.input_mut(|i| i.consume_key(egui::Modifiers::ALT, egui::Key::ArrowLeft)) {
+                    self.workspace.back();
+                }
                 ui.horizontal(|ui| {
                     let left = ui.add(
                         egui::TextEdit::singleline(&mut self.workspace.left_visible)
@@ -55,7 +58,12 @@ impl DiffDialogState {
                             self.workspace.right_visible = p.display().to_string();
                         }
                     }
-                    if ui.button("Compare").clicked() {
+                    if ui
+                        .button("Compare")
+                        .on_hover_text("Compare/change paths (Ctrl+O)")
+                        .clicked()
+                        || ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::O))
+                    {
                         let _ = self.workspace.open_paths(
                             self.workspace.left_visible.clone(),
                             self.workspace.right_visible.clone(),

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -28,7 +28,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         let merge = model.comparison.is_some() && !model.external_conflict.iter().any(|x| *x);
         if ui
             .add_enabled(merge, egui::Button::new("Copy →"))
-            .on_hover_text("Copy current difference left-to-right (Alt+Right)")
+            .on_hover_text("Copy current difference left-to-right (Ctrl+Alt+Right)")
             .clicked()
         {
             if let Err(e) = model.copy_hunk(DiffSide::Left) {
@@ -37,7 +37,9 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         }
         if ui
             .add_enabled(merge, egui::Button::new("← Copy"))
-            .on_hover_text("Copy current difference right-to-left (Alt+Left)")
+            .on_hover_text(
+                "Copy current difference right-to-left (Ctrl+Alt+Left; Alt+Left is Back)",
+            )
             .clicked()
         {
             if let Err(e) = model.copy_hunk(DiffSide::Right) {
@@ -131,6 +133,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         if model.recalculating {
             ui.label("⏳ Recalculating… (showing last valid alignment)");
         }
+        ui.label(model.large_file_tier.explanation());
     });
 }
 fn pane(ui: &mut egui::Ui, workspace: u64, view: u64, side: DiffSide, model: &mut TextViewModel) {
@@ -257,6 +260,42 @@ fn shortcuts(ui: &egui::Ui, m: &mut TextViewModel) {
         }
         if i.consume_key(egui::Modifiers::CTRL, egui::Key::S) {
             m.save(m.active_side);
+        }
+        if i.consume_key(
+            egui::Modifiers {
+                ctrl: true,
+                shift: true,
+                ..Default::default()
+            },
+            egui::Key::S,
+        ) {
+            if m.left.is_dirty() {
+                m.save(DiffSide::Left);
+            }
+            if m.right.is_dirty() {
+                m.save(DiffSide::Right);
+            }
+        }
+        let copy_modifiers = egui::Modifiers {
+            alt: true,
+            ctrl: true,
+            ..Default::default()
+        };
+        if i.consume_key(copy_modifiers, egui::Key::ArrowRight) {
+            if let Err(error) = m.copy_hunk(DiffSide::Left) {
+                m.right_error = Some(error);
+            }
+        }
+        if i.consume_key(copy_modifiers, egui::Key::ArrowLeft) {
+            if let Err(error) = m.copy_hunk(DiffSide::Right) {
+                m.left_error = Some(error);
+            }
+        }
+        if i.consume_key(egui::Modifiers::CTRL, egui::Key::Num1) {
+            m.active_side = DiffSide::Left;
+        }
+        if i.consume_key(egui::Modifiers::CTRL, egui::Key::Num2) {
+            m.active_side = DiffSide::Right;
         }
     });
 }


### PR DESCRIPTION
### Motivation

- Provide a single, testable coordination layer for all Diff background operations so workers can be written and consumed deterministically and without egui types. 
- Add cooperative cancellation, monotonic request ids and generation invalidation so replaced or cancelled jobs cannot update newer views. 
- Surface configurable large-file tiers (normal/large/extreme) to reduce expensive features on big inputs and make the active tier visible in the UI. 
- Centralize revision-aware cache keys and bounded caches to keep memory and emission costs bounded during scans, comparisons, syntax work, and mutations.

### Description

- Implemented a new shared coordinator at `src/diff/worker.rs` that defines `DiffRequest`/`DiffResult` types, `JobTag`/`JobCoordinator`, `CancellationToken`, `ResultSender`/`ResultReceiver`, `Acceptance` stale-result predicate, `TextResultKey`/`SyntaxKey`/`FolderContentKey`/`WrappedLayoutKey`, chunked cancellable I/O helpers (`read_cancellable`, `byte_equal_cancellable`), `bounded_batches`, and a bounded LRU `BoundedCache` with unit tests. 
- Added configurable large-file policy and mapping in `src/diff/settings.rs` (`large_file_bytes`, `extreme_file_bytes`, estimated-row thresholds and `large_file_policy()` helper). 
- Plumbed tier awareness into `src/diff/model.rs` `TextViewModel` (compute `large_file_tier`, enable/disable syntax and editability checks, show explanatory text and refuse edits on extreme tier). 
- Extended UI keyboard workflow and tooltips in `src/gui/diff_dialog/text_view.rs` and `src/gui/diff_dialog/mod.rs` to expose `Ctrl+O`, `Ctrl+Shift+S`, pane selection shortcuts, and clarified copy bindings (Ctrl+Alt+Arrow). 
- Documented a 25-item Diff acceptance/manual-smoke matrix in `docs/manual-smoke-tests.md` to cover focus, stale jobs, cancellation, tiers, cache invalidation, and mutation paths.

### Testing

- Ran `cargo fmt --all` and `git diff --check` to ensure formatting and no trivial diffs, both succeeded. 
- Built the test profile with `cargo check --tests`, which compiles unit/integration tests and type-checks the added `worker` tests; the build completed in this environment (note: some unrelated Windows-target APIs in the repo require platform-specific gating or native SDKs). 
- Added small deterministic unit tests inside `src/diff/worker.rs` that validate generation replacement, tier selection, cache bounds, and cooperative I/O/batching; those tests were type-checked as part of `cargo check --tests`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a788a2beaa08332b8456b668ac2f95e)