### PR TITLE
Retain folder state when opening child comparisons

### DIFF
--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -62,6 +62,8 @@ pub struct FolderCompareState {
     pub timestamp_tolerance: Duration,
     pub left_scan_complete: bool,
     pub right_scan_complete: bool,
+    /// Children changed by an editor and awaiting a targeted metadata refresh.
+    pub stale_paths: BTreeSet<PathBuf>,
 }
 impl Default for FolderCompareState {
     fn default() -> Self {
@@ -85,6 +87,7 @@ impl Default for FolderCompareState {
             timestamp_tolerance: Duration::from_secs(2),
             left_scan_complete: false,
             right_scan_complete: false,
+            stale_paths: BTreeSet::new(),
         }
     }
 }
@@ -105,6 +108,7 @@ pub struct TextCompareState {
 pub enum DiffView {
     Start,
     TextCompare(TextCompareState),
+    BinaryCompare(TextCompareState),
     FolderCompare(FolderCompareState),
 }
 #[derive(Debug, Clone, PartialEq)]
@@ -198,12 +202,16 @@ impl DiffWorkspace {
             }
         };
         let view = if lm.is_file() && rm.is_file() {
-            DiffView::TextCompare(TextCompareState {
+            let state = TextCompareState {
                 left: Some(lp.clone()),
                 right: Some(rp.clone()),
                 relative_path: None,
                 kind: detect_kind(&lp, &rp),
-            })
+            };
+            match state.kind {
+                FileComparisonKind::Text => DiffView::TextCompare(state),
+                FileComparisonKind::Binary => DiffView::BinaryCompare(state),
+            }
         } else if lm.is_dir() && rm.is_dir() {
             DiffView::FolderCompare(FolderCompareState {
                 left_root: lp,
@@ -245,14 +253,18 @@ impl DiffWorkspace {
             (Some(l), Some(r)) => detect_kind(l, r),
             _ => FileComparisonKind::Text,
         };
+        let state = TextCompareState {
+            left,
+            right,
+            relative_path: Some(relative_path),
+            kind,
+        };
         let next = RetainedView {
             id: id(),
-            view: DiffView::TextCompare(TextCompareState {
-                left,
-                right,
-                relative_path: Some(relative_path),
-                kind,
-            }),
+            view: match state.kind {
+                FileComparisonKind::Text => DiffView::TextCompare(state),
+                FileComparisonKind::Binary => DiffView::BinaryCompare(state),
+            },
         };
         let old = std::mem::replace(&mut self.current_view, next);
         self.navigation_stack.push(old);
@@ -420,6 +432,8 @@ pub struct TextViewModel {
     pub right_error: Option<String>,
     pub external_conflict: [bool; 2],
     pub cursor: Option<SourcePosition>,
+    /// Set only after a successful write, so returning without saving is inert.
+    pub saved_filesystem_mutation: bool,
     generation: u64,
     receiver: Option<Receiver<CompareMessage>>,
 }
@@ -474,6 +488,7 @@ impl TextViewModel {
             right_error: None,
             external_conflict: [false, false],
             cursor: None,
+            saved_filesystem_mutation: false,
             generation: 0,
             receiver: None,
         };
@@ -644,10 +659,14 @@ impl TextViewModel {
                 &mut self.right_error,
             ),
         };
+        let was_dirty = doc.is_dirty();
         let result = path
             .ok_or_else(|| anyhow::anyhow!("Choose a path before saving"))
             .and_then(|p| doc.save(p));
         *err = result.as_ref().err().map(ToString::to_string);
+        if result.is_ok() && was_dirty {
+            self.saved_filesystem_mutation = true;
+        }
         result.is_ok()
     }
     pub fn has_dirty(&self) -> bool {
@@ -779,6 +798,80 @@ mod tests {
         assert_eq!(w.current_view.id, 99);
         assert!(matches!(&w.current_view.view,DiffView::FolderCompare(s)
             if s.path_filter=="rs" && s.left_root == Path::new("/left") && s.right_root == Path::new("/right")));
+    }
+    #[test]
+    fn paired_binary_child_routes_to_binary_compare() {
+        let temp = tempfile::tempdir().unwrap();
+        let left = temp.path().join("left.bin");
+        let right = temp.path().join("right.bin");
+        fs::write(&left, [0, 1, 2]).unwrap();
+        fs::write(&right, [3, 0, 4]).unwrap();
+        let mut workspace = DiffWorkspace::default();
+        workspace.current_view = RetainedView {
+            id: 100,
+            view: DiffView::FolderCompare(FolderCompareState::default()),
+        };
+        workspace
+            .push_file_compare("pair.bin".into(), Some(left.clone()), Some(right.clone()))
+            .unwrap();
+        assert!(matches!(
+            &workspace.current_view.view,
+            DiffView::BinaryCompare(state)
+                if state.left.as_ref() == Some(&left) && state.right.as_ref() == Some(&right)
+        ));
+    }
+
+    #[test]
+    fn complete_folder_state_is_retained_unchanged_across_child_back() {
+        use crate::diff::folder_compare::{FolderEntry, FolderStatus};
+        let mut folder = FolderCompareState {
+            left_root: "/left".into(),
+            right_root: "/right".into(),
+            path_filter: "needle".into(),
+            display_filter: FolderDisplayFilter::RightOnly,
+            sort: FolderSortState {
+                column: "size".into(),
+                descending: true,
+            },
+            ..Default::default()
+        };
+        folder.expanded_nodes.insert("dir".into());
+        folder
+            .selected_paths
+            .extend([PathBuf::from("a"), PathBuf::from("b")]);
+        folder.primary_selection = Some("b".into());
+        folder.scroll_anchor = Some("b".into());
+        folder.scan_rules.includes = vec!["*.txt".into()];
+        folder.scan_rules.excludes = vec!["target/".into()];
+        folder.model.entries.insert(
+            "a".into(),
+            FolderEntry {
+                relative_path: "a".into(),
+                left: None,
+                right: None,
+                metadata_status: FolderStatus::LeftOnly,
+                effective_status: FolderStatus::LeftOnly,
+                content_checked: true,
+            },
+        );
+        let expected = folder.clone();
+        let mut workspace = DiffWorkspace::default();
+        workspace.current_view = RetainedView {
+            id: 101,
+            view: DiffView::FolderCompare(folder),
+        };
+        workspace
+            .push_file_compare("child.txt".into(), Some("/left/child.txt".into()), None)
+            .unwrap();
+        assert_eq!(
+            workspace.navigation_stack[0].view,
+            DiffView::FolderCompare(expected.clone())
+        );
+        assert!(workspace.back());
+        assert_eq!(
+            workspace.current_view.view,
+            DiffView::FolderCompare(expected)
+        );
     }
     #[test]
     fn splitter_and_virtual_range_are_bounded() {

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -1,6 +1,7 @@
 //! Folder tree presentation. Every view operation is a pure projection of retained data.
 use crate::diff::folder_compare::{
-    FolderProjectionRow, FolderStatus, expand_ancestors, project_folder_rows,
+    EntryKind, FolderEntry, FolderProjectionRow, FolderStatus, expand_ancestors,
+    project_folder_rows,
 };
 use crate::diff::model::{FolderCompareState, FolderDisplayFilter};
 use eframe::egui;
@@ -354,28 +355,77 @@ fn render_row(
                 },
             );
         }
+        if response.double_clicked() {
+            *action = activate_entry(state, &entry);
+        }
         if state.scroll_anchor.as_ref() == Some(&row.path) {
             response.scroll_to_me(Some(egui::Align::Center));
         }
     });
     ui.label(side_details(entry.left.as_ref()));
     ui.label(status_label(entry.effective_status));
-    ui.label(
-        entry
-            .right
-            .as_ref()
-            .map(|_| row.path.display().to_string())
-            .unwrap_or_default(),
-    );
+    let right_name = entry
+        .right
+        .as_ref()
+        .map(|_| row.path.display().to_string())
+        .unwrap_or_default();
+    let right_response = ui.selectable_label(selected, right_name);
+    if right_response.clicked() {
+        let modifiers = ui.input(|i| i.modifiers);
+        apply_selection(
+            state,
+            paths,
+            Some(&row.path),
+            if modifiers.shift {
+                SelectionGesture::Range
+            } else if modifiers.command {
+                SelectionGesture::Toggle
+            } else {
+                SelectionGesture::Click
+            },
+        );
+    }
+    if right_response.double_clicked() {
+        *action = activate_entry(state, &entry);
+    }
     ui.label(side_details(entry.right.as_ref()));
-    if ui.small_button("Open").clicked() {
-        *action = FolderViewAction::OpenChild {
-            relative_path: row.path.clone(),
-            left: entry.left.map(|s| s.path),
-            right: entry.right.map(|s| s.path),
-        };
+    if ui
+        .small_button(if is_directory(&entry) {
+            "Toggle"
+        } else {
+            "Open"
+        })
+        .clicked()
+    {
+        *action = activate_entry(state, &entry);
     }
     ui.end_row();
+}
+
+fn is_directory(entry: &FolderEntry) -> bool {
+    entry
+        .left
+        .as_ref()
+        .or(entry.right.as_ref())
+        .and_then(|side| side.metadata.as_ref())
+        .is_some_and(|metadata| metadata.kind == EntryKind::Directory)
+}
+
+/// Converts activation into a workspace action without deriving operation paths
+/// from the relative/display path.
+fn activate_entry(state: &mut FolderCompareState, entry: &FolderEntry) -> FolderViewAction {
+    if is_directory(entry) {
+        if !state.expanded_nodes.remove(&entry.relative_path) {
+            state.expanded_nodes.insert(entry.relative_path.clone());
+        }
+        FolderViewAction::Noop
+    } else {
+        FolderViewAction::OpenChild {
+            relative_path: entry.relative_path.clone(),
+            left: entry.left.as_ref().map(|side| side.path.clone()),
+            right: entry.right.as_ref().map(|side| side.path.clone()),
+        }
+    }
 }
 fn side_details(side: Option<&crate::diff::folder_compare::EntrySide>) -> String {
     let Some(metadata) = side.and_then(|s| s.metadata.as_ref()) else {
@@ -424,7 +474,8 @@ pub(crate) fn selection_snapshot(state: &FolderCompareState) -> BTreeSet<PathBuf
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::diff::folder_compare::FolderEntry;
+    use crate::diff::folder_compare::{EntryMetadata, EntrySide, FolderEntry};
+    use std::time::SystemTime;
 
     fn state(items: &[(&str, FolderStatus)]) -> FolderCompareState {
         let mut state = FolderCompareState::default();
@@ -445,6 +496,70 @@ mod tests {
     }
     fn paths(state: &FolderCompareState) -> Vec<PathBuf> {
         ordered_visible(state)
+    }
+
+    fn side(path: &str, kind: EntryKind) -> EntrySide {
+        EntrySide {
+            path: path.into(),
+            metadata: Some(EntryMetadata {
+                kind,
+                size: 0,
+                modified: Some(SystemTime::UNIX_EPOCH),
+                identity: None,
+            }),
+            error: None,
+        }
+    }
+
+    fn entry(
+        relative: &str,
+        left: Option<&str>,
+        right: Option<&str>,
+        kind: EntryKind,
+    ) -> FolderEntry {
+        FolderEntry {
+            relative_path: relative.into(),
+            left: left.map(|path| side(path, kind)),
+            right: right.map(|path| side(path, kind)),
+            metadata_status: FolderStatus::Different,
+            effective_status: FolderStatus::Different,
+            content_checked: false,
+        }
+    }
+
+    #[test]
+    fn child_actions_use_stored_paired_and_one_sided_paths() {
+        for (left, right) in [
+            (Some("/actual-left/name"), Some("/actual-right/name")),
+            (Some("/actual-left/only"), None),
+            (None, Some("/actual-right/only")),
+        ] {
+            let mut state = FolderCompareState::default();
+            let entry = entry("display/name", left, right, EntryKind::File);
+            assert_eq!(
+                activate_entry(&mut state, &entry),
+                FolderViewAction::OpenChild {
+                    relative_path: "display/name".into(),
+                    left: left.map(Into::into),
+                    right: right.map(Into::into),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn directory_activation_only_toggles_expansion() {
+        let mut state = FolderCompareState::default();
+        let entry = entry(
+            "directory",
+            Some("/left/directory"),
+            None,
+            EntryKind::Directory,
+        );
+        assert_eq!(activate_entry(&mut state, &entry), FolderViewAction::Noop);
+        assert!(state.expanded_nodes.contains(Path::new("directory")));
+        assert_eq!(activate_entry(&mut state, &entry), FolderViewAction::Noop);
+        assert!(!state.expanded_nodes.contains(Path::new("directory")));
     }
 
     #[test]

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -72,8 +72,7 @@ impl DiffDialogState {
         }
         let response = window.show(ctx, |ui| {
             if ui.input_mut(|i| i.consume_key(egui::Modifiers::ALT, egui::Key::ArrowLeft)) {
-                self.workspace.back();
-                self.reconcile_runtime_resources();
+                self.navigate_back();
             }
             ui.horizontal(|ui| {
                 let left = ui.add(
@@ -112,8 +111,7 @@ impl DiffDialogState {
                 ui.colored_label(egui::Color32::RED, error);
             }
             if self.workspace.navigation_stack.len() > 0 && ui.button("← Back").clicked() {
-                self.workspace.back();
-                self.reconcile_runtime_resources();
+                self.navigate_back();
             }
             ui.separator();
             // Copy only lightweight context before borrowing the retained view.
@@ -127,32 +125,35 @@ impl DiffDialogState {
                     ui.label("Choose two files or two folders to compare.");
                 }
                 DiffView::TextCompare(s) => {
-                    if matches!(s.kind, crate::diff::model::FileComparisonKind::Binary) {
-                        ui.heading(match s.kind {
-                            crate::diff::model::FileComparisonKind::Text => "Text comparison",
-                            crate::diff::model::FileComparisonKind::Binary => "Binary files",
-                        });
-                        ui.label(format!(
-                            "Left: {}",
-                            s.left
-                                .as_ref()
-                                .map_or("(missing)".into(), |p| p.display().to_string())
-                        ));
-                    } else {
-                        if !self.text_views.contains_key(&view_id) {
-                            match crate::diff::model::TextViewModel::load(&s, &settings) {
-                                Ok(m) => {
-                                    self.text_views.insert(view_id, m);
-                                }
-                                Err(e) => {
-                                    render_error = Some(e);
-                                }
+                    if !self.text_views.contains_key(&view_id) {
+                        match crate::diff::model::TextViewModel::load(s, &settings) {
+                            Ok(m) => {
+                                self.text_views.insert(view_id, m);
+                            }
+                            Err(e) => {
+                                render_error = Some(e);
                             }
                         }
-                        if let Some(m) = self.text_views.get_mut(&view_id) {
-                            text_view::show(ui, workspace_id, view_id, m);
-                        }
                     }
+                    if let Some(m) = self.text_views.get_mut(&view_id) {
+                        text_view::show(ui, workspace_id, view_id, m);
+                    }
+                    ui.label(format!(
+                        "Right: {}",
+                        s.right
+                            .as_ref()
+                            .map_or("(missing)".into(), |p| p.display().to_string())
+                    ));
+                }
+                DiffView::BinaryCompare(s) => {
+                    self.binary_views.entry(view_id).or_insert(());
+                    ui.heading("Binary comparison");
+                    ui.label(format!(
+                        "Left: {}",
+                        s.left
+                            .as_ref()
+                            .map_or("(missing)".into(), |p| p.display().to_string())
+                    ));
                     ui.label(format!(
                         "Right: {}",
                         s.right
@@ -245,7 +246,7 @@ impl DiffDialogState {
                 }
             }
             folder_view::FolderViewAction::NavigateBack => {
-                self.workspace.back();
+                self.navigate_back();
             }
             folder_view::FolderViewAction::RequestRescan => {
                 if let Some(runtime) = self.folder_runtimes.remove(&self.workspace.current_view.id)
@@ -256,6 +257,28 @@ impl DiffDialogState {
         }
         self.reconcile_runtime_resources();
     }
+
+    /// The single Back transition used by both keyboard and button activation.
+    fn navigate_back(&mut self) -> bool {
+        let changed_relative = match &self.workspace.current_view.view {
+            DiffView::TextCompare(state) => self
+                .text_views
+                .get(&self.workspace.current_view.id)
+                .filter(|model| model.saved_filesystem_mutation)
+                .and_then(|_| state.relative_path.clone()),
+            _ => None,
+        };
+        let moved = self.workspace.back();
+        if moved {
+            if let (Some(relative), DiffView::FolderCompare(folder)) =
+                (changed_relative, &mut self.workspace.current_view.view)
+            {
+                folder.stale_paths.insert(relative);
+            }
+            self.reconcile_runtime_resources();
+        }
+        moved
+    }
 }
 
 fn poll_folder_runtime(
@@ -264,6 +287,43 @@ fn poll_folder_runtime(
 ) {
     use crate::diff::folder_compare::PathKeyPolicy;
     use crate::diff::folder_scan::{RootIdentity, ScanEvent};
+
+    // A child editor can invalidate one row. Refresh it directly instead of
+    // discarding the retained folder model or restarting both root scans.
+    for relative in std::mem::take(&mut state.stale_paths) {
+        if let Some(entry) = state
+            .model
+            .entries
+            .values_mut()
+            .find(|entry| entry.relative_path == relative)
+        {
+            for side in [&mut entry.left, &mut entry.right].into_iter().flatten() {
+                match std::fs::metadata(&side.path) {
+                    Ok(metadata) => {
+                        let kind = side
+                            .metadata
+                            .as_ref()
+                            .map_or(crate::diff::folder_compare::EntryKind::File, |metadata| {
+                                metadata.kind
+                            });
+                        side.metadata = Some(crate::diff::folder_compare::EntryMetadata::from_fs(
+                            &metadata, kind,
+                        ));
+                        side.error = None;
+                    }
+                    Err(error) => side.error = Some(error.to_string()),
+                }
+            }
+            entry.metadata_status = crate::diff::folder_compare::fast_status(
+                entry.left.as_ref(),
+                entry.right.as_ref(),
+                state.timestamp_tolerance,
+            );
+            entry.effective_status = entry.metadata_status;
+            entry.content_checked = false;
+            state.model.revision = state.model.revision.wrapping_add(1);
+        }
+    }
 
     let left_identity = RootIdentity::new(state.left_root.clone());
     let right_identity = RootIdentity::new(state.right_root.clone());
@@ -455,5 +515,34 @@ mod tests {
             &dialog.workspace.current_view.view,
             DiffView::FolderCompare(state) if state.path_filter == "kept"
         ));
+    }
+
+    #[test]
+    fn alt_left_and_button_back_share_the_same_transition() {
+        fn opened_dialog() -> DiffDialogState {
+            let mut dialog = folder_dialog(71);
+            dialog.apply_folder_action(folder_view::FolderViewAction::OpenChild {
+                relative_path: "child.txt".into(),
+                left: Some("child.txt".into()),
+                right: None,
+            });
+            dialog
+        }
+
+        // The Alt+Left handler calls navigate_back directly; the button emits
+        // NavigateBack through apply_folder_action. Both must produce the same
+        // retained workspace transition.
+        let mut alt = opened_dialog();
+        let mut button = opened_dialog();
+        assert!(alt.navigate_back());
+        button.apply_folder_action(folder_view::FolderViewAction::NavigateBack);
+        assert_eq!(
+            alt.workspace.current_view.view,
+            button.workspace.current_view.view
+        );
+        assert_eq!(
+            alt.workspace.navigation_stack,
+            button.workspace.navigation_stack
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Open folder rows should start comparisons using the actual stored side paths instead of deriving paths from display strings, and double-clicking files must open the correct child comparison while directory double-clicks only toggle expansion.
- Child comparisons must route correctly to text or binary viewers and support one-sided comparisons (empty in-memory document on the missing side).
- Returning from a child should restore the complete retained folder view state (no implicit rescan just because a child was opened and not changed) and, if a child saved to disk, only refresh the affected entries rather than restarting full scans.

### Description
- Folder UI: added double-click handlers and an `activate_entry` helper that uses the retained `EntrySide.path` values and never reconstructs operations from display strings, and made directory activation toggle expansion instead of opening a comparison (`src/gui/diff_dialog/folder_view.rs`).
- Comparison routing: introduced `BinaryCompare` variant and route paired binary files to it while preserving text comparison for paired/one-sided text files (`src/diff/model.rs`).
- Navigation/back semantics: unified Alt+Left and Back button into a single `navigate_back` path that restores the full `FolderCompareState` from `navigation_stack` and avoids automatic rescans when returning from an unmodified child (`src/gui/diff_dialog/mod.rs`).
- Targeted refresh: tracked successful saved filesystem mutations with `TextViewModel::saved_filesystem_mutation` and added `FolderCompareState::stale_paths` to mark only affected entries/subtrees stale; `poll_folder_runtime` will refresh metadata for those entries without discarding the retained folder model or restarting both root scans (`src/diff/model.rs`, `src/gui/diff_dialog/mod.rs`).
- Tests: added unit tests for child path construction (paired/left-only/right-only), binary routing to `BinaryCompare`, directory activation toggling expansion, complete folder-state retention across child-open/back, and parity between Alt+Left and Back button transitions (`src/gui/diff_dialog/folder_view.rs`, `src/diff/model.rs`, `src/gui/diff_dialog/mod.rs`).

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `git diff --check` which succeeded.
- Attempted `cargo test --lib`; compilation proceeds but the full test run cannot complete in this Linux environment because the repository contains unguarded Windows-specific `windows::Win32`/`windows::core` imports that fail to resolve here, so the added unit tests are present but full execution is blocked by platform-specific build failures (they should pass in a platform-appropriate environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78c0acf3788332b833d8f305c0333e)