### PR TITLE
Add safe folder mutation previews and execution flow

### DIFF
--- a/src/diff/file_ops.rs
+++ b/src/diff/file_ops.rs
@@ -515,10 +515,7 @@ fn fresh(plan: &CopyPlan, item: &PlannedCopy, dirty: &HashSet<PathBuf>) -> Resul
     if FileIdentity::read(&src).map_err(|e| e.to_string())? != item.expected_source {
         return Err("source changed since confirmation".into());
     }
-    if dirty
-        .iter()
-        .any(|path| path == &dst || path.starts_with(&dst))
-    {
+    if mutation_contains_dirty_path(&dst, dirty) {
         return Err("destination has unsaved Diff changes".into());
     }
     let now = FileIdentity::read(&dst).ok();
@@ -526,6 +523,18 @@ fn fresh(plan: &CopyPlan, item: &PlannedCopy, dirty: &HashSet<PathBuf>) -> Resul
         return Err("destination type or overwrite state changed since confirmation".into());
     }
     Ok(())
+}
+
+/// Returns whether mutating `target` would replace a dirty document or an
+/// ancestor which contains one. Canonicalization is essential on Windows,
+/// where captured roots use verbatim (`\\?\`) paths while editor paths may use
+/// their ordinary spelling.
+pub(crate) fn mutation_contains_dirty_path(target: &Path, dirty: &HashSet<PathBuf>) -> bool {
+    let canonical_target = fs::canonicalize(target).unwrap_or_else(|_| target.to_path_buf());
+    dirty.iter().any(|path| {
+        let canonical_dirty = fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        canonical_dirty == canonical_target || canonical_dirty.starts_with(&canonical_target)
+    })
 }
 
 fn same_root_identity(root: &CapturedRoot) -> Result<bool, String> {
@@ -827,7 +836,7 @@ pub fn execute_delete(
         let validation = ensure_contained(&plan.root, &x.relative).and_then(|p| {
             if p != x.target {
                 Err("captured target changed".into())
-            } else if dirty.iter().any(|path| path == &p || path.starts_with(&p)) {
+            } else if mutation_contains_dirty_path(&p, dirty) {
                 Err("item has unsaved Diff changes".into())
             } else if FileIdentity::read(&p).map_err(|e| e.to_string())? != x.expected {
                 Err("item changed since confirmation".into())

--- a/src/diff/file_ops.rs
+++ b/src/diff/file_ops.rs
@@ -112,7 +112,7 @@ pub struct PreviewTotals {
     pub errors: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyPlan {
     pub direction: CopyDirection,
     pub source_root: CapturedRoot,
@@ -515,7 +515,10 @@ fn fresh(plan: &CopyPlan, item: &PlannedCopy, dirty: &HashSet<PathBuf>) -> Resul
     if FileIdentity::read(&src).map_err(|e| e.to_string())? != item.expected_source {
         return Err("source changed since confirmation".into());
     }
-    if dirty.contains(&dst) {
+    if dirty
+        .iter()
+        .any(|path| path == &dst || path.starts_with(&dst))
+    {
         return Err("destination has unsaved Diff changes".into());
     }
     let now = FileIdentity::read(&dst).ok();
@@ -688,13 +691,13 @@ pub enum DeleteMode {
     Recycle,
     Permanent,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlannedDelete {
     pub relative: PathBuf,
     pub target: PathBuf,
     pub expected: FileIdentity,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeletePlan {
     pub root: CapturedRoot,
     pub generation: u64,
@@ -732,7 +735,28 @@ pub fn plan_delete(
     let root = root(root_path)?;
     let mut items = vec![];
     let mut errors = vec![];
+    let mut normalized = BTreeSet::new();
     for rel in selected {
+        match validate_relative(&rel) {
+            Ok(path) => {
+                normalized.insert(path);
+            }
+            Err(message) => errors.push(ValidationError {
+                relative: Some(rel),
+                message,
+                fatal: true,
+            }),
+        }
+    }
+    let all = normalized.clone();
+    normalized.retain(|path| {
+        !path
+            .ancestors()
+            .skip(1)
+            .filter(|ancestor| !ancestor.as_os_str().is_empty())
+            .any(|ancestor| all.contains(ancestor))
+    });
+    for rel in normalized {
         match validate_relative(&rel).and_then(|validated| {
             ensure_contained(&root, &validated).and_then(|target| {
                 FileIdentity::read(&target)
@@ -776,6 +800,21 @@ pub fn execute_delete(
 ) -> ExecutionReport {
     let mut results = vec![];
     let mut affected = vec![];
+    if !same_root_identity(&plan.root).unwrap_or(false) {
+        return ExecutionReport {
+            generation: plan.generation,
+            items: plan
+                .items
+                .iter()
+                .map(|item| ItemResult {
+                    relative: item.relative.clone(),
+                    outcome: ItemOutcome::Failed("comparison root identity changed".into()),
+                })
+                .collect(),
+            affected_subtree: None,
+            cancelled: false,
+        };
+    }
     for x in &plan.items {
         if cancel.load(Ordering::Acquire) {
             return ExecutionReport {
@@ -788,7 +827,7 @@ pub fn execute_delete(
         let validation = ensure_contained(&plan.root, &x.relative).and_then(|p| {
             if p != x.target {
                 Err("captured target changed".into())
-            } else if dirty.contains(&p) {
+            } else if dirty.iter().any(|path| path == &p || path.starts_with(&p)) {
                 Err("item has unsaved Diff changes".into())
             } else if FileIdentity::read(&p).map_err(|e| e.to_string())? != x.expected {
                 Err("item changed since confirmation".into())
@@ -823,4 +862,28 @@ pub fn execute_delete(
         affected_subtree: smallest_common_subtree(&affected),
         cancelled: false,
     }
+}
+
+/// Spawn execution of the already-confirmed recycle plan.  The GUI never
+/// constructs permanent plans; retaining the mode check here makes that
+/// boundary explicit even if a future caller is added accidentally.
+pub fn spawn_recycle_delete(
+    plan: DeletePlan,
+    dirty: HashSet<PathBuf>,
+    backend: Arc<dyn TrashBackend>,
+) -> Result<OperationHandle, String> {
+    if plan.mode != DeleteMode::Recycle {
+        return Err("GUI deletion only supports recycling".into());
+    }
+    let cancel = Arc::new(AtomicBool::new(false));
+    let c = cancel.clone();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let report = execute_delete(&plan, &dirty, backend.as_ref(), &c);
+        let _ = tx.send(OperationEvent::Completed(report));
+    });
+    Ok(OperationHandle {
+        receiver: rx,
+        cancel,
+    })
 }

--- a/src/diff/folder_runtime.rs
+++ b/src/diff/folder_runtime.rs
@@ -117,6 +117,12 @@ impl FolderRuntime {
             || !self.in_flight.is_empty()
     }
 
+    /// Mutation previews and plans deliberately live in dialog state; this
+    /// runtime owns only the currently executing operation handle.
+    pub fn mutation_active(&self) -> bool {
+        self.active_operation.is_some()
+    }
+
     /// Rebuild the deduplicated queue in user-visible priority order.
     pub fn prioritize(
         &mut self,

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -19,6 +19,15 @@ pub(super) enum FolderViewAction {
     },
     NavigateBack,
     RequestRescan,
+    RequestMutation(MutationKind),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MutationKind {
+    CopyRight,
+    CopyLeft,
+    DeleteLeft,
+    DeleteRight,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -241,6 +250,7 @@ pub(super) fn show(
         ui.label("Find path:");
         ui.text_edit_singleline(&mut state.path_filter);
     });
+    mutation_buttons(ui, state, runtime, &mut action);
     let scans_done = state.left_scan_complete && state.right_scan_complete;
     ui.label(format!(
         "Scanned entries: left {} ({}) / right {} ({})",
@@ -320,7 +330,14 @@ pub(super) fn show(
                 }
                 ui.end_row();
                 for row in &projected {
-                    render_row(ui, state, &paths, row, &mut action);
+                    render_row(
+                        ui,
+                        state,
+                        &paths,
+                        row,
+                        runtime.mutation_active(),
+                        &mut action,
+                    );
                 }
             });
     });
@@ -332,6 +349,7 @@ fn render_row(
     state: &mut FolderCompareState,
     paths: &[PathBuf],
     row: &FolderProjectionRow,
+    operation_active: bool,
     action: &mut FolderViewAction,
 ) {
     let entry = state
@@ -362,6 +380,7 @@ fn render_row(
             .map(|_| row.path.display().to_string())
             .unwrap_or_default();
         let response = ui.selectable_label(selected, name);
+        response.context_menu(|ui| mutation_menu(ui, state, operation_active, action));
         if response.clicked() {
             let modifiers = ui.input(|i| i.modifiers);
             apply_selection(
@@ -392,6 +411,7 @@ fn render_row(
         .map(|_| row.path.display().to_string())
         .unwrap_or_default();
     let right_response = ui.selectable_label(selected, right_name);
+    right_response.context_menu(|ui| mutation_menu(ui, state, operation_active, action));
     if right_response.clicked() {
         let modifiers = ui.input(|i| i.modifiers);
         apply_selection(
@@ -422,6 +442,71 @@ fn render_row(
         *action = activate_entry(state, &entry);
     }
     ui.end_row();
+}
+
+fn applicable(state: &FolderCompareState, left: bool) -> bool {
+    !state.selected_paths.is_empty()
+        && state.selected_paths.iter().any(|path| {
+            state.model.entries.values().any(|entry| {
+                &entry.relative_path == path
+                    && if left {
+                        entry.left.is_some()
+                    } else {
+                        entry.right.is_some()
+                    }
+            })
+        })
+}
+
+fn mutation_buttons(
+    ui: &mut egui::Ui,
+    state: &FolderCompareState,
+    runtime: &crate::diff::folder_runtime::FolderRuntime,
+    action: &mut FolderViewAction,
+) {
+    ui.horizontal(|ui| {
+        for (label, kind, left) in [
+            ("Copy →", MutationKind::CopyRight, true),
+            ("← Copy", MutationKind::CopyLeft, false),
+            ("Delete Left…", MutationKind::DeleteLeft, true),
+            ("Delete Right…", MutationKind::DeleteRight, false),
+        ] {
+            if ui
+                .add_enabled(
+                    !runtime.mutation_active() && applicable(state, left),
+                    egui::Button::new(label),
+                )
+                .clicked()
+            {
+                *action = FolderViewAction::RequestMutation(kind);
+            }
+        }
+    });
+}
+
+fn mutation_menu(
+    ui: &mut egui::Ui,
+    state: &FolderCompareState,
+    operation_active: bool,
+    action: &mut FolderViewAction,
+) {
+    for (label, kind, left) in [
+        ("Copy →", MutationKind::CopyRight, true),
+        ("← Copy", MutationKind::CopyLeft, false),
+        ("Delete Left…", MutationKind::DeleteLeft, true),
+        ("Delete Right…", MutationKind::DeleteRight, false),
+    ] {
+        if ui
+            .add_enabled(
+                !operation_active && applicable(state, left),
+                egui::Button::new(label),
+            )
+            .clicked()
+        {
+            *action = FolderViewAction::RequestMutation(kind);
+            ui.close_menu();
+        }
+    }
 }
 
 fn is_directory(entry: &FolderEntry) -> bool {

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -4,6 +4,7 @@ use eframe::egui;
 use std::collections::HashMap;
 use std::collections::HashSet;
 mod folder_view;
+mod operation_preview;
 mod text_view;
 
 fn render_retained_folder(
@@ -19,6 +20,7 @@ pub struct DiffDialogState {
     pub workspace: DiffWorkspace,
     text_views: HashMap<u64, crate::diff::model::TextViewModel>,
     folder_runtimes: HashMap<u64, crate::diff::folder_runtime::FolderRuntime>,
+    operation_preview: Option<operation_preview::OperationPreview>,
     // Binary renderers will keep their ephemeral resources in this view-id map.
     binary_views: HashMap<u64, ()>,
     close_prompt: bool,
@@ -184,6 +186,7 @@ impl DiffDialogState {
             }
             self.apply_folder_action(action);
         });
+        self.show_operation_preview(ctx);
         if let Some(response) = response {
             let rect = response.response.rect;
             self.persistence.window_size = Some([rect.width(), rect.height()]);
@@ -267,8 +270,172 @@ impl DiffDialogState {
                     }
                 }
             }
+            folder_view::FolderViewAction::RequestMutation(kind) => self.plan_mutation(kind),
         }
         self.reconcile_runtime_resources();
+    }
+
+    fn plan_mutation(&mut self, kind: folder_view::MutationKind) {
+        use crate::diff::file_ops::{CopyDirection, DeleteMode};
+        let view_id = self.workspace.current_view.id;
+        let Some(runtime) = self.folder_runtimes.get(&view_id) else {
+            return;
+        };
+        if runtime.mutation_active() {
+            return;
+        }
+        let DiffView::FolderCompare(state) = &self.workspace.current_view.view else {
+            return;
+        };
+        // Capture once. Filtering also ensures a command is never routed for a
+        // selection which exists only on the other side.
+        let mut captured = folder_view::selection_snapshot(state);
+        let source_is_left = matches!(
+            kind,
+            folder_view::MutationKind::CopyRight | folder_view::MutationKind::DeleteLeft
+        );
+        captured.retain(|path| {
+            state.model.entries.values().any(|entry| {
+                &entry.relative_path == path
+                    && if source_is_left {
+                        entry.left.is_some()
+                    } else {
+                        entry.right.is_some()
+                    }
+            })
+        });
+        if captured.is_empty() {
+            return;
+        }
+        let generation = runtime.generation;
+        let planned = match kind {
+            folder_view::MutationKind::CopyRight => crate::diff::file_ops::plan_copy(
+                &state.left_root,
+                &state.right_root,
+                CopyDirection::LeftToRight,
+                captured,
+                generation,
+            )
+            .map(operation_preview::PreviewPlan::Copy),
+            folder_view::MutationKind::CopyLeft => crate::diff::file_ops::plan_copy(
+                &state.right_root,
+                &state.left_root,
+                CopyDirection::RightToLeft,
+                captured,
+                generation,
+            )
+            .map(operation_preview::PreviewPlan::Copy),
+            folder_view::MutationKind::DeleteLeft => crate::diff::file_ops::plan_delete(
+                &state.left_root,
+                "Left",
+                captured,
+                generation,
+                DeleteMode::Recycle,
+            )
+            .map(operation_preview::PreviewPlan::Delete),
+            folder_view::MutationKind::DeleteRight => crate::diff::file_ops::plan_delete(
+                &state.right_root,
+                "Right",
+                captured,
+                generation,
+                DeleteMode::Recycle,
+            )
+            .map(operation_preview::PreviewPlan::Delete),
+        };
+        let dirty = self.dirty_paths();
+        match planned {
+            Ok(plan) => {
+                let conflicts: Vec<_> = match &plan {
+                    operation_preview::PreviewPlan::Copy(copy) => copy
+                        .copies
+                        .iter()
+                        .filter(|item| {
+                            dirty
+                                .iter()
+                                .any(|path| path == &item.target || path.starts_with(&item.target))
+                        })
+                        .map(|item| item.relative.display().to_string())
+                        .collect(),
+                    operation_preview::PreviewPlan::Delete(delete) => delete
+                        .items
+                        .iter()
+                        .filter(|item| {
+                            dirty
+                                .iter()
+                                .any(|path| path == &item.target || path.starts_with(&item.target))
+                        })
+                        .map(|item| item.relative.display().to_string())
+                        .collect(),
+                };
+                self.operation_preview = Some(operation_preview::OperationPreview {
+                    view_id,
+                    plan,
+                    planning_error: (!conflicts.is_empty()).then(|| {
+                        format!(
+                            "Blocked: unsaved Diff changes would be overwritten or deleted at {}",
+                            conflicts.join(", ")
+                        )
+                    }),
+                })
+            }
+            Err(error) => {
+                self.workspace.error = Some(format!("Cannot plan folder operation: {error}"))
+            }
+        }
+    }
+
+    fn dirty_paths(&self) -> HashSet<std::path::PathBuf> {
+        let mut paths = HashSet::new();
+        for model in self.text_views.values() {
+            if model.left.is_dirty() {
+                if let Some(path) = &model.left_path {
+                    paths.insert(path.clone());
+                }
+            }
+            if model.right.is_dirty() {
+                if let Some(path) = &model.right_path {
+                    paths.insert(path.clone());
+                }
+            }
+        }
+        paths
+    }
+
+    fn show_operation_preview(&mut self, ctx: &egui::Context) {
+        let active = self
+            .operation_preview
+            .as_ref()
+            .and_then(|p| self.folder_runtimes.get(&p.view_id))
+            .is_some_and(|runtime| runtime.mutation_active());
+        let response = self.operation_preview.as_mut().map(|p| p.show(ctx, active));
+        match response {
+            Some(operation_preview::PreviewResponse::Cancel) => self.operation_preview = None,
+            Some(operation_preview::PreviewResponse::Execute) => {
+                let dirty = self.dirty_paths();
+                let preview = self.operation_preview.take().expect("preview exists");
+                let handle = match preview.plan {
+                    operation_preview::PreviewPlan::Copy(plan) => {
+                        Ok(crate::diff::file_ops::spawn_copy(plan, dirty))
+                    }
+                    operation_preview::PreviewPlan::Delete(plan) => {
+                        crate::diff::file_ops::spawn_recycle_delete(
+                            plan,
+                            dirty,
+                            std::sync::Arc::new(crate::diff::file_ops::SystemTrash),
+                        )
+                    }
+                };
+                match handle {
+                    Ok(handle) => {
+                        if let Some(runtime) = self.folder_runtimes.get_mut(&preview.view_id) {
+                            runtime.active_operation = Some(handle);
+                        }
+                    }
+                    Err(error) => self.workspace.error = Some(error),
+                }
+            }
+            _ => {}
+        }
     }
 
     /// The single Back transition used by both keyboard and button activation.
@@ -300,6 +467,21 @@ fn poll_folder_runtime(
 ) {
     use crate::diff::folder_compare::PathKeyPolicy;
     use crate::diff::folder_scan::{RootIdentity, ScanEvent};
+
+    let completed = runtime.active_operation.as_ref().and_then(|operation| {
+        operation.receiver.try_iter().find_map(|event| match event {
+            crate::diff::file_ops::OperationEvent::Completed(report)
+                if report.generation == runtime.generation =>
+            {
+                Some(report)
+            }
+            _ => None,
+        })
+    });
+    if let Some(report) = completed {
+        runtime.active_operation = None;
+        refresh_after_mutation(state, runtime, report.affected_subtree);
+    }
 
     // A child editor can invalidate one row. Refresh it directly instead of
     // discarding the retained folder model or restarting both root scans.
@@ -469,6 +651,22 @@ fn poll_folder_runtime(
             }
         }
     }
+}
+
+/// Refresh boundary intentionally accepts the affected subtree even though the
+/// first implementation performs a generation-safe full comparison scan.
+fn refresh_after_mutation(
+    state: &mut crate::diff::model::FolderCompareState,
+    runtime: &mut crate::diff::folder_runtime::FolderRuntime,
+    _affected_subtree: Option<std::path::PathBuf>,
+) {
+    state.model = Default::default();
+    state.left_scan_complete = false;
+    state.right_scan_complete = false;
+    state.stale_paths.clear();
+    // selected_paths, primary_selection, and scroll_anchor deliberately
+    // survive until completed scans reconcile them against surviving rows.
+    runtime.prepare_rescan();
 }
 
 fn picker_menu(

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -350,9 +350,10 @@ impl DiffDialogState {
                         .copies
                         .iter()
                         .filter(|item| {
-                            dirty
-                                .iter()
-                                .any(|path| path == &item.target || path.starts_with(&item.target))
+                            crate::diff::file_ops::mutation_contains_dirty_path(
+                                &item.target,
+                                &dirty,
+                            )
                         })
                         .map(|item| item.relative.display().to_string())
                         .collect(),
@@ -360,9 +361,10 @@ impl DiffDialogState {
                         .items
                         .iter()
                         .filter(|item| {
-                            dirty
-                                .iter()
-                                .any(|path| path == &item.target || path.starts_with(&item.target))
+                            crate::diff::file_ops::mutation_contains_dirty_path(
+                                &item.target,
+                                &dirty,
+                            )
                         })
                         .map(|item| item.relative.display().to_string())
                         .collect(),

--- a/src/gui/diff_dialog/operation_preview.rs
+++ b/src/gui/diff_dialog/operation_preview.rs
@@ -1,0 +1,95 @@
+//! Non-persisted confirmation state for folder mutations.
+use crate::diff::file_ops::{CopyPlan, DeletePlan, EntryType};
+use eframe::egui;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PreviewPlan {
+    Copy(CopyPlan),
+    Delete(DeletePlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct OperationPreview {
+    pub view_id: u64,
+    pub plan: PreviewPlan,
+    pub planning_error: Option<String>,
+}
+
+impl OperationPreview {
+    pub fn show(&mut self, ctx: &egui::Context, operation_active: bool) -> PreviewResponse {
+        let mut response = PreviewResponse::Keep;
+        egui::Window::new("Confirm folder operation")
+            .id(egui::Id::new(("folder-operation-preview", self.view_id)))
+            .collapsible(false)
+            .resizable(true)
+            .show(ctx, |ui| {
+                if let Some(error) = &self.planning_error {
+                    ui.colored_label(egui::Color32::RED, error);
+                }
+                let executable = match &self.plan {
+                    PreviewPlan::Copy(plan) => {
+                        ui.heading(match plan.direction {
+                            crate::diff::file_ops::CopyDirection::LeftToRight => "Copy →",
+                            crate::diff::file_ops::CopyDirection::RightToLeft => "← Copy",
+                        });
+                        ui.label(format!(
+                            "Files: {}  Directories: {}  Overwrites: {}  Skipped: {}  Conflicts: {}  Validation errors: {}",
+                            plan.totals.files_copied, plan.totals.directories_created,
+                            plan.totals.overwrites, plan.totals.skips, plan.totals.conflicts,
+                            plan.totals.errors
+                        ));
+                        details(ui, "Overwrites", plan.copies.iter().filter(|x| x.overwrite)
+                            .map(|x| (x.relative.display().to_string(), "existing destination will be replaced".to_owned())));
+                        details(ui, "Conflicts", plan.conflicts.iter()
+                            .map(|x| (x.relative.display().to_string(), x.message.clone())));
+                        details(ui, "Skipped", plan.skipped.iter()
+                            .map(|x| (x.relative.display().to_string(), x.reason.clone())));
+                        details(ui, "Validation errors", plan.errors.iter().map(|x| (
+                            x.relative.as_ref().map_or_else(|| "root".into(), |p| p.display().to_string()),
+                            x.message.clone(),
+                        )));
+                        !plan.has_fatal_errors()
+                    }
+                    PreviewPlan::Delete(plan) => {
+                        ui.heading(format!("Delete {} (Recycle Bin)", plan.side));
+                        let files = plan.items.iter().filter(|x| x.expected.kind == EntryType::File).count();
+                        let directories = plan.items.len() - files;
+                        ui.label(format!("Files: {files}  Directories: {directories}"));
+                        details(ui, "Affected paths", plan.items.iter().map(|x| (
+                            x.relative.display().to_string(), "move to Recycle Bin".into(),
+                        )));
+                        details(ui, "Validation errors", plan.errors.iter().map(|x| (
+                            x.relative.as_ref().map_or_else(|| "root".into(), |p| p.display().to_string()),
+                            x.message.clone(),
+                        )));
+                        plan.errors.iter().all(|x| !x.fatal)
+                    }
+                } && self.planning_error.is_none();
+                ui.horizontal(|ui| {
+                    if ui.add_enabled(executable && !operation_active, egui::Button::new("Execute")).clicked() {
+                        response = PreviewResponse::Execute;
+                    }
+                    if ui.button("Cancel").clicked() { response = PreviewResponse::Cancel; }
+                });
+            });
+        response
+    }
+}
+
+fn details(ui: &mut egui::Ui, title: &str, items: impl Iterator<Item = (String, String)>) {
+    let items: Vec<_> = items.collect();
+    if !items.is_empty() {
+        ui.collapsing(format!("{title} ({})", items.len()), |ui| {
+            for (path, explanation) in items {
+                ui.label(format!("{} — {}", path, explanation));
+            }
+        });
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreviewResponse {
+    Keep,
+    Execute,
+    Cancel,
+}

--- a/tests/diff_file_ops.rs
+++ b/tests/diff_file_ops.rs
@@ -116,3 +116,71 @@ fn recycle_failure_never_falls_back_to_permanent_delete() {
     );
     assert!(d.path().join("x").exists());
 }
+
+#[test]
+fn right_to_left_plan_retains_direction_and_executes_previewed_object() {
+    let left = tempfile::tempdir().unwrap();
+    let right = tempfile::tempdir().unwrap();
+    fs::write(right.path().join("from-right"), "content").unwrap();
+    let preview = plan_copy(
+        right.path(),
+        left.path(),
+        CopyDirection::RightToLeft,
+        [PathBuf::from("from-right")],
+        42,
+    )
+    .unwrap();
+    let executed = preview.clone();
+    assert_eq!(executed, preview);
+    let report = execute_copy(&executed, &HashSet::new(), &AtomicBool::new(false));
+    assert!(matches!(report.items[0].outcome, ItemOutcome::Copied));
+    assert_eq!(
+        fs::read_to_string(left.path().join("from-right")).unwrap(),
+        "content"
+    );
+}
+
+#[test]
+fn delete_normalizes_parent_child_and_dirty_descendant_blocks_parent() {
+    let root = tempfile::tempdir().unwrap();
+    fs::create_dir(root.path().join("folder")).unwrap();
+    fs::write(root.path().join("folder/dirty"), "unsaved on screen").unwrap();
+    let plan = plan_delete(
+        root.path(),
+        "Left",
+        [PathBuf::from("folder"), PathBuf::from("folder/dirty")],
+        8,
+        DeleteMode::Recycle,
+    )
+    .unwrap();
+    assert_eq!(plan.items.len(), 1);
+    let backend = FakeTrash::default();
+    let dirty = HashSet::from([root.path().join("folder/dirty")]);
+    let report = execute_delete(&plan, &dirty, &backend, &AtomicBool::new(false));
+    assert!(
+        matches!(&report.items[0].outcome, ItemOutcome::Failed(message)
+        if message.contains("unsaved Diff changes"))
+    );
+    assert_eq!(backend.recycle.load(std::sync::atomic::Ordering::SeqCst), 0);
+}
+
+#[test]
+fn gui_spawn_boundary_rejects_permanent_deletion() {
+    let root = tempfile::tempdir().unwrap();
+    fs::write(root.path().join("x"), "x").unwrap();
+    let plan = plan_delete(
+        root.path(),
+        "Left",
+        [PathBuf::from("x")],
+        1,
+        DeleteMode::Permanent,
+    )
+    .unwrap();
+    let result = spawn_recycle_delete(
+        plan,
+        HashSet::new(),
+        std::sync::Arc::new(FakeTrash::default()),
+    );
+    assert!(result.is_err());
+    assert!(root.path().join("x").exists());
+}


### PR DESCRIPTION
### Motivation

- Provide explicit, selection-aware folder mutation actions (`Copy →`, `← Copy`, `Delete Left…`, `Delete Right…`) in the Folder Compare UI while preventing accidental destructive actions and preserving user intent. 
- Make planning immutable for UI previews so the exact plan shown is the one executed, and revalidate identities and dirty buffers at execution time to avoid losing unsaved edits.
- Ensure the runtime only retains the active operation handle while plans and dialog state remain ephemeral to the UI.

### Description

- Added UI controls and context-menu entries for copy/delete mutations in `src/gui/diff_dialog/folder_view.rs` and a `MutationKind` / `FolderViewAction::RequestMutation` flow that enables actions only when the captured selection has applicable entries and no mutation is active. 
- Introduced `src/gui/diff_dialog/operation_preview.rs` implementing `OperationPreview` which holds immutable `CopyPlan` or `DeletePlan` previews, shows totals and expandable details, and disables execution when there are fatal validation errors or dirty-document conflicts. 
- Snapshot selection before planning in `diff_dialog::plan_mutation`, call `file_ops::plan_copy()` / `file_ops::plan_delete()` with validated roots and the captured selection, and retain the exact returned plan for preview and execution without replanning. 
- Added `spawn_recycle_delete()` in `src/diff/file_ops.rs` as the GUI-facing spawn boundary that rejects `DeleteMode::Permanent`, and kept a `spawn_copy()` path for executing previewed `CopyPlan`s; preserved existing pre-execution safeguards and added checks for dirty descendants and root-identity revalidation. 
- Normalized parent/child delete selections in `plan_delete()` and prevented traversal/symlink escapes via existing `validate_relative()` / `ensure_contained()` logic, while `fresh()` / `execute_*` now check for dirty path descendants using prefix checks. 
- Kept only the active operation handle in `FolderRuntime` via `mutation_active()`, consumed `ExecutionReport::affected_subtree` on completion, and wired `refresh_after_mutation()` (currently a generation-safe full rescan that preserves selection and scroll anchor) to be pluggable for targeted subtree refresh later. 
- Added unit tests in `tests/diff_file_ops.rs` covering right-to-left planning/execution equivalence, recursive parent/child normalization, dirty-descendant blocking, and the GUI spawn boundary rejecting permanent deletes.

### Testing

- Ran `cargo fmt --all -- --check` and `git diff --check` with no formatting or diff-check failures. 
- Built and type-checked for the Windows target with `cargo check --target x86_64-pc-windows-gnu` which completed successfully in this environment. 
- Compiled the folder/file operation tests for the Windows target (`cargo test --target x86_64-pc-windows-gnu --test diff_file_ops --no-run`) and produced the test binary successfully. 
- Native Linux test run encountered pre-existing platform-specific compilation issues unrelated to these changes (Windows APIs and platform crates), so GUI integration tests that require the full native build were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78cce8371c8332867cdc8745ca8eba)