### PR TITLE
Integrate retained folder scanning with authoritative FolderModel

### DIFF
--- a/src/diff/folder_compare.rs
+++ b/src/diff/folder_compare.rs
@@ -159,7 +159,7 @@ pub fn fast_status(
         }
     }
 }
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FolderModel {
     pub entries: BTreeMap<String, FolderEntry>,
     pub revision: u64,
@@ -293,5 +293,135 @@ impl ContentCache {
         e.effective_status = v;
         e.content_checked = true;
         Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn side(kind: EntryKind, size: u64, modified: u64) -> EntrySide {
+        EntrySide {
+            path: PathBuf::from("item"),
+            metadata: Some(EntryMetadata {
+                kind,
+                size,
+                modified: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(modified)),
+                identity: None,
+            }),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn metadata_status_matrix_and_tolerance() {
+        let file = side(EntryKind::File, 10, 100);
+        assert_eq!(
+            fast_status(Some(&file), Some(&file), Duration::ZERO),
+            FolderStatus::PendingContentComparison
+        );
+        assert_eq!(
+            fast_status(
+                Some(&file),
+                Some(&side(EntryKind::File, 11, 100)),
+                Duration::ZERO
+            ),
+            FolderStatus::Different
+        );
+        assert_eq!(
+            fast_status(Some(&file), None, Duration::ZERO),
+            FolderStatus::LeftOnly
+        );
+        assert_eq!(
+            fast_status(None, Some(&file), Duration::ZERO),
+            FolderStatus::RightOnly
+        );
+        assert_eq!(
+            fast_status(
+                Some(&side(EntryKind::File, 10, 103)),
+                Some(&file),
+                Duration::from_secs(2)
+            ),
+            FolderStatus::LeftNewer
+        );
+        assert_eq!(
+            fast_status(
+                Some(&file),
+                Some(&side(EntryKind::File, 10, 103)),
+                Duration::from_secs(2)
+            ),
+            FolderStatus::RightNewer
+        );
+        assert_eq!(
+            fast_status(
+                Some(&file),
+                Some(&side(EntryKind::File, 10, 101)),
+                Duration::from_secs(2)
+            ),
+            FolderStatus::PendingContentComparison
+        );
+        assert_eq!(
+            fast_status(
+                Some(&file),
+                Some(&side(EntryKind::Directory, 10, 100)),
+                Duration::ZERO
+            ),
+            FolderStatus::Different
+        );
+        let unreadable = EntrySide {
+            path: "bad".into(),
+            metadata: None,
+            error: Some("denied".into()),
+        };
+        assert_eq!(
+            fast_status(Some(&unreadable), Some(&file), Duration::ZERO),
+            FolderStatus::Unreadable
+        );
+    }
+
+    #[test]
+    fn insensitive_pairing_and_large_upserts_are_lossless() {
+        let mut model = FolderModel::default();
+        model
+            .upsert(
+                Path::new("Dir/FILE.txt"),
+                side(EntryKind::File, 1, 1),
+                true,
+                PathKeyPolicy::Insensitive,
+                Duration::ZERO,
+            )
+            .unwrap();
+        model
+            .upsert(
+                Path::new("dir/file.TXT"),
+                side(EntryKind::File, 1, 1),
+                false,
+                PathKeyPolicy::Insensitive,
+                Duration::ZERO,
+            )
+            .unwrap();
+        assert_eq!(model.entries.len(), 1);
+        for i in 0..10_000 {
+            let path = PathBuf::from(format!("batch/{i}.txt"));
+            model
+                .upsert(
+                    &path,
+                    side(EntryKind::File, i, 1),
+                    true,
+                    PathKeyPolicy::Sensitive,
+                    Duration::ZERO,
+                )
+                .unwrap();
+        }
+        assert_eq!(model.entries.len(), 10_001);
+        assert_eq!(
+            model
+                .entries
+                .values()
+                .map(|e| &e.relative_path)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            10_001
+        );
     }
 }

--- a/src/diff/folder_runtime.rs
+++ b/src/diff/folder_runtime.rs
@@ -4,10 +4,13 @@
 //! may be cloned or persisted, while receivers and operation handles may not.
 
 use crate::diff::file_ops::OperationHandle;
+use crate::diff::folder_compare::{ContentCache, FolderStatus};
 use crate::diff::folder_scan::{RootIdentity, ScanHandle};
-use crate::diff::model::DiffStatus;
 use std::collections::{BTreeMap, VecDeque};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Default)]
 pub struct FolderRuntime {
@@ -16,15 +19,25 @@ pub struct FolderRuntime {
     pub generation: u64,
     pub left_root: Option<RootIdentity>,
     pub right_root: Option<RootIdentity>,
-    pub discovered: u64,
-    pub compared: u64,
+    pub left_visited: u64,
+    pub right_visited: u64,
     pub comparison_queue: VecDeque<PathBuf>,
-    pub comparison_cache: BTreeMap<PathBuf, DiffStatus>,
+    pub comparison_results: BTreeMap<PathBuf, FolderStatus>,
+    pub content_cache: ContentCache,
     pub active_operation: Option<OperationHandle>,
+    pub left_error: Option<String>,
+    pub right_error: Option<String>,
     // Filesystem watchers belong here when live refresh is implemented.
 }
 
 impl FolderRuntime {
+    pub fn next_generation() -> u64 {
+        NEXT_GENERATION.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.left_scan.is_some() || self.right_scan.is_some() || !self.comparison_queue.is_empty()
+    }
     pub fn cancel(&self) {
         if let Some(scan) = &self.left_scan {
             scan.cancel();

--- a/src/diff/folder_scan.rs
+++ b/src/diff/folder_scan.rs
@@ -91,7 +91,7 @@ impl ScanEvent {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ScanRules {
     pub includes: Vec<String>,
     pub excludes: Vec<String>,
@@ -211,6 +211,13 @@ fn scan(
         },
         &c,
     ) {
+        if c.load(Ordering::Acquire) {
+            let _ = tx.send(ScanEvent::Cancelled {
+                generation: g,
+                root,
+                visited: 0,
+            });
+        }
         return;
     }
     let mut stack = vec![base.to_path_buf()];
@@ -386,5 +393,57 @@ mod tests {
         assert!(!r.permits(Path::new("x/a.tmp"), false));
         assert!(!r.permits(Path::new("a/x.bak"), false));
         assert!(r.permits(Path::new("b/x.bak"), false));
+    }
+
+    #[test]
+    fn event_rejects_stale_generation_and_wrong_root() {
+        let root = RootIdentity {
+            path: "a".into(),
+            token: None,
+        };
+        let event = ScanEvent::Progress {
+            generation: 7,
+            root: root.clone(),
+            visited: 1,
+        };
+        assert!(event.is_current(7, &root));
+        assert!(!event.is_current(8, &root));
+        assert!(!event.is_current(
+            7,
+            &RootIdentity {
+                path: "b".into(),
+                token: None
+            }
+        ));
+    }
+
+    #[test]
+    fn recursive_scan_batches_and_does_not_follow_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        for i in 0..130 {
+            fs::write(nested.join(format!("{i}.txt")), b"x").unwrap();
+        }
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&nested, temp.path().join("link")).unwrap();
+        let handle = spawn_scan(temp.path().to_path_buf(), 4, ScanRules::default());
+        let events: Vec<_> = handle.receiver.iter().collect();
+        let batches: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                ScanEvent::EntriesDiscovered { entries, .. } => Some(entries),
+                _ => None,
+            })
+            .collect();
+        assert!(batches.len() >= 3);
+        let paths: std::collections::BTreeSet<_> = batches
+            .iter()
+            .flat_map(|b| b.iter().map(|e| e.relative_path.clone()))
+            .collect();
+        assert_eq!(paths.len(), 131 + usize::from(cfg!(unix)));
+        #[cfg(unix)]
+        assert!(!paths.iter().any(|p| p.starts_with("link/")));
+        assert!(matches!(events.last(), Some(ScanEvent::Completed { .. })));
     }
 }

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -1,10 +1,12 @@
+use crate::diff::folder_compare::FolderModel;
+use crate::diff::folder_scan::ScanRules;
 use crate::diff::settings::DiffConfigV1;
 use crate::diff::text_compare::{
     self, AlignedDiffRow, CompiledRules, NavigationDirection, TextComparisonResult,
     TextComparisonRules,
 };
 use crate::diff::text_file::{LineEdit, TextDocument, load_text_file};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -16,14 +18,6 @@ fn id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DiffStatus {
-    Identical,
-    Modified,
-    LeftOnly,
-    RightOnly,
-    Error,
-}
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum FolderDisplayFilter {
     #[default]
@@ -37,20 +31,40 @@ pub struct FolderSortState {
     pub column: String,
     pub descending: bool,
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContentComparisonMode {
+    Metadata,
+    #[default]
+    OnDemand,
+    Always,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FolderCompareState {
-    pub selected_relative_path: Option<PathBuf>,
+    pub left_root: PathBuf,
+    pub right_root: PathBuf,
+    pub model: FolderModel,
+    pub selected_paths: BTreeSet<PathBuf>,
+    pub primary_selection: Option<PathBuf>,
     pub expanded_nodes: BTreeSet<PathBuf>,
     pub scroll_anchor: Option<PathBuf>,
     pub display_filter: FolderDisplayFilter,
     pub path_filter: String,
     pub sort: FolderSortState,
-    pub content_statuses: BTreeMap<PathBuf, DiffStatus>,
+    pub scan_rules: ScanRules,
+    pub content_comparison: ContentComparisonMode,
+    pub timestamp_tolerance: Duration,
+    pub left_scan_complete: bool,
+    pub right_scan_complete: bool,
 }
 impl Default for FolderCompareState {
     fn default() -> Self {
         Self {
-            selected_relative_path: None,
+            left_root: PathBuf::new(),
+            right_root: PathBuf::new(),
+            model: FolderModel::default(),
+            selected_paths: BTreeSet::new(),
+            primary_selection: None,
             expanded_nodes: BTreeSet::new(),
             scroll_anchor: None,
             display_filter: FolderDisplayFilter::All,
@@ -59,7 +73,11 @@ impl Default for FolderCompareState {
                 column: "path".into(),
                 descending: false,
             },
-            content_statuses: BTreeMap::new(),
+            scan_rules: ScanRules::default(),
+            content_comparison: ContentComparisonMode::default(),
+            timestamp_tolerance: Duration::from_secs(2),
+            left_scan_complete: false,
+            right_scan_complete: false,
         }
     }
 }
@@ -180,7 +198,11 @@ impl DiffWorkspace {
                 kind: detect_kind(&lp, &rp),
             })
         } else if lm.is_dir() && rm.is_dir() {
-            DiffView::FolderCompare(FolderCompareState::default())
+            DiffView::FolderCompare(FolderCompareState {
+                left_root: lp,
+                right_root: rp,
+                ..FolderCompareState::default()
+            })
         } else {
             let msg = "Left and right paths must both be files or both be directories".to_string();
             self.error = Some(msg.clone());
@@ -738,6 +760,8 @@ mod tests {
         w.current_view = RetainedView {
             id: 99,
             view: DiffView::FolderCompare(FolderCompareState {
+                left_root: "/left".into(),
+                right_root: "/right".into(),
                 path_filter: "rs".into(),
                 ..Default::default()
             }),
@@ -746,7 +770,8 @@ mod tests {
             .unwrap();
         assert!(w.back());
         assert_eq!(w.current_view.id, 99);
-        assert!(matches!(&w.current_view.view,DiffView::FolderCompare(s) if s.path_filter=="rs"));
+        assert!(matches!(&w.current_view.view,DiffView::FolderCompare(s)
+            if s.path_filter=="rs" && s.left_root == Path::new("/left") && s.right_root == Path::new("/right")));
     }
     #[test]
     fn splitter_and_virtual_range_are_bounded() {

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -1,6 +1,6 @@
-//! Folder tree presentation. Filtering is a projection of retained rows and
-//! sorting is intentionally performed within each parent rather than flattening.
-use crate::diff::model::{DiffStatus, FolderCompareState, FolderDisplayFilter};
+//! Folder tree presentation. Filtering is a projection of the authoritative model.
+use crate::diff::folder_compare::FolderStatus;
+use crate::diff::model::{FolderCompareState, FolderDisplayFilter};
 use eframe::egui;
 use std::path::{Path, PathBuf};
 
@@ -19,8 +19,13 @@ pub(super) enum FolderViewAction {
 
 pub(super) fn show(ui: &mut egui::Ui, state: &mut FolderCompareState) -> FolderViewAction {
     ui.heading("Folder comparison");
+    ui.label(format!(
+        "{} ↔ {}",
+        state.left_root.display(),
+        state.right_root.display()
+    ));
+    let mut action = FolderViewAction::Noop;
     ui.horizontal(|ui| {
-        ui.label("Show retained results:");
         for (label, f) in [
             ("All", FolderDisplayFilter::All),
             ("Differences", FolderDisplayFilter::Changed),
@@ -34,99 +39,145 @@ pub(super) fn show(ui: &mut egui::Ui, state: &mut FolderCompareState) -> FolderV
                 state.display_filter = f
             }
         }
+        if ui.button("Rescan").clicked() {
+            action = FolderViewAction::RequestRescan;
+        }
     });
     ui.horizontal(|ui| {
-        ui.label("Find path (display only):");
+        ui.label("Find path:");
         ui.text_edit_singleline(&mut state.path_filter);
     });
-    ui.horizontal(|ui| {
-        ui.label("Scan include/exclude rules (requires Rescan):");
-        ui.add_enabled(
-            false,
-            egui::TextEdit::singleline(&mut String::new()).hint_text(".git/, target/, *.tmp"),
-        );
-    });
-    ui.label(
-        "Status is shown with text and a symbol; metadata matches await content verification.",
-    );
+    ui.label(format!(
+        "Scanned: left {} / right {}",
+        complete(state.left_scan_complete),
+        complete(state.right_scan_complete)
+    ));
     ui.separator();
     let rows = ordered_visible(state);
     egui::ScrollArea::vertical().show(ui, |ui| {
         for p in rows {
-            let status = &state.content_statuses[&p];
+            let entry = state
+                .model
+                .entries
+                .values()
+                .find(|e| e.relative_path == p)
+                .expect("visible model row");
+            let status = entry.effective_status;
+            let left = entry.left.as_ref().map(|s| s.path.clone());
+            let right = entry.right.as_ref().map(|s| s.path.clone());
             let depth = p.components().count().saturating_sub(1);
             ui.horizontal(|ui| {
                 ui.add_space(depth as f32 * 14.0);
-                let symbol = match status {
-                    DiffStatus::Identical => "✓",
-                    DiffStatus::Modified => "≠",
-                    DiffStatus::LeftOnly => "←",
-                    DiffStatus::RightOnly => "→",
-                    DiffStatus::Error => "!",
-                };
+                let selected = state.selected_paths.contains(&p);
                 if ui
                     .selectable_label(
-                        state.selected_relative_path.as_ref() == Some(&p),
-                        format!("{symbol}  {} — {}", p.display(), status_text(status)),
+                        selected,
+                        format!(
+                            "{}  {} — {}",
+                            symbol(status),
+                            p.display(),
+                            status_text(status)
+                        ),
                     )
                     .clicked()
                 {
-                    state.selected_relative_path = Some(p.clone());
-                    state.scroll_anchor = Some(p)
+                    state.selected_paths.clear();
+                    state.selected_paths.insert(p.clone());
+                    state.primary_selection = Some(p.clone());
+                    state.scroll_anchor = Some(p.clone());
+                }
+                if ui.small_button("Open").clicked() {
+                    action = FolderViewAction::OpenChild {
+                        relative_path: p.clone(),
+                        left,
+                        right,
+                    };
                 }
             });
         }
     });
-    FolderViewAction::Noop
+    action
 }
-fn status_text(s: &DiffStatus) -> &'static str {
+fn complete(value: bool) -> &'static str {
+    if value { "complete" } else { "running" }
+}
+fn symbol(s: FolderStatus) -> &'static str {
     match s {
-        DiffStatus::Identical => "Identical (content checked)",
-        DiffStatus::Modified => "Different",
-        DiffStatus::LeftOnly => "Left only",
-        DiffStatus::RightOnly => "Right only",
-        DiffStatus::Error => "Error / unreadable",
+        FolderStatus::Identical => "✓",
+        FolderStatus::Different => "≠",
+        FolderStatus::LeftOnly => "←",
+        FolderStatus::RightOnly => "→",
+        FolderStatus::LeftNewer => "←+",
+        FolderStatus::RightNewer => "+→",
+        FolderStatus::PendingContentComparison => "…",
+        FolderStatus::Unreadable => "?",
+        FolderStatus::Error => "!",
     }
 }
-/// Stable depth-first ordering; only children sharing a parent are sorted.
+fn status_text(s: FolderStatus) -> &'static str {
+    match s {
+        FolderStatus::Identical => "Identical",
+        FolderStatus::Different => "Different",
+        FolderStatus::LeftOnly => "Left only",
+        FolderStatus::RightOnly => "Right only",
+        FolderStatus::LeftNewer => "Left newer",
+        FolderStatus::RightNewer => "Right newer",
+        FolderStatus::PendingContentComparison => "Pending content comparison",
+        FolderStatus::Unreadable => "Unreadable",
+        FolderStatus::Error => "Error",
+    }
+}
+
 pub(crate) fn ordered_visible(state: &FolderCompareState) -> Vec<PathBuf> {
     let q = state.path_filter.to_lowercase();
     let mut v: Vec<_> = state
-        .content_statuses
-        .iter()
-        .filter(|(p, s)| {
-            p.to_string_lossy().to_lowercase().contains(&q)
+        .model
+        .entries
+        .values()
+        .filter(|e| {
+            e.relative_path
+                .to_string_lossy()
+                .to_lowercase()
+                .contains(&q)
                 && match state.display_filter {
                     FolderDisplayFilter::All => true,
-                    FolderDisplayFilter::Changed => **s != DiffStatus::Identical,
-                    FolderDisplayFilter::Identical => **s == DiffStatus::Identical,
-                    FolderDisplayFilter::OneSided => {
-                        matches!(s, DiffStatus::LeftOnly | DiffStatus::RightOnly)
-                    }
+                    FolderDisplayFilter::Changed => e.effective_status != FolderStatus::Identical,
+                    FolderDisplayFilter::Identical => e.effective_status == FolderStatus::Identical,
+                    FolderDisplayFilter::OneSided => matches!(
+                        e.effective_status,
+                        FolderStatus::LeftOnly | FolderStatus::RightOnly
+                    ),
                 }
         })
-        .map(|(p, _)| p.clone())
+        .map(|e| e.relative_path.clone())
         .collect();
     v.sort_by(|a, b| {
-        let ap = a.parent().unwrap_or(Path::new(""));
-        let bp = b.parent().unwrap_or(Path::new(""));
-        ap.cmp(bp).then_with(|| a.file_name().cmp(&b.file_name()))
+        a.parent()
+            .unwrap_or(Path::new(""))
+            .cmp(b.parent().unwrap_or(Path::new("")))
+            .then_with(|| a.file_name().cmp(&b.file_name()))
     });
     if state.sort.descending {
         v.reverse()
     }
     v
 }
-/// Navigation wraps at both ends and follows the current retained projection.
 pub(crate) fn adjacent_difference(
     rows: &[PathBuf],
-    statuses: &std::collections::BTreeMap<PathBuf, DiffStatus>,
+    state: &FolderCompareState,
     current: Option<&Path>,
     forward: bool,
 ) -> Option<PathBuf> {
     let d: Vec<_> = rows
         .iter()
-        .filter(|p| statuses.get(*p) != Some(&DiffStatus::Identical))
+        .filter(|p| {
+            state
+                .model
+                .entries
+                .values()
+                .find(|e| &e.relative_path == *p)
+                .is_some_and(|e| e.effective_status != FolderStatus::Identical)
+        })
         .collect();
     if d.is_empty() {
         return None;

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -161,7 +161,19 @@ impl DiffDialogState {
                     ));
                 }
                 DiffView::FolderCompare(s) => {
-                    self.folder_runtimes.entry(view_id).or_default();
+                    let runtime = self.folder_runtimes.entry(view_id).or_default();
+                    poll_folder_runtime(s, runtime);
+                    if runtime.is_active() {
+                        ctx.request_repaint();
+                    }
+                    if runtime.left_error.is_some() || runtime.right_error.is_some() {
+                        let left = runtime.left_error.as_deref().unwrap_or("none");
+                        let right = runtime.right_error.as_deref().unwrap_or("none");
+                        ui.colored_label(
+                            egui::Color32::RED,
+                            format!("Scan failures — left: {left}; right: {right}"),
+                        );
+                    }
                     action = render_retained_folder(s, |state| folder_view::show(ui, state));
                 }
             }
@@ -242,6 +254,112 @@ impl DiffDialogState {
             }
         }
         self.reconcile_runtime_resources();
+    }
+}
+
+fn poll_folder_runtime(
+    state: &mut crate::diff::model::FolderCompareState,
+    runtime: &mut crate::diff::folder_runtime::FolderRuntime,
+) {
+    use crate::diff::folder_compare::PathKeyPolicy;
+    use crate::diff::folder_scan::{RootIdentity, ScanEvent};
+
+    let left_identity = RootIdentity::new(state.left_root.clone());
+    let right_identity = RootIdentity::new(state.right_root.clone());
+    if runtime.left_root.as_ref() != Some(&left_identity)
+        || runtime.right_root.as_ref() != Some(&right_identity)
+    {
+        runtime.cancel();
+        runtime.generation = crate::diff::folder_runtime::FolderRuntime::next_generation();
+        runtime.left_root = Some(left_identity.clone());
+        runtime.right_root = Some(right_identity.clone());
+        runtime.left_visited = 0;
+        runtime.right_visited = 0;
+        runtime.left_error = None;
+        runtime.right_error = None;
+        state.left_scan_complete = false;
+        state.right_scan_complete = false;
+        runtime.left_scan = Some(crate::diff::folder_scan::spawn_scan(
+            state.left_root.clone(),
+            runtime.generation,
+            state.scan_rules.clone(),
+        ));
+        runtime.right_scan = Some(crate::diff::folder_scan::spawn_scan(
+            state.right_root.clone(),
+            runtime.generation,
+            state.scan_rules.clone(),
+        ));
+    }
+
+    let left_events: Vec<_> = runtime
+        .left_scan
+        .as_ref()
+        .map(|h| h.receiver.try_iter().collect())
+        .unwrap_or_default();
+    let right_events: Vec<_> = runtime
+        .right_scan
+        .as_ref()
+        .map(|h| h.receiver.try_iter().collect())
+        .unwrap_or_default();
+    process_scan_events(state, runtime, true, &left_identity, left_events);
+    process_scan_events(state, runtime, false, &right_identity, right_events);
+
+    fn process_scan_events(
+        state: &mut crate::diff::model::FolderCompareState,
+        runtime: &mut crate::diff::folder_runtime::FolderRuntime,
+        left: bool,
+        expected: &RootIdentity,
+        events: Vec<ScanEvent>,
+    ) {
+        for event in events {
+            if !event.is_current(runtime.generation, expected) {
+                continue;
+            }
+            match event {
+                ScanEvent::ScanStarted { .. } => {}
+                ScanEvent::EntriesDiscovered { entries, .. }
+                | ScanEvent::EntriesUpdated { entries, .. } => {
+                    for item in entries {
+                        let _ = state.model.upsert(
+                            &item.relative_path,
+                            item.side,
+                            left,
+                            PathKeyPolicy::Platform,
+                            state.timestamp_tolerance,
+                        );
+                    }
+                }
+                ScanEvent::Progress { visited, .. } => {
+                    if left {
+                        runtime.left_visited = visited
+                    } else {
+                        runtime.right_visited = visited
+                    }
+                }
+                ScanEvent::Completed { visited, .. } | ScanEvent::Cancelled { visited, .. } => {
+                    if left {
+                        runtime.left_visited = visited;
+                        state.left_scan_complete = true;
+                        runtime.left_scan = None;
+                    } else {
+                        runtime.right_visited = visited;
+                        state.right_scan_complete = true;
+                        runtime.right_scan = None;
+                    }
+                }
+                ScanEvent::Failed { error, .. } => {
+                    if left {
+                        runtime.left_error = Some(error);
+                        state.left_scan_complete = true;
+                        runtime.left_scan = None;
+                    } else {
+                        runtime.right_error = Some(error);
+                        state.right_scan_complete = true;
+                        runtime.right_scan = None;
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

- Replace the ad-hoc folder-status map and generic `DiffStatus` usage with the authoritative folder model and rich per-view state so folder comparisons are consistent, retain navigable state, and can safely merge scanner events.
- Introduce a runtime layer to manage ephemeral scanner resources, generations, and per-side scan lifecycle so scans can be validated, cancelled, and polled without leaking receivers or handles.

### Description

- Replaced legacy folder status storage with the authoritative `FolderModel`, `FolderEntry`, `EntrySide`, `EntryMetadata`, `EntryKind`, and `FolderStatus` in `src/diff/model.rs` and `src/diff/folder_compare.rs`, and removed the previous generic `DiffStatus` usage. 
- Expanded `FolderCompareState` to retain `left_root`, `right_root`, the `FolderModel`, `selected_paths`, `primary_selection`, `expanded_nodes`, `scroll_anchor`, display/path filters, sort state, `ScanRules`, `ContentComparisonMode`, timestamp tolerance, and per-side scan completion flags in `src/diff/model.rs`.
- Added `FolderRuntime` in `src/diff/folder_runtime.rs` with a monotonically-increasing generation counter, left/right `RootIdentity`, per-side `ScanHandle`s and visited counters, a content cache, comparison result store, active operation handle, and per-side error fields; runtime cancels scans on `Drop` and exposes `is_active()` and generation allocation.
- Integrated scanner lifecycle: when a folder view opens the code spawns one scanner per root with the same generation and rules (`folder_scan::spawn_scan()`), polls both scanner receivers each frame, validates each `ScanEvent` against generation and root identity, and calls `FolderModel::upsert()` for discovered/updated entries with `PathKeyPolicy::Platform` and configured timestamp tolerance in `src/gui/diff_dialog/mod.rs`.
- UI integration: folder view now looks up rows from the authoritative `FolderModel`, renders full `FolderStatus` variants (including newer-side, pending content comparison, unreadable, and error states), shows per-side scan progress/errors, requests repaints while scans or content jobs are active, and preserves both roots and folder state when pushing a child file compare and returning with Back (changes in `src/gui/diff_dialog/folder_view.rs` and `src/gui/diff_dialog/mod.rs`).
- Scan improvements: `ScanRules` made `PartialEq/Eq` where semantically valid and scanner code broadcasts all terminal events; scanner `scan()` sends `Cancelled` when cancelled early; `ScanEvent::is_current()` enforces generation/root matching in `src/diff/folder_scan.rs`.
- Tests: added unit tests exercising metadata-based status decisions (including timestamp tolerance and unreadable cases), case-insensitive pairing and large upserts, recursive scanner discovery and batching, symlink non-traversal, and stale/mismatched event rejection in `src/diff/folder_compare.rs` and `src/diff/folder_scan.rs`.

### Testing

- `cargo fmt -- --check` executed and passed. 
- `git diff --check` executed and passed. 
- Ran a repository scan to confirm legacy references were removed with `rg "DiffStatus|content_statuses|selected_relative_path" src/diff src/gui/diff_dialog -n` and confirmed the code now uses the authoritative model-based API. 
- `cargo check` was attempted; compilation progressed into the application crate but ultimately failed due to pre-existing platform-specific Windows API imports in unrelated modules (unconditional `windows::Win32` usages) on this Linux CI environment, not due to changes in the diff modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78a292169083328f5161cbc72c0e9c)