### PR TITLE
Refactor folder comparison projections and folder view UI (hierarchy, selection, navigation)

### DIFF
--- a/src/diff/folder_compare.rs
+++ b/src/diff/folder_compare.rs
@@ -2,7 +2,7 @@
 //! operation paths and metadata are deliberately retained per side.
 use crate::diff::text_compare::{CompiledRules, TextComparisonRules, project};
 use crate::diff::text_file::{LoadedContent, load_text_file};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -207,6 +207,124 @@ impl FolderModel {
                     && filter.matches(e.effective_status)
             })
             .collect()
+    }
+}
+
+/// One row in the presentation tree.  This is deliberately a value projection:
+/// changing view options cannot mutate, or cause work to be scheduled on, the model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolderProjectionRow {
+    pub path: PathBuf,
+    pub depth: usize,
+    pub has_children: bool,
+}
+
+/// Builds a tree from explicit parent/child links and then flattens its visible
+/// portion. This avoids deriving nesting from incidental ordering of path strings.
+pub fn project_folder_rows(
+    model: &FolderModel,
+    filter: crate::diff::model::FolderDisplayFilter,
+    path_filter: &str,
+    expanded: &BTreeSet<PathBuf>,
+    descending: bool,
+) -> Vec<FolderProjectionRow> {
+    use crate::diff::model::FolderDisplayFilter as F;
+    let query = path_filter.replace('\\', "/").to_lowercase();
+    let mut by_path = BTreeMap::<PathBuf, &FolderEntry>::new();
+    for entry in model.entries.values() {
+        by_path.insert(entry.relative_path.clone(), entry);
+    }
+    let mut children = BTreeMap::<Option<PathBuf>, Vec<PathBuf>>::new();
+    for path in by_path.keys() {
+        let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+        let explicit_parent = parent
+            .filter(|p| by_path.contains_key(*p))
+            .map(Path::to_path_buf);
+        children
+            .entry(explicit_parent)
+            .or_default()
+            .push(path.clone());
+    }
+    fn matches(f: F, status: FolderStatus) -> bool {
+        match f {
+            F::All => true,
+            F::Differences => status.is_different(),
+            F::Identical => status == FolderStatus::Identical,
+            F::LeftOnly => status == FolderStatus::LeftOnly,
+            F::RightOnly => status == FolderStatus::RightOnly,
+            F::LeftNewer => status == FolderStatus::LeftNewer,
+            F::RightNewer => status == FolderStatus::RightNewer,
+            F::Errors => matches!(status, FolderStatus::Unreadable | FolderStatus::Error),
+        }
+    }
+    fn walk(
+        parent: Option<&Path>,
+        depth: usize,
+        by_path: &BTreeMap<PathBuf, &FolderEntry>,
+        children: &BTreeMap<Option<PathBuf>, Vec<PathBuf>>,
+        expanded: &BTreeSet<PathBuf>,
+        filter: F,
+        query: &str,
+        descending: bool,
+        out: &mut Vec<FolderProjectionRow>,
+    ) {
+        let key = parent.map(Path::to_path_buf);
+        let mut paths = children.get(&key).cloned().unwrap_or_default();
+        // Sorting siblings keeps a directory immediately before its subtree.
+        paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        if descending {
+            paths.reverse();
+        }
+        for path in paths {
+            let entry = by_path[&path];
+            let has_children = children.contains_key(&Some(path.clone()));
+            let path_matches = path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .to_lowercase()
+                .contains(query);
+            if path_matches && matches(filter.clone(), entry.effective_status) {
+                out.push(FolderProjectionRow {
+                    path: path.clone(),
+                    depth,
+                    has_children,
+                });
+            }
+            if has_children && expanded.contains(&path) {
+                walk(
+                    Some(&path),
+                    depth + 1,
+                    by_path,
+                    children,
+                    expanded,
+                    filter.clone(),
+                    query,
+                    descending,
+                    out,
+                );
+            }
+        }
+    }
+    let mut rows = Vec::new();
+    walk(
+        None, 0, &by_path, &children, expanded, filter, &query, descending, &mut rows,
+    );
+    rows
+}
+
+/// Expands every retained directory entry above `target`.
+pub fn expand_ancestors(model: &FolderModel, target: &Path, expanded: &mut BTreeSet<PathBuf>) {
+    let paths: BTreeSet<_> = model
+        .entries
+        .values()
+        .map(|e| e.relative_path.as_path())
+        .collect();
+    let mut parent = target.parent();
+    while let Some(path) = parent.filter(|p| !p.as_os_str().is_empty()) {
+        if paths.contains(path) {
+            expanded.insert(path.to_path_buf());
+        }
+        parent = path.parent();
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -22,9 +22,13 @@ fn id() -> u64 {
 pub enum FolderDisplayFilter {
     #[default]
     All,
-    Changed,
+    Differences,
     Identical,
-    OneSided,
+    LeftOnly,
+    RightOnly,
+    LeftNewer,
+    RightNewer,
+    Errors,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FolderSortState {

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -1,7 +1,10 @@
-//! Folder tree presentation. Filtering is a projection of the authoritative model.
-use crate::diff::folder_compare::FolderStatus;
+//! Folder tree presentation. Every view operation is a pure projection of retained data.
+use crate::diff::folder_compare::{
+    FolderProjectionRow, FolderStatus, expand_ancestors, project_folder_rows,
+};
 use crate::diff::model::{FolderCompareState, FolderDisplayFilter};
 use eframe::egui;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -17,6 +20,156 @@ pub(super) enum FolderViewAction {
     RequestRescan,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectionGesture {
+    Click,
+    Toggle,
+    Range,
+    SelectAll,
+    MoveUp,
+    MoveDown,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DifferenceNavigation {
+    First,
+    Previous,
+    Next,
+    Last,
+}
+
+pub(crate) fn apply_selection(
+    state: &mut FolderCompareState,
+    rows: &[PathBuf],
+    target: Option<&Path>,
+    gesture: SelectionGesture,
+) {
+    if rows.is_empty() {
+        if gesture == SelectionGesture::SelectAll {
+            state.selected_paths.clear();
+            state.primary_selection = None;
+        }
+        return;
+    }
+    let target_index = target.and_then(|p| rows.iter().position(|r| r == p));
+    match gesture {
+        SelectionGesture::Click => {
+            if let Some(i) = target_index {
+                state.selected_paths.clear();
+                state.selected_paths.insert(rows[i].clone());
+                state.primary_selection = Some(rows[i].clone());
+            }
+        }
+        SelectionGesture::Toggle => {
+            if let Some(i) = target_index {
+                let path = rows[i].clone();
+                if !state.selected_paths.remove(&path) {
+                    state.selected_paths.insert(path.clone());
+                }
+                state.primary_selection = state
+                    .selected_paths
+                    .contains(&path)
+                    .then_some(path)
+                    .or_else(|| state.selected_paths.iter().next().cloned());
+            }
+        }
+        SelectionGesture::Range => {
+            if let Some(end) = target_index {
+                let start = state
+                    .primary_selection
+                    .as_ref()
+                    .and_then(|p| rows.iter().position(|r| r == p))
+                    .unwrap_or(end);
+                state.selected_paths.clear();
+                for path in &rows[start.min(end)..=start.max(end)] {
+                    state.selected_paths.insert(path.clone());
+                }
+                state.primary_selection = Some(rows[end].clone());
+            }
+        }
+        SelectionGesture::SelectAll => {
+            state.selected_paths = rows.iter().cloned().collect();
+            if state
+                .primary_selection
+                .as_ref()
+                .is_none_or(|p| !state.selected_paths.contains(p))
+            {
+                state.primary_selection = rows.first().cloned();
+            }
+        }
+        SelectionGesture::MoveUp | SelectionGesture::MoveDown => {
+            let current = state
+                .primary_selection
+                .as_ref()
+                .and_then(|p| rows.iter().position(|r| r == p));
+            let i = match (gesture, current) {
+                (SelectionGesture::MoveUp, Some(i)) => i.saturating_sub(1),
+                (SelectionGesture::MoveDown, Some(i)) => (i + 1).min(rows.len() - 1),
+                (SelectionGesture::MoveUp, None) => rows.len() - 1,
+                _ => 0,
+            };
+            state.selected_paths.clear();
+            state.selected_paths.insert(rows[i].clone());
+            state.primary_selection = Some(rows[i].clone());
+        }
+    }
+    state.scroll_anchor = state.primary_selection.clone();
+}
+
+pub(crate) fn adjacent_difference(
+    rows: &[PathBuf],
+    state: &FolderCompareState,
+    current: Option<&Path>,
+    forward: bool,
+) -> Option<PathBuf> {
+    navigate_difference(
+        rows,
+        state,
+        current,
+        if forward {
+            DifferenceNavigation::Next
+        } else {
+            DifferenceNavigation::Previous
+        },
+    )
+}
+
+pub(crate) fn navigate_difference(
+    rows: &[PathBuf],
+    state: &FolderCompareState,
+    current: Option<&Path>,
+    nav: DifferenceNavigation,
+) -> Option<PathBuf> {
+    let differences: Vec<_> = rows
+        .iter()
+        .filter(|path| {
+            state.model.entries.values().any(|e| {
+                e.relative_path.as_path() == path.as_path() && e.effective_status.is_different()
+            })
+        })
+        .collect();
+    if differences.is_empty() {
+        return None;
+    }
+    let at = current.and_then(|p| differences.iter().position(|r| r.as_path() == p));
+    let index = match nav {
+        DifferenceNavigation::First => 0,
+        DifferenceNavigation::Last => differences.len() - 1,
+        DifferenceNavigation::Next => at.map_or(0, |i| (i + 1) % differences.len()),
+        DifferenceNavigation::Previous => at.map_or(differences.len() - 1, |i| {
+            if i == 0 { differences.len() - 1 } else { i - 1 }
+        }),
+    };
+    Some(differences[index].clone())
+}
+
+fn select_navigation_target(state: &mut FolderCompareState, target: PathBuf) {
+    expand_ancestors(&state.model, &target, &mut state.expanded_nodes);
+    state.selected_paths.clear();
+    state.selected_paths.insert(target.clone());
+    state.primary_selection = Some(target.clone());
+    state.scroll_anchor = Some(target);
+}
+
 pub(super) fn show(
     ui: &mut egui::Ui,
     state: &mut FolderCompareState,
@@ -29,18 +182,22 @@ pub(super) fn show(
         state.right_root.display()
     ));
     let mut action = FolderViewAction::Noop;
-    ui.horizontal(|ui| {
-        for (label, f) in [
+    ui.horizontal_wrapped(|ui| {
+        for (label, filter) in [
             ("All", FolderDisplayFilter::All),
-            ("Differences", FolderDisplayFilter::Changed),
+            ("Differences", FolderDisplayFilter::Differences),
             ("Identical", FolderDisplayFilter::Identical),
-            ("Left / Right only", FolderDisplayFilter::OneSided),
+            ("Left only", FolderDisplayFilter::LeftOnly),
+            ("Right only", FolderDisplayFilter::RightOnly),
+            ("Left newer", FolderDisplayFilter::LeftNewer),
+            ("Right newer", FolderDisplayFilter::RightNewer),
+            ("Errors", FolderDisplayFilter::Errors),
         ] {
             if ui
-                .selectable_label(state.display_filter == f, label)
+                .selectable_label(state.display_filter == filter, label)
                 .clicked()
             {
-                state.display_filter = f
+                state.display_filter = filter;
             }
         }
         if ui.button("Rescan").clicked() {
@@ -74,140 +231,329 @@ pub(super) fn show(
             String::new()
         }
     ));
-    ui.separator();
-    let rows = ordered_visible(state);
-    egui::ScrollArea::vertical().show(ui, |ui| {
-        for p in rows {
-            let entry = state
-                .model
-                .entries
-                .values()
-                .find(|e| e.relative_path == p)
-                .expect("visible model row");
-            let status = entry.effective_status;
-            let left = entry.left.as_ref().map(|s| s.path.clone());
-            let right = entry.right.as_ref().map(|s| s.path.clone());
-            let depth = p.components().count().saturating_sub(1);
-            ui.horizontal(|ui| {
-                ui.add_space(depth as f32 * 14.0);
-                let selected = state.selected_paths.contains(&p);
-                if ui
-                    .selectable_label(
-                        selected,
-                        format!(
-                            "{}  {} — {}",
-                            symbol(status),
-                            p.display(),
-                            status_text(status)
-                        ),
-                    )
-                    .clicked()
+
+    let mut projected = projected_rows(state);
+    let mut paths: Vec<_> = projected.iter().map(|r| r.path.clone()).collect();
+    let keys = ui.input(|i| {
+        (
+            i.modifiers.command && i.key_pressed(egui::Key::A),
+            i.key_pressed(egui::Key::ArrowUp),
+            i.key_pressed(egui::Key::ArrowDown),
+        )
+    });
+    if keys.0 {
+        apply_selection(state, &paths, None, SelectionGesture::SelectAll);
+    }
+    if keys.1 {
+        apply_selection(state, &paths, None, SelectionGesture::MoveUp);
+    }
+    if keys.2 {
+        apply_selection(state, &paths, None, SelectionGesture::MoveDown);
+    }
+    ui.horizontal(|ui| {
+        for (label, nav) in [
+            ("First", DifferenceNavigation::First),
+            ("Previous", DifferenceNavigation::Previous),
+            ("Next", DifferenceNavigation::Next),
+            ("Last", DifferenceNavigation::Last),
+        ] {
+            if ui.button(label).clicked() {
+                if let Some(target) =
+                    navigate_difference(&paths, state, state.primary_selection.as_deref(), nav)
                 {
-                    state.selected_paths.clear();
-                    state.selected_paths.insert(p.clone());
-                    state.primary_selection = Some(p.clone());
-                    state.scroll_anchor = Some(p.clone());
+                    select_navigation_target(state, target);
                 }
-                if ui.small_button("Open").clicked() {
-                    action = FolderViewAction::OpenChild {
-                        relative_path: p.clone(),
-                        left,
-                        right,
-                    };
-                }
-            });
+            }
         }
     });
+    // Navigation may have expanded a hidden target, so calculate the projection again.
+    projected = projected_rows(state);
+    paths = projected.iter().map(|r| r.path.clone()).collect();
+    ui.separator();
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        egui::Grid::new("folder-results")
+            .striped(true)
+            .num_columns(6)
+            .show(ui, |ui| {
+                for heading in [
+                    "Left path",
+                    "Left size / modified",
+                    "Status",
+                    "Right path",
+                    "Right size / modified",
+                    "",
+                ] {
+                    ui.strong(heading);
+                }
+                ui.end_row();
+                for row in &projected {
+                    render_row(ui, state, &paths, row, &mut action);
+                }
+            });
+    });
     action
+}
+
+fn render_row(
+    ui: &mut egui::Ui,
+    state: &mut FolderCompareState,
+    paths: &[PathBuf],
+    row: &FolderProjectionRow,
+    action: &mut FolderViewAction,
+) {
+    let entry = state
+        .model
+        .entries
+        .values()
+        .find(|e| e.relative_path == row.path)
+        .expect("projected row")
+        .clone();
+    let selected = state.selected_paths.contains(&row.path);
+    ui.horizontal(|ui| {
+        ui.add_space(row.depth as f32 * 14.0);
+        if row.has_children {
+            let open = state.expanded_nodes.contains(&row.path);
+            if ui.small_button(if open { "▼" } else { "▶" }).clicked() {
+                if open {
+                    state.expanded_nodes.remove(&row.path);
+                } else {
+                    state.expanded_nodes.insert(row.path.clone());
+                }
+            }
+        } else {
+            ui.add_space(22.0);
+        }
+        let name = entry
+            .left
+            .as_ref()
+            .map(|_| row.path.display().to_string())
+            .unwrap_or_default();
+        let response = ui.selectable_label(selected, name);
+        if response.clicked() {
+            let modifiers = ui.input(|i| i.modifiers);
+            apply_selection(
+                state,
+                paths,
+                Some(&row.path),
+                if modifiers.shift {
+                    SelectionGesture::Range
+                } else if modifiers.command {
+                    SelectionGesture::Toggle
+                } else {
+                    SelectionGesture::Click
+                },
+            );
+        }
+        if state.scroll_anchor.as_ref() == Some(&row.path) {
+            response.scroll_to_me(Some(egui::Align::Center));
+        }
+    });
+    ui.label(side_details(entry.left.as_ref()));
+    ui.label(status_label(entry.effective_status));
+    ui.label(
+        entry
+            .right
+            .as_ref()
+            .map(|_| row.path.display().to_string())
+            .unwrap_or_default(),
+    );
+    ui.label(side_details(entry.right.as_ref()));
+    if ui.small_button("Open").clicked() {
+        *action = FolderViewAction::OpenChild {
+            relative_path: row.path.clone(),
+            left: entry.left.map(|s| s.path),
+            right: entry.right.map(|s| s.path),
+        };
+    }
+    ui.end_row();
+}
+fn side_details(side: Option<&crate::diff::folder_compare::EntrySide>) -> String {
+    let Some(metadata) = side.and_then(|s| s.metadata.as_ref()) else {
+        return String::new();
+    };
+    let modified = metadata
+        .modified
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|| "—".into());
+    format!("{} B / {}", metadata.size, modified)
 }
 fn complete(value: bool) -> &'static str {
     if value { "complete" } else { "running" }
 }
-fn symbol(s: FolderStatus) -> &'static str {
-    match s {
-        FolderStatus::Identical => "✓",
-        FolderStatus::Different => "≠",
-        FolderStatus::LeftOnly => "←",
-        FolderStatus::RightOnly => "→",
-        FolderStatus::LeftNewer => "←+",
-        FolderStatus::RightNewer => "+→",
-        FolderStatus::PendingContentComparison => "…",
-        FolderStatus::Unreadable => "?",
-        FolderStatus::Error => "!",
+fn status_label(status: FolderStatus) -> &'static str {
+    match status {
+        FolderStatus::Identical => "✓ Identical",
+        FolderStatus::Different => "≠ Different",
+        FolderStatus::LeftOnly => "← Left only",
+        FolderStatus::RightOnly => "→ Right only",
+        FolderStatus::LeftNewer => "L+ Left newer",
+        FolderStatus::RightNewer => "R+ Right newer",
+        FolderStatus::PendingContentComparison => "◌ Checking contents",
+        FolderStatus::Unreadable | FolderStatus::Error => "! Error",
     }
 }
-fn status_text(s: FolderStatus) -> &'static str {
-    match s {
-        FolderStatus::Identical => "Identical",
-        FolderStatus::Different => "Different",
-        FolderStatus::LeftOnly => "Left only",
-        FolderStatus::RightOnly => "Right only",
-        FolderStatus::LeftNewer => "Left newer",
-        FolderStatus::RightNewer => "Right newer",
-        FolderStatus::PendingContentComparison => "Pending content comparison",
-        FolderStatus::Unreadable => "Unreadable",
-        FolderStatus::Error => "Error",
-    }
+pub(crate) fn projected_rows(state: &FolderCompareState) -> Vec<FolderProjectionRow> {
+    project_folder_rows(
+        &state.model,
+        state.display_filter.clone(),
+        &state.path_filter,
+        &state.expanded_nodes,
+        state.sort.descending,
+    )
+}
+pub(crate) fn ordered_visible(state: &FolderCompareState) -> Vec<PathBuf> {
+    projected_rows(state).into_iter().map(|r| r.path).collect()
 }
 
-pub(crate) fn ordered_visible(state: &FolderCompareState) -> Vec<PathBuf> {
-    let q = state.path_filter.to_lowercase();
-    let mut v: Vec<_> = state
-        .model
-        .entries
-        .values()
-        .filter(|e| {
-            e.relative_path
-                .to_string_lossy()
-                .to_lowercase()
-                .contains(&q)
-                && match state.display_filter {
-                    FolderDisplayFilter::All => true,
-                    FolderDisplayFilter::Changed => e.effective_status != FolderStatus::Identical,
-                    FolderDisplayFilter::Identical => e.effective_status == FolderStatus::Identical,
-                    FolderDisplayFilter::OneSided => matches!(
-                        e.effective_status,
-                        FolderStatus::LeftOnly | FolderStatus::RightOnly
-                    ),
-                }
-        })
-        .map(|e| e.relative_path.clone())
-        .collect();
-    v.sort_by(|a, b| {
-        a.parent()
-            .unwrap_or(Path::new(""))
-            .cmp(b.parent().unwrap_or(Path::new("")))
-            .then_with(|| a.file_name().cmp(&b.file_name()))
-    });
-    if state.sort.descending {
-        v.reverse()
-    }
-    v
+/// A mutation command must call this once and operate on the returned value.
+pub(crate) fn selection_snapshot(state: &FolderCompareState) -> BTreeSet<PathBuf> {
+    state.selected_paths.clone()
 }
-pub(crate) fn adjacent_difference(
-    rows: &[PathBuf],
-    state: &FolderCompareState,
-    current: Option<&Path>,
-    forward: bool,
-) -> Option<PathBuf> {
-    let d: Vec<_> = rows
-        .iter()
-        .filter(|p| {
-            state
-                .model
-                .entries
-                .values()
-                .find(|e| &e.relative_path == *p)
-                .is_some_and(|e| e.effective_status != FolderStatus::Identical)
-        })
-        .collect();
-    if d.is_empty() {
-        return None;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::folder_compare::FolderEntry;
+
+    fn state(items: &[(&str, FolderStatus)]) -> FolderCompareState {
+        let mut state = FolderCompareState::default();
+        for (path, status) in items {
+            state.model.entries.insert(
+                (*path).into(),
+                FolderEntry {
+                    relative_path: PathBuf::from(path),
+                    left: None,
+                    right: None,
+                    metadata_status: *status,
+                    effective_status: *status,
+                    content_checked: true,
+                },
+            );
+        }
+        state
     }
-    let at = current.and_then(|c| d.iter().position(|p| p.as_path() == c));
-    Some(if forward {
-        d[(at.map_or(0, |x| x + 1)) % d.len()].clone()
-    } else {
-        d[at.map_or(d.len() - 1, |x| if x == 0 { d.len() - 1 } else { x - 1 })].clone()
-    })
+    fn paths(state: &FolderCompareState) -> Vec<PathBuf> {
+        ordered_visible(state)
+    }
+
+    #[test]
+    fn hierarchy_collapse_and_ancestor_expansion() {
+        let mut s = state(&[
+            ("dir", FolderStatus::Identical),
+            ("dir/child", FolderStatus::Different),
+            ("dir/child/grand", FolderStatus::LeftOnly),
+        ]);
+        assert_eq!(paths(&s), vec![PathBuf::from("dir")]);
+        s.expanded_nodes.insert("dir".into());
+        assert_eq!(
+            paths(&s),
+            vec![PathBuf::from("dir"), PathBuf::from("dir/child")]
+        );
+        select_navigation_target(&mut s, "dir/child/grand".into());
+        assert!(s.expanded_nodes.contains(Path::new("dir/child")));
+        assert_eq!(s.scroll_anchor, Some("dir/child/grand".into()));
+        assert_eq!(paths(&s).last(), Some(&PathBuf::from("dir/child/grand")));
+    }
+
+    #[test]
+    fn every_filter_combines_with_path_filter_without_mutating_model() {
+        let items = [
+            ("same", FolderStatus::Identical),
+            ("different", FolderStatus::Different),
+            ("left", FolderStatus::LeftOnly),
+            ("right", FolderStatus::RightOnly),
+            ("left-new", FolderStatus::LeftNewer),
+            ("right-new", FolderStatus::RightNewer),
+            ("bad", FolderStatus::Error),
+        ];
+        let mut s = state(&items);
+        let before = s.model.clone();
+        for (filter, expected) in [
+            (FolderDisplayFilter::All, 7),
+            (FolderDisplayFilter::Differences, 6),
+            (FolderDisplayFilter::Identical, 1),
+            (FolderDisplayFilter::LeftOnly, 1),
+            (FolderDisplayFilter::RightOnly, 1),
+            (FolderDisplayFilter::LeftNewer, 1),
+            (FolderDisplayFilter::RightNewer, 1),
+            (FolderDisplayFilter::Errors, 1),
+        ] {
+            s.display_filter = filter;
+            assert_eq!(paths(&s).len(), expected);
+        }
+        s.display_filter = FolderDisplayFilter::Differences;
+        s.path_filter = "new".into();
+        assert_eq!(
+            paths(&s),
+            vec![PathBuf::from("left-new"), PathBuf::from("right-new")]
+        );
+        assert_eq!(s.model, before); // projections neither alter contents nor revision (scan generation)
+    }
+
+    #[test]
+    fn selection_gestures_and_keyboard_transitions() {
+        let mut s = state(&[]);
+        let rows: Vec<PathBuf> = ["a", "b", "c"].into_iter().map(Into::into).collect();
+        apply_selection(&mut s, &rows, Some(Path::new("b")), SelectionGesture::Click);
+        assert_eq!(s.primary_selection, Some("b".into()));
+        apply_selection(
+            &mut s,
+            &rows,
+            Some(Path::new("c")),
+            SelectionGesture::Toggle,
+        );
+        assert_eq!(s.selected_paths.len(), 2);
+        apply_selection(&mut s, &rows, Some(Path::new("a")), SelectionGesture::Range);
+        assert_eq!(s.selected_paths.len(), 2);
+        apply_selection(&mut s, &rows, None, SelectionGesture::SelectAll);
+        assert_eq!(s.selected_paths.len(), 3);
+        apply_selection(&mut s, &rows, None, SelectionGesture::MoveDown);
+        assert_eq!(s.primary_selection, Some("b".into()));
+        apply_selection(&mut s, &rows, None, SelectionGesture::MoveUp);
+        assert_eq!(s.primary_selection, Some("a".into()));
+        assert!(
+            s.selected_paths
+                .contains(s.primary_selection.as_ref().unwrap())
+        );
+    }
+
+    #[test]
+    fn difference_navigation_endpoints_wrap_and_exclude_hidden_rows() {
+        let s = state(&[
+            ("a", FolderStatus::Different),
+            ("b", FolderStatus::Identical),
+            ("c", FolderStatus::LeftOnly),
+        ]);
+        let visible = vec![PathBuf::from("a"), PathBuf::from("b"), PathBuf::from("c")];
+        assert_eq!(
+            navigate_difference(&visible, &s, None, DifferenceNavigation::First),
+            Some("a".into())
+        );
+        assert_eq!(
+            navigate_difference(&visible, &s, None, DifferenceNavigation::Last),
+            Some("c".into())
+        );
+        assert_eq!(
+            adjacent_difference(&visible, &s, Some(Path::new("c")), true),
+            Some("a".into())
+        );
+        assert_eq!(
+            adjacent_difference(&visible, &s, Some(Path::new("a")), false),
+            Some("c".into())
+        );
+        assert_eq!(
+            navigate_difference(
+                &visible[..2],
+                &s,
+                Some(Path::new("a")),
+                DifferenceNavigation::Next
+            ),
+            Some("a".into())
+        );
+        assert_eq!(
+            navigate_difference(&[PathBuf::from("b")], &s, None, DifferenceNavigation::Next),
+            None
+        );
+    }
 }

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -62,14 +62,24 @@ pub(crate) fn apply_selection(
         SelectionGesture::Toggle => {
             if let Some(i) = target_index {
                 let path = rows[i].clone();
-                if !state.selected_paths.remove(&path) {
+                let removed = state.selected_paths.remove(&path);
+                if !removed {
                     state.selected_paths.insert(path.clone());
                 }
-                state.primary_selection = state
-                    .selected_paths
-                    .contains(&path)
-                    .then_some(path)
-                    .or_else(|| state.selected_paths.iter().next().cloned());
+                // Ctrl-click changes membership without moving the range anchor.
+                // Only replace the primary selection when it no longer belongs to
+                // the selection (or when this is the first selected row).
+                if state
+                    .primary_selection
+                    .as_ref()
+                    .is_none_or(|primary| !state.selected_paths.contains(primary))
+                {
+                    state.primary_selection = if removed {
+                        state.selected_paths.iter().next().cloned()
+                    } else {
+                        Some(path)
+                    };
+                }
             }
         }
         SelectionGesture::Range => {
@@ -504,6 +514,7 @@ mod tests {
             SelectionGesture::Toggle,
         );
         assert_eq!(s.selected_paths.len(), 2);
+        assert_eq!(s.primary_selection, Some("b".into()));
         apply_selection(&mut s, &rows, Some(Path::new("a")), SelectionGesture::Range);
         assert_eq!(s.selected_paths.len(), 2);
         apply_selection(&mut s, &rows, None, SelectionGesture::SelectAll);


### PR DESCRIPTION
### Motivation

- Replace brittle flat-path inference with an explicit hierarchical projection so UI operations (filtering, sorting, expansion) are pure projections over retained `FolderModel` data.
- Render aligned columns and non-color-only status labels so comparisons are clearer and accessible.
- Support expanded selection semantics, stable navigation, and ancestor expansion for robust keyboard/mouse workflows.

### Description

- Add `FolderProjectionRow`, `project_folder_rows`, and `expand_ancestors` to `src/diff/folder_compare.rs` to build an explicit parent/child tree and produce a flattened visible projection without mutating the model.  
- Extend `FolderDisplayFilter` in `src/diff/model.rs` to include `Differences`, `LeftOnly`, `RightOnly`, `LeftNewer`, `RightNewer`, and `Errors` so display filters map directly to `FolderStatus`.  
- Replace `src/gui/diff_dialog/folder_view.rs` contents with a projection-driven view that renders six aligned columns (left path, left metadata, status, right path, right metadata, action), uses textual status labels (e.g. `✓ Identical`, `≠ Different`, `← Left only`, `→ Right only`, `L+ Left newer`, `R+ Right newer`, `◌ Checking contents`, `! Error`), and shows directories before their children.  
- Implement pure projection helpers for selection and navigation: `apply_selection`, selection gestures (`Click`, `Toggle`, `Range`, `SelectAll`, `MoveUp`, `MoveDown`), navigation helpers (`navigate_difference`, `adjacent_difference`, `select_navigation_target`), `selection_snapshot`, and auto-expansion of ancestors when navigating to a hidden descendant.  
- Add unit tests in `src/gui/diff_dialog/folder_view.rs` covering hierarchy/collapse and ancestor expansion, display filters combined with path filtering, projection immutability, selection gestures and keyboard transitions, and difference navigation (endpoints, wrapping, and hidden-row exclusion). 

### Testing

- Ran `cargo fmt` which succeeded and produced a clean format pass.  
- Attempted `cargo check` / `cargo test` during development; initial builds failed due to missing system pkg-config libraries (ALSA) which were installed and allowed compilation to progress, but full `cargo test` could not complete in this environment because other platform-specific crates (Windows APIs) are unconditionally referenced and produced unresolved import errors when building on Linux.  
- Unit tests were added (see `src/gui/diff_dialog/folder_view.rs`) but could not be executed to completion in this CI-like environment due to the platform-specific build failures described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78b763cd90833283cd86a73ff9161d)