### PR TITLE
Add block-oriented binary comparison view

### DIFF
--- a/src/diff/binary_compare.rs
+++ b/src/diff/binary_compare.rs
@@ -1,0 +1,323 @@
+//! File-backed, block-oriented binary comparison.
+use crate::diff::model::{BinaryCompareState, validated_splitter};
+use crate::diff::text_compare::NavigationDirection;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+pub const COMPARISON_BLOCK_SIZE: usize = 64 * 1024;
+
+#[derive(Debug)]
+pub struct BinaryDocument {
+    pub path: Option<PathBuf>,
+    pub len: u64,
+    file: Option<File>,
+}
+impl BinaryDocument {
+    pub fn open(path: Option<&Path>) -> Result<Self, String> {
+        match path {
+            Some(path) => {
+                let file = File::open(path).map_err(|e| format!("{}: {e}", path.display()))?;
+                let len = file
+                    .metadata()
+                    .map_err(|e| format!("{}: {e}", path.display()))?
+                    .len();
+                Ok(Self {
+                    path: Some(path.to_owned()),
+                    len,
+                    file: Some(file),
+                })
+            }
+            None => Ok(Self {
+                path: None,
+                len: 0,
+                file: None,
+            }),
+        }
+    }
+    pub fn read_at(&mut self, offset: u64, limit: usize) -> Result<Vec<u8>, String> {
+        let Some(file) = &mut self.file else {
+            return Ok(vec![]);
+        };
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|e| e.to_string())?;
+        let mut out = vec![0; limit.min(self.len.saturating_sub(offset) as usize)];
+        file.read_exact(&mut out).map_err(|e| e.to_string())?;
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BinaryDiffRange {
+    pub start: u64,
+    pub left_len: u64,
+    pub right_len: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BinaryDifferenceIndex {
+    pub ranges: Vec<BinaryDiffRange>,
+}
+
+impl BinaryDifferenceIndex {
+    pub fn build(left: &mut BinaryDocument, right: &mut BinaryDocument) -> Result<Self, String> {
+        let total = left.len.max(right.len);
+        let mut ranges = Vec::<BinaryDiffRange>::new();
+        let mut offset = 0u64;
+        while offset < total {
+            let count = COMPARISON_BLOCK_SIZE.min((total - offset) as usize);
+            let l = left.read_at(offset, count)?;
+            let r = right.read_at(offset, count)?;
+            let mut i = 0;
+            while i < l.len().max(r.len()) {
+                if l.get(i) == r.get(i) {
+                    i += 1;
+                    continue;
+                }
+                let start = i;
+                while i < l.len().max(r.len()) && l.get(i) != r.get(i) {
+                    i += 1;
+                }
+                let candidate = BinaryDiffRange {
+                    start: offset + start as u64,
+                    left_len: (i.min(l.len()) - start.min(l.len())) as u64,
+                    right_len: (i.min(r.len()) - start.min(r.len())) as u64,
+                };
+                if let Some(last) = ranges.last_mut().filter(|last| {
+                    last.start + last.left_len.max(last.right_len) == candidate.start
+                }) {
+                    last.left_len += candidate.left_len;
+                    last.right_len += candidate.right_len;
+                } else {
+                    ranges.push(candidate);
+                }
+            }
+            offset += count as u64;
+        }
+        Ok(Self { ranges })
+    }
+    pub fn contains(&self, offset: u64) -> bool {
+        self.ranges
+            .iter()
+            .any(|r| offset >= r.start && offset < r.start + r.left_len.max(r.right_len))
+    }
+}
+
+#[derive(Debug)]
+pub struct BinaryViewModel {
+    pub left: BinaryDocument,
+    pub right: BinaryDocument,
+    pub differences: BinaryDifferenceIndex,
+    pub current_difference: Option<usize>,
+    pub bytes_per_row: usize,
+    pub splitter: f32,
+    pub visible_byte_offset: u64,
+    pub pending_scroll_offset: Option<u64>,
+}
+impl BinaryViewModel {
+    pub fn load(state: &BinaryCompareState, splitter: f32) -> Result<Self, String> {
+        let mut left = BinaryDocument::open(state.left.as_deref())?;
+        let mut right = BinaryDocument::open(state.right.as_deref())?;
+        let differences = BinaryDifferenceIndex::build(&mut left, &mut right)?;
+        Ok(Self {
+            left,
+            right,
+            differences,
+            current_difference: None,
+            bytes_per_row: 16,
+            splitter: validated_splitter(splitter),
+            visible_byte_offset: 0,
+            pending_scroll_offset: None,
+        })
+    }
+    pub fn navigate(&mut self, direction: NavigationDirection) {
+        let n = self.differences.ranges.len();
+        if n == 0 {
+            self.current_difference = None;
+            self.pending_scroll_offset = None;
+            return;
+        }
+        let next = match direction {
+            NavigationDirection::First => 0,
+            NavigationDirection::Last => n - 1,
+            NavigationDirection::Next => self.current_difference.map_or(0, |i| (i + 1) % n),
+            NavigationDirection::Previous => {
+                self.current_difference.map_or(n - 1, |i| (i + n - 1) % n)
+            }
+        };
+        self.current_difference = Some(next);
+        self.pending_scroll_offset = Some(self.differences.ranges[next].start);
+    }
+    pub fn row(&mut self, offset: u64) -> Result<BinaryRow, String> {
+        let left = self.left.read_at(offset, self.bytes_per_row)?;
+        let right = self.right.read_at(offset, self.bytes_per_row)?;
+        Ok(BinaryRow::new(
+            offset,
+            left,
+            right,
+            self.bytes_per_row,
+            &self.differences,
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinaryCell {
+    pub byte: Option<u8>,
+    pub changed: bool,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinaryRow {
+    pub offset: u64,
+    pub left: Vec<BinaryCell>,
+    pub right: Vec<BinaryCell>,
+}
+impl BinaryRow {
+    fn new(
+        offset: u64,
+        left: Vec<u8>,
+        right: Vec<u8>,
+        width: usize,
+        index: &BinaryDifferenceIndex,
+    ) -> Self {
+        let cells = |side: &[u8]| {
+            (0..width)
+                .map(|i| BinaryCell {
+                    byte: side.get(i).copied(),
+                    changed: index.contains(offset + i as u64),
+                })
+                .collect()
+        };
+        Self {
+            offset,
+            left: cells(&left),
+            right: cells(&right),
+        }
+    }
+    pub fn hex(cells: &[BinaryCell]) -> String {
+        cells
+            .iter()
+            .map(|c| c.byte.map_or("--".into(), |b| format!("{b:02X}")))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+    pub fn ascii(cells: &[BinaryCell]) -> String {
+        cells
+            .iter()
+            .map(|c| {
+                c.byte.map_or(' ', |b| {
+                    if b.is_ascii_graphic() || b == b' ' {
+                        b as char
+                    } else {
+                        '.'
+                    }
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn docs(a: &[u8], b: &[u8]) -> (tempfile::TempDir, BinaryDocument, BinaryDocument) {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("a"), a).unwrap();
+        std::fs::write(d.path().join("b"), b).unwrap();
+        let l = BinaryDocument::open(Some(&d.path().join("a"))).unwrap();
+        let r = BinaryDocument::open(Some(&d.path().join("b"))).unwrap();
+        (d, l, r)
+    }
+    #[test]
+    fn ranges_and_boundaries() {
+        let (_d, mut l, mut r) = docs(&vec![1; COMPARISON_BLOCK_SIZE + 2], &{
+            let mut x = vec![1; COMPARISON_BLOCK_SIZE + 2];
+            x[COMPARISON_BLOCK_SIZE - 1] = 2;
+            x[COMPARISON_BLOCK_SIZE] = 2;
+            x
+        });
+        let i = BinaryDifferenceIndex::build(&mut l, &mut r).unwrap();
+        assert_eq!(
+            i.ranges,
+            [BinaryDiffRange {
+                start: COMPARISON_BLOCK_SIZE as u64 - 1,
+                left_len: 2,
+                right_len: 2
+            }]
+        );
+    }
+    #[test]
+    fn equal_middle_separate_and_tail() {
+        for (a, b, n) in [
+            (b"abc".as_slice(), b"abc".as_slice(), 0),
+            (b"abc", b"axc", 1),
+            (b"abcde", b"axcye", 2),
+            (b"abc", b"abcde", 1),
+        ] {
+            let (_d, mut l, mut r) = docs(a, b);
+            assert_eq!(
+                BinaryDifferenceIndex::build(&mut l, &mut r)
+                    .unwrap()
+                    .ranges
+                    .len(),
+                n
+            );
+        }
+    }
+    #[test]
+    fn first_byte_is_one_contiguous_range() {
+        let (_d, mut left, mut right) = docs(b"abc", b"xbc");
+        assert_eq!(
+            BinaryDifferenceIndex::build(&mut left, &mut right)
+                .unwrap()
+                .ranges,
+            [BinaryDiffRange {
+                start: 0,
+                left_len: 1,
+                right_len: 1
+            }]
+        );
+    }
+    #[test]
+    fn formatting_missing() {
+        let (_d, mut l, mut r) = docs(b"A\0", b"B");
+        let i = BinaryDifferenceIndex::build(&mut l, &mut r).unwrap();
+        let row = BinaryRow::new(
+            0,
+            l.read_at(0, 16).unwrap(),
+            r.read_at(0, 16).unwrap(),
+            2,
+            &i,
+        );
+        assert_eq!(BinaryRow::hex(&row.left), "41 00");
+        assert_eq!(BinaryRow::hex(&row.right), "42 --");
+        assert_eq!(BinaryRow::ascii(&row.left), "A.");
+    }
+    #[test]
+    fn navigation_wraps_and_scrolls_to_range_start() {
+        let d = tempfile::tempdir().unwrap();
+        let left = d.path().join("left");
+        let right = d.path().join("right");
+        std::fs::write(&left, b"abcde").unwrap();
+        std::fs::write(&right, b"axcye").unwrap();
+        let mut model = BinaryViewModel::load(
+            &BinaryCompareState {
+                left: Some(left),
+                right: Some(right),
+                relative_path: None,
+            },
+            0.5,
+        )
+        .unwrap();
+        model.navigate(NavigationDirection::Previous);
+        assert_eq!(model.current_difference, Some(1));
+        assert_eq!(model.pending_scroll_offset, Some(3));
+        model.navigate(NavigationDirection::Next);
+        assert_eq!(model.current_difference, Some(0));
+        assert_eq!(model.pending_scroll_offset, Some(1));
+        model.navigate(NavigationDirection::Last);
+        assert_eq!(model.current_difference, Some(1));
+        model.navigate(NavigationDirection::First);
+        assert_eq!(model.current_difference, Some(0));
+    }
+}

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -4,6 +4,7 @@
 //! folders, Git-specific UI, media/image comparison, cloud protocols, fuzzy
 //! filename pairing, and a hex editor.
 
+pub mod binary_compare;
 pub mod file_ops;
 pub mod folder_compare;
 pub mod folder_runtime;

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -121,22 +121,22 @@ impl FolderCompareState {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum FileComparisonKind {
-    Text,
-    Binary,
-}
-#[derive(Debug, Clone, PartialEq)]
 pub struct TextCompareState {
     pub left: Option<PathBuf>,
     pub right: Option<PathBuf>,
     pub relative_path: Option<PathBuf>,
-    pub kind: FileComparisonKind,
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinaryCompareState {
+    pub left: Option<PathBuf>,
+    pub right: Option<PathBuf>,
+    pub relative_path: Option<PathBuf>,
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum DiffView {
     Start,
     TextCompare(TextCompareState),
-    BinaryCompare(TextCompareState),
+    BinaryCompare(BinaryCompareState),
     FolderCompare(FolderCompareState),
 }
 #[derive(Debug, Clone, PartialEq)]
@@ -230,15 +230,18 @@ impl DiffWorkspace {
             }
         };
         let view = if lm.is_file() && rm.is_file() {
-            let state = TextCompareState {
-                left: Some(lp.clone()),
-                right: Some(rp.clone()),
-                relative_path: None,
-                kind: detect_kind(&lp, &rp),
-            };
-            match state.kind {
-                FileComparisonKind::Text => DiffView::TextCompare(state),
-                FileComparisonKind::Binary => DiffView::BinaryCompare(state),
+            if paths_are_binary(Some(&lp), Some(&rp)) {
+                DiffView::BinaryCompare(BinaryCompareState {
+                    left: Some(lp.clone()),
+                    right: Some(rp.clone()),
+                    relative_path: None,
+                })
+            } else {
+                DiffView::TextCompare(TextCompareState {
+                    left: Some(lp.clone()),
+                    right: Some(rp.clone()),
+                    relative_path: None,
+                })
             }
         } else if lm.is_dir() && rm.is_dir() {
             DiffView::FolderCompare(FolderCompareState {
@@ -277,21 +280,20 @@ impl DiffWorkspace {
         if left.is_none() && right.is_none() {
             return Err("A folder child must exist on at least one side".into());
         }
-        let kind = match (&left, &right) {
-            (Some(l), Some(r)) => detect_kind(l, r),
-            _ => FileComparisonKind::Text,
-        };
-        let state = TextCompareState {
-            left,
-            right,
-            relative_path: Some(relative_path),
-            kind,
-        };
         let next = RetainedView {
             id: id(),
-            view: match state.kind {
-                FileComparisonKind::Text => DiffView::TextCompare(state),
-                FileComparisonKind::Binary => DiffView::BinaryCompare(state),
+            view: if paths_are_binary(left.as_deref(), right.as_deref()) {
+                DiffView::BinaryCompare(BinaryCompareState {
+                    left,
+                    right,
+                    relative_path: Some(relative_path),
+                })
+            } else {
+                DiffView::TextCompare(TextCompareState {
+                    left,
+                    right,
+                    relative_path: Some(relative_path),
+                })
             },
         };
         let old = std::mem::replace(&mut self.current_view, next);
@@ -330,17 +332,26 @@ pub fn validated_window_geometry(
 fn metadata(path: &Path, side: &str) -> Result<fs::Metadata, String> {
     fs::metadata(path).map_err(|e| format!("{side} path '{}': {e}", path.display()))
 }
-fn detect_kind(left: &Path, right: &Path) -> FileComparisonKind {
+fn paths_are_binary(left: Option<&Path>, right: Option<&Path>) -> bool {
     let binary = |p: &Path| {
-        fs::read(p)
+        const ARCHIVES: &[&str] = &[
+            "zip", "7z", "rar", "tar", "gz", "tgz", "bz2", "xz", "zst", "lz", "jar", "war", "apk",
+            "cab", "arj", "iso", "dmg", "deb", "rpm",
+        ];
+        if p.extension()
+            .and_then(|v| v.to_str())
+            .is_some_and(|v| ARCHIVES.iter().any(|x| v.eq_ignore_ascii_case(x)))
+        {
+            return true;
+        }
+        let mut bytes = [0; 8192];
+        use std::io::Read;
+        fs::File::open(p)
             .ok()
-            .is_some_and(|b| b.iter().take(8192).any(|v| *v == 0))
+            .and_then(|mut f| f.read(&mut bytes).ok())
+            .is_some_and(|n| bytes[..n].contains(&0) || std::str::from_utf8(&bytes[..n]).is_err())
     };
-    if binary(left) || binary(right) {
-        FileComparisonKind::Binary
-    } else {
-        FileComparisonKind::Text
-    }
+    left.is_some_and(binary) || right.is_some_and(binary)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -903,6 +914,26 @@ mod tests {
             &workspace.current_view.view,
             DiffView::BinaryCompare(state)
                 if state.left.as_ref() == Some(&left) && state.right.as_ref() == Some(&right)
+        ));
+    }
+
+    #[test]
+    fn zip_routes_to_binary_without_content_inspection() {
+        let temp = tempfile::tempdir().unwrap();
+        let left = temp.path().join("left.zip");
+        let right = temp.path().join("right.zip");
+        fs::write(&left, "plain but archive-named").unwrap();
+        fs::write(&right, "also plain").unwrap();
+        let mut workspace = DiffWorkspace::default();
+        workspace
+            .open_paths(
+                left.to_string_lossy().into(),
+                right.to_string_lossy().into(),
+            )
+            .unwrap();
+        assert!(matches!(
+            workspace.current_view.view,
+            DiffView::BinaryCompare(_)
         ));
     }
 

--- a/src/gui/diff_dialog/binary_view.rs
+++ b/src/gui/diff_dialog/binary_view.rs
@@ -1,0 +1,69 @@
+use crate::diff::binary_compare::{BinaryCell, BinaryRow, BinaryViewModel};
+use crate::diff::text_compare::NavigationDirection;
+use eframe::egui::{self, Color32, RichText};
+
+pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut BinaryViewModel) {
+    ui.horizontal(|ui| {
+        for (label, direction) in [
+            ("First", NavigationDirection::First),
+            ("Previous", NavigationDirection::Previous),
+            ("Next", NavigationDirection::Next),
+            ("Last", NavigationDirection::Last),
+        ] {
+            if ui.button(label).clicked() {
+                model.navigate(direction);
+            }
+        }
+        ui.label(model.current_difference.map_or_else(
+            || format!("0/{} differences", model.differences.ranges.len()),
+            |i| format!("Difference {}/{}", i + 1, model.differences.ranges.len()),
+        ));
+        ui.label("Read-only · 16 bytes/row");
+    });
+    let row_height = 22.0;
+    let rows = model
+        .left
+        .len
+        .max(model.right.len)
+        .div_ceil(model.bytes_per_row as u64) as usize;
+    let pending = model.pending_scroll_offset.take();
+    if let Some(offset) = pending {
+        model.visible_byte_offset =
+            offset / model.bytes_per_row as u64 * model.bytes_per_row as u64;
+    }
+    let mut scroll = egui::ScrollArea::vertical().id_source((workspace, view, "binary_scroll"));
+    if pending.is_some() {
+        scroll = scroll.vertical_scroll_offset(
+            (model.visible_byte_offset / model.bytes_per_row as u64) as f32 * row_height,
+        );
+    }
+    scroll.show_rows(ui, row_height, rows, |ui, range| {
+        for row_index in range {
+            let offset = row_index as u64 * model.bytes_per_row as u64;
+            if let Ok(row) = model.row(offset) {
+                ui.horizontal(|ui| {
+                    side(ui, row.offset, &row.left);
+                    ui.separator();
+                    side(ui, row.offset, &row.right);
+                });
+            }
+        }
+    });
+}
+
+fn side(ui: &mut egui::Ui, offset: u64, cells: &[BinaryCell]) {
+    ui.label(RichText::new(format!("{offset:08X}")).monospace().weak());
+    for cell in cells {
+        let text = cell.byte.map_or("--".to_owned(), |b| format!("{b:02X}"));
+        ui.label(
+            RichText::new(text)
+                .monospace()
+                .background_color(if cell.changed {
+                    Color32::from_rgb(100, 65, 20)
+                } else {
+                    Color32::TRANSPARENT
+                }),
+        );
+    }
+    ui.label(RichText::new(BinaryRow::ascii(cells)).monospace());
+}

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -3,6 +3,7 @@ use crate::diff::query::DiffOpenPayload;
 use eframe::egui;
 use std::collections::HashMap;
 use std::collections::HashSet;
+mod binary_view;
 mod folder_view;
 mod operation_preview;
 mod rules_dialog;
@@ -22,8 +23,7 @@ pub struct DiffDialogState {
     text_views: HashMap<u64, crate::diff::model::TextViewModel>,
     folder_runtimes: HashMap<u64, crate::diff::folder_runtime::FolderRuntime>,
     operation_preview: Option<operation_preview::OperationPreview>,
-    // Binary renderers will keep their ephemeral resources in this view-id map.
-    binary_views: HashMap<u64, ()>,
+    binary_views: HashMap<u64, crate::diff::binary_compare::BinaryViewModel>,
     close_prompt: bool,
     pub persistence: crate::diff::persistence::DiffPersistenceV1,
 }
@@ -149,20 +149,22 @@ impl DiffDialogState {
                     ));
                 }
                 DiffView::BinaryCompare(s) => {
-                    self.binary_views.entry(view_id).or_insert(());
-                    ui.heading("Binary comparison");
-                    ui.label(format!(
-                        "Left: {}",
-                        s.left
-                            .as_ref()
-                            .map_or("(missing)".into(), |p| p.display().to_string())
-                    ));
-                    ui.label(format!(
-                        "Right: {}",
-                        s.right
-                            .as_ref()
-                            .map_or("(missing)".into(), |p| p.display().to_string())
-                    ));
+                    if !self.binary_views.contains_key(&view_id) {
+                        match crate::diff::binary_compare::BinaryViewModel::load(
+                            s,
+                            settings.pane_split,
+                        ) {
+                            Ok(model) => {
+                                self.binary_views.insert(view_id, model);
+                            }
+                            Err(error) => {
+                                render_error = Some(error);
+                            }
+                        }
+                    }
+                    if let Some(model) = self.binary_views.get_mut(&view_id) {
+                        binary_view::show(ui, workspace_id, view_id, model);
+                    }
                 }
                 DiffView::FolderCompare(s) => {
                     let runtime = self.folder_runtimes.entry(view_id).or_default();

--- a/src/gui/diff_dialog/rules_dialog.rs
+++ b/src/gui/diff_dialog/rules_dialog.rs
@@ -147,7 +147,6 @@ mod tests {
             left: Some(left),
             right: Some(right),
             relative_path: None,
-            kind: crate::diff::model::FileComparisonKind::Text,
         };
         let mut model = TextViewModel::load(&state, &Default::default()).unwrap();
         model.recalculate_at = None;


### PR DESCRIPTION
### Motivation

- Provide a dedicated, read-only binary-diff view variant that compares large files efficiently without loading entire files into memory. 
- Route archive and detected-binary paths (e.g. `.zip`) to a binary comparison UI without attempting archive introspection. 
- Remove binary-kind metadata from the text comparison state so text and binary comparisons are represented by separate view types. 

### Description

- Introduce `BinaryCompareState` and `DiffView::BinaryCompare` and remove `FileComparisonKind` from `TextCompareState`, moving file-type classification into `DiffWorkspace::open_paths()` and `push_file_compare()`. 
- Add a new module `src/diff/binary_compare.rs` implementing file-backed `BinaryDocument`, block-oriented `BinaryDifferenceIndex` that builds merged `BinaryDiffRange { start, left_len, right_len }` across 64 KiB comparison blocks, and a runtime `BinaryViewModel` with 16-byte rows, splitter, synchronized visible offset, `pending_scroll_offset`, and wrapping navigation. 
- Add a GUI renderer `src/gui/diff_dialog/binary_view.rs` and integrate per-view `BinaryViewModel` instances into the dialog (`binary_views` hashmap), with virtualized rows rendering offset, hex cells, ASCII projection, explicit missing-byte cells, and changed-byte emphasis. 
- Classify common archive extensions (e.g. `zip`, `tar`, `gz`, `tgz`, `jar`, `apk`, etc.) as binary by extension and route them to the binary view without inspecting archive contents. 

### Testing

- Ran `cargo fmt --all` and `git diff --check` successfully and committed the changes as `Add block-oriented binary comparison view`. 
- Attempted `cargo test diff:: --lib` but the full test/build run on this host was blocked by platform-specific native dependency issues; initial compile failures due to missing system pkg-config libraries (`alsa`, `xi`) were addressed by installing `libasound2-dev` and `libxi-dev`, after which the build failed on unconditional Windows API imports (`windows::Win32` / `windows::core`) that cannot resolve on the Linux target. 
- Unit tests were added alongside the binary engine in `src/diff/binary_compare.rs` (equal files, first-byte diff, middle diffs, unequal tails, range merging, missing-byte rendering, formatting, navigation/wrapping and `pending_scroll_offset` behavior), but a full `cargo test` run for those tests could not complete due to the platform build issue described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78db854c388332a616469e171f5f14)