### PR TITLE
Improve diff browsing, layout, and navigation

### DIFF
--- a/src/diff/file_ops.rs
+++ b/src/diff/file_ops.rs
@@ -579,7 +579,7 @@ pub fn execute_copy(
                 });
                 affected.push(d.relative.clone())
             }
-            Err(e) if d.target.is_dir() => {}
+            Err(_e) if d.target.is_dir() => {}
             Err(e) => items.push(ItemResult {
                 relative: d.relative.clone(),
                 outcome: ItemOutcome::Failed(e),

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -193,6 +193,15 @@ impl DiffWorkspace {
         self.status = Some("Comparison ready".into());
         Ok(())
     }
+    /// Assigns a picker result without starting or disturbing a comparison.
+    pub fn assign_selected_path(&mut self, side: DiffSide, selected: Option<PathBuf>) {
+        let Some(path) = selected else { return };
+        let display = path.as_os_str().to_string_lossy().into_owned();
+        match side {
+            DiffSide::Left => self.left_visible = display,
+            DiffSide::Right => self.right_visible = display,
+        }
+    }
     /// Opens a folder child; either side may be absent without weakening root validation.
     pub fn push_file_compare(
         &mut self,
@@ -228,6 +237,26 @@ impl DiffWorkspace {
             false
         }
     }
+}
+
+/// Returns safe initial window geometry. A position is accepted when at least
+/// part of the window intersects the available screen.
+pub fn validated_window_geometry(
+    persistence: &crate::diff::persistence::DiffPersistenceV1,
+    screen: [f32; 4],
+) -> ([f32; 2], Option<[f32; 2]>) {
+    let size = persistence
+        .window_size
+        .filter(|s| s.iter().all(|v| v.is_finite()) && s[0] >= 600.0 && s[1] >= 350.0)
+        .unwrap_or([900.0, 650.0]);
+    let position = persistence.window_position.filter(|p| {
+        p.iter().all(|v| v.is_finite())
+            && p[0] + size[0] > screen[0]
+            && p[1] + size[1] > screen[1]
+            && p[0] < screen[2]
+            && p[1] < screen[3]
+    });
+    (size, position)
 }
 fn metadata(path: &Path, side: &str) -> Result<fs::Metadata, String> {
     fs::metadata(path).map_err(|e| format!("{side} path '{}': {e}", path.display()))
@@ -350,6 +379,8 @@ pub struct TextViewModel {
     pub rules: TextComparisonRules,
     pub active_side: DiffSide,
     pub current_row: Option<usize>,
+    /// A model-row navigation target waiting to be consumed by the view.
+    pub pending_scroll_row: Option<usize>,
     pub wrap: bool,
     pub syntax: bool,
     pub large_file_tier: crate::diff::worker::LargeFileTier,
@@ -403,6 +434,7 @@ impl TextViewModel {
             rules: TextComparisonRules::default(),
             active_side: DiffSide::Left,
             current_row: None,
+            pending_scroll_row: None,
             wrap,
             syntax: settings.syntax_highlighting && large_file_tier.syntax_enabled(),
             large_file_tier,
@@ -475,7 +507,28 @@ impl TextViewModel {
     }
     pub fn navigate(&mut self, direction: NavigationDirection) {
         if let Some(c) = &self.comparison {
-            self.current_row = c.navigate(self.current_row, direction, false, true);
+            let row = c.navigate(self.current_row, direction, false, true);
+            self.current_row = row;
+            self.pending_scroll_row = row;
+        }
+    }
+    pub fn set_current_row(&mut self, row: Option<usize>) {
+        self.current_row = row;
+        self.pending_scroll_row = row;
+    }
+    pub fn set_ignore_all_whitespace(&mut self, value: bool) {
+        if self.rules.ignore_all_whitespace != value {
+            self.rules.ignore_all_whitespace = value;
+            self.rules.revision = self.rules.revision.wrapping_add(1);
+            self.schedule_compare();
+        }
+    }
+    pub fn set_rules(&mut self, mut rules: TextComparisonRules) {
+        rules.revision = self.rules.revision;
+        if rules != self.rules {
+            rules.revision = self.rules.revision.wrapping_add(1);
+            self.rules = rules;
+            self.schedule_compare();
         }
     }
     pub fn undo(&mut self) -> bool {
@@ -603,6 +656,81 @@ mod tests {
                 .is_err()
         );
         assert_eq!(w.left_visible, f.display().to_string());
+    }
+    #[test]
+    fn picker_assignment_is_side_specific_exact_and_cancellation_is_noop() {
+        let mut w = DiffWorkspace::default();
+        w.left_visible = "left old".into();
+        w.right_visible = "right old".into();
+        w.left_normalized = Some("normalized-left".into());
+        let view_id = w.current_view.id;
+        w.assign_selected_path(DiffSide::Left, Some(PathBuf::from("folder/a file.txt")));
+        assert_eq!(
+            w.left_visible,
+            PathBuf::from("folder/a file.txt").to_string_lossy()
+        );
+        assert_eq!(w.right_visible, "right old");
+        w.assign_selected_path(DiffSide::Right, Some(PathBuf::from(r"\\server\share\a b")));
+        assert_eq!(w.right_visible, r"\\server\share\a b");
+        let snapshot = (
+            w.left_visible.clone(),
+            w.right_visible.clone(),
+            w.left_normalized.clone(),
+            w.current_view.id,
+        );
+        w.assign_selected_path(DiffSide::Left, None);
+        assert_eq!(
+            snapshot,
+            (w.left_visible, w.right_visible, w.left_normalized, view_id)
+        );
+    }
+    #[test]
+    fn validates_file_file_folder_folder_and_rejects_mixed() {
+        let d = tempfile::tempdir().unwrap();
+        let dirs = [d.path().join("a"), d.path().join("b")];
+        fs::create_dir_all(&dirs[0]).unwrap();
+        fs::create_dir_all(&dirs[1]).unwrap();
+        let files = [d.path().join("a.txt"), d.path().join("b.txt")];
+        fs::write(&files[0], "a").unwrap();
+        fs::write(&files[1], "b").unwrap();
+        let mut w = DiffWorkspace::default();
+        assert!(
+            w.open_paths(
+                files[0].to_string_lossy().into(),
+                files[1].to_string_lossy().into()
+            )
+            .is_ok()
+        );
+        assert!(
+            w.open_paths(
+                dirs[0].to_string_lossy().into(),
+                dirs[1].to_string_lossy().into()
+            )
+            .is_ok()
+        );
+        assert!(
+            w.open_paths(
+                files[0].to_string_lossy().into(),
+                dirs[0].to_string_lossy().into()
+            )
+            .is_err()
+        );
+    }
+    #[test]
+    fn persisted_geometry_round_trips_and_corruption_falls_back() {
+        let mut p = crate::diff::persistence::DiffPersistenceV1::default();
+        p.window_size = Some([1000.0, 700.0]);
+        p.window_position = Some([20.0, 30.0]);
+        assert_eq!(
+            validated_window_geometry(&p, [0.0, 0.0, 1920.0, 1080.0]),
+            ([1000.0, 700.0], Some([20.0, 30.0]))
+        );
+        p.window_size = Some([f32::NAN, 1.0]);
+        p.window_position = Some([5000.0, 5000.0]);
+        assert_eq!(
+            validated_window_geometry(&p, [0.0, 0.0, 1920.0, 1080.0]),
+            ([900.0, 650.0], None)
+        );
     }
     #[test]
     fn push_back_restores_same_folder_state() {

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -22,6 +22,7 @@ pub struct DiffDialogState {
     // Binary renderers will keep their ephemeral resources in this view-id map.
     binary_views: HashMap<u64, ()>,
     close_prompt: bool,
+    pub persistence: crate::diff::persistence::DiffPersistenceV1,
 }
 
 impl DiffDialogState {
@@ -55,118 +56,125 @@ impl DiffDialogState {
             return;
         }
         let mut open = self.open;
-        egui::Window::new("Diff")
+        let screen = ctx.input(|i| i.screen_rect());
+        let (initial_size, initial_position) = crate::diff::model::validated_window_geometry(
+            &self.persistence,
+            [screen.left(), screen.top(), screen.right(), screen.bottom()],
+        );
+        let mut window = egui::Window::new("Diff")
             .id(egui::Id::new(("diff_window", self.workspace.workspace_id)))
             .open(&mut open)
-            .default_size([900.0, 650.0])
-            .show(ctx, |ui| {
-                if ui.input_mut(|i| i.consume_key(egui::Modifiers::ALT, egui::Key::ArrowLeft)) {
-                    self.workspace.back();
-                    self.reconcile_runtime_resources();
+            .resizable(true)
+            .default_size(initial_size)
+            .min_size([600.0, 350.0]);
+        if let Some(position) = initial_position {
+            window = window.default_pos(position);
+        }
+        let response = window.show(ctx, |ui| {
+            if ui.input_mut(|i| i.consume_key(egui::Modifiers::ALT, egui::Key::ArrowLeft)) {
+                self.workspace.back();
+                self.reconcile_runtime_resources();
+            }
+            ui.horizontal(|ui| {
+                let left = ui.add(
+                    egui::TextEdit::singleline(&mut self.workspace.left_visible)
+                        .id(egui::Id::new((self.workspace.workspace_id, "left")))
+                        .hint_text("Left file or folder"),
+                );
+                if self.workspace.focus_left_requested {
+                    left.request_focus();
+                    self.workspace.focus_left_requested = false;
                 }
-                ui.horizontal(|ui| {
-                    let left = ui.add(
-                        egui::TextEdit::singleline(&mut self.workspace.left_visible)
-                            .id(egui::Id::new((self.workspace.workspace_id, "left")))
-                            .hint_text("Left file or folder"),
+                picker_menu(ui, &mut self.workspace, crate::diff::model::DiffSide::Left);
+                ui.label("↔");
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.workspace.right_visible)
+                        .id(egui::Id::new((self.workspace.workspace_id, "right")))
+                        .hint_text("Right file or folder"),
+                );
+                picker_menu(ui, &mut self.workspace, crate::diff::model::DiffSide::Right);
+                if ui
+                    .button("Compare")
+                    .on_hover_text("Compare/change paths (Ctrl+O)")
+                    .clicked()
+                    || ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::O))
+                {
+                    let result = self.workspace.open_paths(
+                        self.workspace.left_visible.clone(),
+                        self.workspace.right_visible.clone(),
                     );
-                    if self.workspace.focus_left_requested {
-                        left.request_focus();
-                        self.workspace.focus_left_requested = false;
+                    if result.is_ok() {
+                        self.reconcile_runtime_resources();
                     }
-                    if ui.button("Browse…").clicked() {
-                        if let Some(p) = rfd::FileDialog::new().pick_file() {
-                            self.workspace.left_visible = p.display().to_string();
-                        }
-                    }
-                    ui.label("↔");
-                    ui.add(
-                        egui::TextEdit::singleline(&mut self.workspace.right_visible)
-                            .id(egui::Id::new((self.workspace.workspace_id, "right")))
-                            .hint_text("Right file or folder"),
-                    );
-                    if ui.button("Browse…").clicked() {
-                        if let Some(p) = rfd::FileDialog::new().pick_file() {
-                            self.workspace.right_visible = p.display().to_string();
-                        }
-                    }
-                    if ui
-                        .button("Compare")
-                        .on_hover_text("Compare/change paths (Ctrl+O)")
-                        .clicked()
-                        || ui.input_mut(|i| i.consume_key(egui::Modifiers::CTRL, egui::Key::O))
-                    {
-                        let result = self.workspace.open_paths(
-                            self.workspace.left_visible.clone(),
-                            self.workspace.right_visible.clone(),
-                        );
-                        if result.is_ok() {
-                            self.reconcile_runtime_resources();
-                        }
-                    }
-                });
-                if let Some(error) = &self.workspace.error {
-                    ui.colored_label(egui::Color32::RED, error);
                 }
-                if self.workspace.navigation_stack.len() > 0 && ui.button("← Back").clicked() {
-                    self.workspace.back();
-                    self.reconcile_runtime_resources();
+            });
+            if let Some(error) = &self.workspace.error {
+                ui.colored_label(egui::Color32::RED, error);
+            }
+            if self.workspace.navigation_stack.len() > 0 && ui.button("← Back").clicked() {
+                self.workspace.back();
+                self.reconcile_runtime_resources();
+            }
+            ui.separator();
+            // Copy only lightweight context before borrowing the retained view.
+            let workspace_id = self.workspace.workspace_id;
+            let view_id = self.workspace.current_view.id;
+            let settings = self.workspace.settings.clone();
+            let mut action = folder_view::FolderViewAction::Noop;
+            let mut render_error = None;
+            match &mut self.workspace.current_view.view {
+                DiffView::Start => {
+                    ui.label("Choose two files or two folders to compare.");
                 }
-                ui.separator();
-                // Copy only lightweight context before borrowing the retained view.
-                let workspace_id = self.workspace.workspace_id;
-                let view_id = self.workspace.current_view.id;
-                let settings = self.workspace.settings.clone();
-                let mut action = folder_view::FolderViewAction::Noop;
-                let mut render_error = None;
-                match &mut self.workspace.current_view.view {
-                    DiffView::Start => {
-                        ui.label("Choose two files or two folders to compare.");
-                    }
-                    DiffView::TextCompare(s) => {
-                        if matches!(s.kind, crate::diff::model::FileComparisonKind::Binary) {
-                            ui.heading(match s.kind {
-                                crate::diff::model::FileComparisonKind::Text => "Text comparison",
-                                crate::diff::model::FileComparisonKind::Binary => "Binary files",
-                            });
-                            ui.label(format!(
-                                "Left: {}",
-                                s.left
-                                    .as_ref()
-                                    .map_or("(missing)".into(), |p| p.display().to_string())
-                            ));
-                        } else {
-                            if !self.text_views.contains_key(&view_id) {
-                                match crate::diff::model::TextViewModel::load(&s, &settings) {
-                                    Ok(m) => {
-                                        self.text_views.insert(view_id, m);
-                                    }
-                                    Err(e) => {
-                                        render_error = Some(e);
-                                    }
-                                }
-                            }
-                            if let Some(m) = self.text_views.get_mut(&view_id) {
-                                text_view::show(ui, workspace_id, view_id, m);
-                            }
-                        }
+                DiffView::TextCompare(s) => {
+                    if matches!(s.kind, crate::diff::model::FileComparisonKind::Binary) {
+                        ui.heading(match s.kind {
+                            crate::diff::model::FileComparisonKind::Text => "Text comparison",
+                            crate::diff::model::FileComparisonKind::Binary => "Binary files",
+                        });
                         ui.label(format!(
-                            "Right: {}",
-                            s.right
+                            "Left: {}",
+                            s.left
                                 .as_ref()
                                 .map_or("(missing)".into(), |p| p.display().to_string())
                         ));
+                    } else {
+                        if !self.text_views.contains_key(&view_id) {
+                            match crate::diff::model::TextViewModel::load(&s, &settings) {
+                                Ok(m) => {
+                                    self.text_views.insert(view_id, m);
+                                }
+                                Err(e) => {
+                                    render_error = Some(e);
+                                }
+                            }
+                        }
+                        if let Some(m) = self.text_views.get_mut(&view_id) {
+                            text_view::show(ui, workspace_id, view_id, m);
+                        }
                     }
-                    DiffView::FolderCompare(s) => {
-                        self.folder_runtimes.entry(view_id).or_default();
-                        action = render_retained_folder(s, |state| folder_view::show(ui, state));
-                    }
+                    ui.label(format!(
+                        "Right: {}",
+                        s.right
+                            .as_ref()
+                            .map_or("(missing)".into(), |p| p.display().to_string())
+                    ));
                 }
-                if let Some(error) = render_error {
-                    self.workspace.error = Some(error);
+                DiffView::FolderCompare(s) => {
+                    self.folder_runtimes.entry(view_id).or_default();
+                    action = render_retained_folder(s, |state| folder_view::show(ui, state));
                 }
-                self.apply_folder_action(action);
-            });
+            }
+            if let Some(error) = render_error {
+                self.workspace.error = Some(error);
+            }
+            self.apply_folder_action(action);
+        });
+        if let Some(response) = response {
+            let rect = response.response.rect;
+            self.persistence.window_size = Some([rect.width(), rect.height()]);
+            self.persistence.window_position = Some([rect.left(), rect.top()]);
+        }
         if !open && self.text_views.values().any(|m| m.has_dirty()) {
             self.close_prompt = true;
             open = true;
@@ -235,6 +243,23 @@ impl DiffDialogState {
         }
         self.reconcile_runtime_resources();
     }
+}
+
+fn picker_menu(
+    ui: &mut egui::Ui,
+    workspace: &mut DiffWorkspace,
+    side: crate::diff::model::DiffSide,
+) {
+    ui.menu_button("Browse ▾", |ui| {
+        if ui.button("Select File…").clicked() {
+            workspace.assign_selected_path(side, rfd::FileDialog::new().pick_file());
+            ui.close_menu();
+        }
+        if ui.button("Select Folder…").clicked() {
+            workspace.assign_selected_path(side, rfd::FileDialog::new().pick_folder());
+            ui.close_menu();
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -8,8 +8,14 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
     ui.horizontal_wrapped(|ui| {
         ui.button("Rules…").on_hover_text("Comparison rules");
         ui.label("Differences:");
-        ui.selectable_value(&mut model.rules.ignore_all_whitespace, false, "All");
-        ui.selectable_value(&mut model.rules.ignore_all_whitespace, true, "Important");
+        let mut ignore = model.rules.ignore_all_whitespace;
+        let all_changed = ui.selectable_value(&mut ignore, false, "All").changed();
+        let important_changed = ui
+            .selectable_value(&mut ignore, true, "Important")
+            .changed();
+        if all_changed || important_changed {
+            model.set_ignore_all_whitespace(ignore);
+        }
         if ui.button("⏮ First").clicked() {
             model.navigate(NavigationDirection::First)
         }
@@ -80,38 +86,11 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         }
     });
     ui.separator();
-    let available = ui.available_width();
-    model.splitter = crate::diff::model::validated_splitter(model.splitter);
-    let left_width = (available - 8.0) * model.splitter;
-    ui.horizontal(|ui| {
-        ui.allocate_ui_with_layout(
-            egui::vec2(left_width, ui.available_height() - 30.0),
-            egui::Layout::top_down(egui::Align::Min),
-            |ui| pane(ui, workspace, view, DiffSide::Left, model),
-        );
-        let (rect, response) = ui.allocate_exact_size(
-            egui::vec2(8.0, ui.available_height() - 30.0),
-            egui::Sense::drag(),
-        );
-        ui.painter()
-            .rect_filled(rect, 2.0, ui.visuals().widgets.inactive.bg_fill);
-        if response.dragged() {
-            model.splitter = crate::diff::model::validated_splitter(
-                model.splitter + response.drag_delta().x / available,
-            );
-        }
-        ui.allocate_ui_with_layout(
-            egui::vec2(ui.available_width(), ui.available_height() - 30.0),
-            egui::Layout::top_down(egui::Align::Min),
-            |ui| pane(ui, workspace, view, DiffSide::Right, model),
-        );
-    });
     let number = model.comparison.as_ref().and_then(|c| {
         model
             .current_row
             .and_then(|r| c.difference_number(r, false))
     });
-    ui.separator();
     ui.horizontal_wrapped(|ui| {
         ui.label(number.map_or("Difference —/—".into(), |(n, t)| {
             format!("Difference {n}/{t}")
@@ -135,13 +114,51 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         }
         ui.label(model.large_file_tier.explanation());
     });
+    ui.separator();
+    let available = ui.available_width();
+    let comparison_height = ui.available_height();
+    model.splitter = crate::diff::model::validated_splitter(model.splitter);
+    let left_width = (available - 8.0) * model.splitter;
+    let pending = model.pending_scroll_row;
+    let mut scroll_accepted = pending.is_none();
+    ui.horizontal(|ui| {
+        ui.allocate_ui_with_layout(
+            egui::vec2(left_width, comparison_height),
+            egui::Layout::top_down(egui::Align::Min),
+            |ui| scroll_accepted &= pane(ui, workspace, view, DiffSide::Left, model, pending),
+        );
+        let (rect, response) =
+            ui.allocate_exact_size(egui::vec2(8.0, comparison_height), egui::Sense::drag());
+        ui.painter()
+            .rect_filled(rect, 2.0, ui.visuals().widgets.inactive.bg_fill);
+        if response.dragged() {
+            model.splitter = crate::diff::model::validated_splitter(
+                model.splitter + response.drag_delta().x / available,
+            );
+        }
+        ui.allocate_ui_with_layout(
+            egui::vec2(ui.available_width(), comparison_height),
+            egui::Layout::top_down(egui::Align::Min),
+            |ui| scroll_accepted &= pane(ui, workspace, view, DiffSide::Right, model, pending),
+        );
+    });
+    if scroll_accepted {
+        model.pending_scroll_row = None;
+    }
 }
-fn pane(ui: &mut egui::Ui, workspace: u64, view: u64, side: DiffSide, model: &mut TextViewModel) {
+fn pane(
+    ui: &mut egui::Ui,
+    workspace: u64,
+    view: u64,
+    side: DiffSide,
+    model: &mut TextViewModel,
+    pending: Option<usize>,
+) -> bool {
     let Some(c) = model.comparison.as_ref() else {
         ui.centered_and_justified(|ui| {
             ui.spinner();
         });
-        return;
+        return false;
     };
     let source = match side {
         DiffSide::Left => model.left.source(),
@@ -149,72 +166,73 @@ fn pane(ui: &mut egui::Ui, workspace: u64, view: u64, side: DiffSide, model: &mu
     };
     let rows = &c.rows;
     let row_height = if model.wrap { 34.0 } else { 20.0 };
-    egui::ScrollArea::vertical()
-        .id_source((workspace, view, "shared_diff_scroll"))
-        .show_rows(ui, row_height, rows.len(), |ui, range| {
-            for i in range {
-                let row = &rows[i];
-                let current = model.current_row == Some(i);
-                let bg = match (row.kind, row.importance) {
-                    (_, ChangeImportance::Unimportant) => Color32::from_rgb(70, 65, 35),
-                    (DiffRowKind::Equal, _) => Color32::TRANSPARENT,
-                    (DiffRowKind::Inserted, _) => Color32::from_rgb(28, 70, 42),
-                    (DiffRowKind::Deleted, _) => Color32::from_rgb(80, 35, 35),
-                    (DiffRowKind::Modified, _) => Color32::from_rgb(65, 55, 25),
-                };
-                let frame =
-                    egui::Frame::none().fill(if current { bg.gamma_multiply(1.5) } else { bg });
-                frame.show(ui, |ui| {
-                    ui.set_min_height(row_height);
-                    ui.horizontal(|ui| {
-                        let line = crate::diff::model::visual_to_source(row, side);
-                        ui.label(
-                            RichText::new(line.map_or("·".into(), |n| (n + 1).to_string()))
-                                .monospace()
-                                .weak(),
-                        );
-                        let semantic = match row.kind {
-                            DiffRowKind::Equal => "equal",
-                            DiffRowKind::Inserted => "inserted",
-                            DiffRowKind::Deleted => "deleted",
-                            DiffRowKind::Modified => "modified",
-                        };
-                        ui.label(
-                            RichText::new(match side {
-                                DiffSide::Left => "L",
-                                DiffSide::Right => "R",
-                            })
-                            .strong(),
-                        )
-                        .on_hover_text(semantic);
-                        if let Some(n) = line {
-                            let text = source.lines().nth(n).unwrap_or("");
-                            let id = egui::Id::new((
-                                workspace,
-                                view,
-                                side,
-                                row.id,
-                                c.navigation.row_to_hunk[i],
-                            ));
-                            ui.push_id(id, |ui| {
-                                ui.add(
-                                    egui::Label::new(RichText::new(text).monospace())
-                                        .wrap(model.wrap),
-                                )
-                                .on_hover_text(format!("{semantic} line"));
-                            });
-                        } else if ui
-                            .button("＋ Insert line")
-                            .on_hover_text("Missing on this side; insert real source text")
-                            .clicked()
-                        {
-                            model.active_side = side;
-                            model.current_row = Some(i);
-                        }
-                    });
+    let mut scroll = egui::ScrollArea::vertical().id_source((workspace, view, side, "diff_scroll"));
+    if let Some(row_index) = pending {
+        scroll = scroll.vertical_scroll_offset(row_index as f32 * row_height);
+    }
+    scroll.show_rows(ui, row_height, rows.len(), |ui, range| {
+        for i in range {
+            let row = &rows[i];
+            let current = model.current_row == Some(i);
+            let bg = match (row.kind, row.importance) {
+                (_, ChangeImportance::Unimportant) => Color32::from_rgb(70, 65, 35),
+                (DiffRowKind::Equal, _) => Color32::TRANSPARENT,
+                (DiffRowKind::Inserted, _) => Color32::from_rgb(28, 70, 42),
+                (DiffRowKind::Deleted, _) => Color32::from_rgb(80, 35, 35),
+                (DiffRowKind::Modified, _) => Color32::from_rgb(65, 55, 25),
+            };
+            let frame = egui::Frame::none().fill(if current { bg.gamma_multiply(1.5) } else { bg });
+            frame.show(ui, |ui| {
+                ui.set_min_height(row_height);
+                ui.horizontal(|ui| {
+                    let line = crate::diff::model::visual_to_source(row, side);
+                    ui.label(
+                        RichText::new(line.map_or("·".into(), |n| (n + 1).to_string()))
+                            .monospace()
+                            .weak(),
+                    );
+                    let semantic = match row.kind {
+                        DiffRowKind::Equal => "equal",
+                        DiffRowKind::Inserted => "inserted",
+                        DiffRowKind::Deleted => "deleted",
+                        DiffRowKind::Modified => "modified",
+                    };
+                    ui.label(
+                        RichText::new(match side {
+                            DiffSide::Left => "L",
+                            DiffSide::Right => "R",
+                        })
+                        .strong(),
+                    )
+                    .on_hover_text(semantic);
+                    if let Some(n) = line {
+                        let text = source.lines().nth(n).unwrap_or("");
+                        let id = egui::Id::new((
+                            workspace,
+                            view,
+                            side,
+                            row.id,
+                            c.navigation.row_to_hunk[i],
+                        ));
+                        ui.push_id(id, |ui| {
+                            ui.add(
+                                egui::Label::new(RichText::new(text).monospace()).wrap(model.wrap),
+                            )
+                            .on_hover_text(format!("{semantic} line"));
+                        });
+                    } else if ui
+                        .button("＋ Insert line")
+                        .on_hover_text("Missing on this side; insert real source text")
+                        .clicked()
+                    {
+                        model.active_side = side;
+                        model.set_current_row(Some(i));
+                    }
                 });
-            }
-        });
+            });
+        }
+    });
+    true
 }
 fn side_status(
     ui: &mut egui::Ui,

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -170,6 +170,9 @@ fn pane(
     if let Some(row_index) = pending {
         scroll = scroll.vertical_scroll_offset(row_index as f32 * row_height);
     }
+    // Defer model mutation until after the scroll callback releases its
+    // immutable borrow of the retained comparison.
+    let mut selected_row = None;
     scroll.show_rows(ui, row_height, rows.len(), |ui, range| {
         for i in range {
             let row = &rows[i];
@@ -225,13 +228,16 @@ fn pane(
                         .on_hover_text("Missing on this side; insert real source text")
                         .clicked()
                     {
-                        model.active_side = side;
-                        model.set_current_row(Some(i));
+                        selected_row = Some(i);
                     }
                 });
             });
         }
     });
+    if let Some(row) = selected_row {
+        model.active_side = side;
+        model.set_current_row(Some(row));
+    }
     true
 }
 fn side_status(


### PR DESCRIPTION
### Motivation

- Replace the single-action Browse buttons with compact file/folder picker menus that assign the chosen path only to the requested visible side and preserve exact platform path formatting (spaces, UNC, etc.).
- Make the Diff window resizable with sensible default and minimum sizes and persist validated geometry via the existing `DiffPersistenceV1` object.
- Synchronize text-navigation scrolling by introducing a model-side pending scroll target and ensure navigation and rule changes are handled by model methods that correctly bump revisions and schedule comparisons.

### Description

- Replaced Browse buttons with a compact picker menu in `src/gui/diff_dialog/mod.rs` and added `picker_menu()` to call `rfd::FileDialog::pick_file()` / `pick_folder()` and assign results via a new model helper. The window is now `.resizable(true)` with `.default_size([900.0,650.0])` and `.min_size([600.0,350.0])`, and validated persisted geometry is used for initial placement and stored on close. (`src/gui/diff_dialog/mod.rs`)
- Added `DiffWorkspace::assign_selected_path(side, Option<PathBuf>)` so the picker only updates the requested visible side without invoking `open_paths()` or disturbing normalized paths, navigation, or current comparison. Cancellation (`None`) is a no-op. (`src/diff/model.rs`)
- Added `validated_window_geometry()` to validate persisted `DiffPersistenceV1.window_size` and `window_position` before using them, with safe fallbacks for corrupt or off-screen values. (`src/diff/model.rs`)
- Introduced `pending_scroll_row: Option<usize>` to `TextViewModel`, updated `navigate()` to set both `current_row` and `pending_scroll_row`, and added `set_current_row()` so other actions can set a shared pending target. The view consumes a single pending request and applies a fixed-row offset (`row_index * row_height`) to both panes using a single logical scroll target. (`src/diff/model.rs`, `src/gui/diff_dialog/text_view.rs`)
- Stopped binding GUI widgets directly to rule fields and added focused model setters: `set_ignore_all_whitespace()` and `set_rules()` that only increment `rules.revision` on real changes and call `schedule_compare()` exactly once per real change. The toolbar now uses these setters instead of mutating `model.rules` directly. (`src/diff/model.rs`, `src/gui/diff_dialog/text_view.rs`)
- Reworked text comparison layout so toolbar and status controls use their natural height and the comparison region receives the remaining space; splitter and both panes are responsive at small and large sizes, and the panes accept a single synchronized scroll target. (`src/gui/diff_dialog/text_view.rs`)
- Added unit tests covering side-specific picker assignment (including paths with spaces and UNC paths), picker cancellation no-op behavior, file/file and folder/folder validation plus mixed-type rejection, and persisted geometry validation/fallback. (`src/diff/model.rs` tests)

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `git diff --check` which reported no issues.
- Attempted `cargo test diff::model --lib` to exercise the modified model unit tests; test execution could not be completed in this Linux environment because the overall workspace builds Windows-only modules unconditionally and compilation failed on unrelated platform-specific dependencies (unresolved `windows::Win32` / `windows::core` imports and system libraries), preventing the test binary from being produced here. 
- The new unit tests are added under `src/diff/model.rs` and are written to validate picker assignment, mixed-type validation, and persisted geometry behavior; they should run normally on platforms where the crate can be built end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78983f3ce0833292f865ae55b6316e)