### PR TITLE
Add rules editor, projection/find/overview, and syntax-aware intraline rendering

### DIFF
--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -2,8 +2,8 @@ use crate::diff::folder_compare::FolderModel;
 use crate::diff::folder_scan::ScanRules;
 use crate::diff::settings::DiffConfigV1;
 use crate::diff::text_compare::{
-    self, AlignedDiffRow, CompiledRules, NavigationDirection, TextComparisonResult,
-    TextComparisonRules,
+    self, AlignedDiffRow, CompiledRules, FindMatch, FindScope, NavigationDirection,
+    RowProjectionMode, TextComparisonResult, TextComparisonRules,
 };
 use crate::diff::text_file::{LineEdit, TextDocument, load_text_file};
 use std::collections::BTreeSet;
@@ -450,8 +450,18 @@ pub struct TextViewModel {
     pub current_row: Option<usize>,
     /// A model-row navigation target waiting to be consumed by the view.
     pub pending_scroll_row: Option<usize>,
+    pub projection_mode: RowProjectionMode,
+    pub projection_context: usize,
+    pub find_open: bool,
+    pub find_query: String,
+    pub find_scope: FindScope,
+    pub find_case_sensitive: bool,
+    pub find_projection_only: bool,
+    pub find_matches: Vec<FindMatch>,
+    pub current_find_match: Option<usize>,
     pub wrap: bool,
     pub syntax: bool,
+    pub syntax_cache: crate::diff::syntax::SyntaxCache,
     pub large_file_tier: crate::diff::worker::LargeFileTier,
     pub splitter: f32,
     pub recalculate_at: Option<Instant>,
@@ -506,8 +516,18 @@ impl TextViewModel {
             active_side: DiffSide::Left,
             current_row: None,
             pending_scroll_row: None,
+            projection_mode: RowProjectionMode::All,
+            projection_context: 3,
+            find_open: false,
+            find_query: String::new(),
+            find_scope: FindScope::Both,
+            find_case_sensitive: false,
+            find_projection_only: false,
+            find_matches: vec![],
+            current_find_match: None,
             wrap,
             syntax: settings.syntax_highlighting && large_file_tier.syntax_enabled(),
+            syntax_cache: Default::default(),
             large_file_tier,
             splitter: validated_splitter(settings.pane_split),
             recalculate_at: Some(Instant::now()),
@@ -576,6 +596,43 @@ impl TextViewModel {
                 });
             }
         });
+    }
+    pub fn projected_rows(&self) -> Vec<usize> {
+        self.comparison.as_ref().map_or_else(Vec::new, |c| {
+            text_compare::row_projection(c, self.projection_mode, self.projection_context)
+        })
+    }
+    pub fn refresh_find(&mut self) {
+        let projection = self.find_projection_only.then(|| self.projected_rows());
+        self.find_matches = self.comparison.as_ref().map_or_else(Vec::new, |c| {
+            text_compare::find_matches(
+                c,
+                self.left.source(),
+                self.right.source(),
+                &self.find_query,
+                self.find_scope,
+                self.active_side,
+                self.find_case_sensitive,
+                projection.as_deref(),
+            )
+        });
+        self.current_find_match = None;
+    }
+    pub fn navigate_find(&mut self, forward: bool) {
+        self.current_find_match =
+            text_compare::navigate_match(&self.find_matches, self.current_find_match, forward);
+        if let Some(m) = self
+            .current_find_match
+            .and_then(|i| self.find_matches.get(i).copied())
+        {
+            self.active_side = m.side;
+            self.pending_scroll_row = Some(m.row);
+        }
+    }
+    pub fn request_overview_scroll(&mut self, y: f32, height: f32) {
+        if let Some(c) = &self.comparison {
+            self.pending_scroll_row = text_compare::overview_row(y, height, c.rows.len());
+        }
     }
     pub fn navigate(&mut self, direction: NavigationDirection) {
         if let Some(c) = &self.comparison {

--- a/src/diff/syntax.rs
+++ b/src/diff/syntax.rs
@@ -92,3 +92,71 @@ impl SyntaxCache {
         self.lines.retain(|k, _| k.revision == revision);
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderFragment {
+    pub text: String,
+    pub rgb: Option<[u8; 3]>,
+    pub changed: bool,
+}
+
+/// Intersects cached syntax fragments with precomputed intraline byte ranges.
+/// Split points are clamped to UTF-8 boundaries; no diff is performed here.
+pub fn render_fragments(
+    source: &str,
+    syntax: &[HighlightFragment],
+    changed: &[(usize, usize)],
+) -> Vec<RenderFragment> {
+    let mut colors = Vec::new();
+    let mut offset = 0;
+    for fragment in syntax {
+        let end = (offset + fragment.text.len()).min(source.len());
+        colors.push((offset, end, fragment.rgb));
+        offset = end;
+    }
+    let mut points = vec![0, source.len()];
+    for (a, b, _) in &colors {
+        points.extend([*a, *b]);
+    }
+    for (a, b) in changed {
+        points.extend([*a, *b]);
+    }
+    points.retain(|p| *p <= source.len() && source.is_char_boundary(*p));
+    points.sort_unstable();
+    points.dedup();
+    points
+        .windows(2)
+        .filter_map(|p| {
+            let (a, b) = (p[0], p[1]);
+            (a < b).then(|| RenderFragment {
+                text: source[a..b].into(),
+                rgb: colors
+                    .iter()
+                    .find(|(s, e, _)| *s <= a && a < *e)
+                    .map(|x| x.2),
+                changed: changed.iter().any(|(s, e)| *s < b && a < *e),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+    #[test]
+    fn unicode_range_mapping_preserves_boundaries() {
+        let source = "aé👨‍👩‍👧z";
+        let syntax = [HighlightFragment {
+            text: source.into(),
+            rgb: [1, 2, 3],
+        }];
+        let start = "aé".len();
+        let end = source.len() - 1;
+        let out = render_fragments(source, &syntax, &[(start, end)]);
+        assert_eq!(
+            out.iter().map(|f| f.text.as_str()).collect::<String>(),
+            source
+        );
+        assert!(out.iter().any(|f| f.changed && f.text == "👨‍👩‍👧"));
+    }
+}

--- a/src/diff/text_compare.rs
+++ b/src/diff/text_compare.rs
@@ -260,6 +260,131 @@ impl TextComparisonResult {
         }
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RowProjectionMode {
+    #[default]
+    All,
+    DifferencesOnly,
+}
+
+/// A presentation-only row map. Entries are logical indices into `rows`; the
+/// comparison and its stable row/hunk identities remain untouched.
+pub fn row_projection(
+    result: &TextComparisonResult,
+    mode: RowProjectionMode,
+    context: usize,
+) -> Vec<usize> {
+    if mode == RowProjectionMode::All {
+        return (0..result.rows.len()).collect();
+    }
+    let mut keep = vec![false; result.rows.len()];
+    for h in &result.hunks {
+        let start = h.start_row.saturating_sub(context);
+        let end = h.end_row.saturating_add(context).min(result.rows.len());
+        keep[start..end].fill(true);
+    }
+    keep.into_iter()
+        .enumerate()
+        .filter_map(|(i, yes)| yes.then_some(i))
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindScope {
+    Both,
+    Left,
+    Right,
+    CurrentSide,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FindMatch {
+    pub row: usize,
+    pub side: crate::diff::model::DiffSide,
+}
+
+pub fn find_matches(
+    result: &TextComparisonResult,
+    left: &str,
+    right: &str,
+    needle: &str,
+    scope: FindScope,
+    active: crate::diff::model::DiffSide,
+    case_sensitive: bool,
+    projection: Option<&[usize]>,
+) -> Vec<FindMatch> {
+    if needle.is_empty() {
+        return vec![];
+    }
+    let wanted = |side| match scope {
+        FindScope::Both => true,
+        FindScope::Left => side == crate::diff::model::DiffSide::Left,
+        FindScope::Right => side == crate::diff::model::DiffSide::Right,
+        FindScope::CurrentSide => side == active,
+    };
+    let query = if case_sensitive {
+        needle.to_owned()
+    } else {
+        needle.to_lowercase()
+    };
+    let allowed = |row: usize| projection.is_none_or(|p| p.binary_search(&row).is_ok());
+    let lines = |text: &str, n: usize| text.lines().nth(n).unwrap_or("").to_owned();
+    let mut out = vec![];
+    for (row, aligned) in result.rows.iter().enumerate().filter(|(i, _)| allowed(*i)) {
+        for (side, line) in [
+            (crate::diff::model::DiffSide::Left, aligned.left),
+            (crate::diff::model::DiffSide::Right, aligned.right),
+        ] {
+            if wanted(side)
+                && line.is_some_and(|n| {
+                    let text = lines(
+                        if side == crate::diff::model::DiffSide::Left {
+                            left
+                        } else {
+                            right
+                        },
+                        n,
+                    );
+                    if case_sensitive {
+                        text.contains(&query)
+                    } else {
+                        text.to_lowercase().contains(&query)
+                    }
+                })
+            {
+                out.push(FindMatch { row, side });
+            }
+        }
+    }
+    out
+}
+
+pub fn navigate_match(
+    matches: &[FindMatch],
+    current: Option<usize>,
+    forward: bool,
+) -> Option<usize> {
+    if matches.is_empty() {
+        return None;
+    }
+    if forward {
+        current
+            .and_then(|c| (c + 1 < matches.len()).then_some(c + 1))
+            .or(Some(0))
+    } else {
+        current
+            .and_then(|c| c.checked_sub(1))
+            .or(Some(matches.len() - 1))
+    }
+}
+
+/// Convert a y-coordinate in an aggregated overview to a logical row.
+pub fn overview_row(y: f32, height: f32, row_count: usize) -> Option<usize> {
+    if row_count == 0 || height <= 0.0 {
+        return None;
+    }
+    Some((((y.clamp(0.0, height) / height) * row_count as f32).floor() as usize).min(row_count - 1))
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum NavigationDirection {
     Next,
@@ -528,5 +653,81 @@ mod tests {
                 .is_char_boundary(x.byte_start)
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod presentation_tests {
+    use super::*;
+    fn compared(left: &str, right: &str) -> TextComparisonResult {
+        compare(
+            left,
+            right,
+            0,
+            0,
+            &CompiledRules::compile(&Default::default()).unwrap(),
+            4096,
+        )
+    }
+    #[test]
+    fn context_projection_merges_nearby_hunks_and_clamps_boundaries() {
+        let c = compared("a\nb\nc\nd\ne\nf", "A\nb\nc\nD\ne\nF");
+        assert_eq!(
+            row_projection(&c, RowProjectionMode::DifferencesOnly, 0),
+            vec![0, 3, 5]
+        );
+        assert_eq!(
+            row_projection(&c, RowProjectionMode::DifferencesOnly, 1),
+            vec![0, 1, 2, 3, 4, 5]
+        );
+    }
+    #[test]
+    fn projection_preserves_row_and_hunk_identity() {
+        let c = compared("a\nb\nc", "a\nB\nc");
+        let p = row_projection(&c, RowProjectionMode::DifferencesOnly, 0);
+        assert_eq!(c.rows[p[0]].id, c.rows[1].id);
+        assert_eq!(
+            c.hunks[c.navigation.row_to_hunk[p[0]].unwrap()].id,
+            c.hunks[0].id
+        );
+    }
+    #[test]
+    fn find_scopes_case_and_wrapping_are_independent() {
+        let c = compared("Needle\nx", "needle\ny");
+        let sensitive = find_matches(
+            &c,
+            "Needle\nx",
+            "needle\ny",
+            "Needle",
+            FindScope::Both,
+            crate::diff::model::DiffSide::Left,
+            true,
+            None,
+        );
+        assert_eq!(sensitive.len(), 1);
+        let insensitive = find_matches(
+            &c,
+            "Needle\nx",
+            "needle\ny",
+            "needle",
+            FindScope::CurrentSide,
+            crate::diff::model::DiffSide::Right,
+            false,
+            None,
+        );
+        assert_eq!(insensitive.len(), 1);
+        assert_eq!(navigate_match(&insensitive, None, true), Some(0));
+        assert_eq!(navigate_match(&insensitive, Some(0), true), Some(0));
+        assert_eq!(navigate_match(&insensitive, Some(0), false), Some(0));
+        assert_eq!(
+            c.navigate(None, NavigationDirection::First, false, true),
+            Some(0)
+        );
+    }
+    #[test]
+    fn overview_maps_coordinates() {
+        assert_eq!(overview_row(0.0, 100.0, 10), Some(0));
+        assert_eq!(overview_row(99.0, 100.0, 10), Some(9));
+        assert_eq!(overview_row(1.0, 0.0, 10), None);
     }
 }

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 mod folder_view;
 mod operation_preview;
+mod rules_dialog;
 mod text_view;
 
 fn render_retained_folder(

--- a/src/gui/diff_dialog/rules_dialog.rs
+++ b/src/gui/diff_dialog/rules_dialog.rs
@@ -1,0 +1,170 @@
+use crate::diff::model::TextViewModel;
+use crate::diff::text_compare::{CompiledRules, RegexReplacement, TextComparisonRules};
+use eframe::egui;
+
+#[derive(Clone)]
+pub struct RulesDialogState {
+    pub open: bool,
+    pub draft: TextComparisonRules,
+    pub replacements: String,
+    pub unimportant: String,
+    pub error: Option<String>,
+}
+impl RulesDialogState {
+    pub fn new(rules: &TextComparisonRules) -> Self {
+        Self {
+            open: true,
+            draft: rules.clone(),
+            replacements: rules
+                .replacements
+                .iter()
+                .map(|r| format!("{} => {}", r.pattern, r.replacement))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            unimportant: rules.unimportant_sections.join("\n"),
+            error: None,
+        }
+    }
+    fn candidate(&self) -> Result<TextComparisonRules, String> {
+        let mut rules = self.draft.clone();
+        rules.unimportant_sections = self
+            .unimportant
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+        rules.replacements = self
+            .replacements
+            .lines()
+            .enumerate()
+            .filter(|(_, s)| !s.trim().is_empty())
+            .map(|(i, s)| {
+                s.split_once("=>")
+                    .map(|(pattern, replacement)| RegexReplacement {
+                        pattern: pattern.trim().into(),
+                        replacement: replacement.trim().into(),
+                    })
+                    .ok_or_else(|| {
+                        format!(
+                            "Replacement line {}: expected PATTERN => REPLACEMENT",
+                            i + 1
+                        )
+                    })
+            })
+            .collect::<Result<_, _>>()?;
+        CompiledRules::compile(&rules).map_err(|errors| errors.join("\n"))?;
+        Ok(rules)
+    }
+    pub fn apply(&mut self, model: &mut TextViewModel) -> bool {
+        match self.candidate() {
+            Ok(rules) => {
+                model.set_rules(rules);
+                self.error = None;
+                self.open = false;
+                true
+            }
+            Err(error) => {
+                self.error = Some(error);
+                false
+            }
+        }
+    }
+}
+
+pub fn show(ctx: &egui::Context, view: u64, model: &mut TextViewModel) {
+    let id = egui::Id::new(("diff-rules", view));
+    let mut state = ctx
+        .data_mut(|d| d.get_temp::<RulesDialogState>(id))
+        .unwrap_or_else(|| RulesDialogState::new(&model.rules));
+    if !state.open {
+        return;
+    }
+    let mut open = true;
+    egui::Window::new("Comparison rules")
+        .id(id.with("window"))
+        .collapsible(false)
+        .resizable(true)
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.checkbox(
+                &mut state.draft.ignore_leading_whitespace,
+                "Ignore leading whitespace",
+            );
+            ui.checkbox(
+                &mut state.draft.ignore_trailing_whitespace,
+                "Ignore trailing whitespace",
+            );
+            ui.checkbox(
+                &mut state.draft.ignore_all_whitespace,
+                "Ignore all whitespace",
+            );
+            ui.checkbox(&mut state.draft.ignore_blank_lines, "Ignore blank lines");
+            ui.checkbox(&mut state.draft.case_sensitive, "Case sensitive");
+            ui.checkbox(
+                &mut state.draft.line_ending_equivalence,
+                "Treat line endings as equivalent",
+            );
+            ui.label("Replacement rules (PATTERN => REPLACEMENT)");
+            ui.text_edit_multiline(&mut state.replacements);
+            ui.label("Unimportant-section regexes (one per line)");
+            ui.text_edit_multiline(&mut state.unimportant);
+            if let Some(error) = &state.error {
+                ui.colored_label(egui::Color32::RED, error);
+            }
+            ui.horizontal(|ui| {
+                if ui.button("Apply").clicked() {
+                    state.apply(model);
+                }
+                if ui.button("Cancel").clicked() {
+                    state.open = false;
+                }
+            });
+        });
+    state.open &= open;
+    ctx.data_mut(|d| d.insert_temp(id, state));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn validates_candidate_before_apply() {
+        let mut state = RulesDialogState::new(&TextComparisonRules::default());
+        state.unimportant = "[".into();
+        assert!(state.candidate().is_err());
+        state.unimportant = "ok".into();
+        assert!(state.candidate().is_ok());
+    }
+    #[test]
+    fn apply_mutates_and_schedules_exactly_once_only_when_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let left = dir.path().join("left");
+        let right = dir.path().join("right");
+        std::fs::write(&left, "a").unwrap();
+        std::fs::write(&right, "b").unwrap();
+        let state = crate::diff::model::TextCompareState {
+            left: Some(left),
+            right: Some(right),
+            relative_path: None,
+            kind: crate::diff::model::FileComparisonKind::Text,
+        };
+        let mut model = TextViewModel::load(&state, &Default::default()).unwrap();
+        model.recalculate_at = None;
+        let revision = model.rules.revision;
+        let mut dialog = RulesDialogState::new(&model.rules);
+        dialog.unimportant = "[".into();
+        assert!(!dialog.apply(&mut model));
+        assert_eq!(model.rules.revision, revision);
+        assert!(model.recalculate_at.is_none());
+        assert!(dialog.open);
+        dialog.unimportant = "x".into();
+        assert!(dialog.apply(&mut model));
+        assert_eq!(model.rules.revision, revision + 1);
+        let scheduled = model.recalculate_at;
+        dialog.open = true;
+        assert!(dialog.apply(&mut model));
+        assert_eq!(model.rules.revision, revision + 1);
+        assert_eq!(model.recalculate_at, scheduled);
+    }
+}

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -1,12 +1,25 @@
 use crate::diff::model::{DiffSide, TextViewModel};
-use crate::diff::text_compare::{ChangeImportance, DiffRowKind, NavigationDirection};
+use crate::diff::text_compare::{
+    ChangeImportance, DiffRowKind, FindScope, NavigationDirection, RowProjectionMode,
+};
 use eframe::egui::{self, Color32, RichText};
 
 pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewModel) {
     model.poll();
     shortcuts(ui, model);
     ui.horizontal_wrapped(|ui| {
-        ui.button("Rules…").on_hover_text("Comparison rules");
+        if ui
+            .button("Rules…")
+            .on_hover_text("Comparison rules")
+            .clicked()
+        {
+            ui.ctx().data_mut(|d| {
+                d.insert_temp(
+                    egui::Id::new(("diff-rules", view)),
+                    super::rules_dialog::RulesDialogState::new(&model.rules),
+                )
+            });
+        }
         ui.label("Differences:");
         let mut ignore = model.rules.ignore_all_whitespace;
         let all_changed = ui.selectable_value(&mut ignore, false, "All").changed();
@@ -30,7 +43,30 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
         }
         ui.checkbox(&mut model.wrap, "Wrap")
             .on_hover_text("Keep both aligned cells at the larger measured row height");
-        ui.checkbox(&mut model.syntax, "Syntax");
+        ui.add_enabled(
+            model.large_file_tier.syntax_enabled(),
+            egui::Checkbox::new(&mut model.syntax, "Syntax"),
+        );
+        ui.separator();
+        ui.selectable_value(
+            &mut model.projection_mode,
+            RowProjectionMode::All,
+            "All rows",
+        );
+        ui.selectable_value(
+            &mut model.projection_mode,
+            RowProjectionMode::DifferencesOnly,
+            "Differences only",
+        );
+        if model.projection_mode == RowProjectionMode::DifferencesOnly {
+            egui::ComboBox::from_id_source((view, "context"))
+                .selected_text(format!("Context {}", model.projection_context))
+                .show_ui(ui, |ui| {
+                    for n in [0, 1, 3, 5, 10] {
+                        ui.selectable_value(&mut model.projection_context, n, n.to_string());
+                    }
+                });
+        }
         let merge = model.comparison.is_some() && !model.external_conflict.iter().any(|x| *x);
         if ui
             .add_enabled(merge, egui::Button::new("Copy →"))
@@ -85,6 +121,40 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
             }
         }
     });
+    if model.find_open {
+        ui.horizontal(|ui| {
+            ui.label("Find:");
+            let changed = ui.text_edit_singleline(&mut model.find_query).changed();
+            egui::ComboBox::from_id_source((view, "find-scope"))
+                .selected_text(format!("{:?}", model.find_scope))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(&mut model.find_scope, FindScope::Both, "Both panes");
+                    ui.selectable_value(
+                        &mut model.find_scope,
+                        FindScope::CurrentSide,
+                        "Current pane",
+                    );
+                    ui.selectable_value(&mut model.find_scope, FindScope::Left, "Left");
+                    ui.selectable_value(&mut model.find_scope, FindScope::Right, "Right");
+                });
+            let changed = ui
+                .checkbox(&mut model.find_case_sensitive, "Case sensitive")
+                .changed()
+                | ui.checkbox(&mut model.find_projection_only, "Visible projection only")
+                    .changed()
+                | changed;
+            if changed {
+                model.refresh_find();
+            }
+            if ui.button("Previous").clicked() {
+                model.navigate_find(false);
+            }
+            if ui.button("Next").clicked() {
+                model.navigate_find(true);
+            }
+            ui.label(format!("{} matches", model.find_matches.len()));
+        });
+    }
     ui.separator();
     let number = model.comparison.as_ref().and_then(|c| {
         model
@@ -131,6 +201,41 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
             ui.allocate_exact_size(egui::vec2(8.0, comparison_height), egui::Sense::drag());
         ui.painter()
             .rect_filled(rect, 2.0, ui.visuals().widgets.inactive.bg_fill);
+        if let Some(c) = &model.comparison {
+            let pixels = rect.height().max(1.0) as usize;
+            for pixel in 0..pixels {
+                let a = pixel * c.rows.len() / pixels;
+                let b = ((pixel + 1) * c.rows.len() / pixels).min(c.rows.len());
+                let color = c.rows[a..b]
+                    .iter()
+                    .find_map(|r| match (r.kind, r.importance) {
+                        (_, ChangeImportance::Unimportant) => Some(Color32::YELLOW),
+                        (DiffRowKind::Modified, _) => Some(Color32::from_rgb(240, 180, 40)),
+                        (DiffRowKind::Deleted, _) => Some(Color32::RED),
+                        (DiffRowKind::Inserted, _) => Some(Color32::GREEN),
+                        _ => None,
+                    });
+                if let Some(color) = color {
+                    let y = rect.top() + pixel as f32;
+                    ui.painter().line_segment(
+                        [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
+                        egui::Stroke::new(1.0, color),
+                    );
+                }
+            }
+            if let Some(row) = model.current_row {
+                let y = rect.top() + rect.height() * row as f32 / c.rows.len().max(1) as f32;
+                ui.painter().line_segment(
+                    [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
+                    egui::Stroke::new(2.0, Color32::WHITE),
+                );
+            }
+        }
+        if response.clicked() {
+            if let Some(pos) = response.interact_pointer_pos() {
+                model.request_overview_scroll(pos.y - rect.top(), rect.height());
+            }
+        }
         if response.dragged() {
             model.splitter = crate::diff::model::validated_splitter(
                 model.splitter + response.drag_delta().x / available,
@@ -145,6 +250,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
     if scroll_accepted {
         model.pending_scroll_row = None;
     }
+    super::rules_dialog::show(ui.ctx(), view, model);
 }
 fn pane(
     ui: &mut egui::Ui,
@@ -164,17 +270,26 @@ fn pane(
         DiffSide::Left => model.left.source(),
         DiffSide::Right => model.right.source(),
     };
+    let projected = crate::diff::text_compare::row_projection(
+        c,
+        model.projection_mode,
+        model.projection_context,
+    );
     let rows = &c.rows;
     let row_height = if model.wrap { 34.0 } else { 20.0 };
     let mut scroll = egui::ScrollArea::vertical().id_source((workspace, view, side, "diff_scroll"));
     if let Some(row_index) = pending {
-        scroll = scroll.vertical_scroll_offset(row_index as f32 * row_height);
+        let visual = projected
+            .binary_search(&row_index)
+            .unwrap_or_else(|i| i.min(projected.len().saturating_sub(1)));
+        scroll = scroll.vertical_scroll_offset(visual as f32 * row_height);
     }
     // Defer model mutation until after the scroll callback releases its
     // immutable borrow of the retained comparison.
     let mut selected_row = None;
-    scroll.show_rows(ui, row_height, rows.len(), |ui, range| {
-        for i in range {
+    scroll.show_rows(ui, row_height, projected.len(), |ui, range| {
+        for projected_i in range {
+            let i = projected[projected_i];
             let row = &rows[i];
             let current = model.current_row == Some(i);
             let bg = match (row.kind, row.importance) {
@@ -210,6 +325,54 @@ fn pane(
                     .on_hover_text(semantic);
                     if let Some(n) = line {
                         let text = source.lines().nth(n).unwrap_or("");
+                        let ranges = match side {
+                            DiffSide::Left => &row.left_ranges,
+                            DiffSide::Right => &row.right_ranges,
+                        };
+                        let language = crate::diff::syntax::language_for_path(match side {
+                            DiffSide::Left => model.left_path.as_deref(),
+                            DiffSide::Right => model.right_path.as_deref(),
+                        });
+                        let syntax = if model.syntax && model.large_file_tier.syntax_enabled() {
+                            model
+                                .syntax_cache
+                                .line(
+                                    crate::diff::syntax::HighlightKey {
+                                        revision: match side {
+                                            DiffSide::Left => model.left.revision,
+                                            DiffSide::Right => model.right.revision,
+                                        },
+                                        language,
+                                        theme: "base16-ocean.dark".into(),
+                                        line: n,
+                                    },
+                                    text,
+                                )
+                                .to_vec()
+                        } else {
+                            vec![]
+                        };
+                        let changed: Vec<_> =
+                            ranges.iter().map(|r| (r.byte_start, r.byte_end)).collect();
+                        let fragments =
+                            crate::diff::syntax::render_fragments(text, &syntax, &changed);
+                        let mut job = egui::text::LayoutJob::default();
+                        for fragment in fragments {
+                            let mut format = egui::TextFormat {
+                                font_id: egui::FontId::monospace(14.0),
+                                color: fragment.rgb.map_or(ui.visuals().text_color(), |c| {
+                                    Color32::from_rgb(c[0], c[1], c[2])
+                                }),
+                                ..Default::default()
+                            };
+                            if fragment.changed {
+                                format.background =
+                                    Color32::from_rgba_unmultiplied(255, 190, 40, 75);
+                                format.underline =
+                                    egui::Stroke::new(1.5, Color32::from_rgb(255, 210, 80));
+                            }
+                            job.append(&fragment.text, 0.0, format);
+                        }
                         let id = egui::Id::new((
                             workspace,
                             view,
@@ -218,10 +381,8 @@ fn pane(
                             c.navigation.row_to_hunk[i],
                         ));
                         ui.push_id(id, |ui| {
-                            ui.add(
-                                egui::Label::new(RichText::new(text).monospace()).wrap(model.wrap),
-                            )
-                            .on_hover_text(format!("{semantic} line"));
+                            ui.add(egui::Label::new(job).wrap(model.wrap))
+                                .on_hover_text(format!("{semantic} line"));
                         });
                     } else if ui
                         .button("＋ Insert line")
@@ -263,6 +424,9 @@ fn side_status(
 }
 fn shortcuts(ui: &egui::Ui, m: &mut TextViewModel) {
     ui.input_mut(|i| {
+        if i.consume_key(egui::Modifiers::CTRL, egui::Key::F) {
+            m.find_open = true;
+        }
         if i.consume_key(egui::Modifiers::NONE, egui::Key::F7) {
             m.navigate(NavigationDirection::Previous)
         }


### PR DESCRIPTION
### Motivation

- Provide an editable, validated comparison rules UI so users can adjust whitespace, replacement, and unimportant-section behavior without corrupting the active comparison. 
- Avoid recalculating intraline diffs in the UI and instead render precomputed intraline ranges combined with cached syntax foreground colors to make rendering deterministic and safe for large files. 
- Offer a differences-only projection with configurable context, an independent find feature (Ctrl+F) scoped to panes/projection, and a compact overview strip to navigate very large comparisons. 

### Description

- Added a modal rules editor `src/gui/diff_dialog/rules_dialog.rs` that edits a draft `TextComparisonRules`, validates/compiles all regexes before applying, preserves the last valid comparison on validation failure, and applies valid rules via `TextViewModel::set_rules()`. 
- Extended `TextViewModel` in `src/diff/model.rs` with projection and find state (`projection_mode`, `projection_context`, find booleans/state, `syntax_cache`) and added model methods to project rows, refresh/find matches, navigate find results, and request overview-driven scrolls. 
- Implemented presentation-only projection and find utilities in `src/diff/text_compare.rs` (`RowProjectionMode`, `row_projection`, `FindScope`, `find_matches`, `navigate_match`, `overview_row`) that map logical comparison rows without mutating the comparison or hunk/row identities. 
- Added syntax-aware fragment rendering in `src/diff/syntax.rs` (`render_fragments` + `RenderFragment`) and integrated it into the diff pane renderer in `src/gui/diff_dialog/text_view.rs` to render cached syntax fragments as foreground styling while applying stronger emphasis to changed tokens and preserving diff-background priority; rendering respects `large_file_tier.syntax_enabled()`. 
- Added a small aggregated overview strip (pixel-aggregated markers) and click/drag-to-scroll mapping to logical rows, Ctrl+F bindings and find UI, All vs Differences-only controls with context choices, and tests covering rules validation, projection identity, intraline Unicode mapping, find behavior, and overview mapping. 

### Testing

- `cargo fmt -- --check` succeeded. 
- `git diff --check` succeeded. 
- Attempted `cargo test --no-fail-fast` but the full test run is blocked by platform-specific compilation failures in unrelated Windows-only modules (errors resolving `windows::Win32` and some native pkg-config dependencies); these prevent running the repository-wide test suite in this Linux environment. 
- Focused unit tests were added (rules validation, projection, intraline/render mapping, find and overview mapping) alongside the changes but the CI-local `cargo test` run could not complete due to the platform-specific build errors above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78d6373108833298f541fc2db917d9)