### PR TITLE
Integrate filesystem watchers with Diff views

### DIFF
--- a/src/diff/binary_compare.rs
+++ b/src/diff/binary_compare.rs
@@ -113,6 +113,8 @@ pub struct BinaryViewModel {
     pub splitter: f32,
     pub visible_byte_offset: u64,
     pub pending_scroll_offset: Option<u64>,
+    pub generation: u64,
+    pub stale: bool,
 }
 impl BinaryViewModel {
     pub fn load(state: &BinaryCompareState, splitter: f32) -> Result<Self, String> {
@@ -128,7 +130,17 @@ impl BinaryViewModel {
             splitter: validated_splitter(splitter),
             visible_byte_offset: 0,
             pending_scroll_offset: None,
+            generation: 1,
+            stale: false,
         })
+    }
+    /// Reopens both files and atomically publishes a completely rebuilt index.
+    pub fn refresh_external(&mut self, state: &BinaryCompareState) -> Result<(), String> {
+        self.stale = true;
+        let mut replacement = Self::load(state, self.splitter)?;
+        replacement.generation = self.generation.wrapping_add(1);
+        *self = replacement;
+        Ok(())
     }
     pub fn navigate(&mut self, direction: NavigationDirection) {
         let n = self.differences.ranges.len();
@@ -319,5 +331,26 @@ mod tests {
         assert_eq!(model.current_difference, Some(1));
         model.navigate(NavigationDirection::First);
         assert_eq!(model.current_difference, Some(0));
+    }
+    #[test]
+    fn external_refresh_rebuilds_index_and_advances_generation() {
+        let d = tempfile::tempdir().unwrap();
+        let left = d.path().join("left");
+        let right = d.path().join("right");
+        std::fs::write(&left, [1, 2, 3]).unwrap();
+        std::fs::write(&right, [1, 2, 3]).unwrap();
+        let state = BinaryCompareState {
+            left: Some(left),
+            right: Some(right.clone()),
+            relative_path: None,
+        };
+        let mut model = BinaryViewModel::load(&state, 0.5).unwrap();
+        let generation = model.generation;
+        assert!(model.differences.ranges.is_empty());
+        std::fs::write(right, [1, 9, 3]).unwrap();
+        model.refresh_external(&state).unwrap();
+        assert_eq!(model.generation, generation + 1);
+        assert!(!model.stale);
+        assert!(model.differences.contains(1));
     }
 }

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -488,6 +488,27 @@ pub struct TextViewModel {
 }
 
 impl TextViewModel {
+    /// Installs a clean external reload while monotonically advancing the
+    /// document revision used to reject stale comparison results.
+    pub fn reload_external(
+        &mut self,
+        side: DiffSide,
+        loaded: &crate::diff::text_file::LoadedTextFile,
+    ) -> Result<(), String> {
+        let replacement = TextDocument::from_loaded(loaded)
+            .ok_or_else(|| "externally changed file is no longer text".to_string())?;
+        let document = match side {
+            DiffSide::Left => &mut self.left,
+            DiffSide::Right => &mut self.right,
+        };
+        let next = document.revision.wrapping_add(1);
+        *document = replacement;
+        document.revision = next;
+        document.saved_revision = next;
+        self.external_conflict[if side == DiffSide::Left { 0 } else { 1 }] = false;
+        self.schedule_compare();
+        Ok(())
+    }
     pub fn load(state: &TextCompareState, settings: &DiffConfigV1) -> Result<Self, String> {
         fn doc(path: Option<&PathBuf>) -> Result<TextDocument, String> {
             path.map(|p| {

--- a/src/diff/watch.rs
+++ b/src/diff/watch.rs
@@ -13,6 +13,188 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::mpsc::{self, Receiver};
 use std::time::{Duration, Instant};
 
+/// Ephemeral, per-view watch controller.  It is intentionally not part of any
+/// serde model: owning this value owns (and, on drop, cancels) the OS watcher.
+pub struct ViewWatchRuntime {
+    pub tag: WatchTag,
+    watcher: Option<WatchSet>,
+    coalescer: EventCoalescer,
+    kind: ViewWatchKind,
+}
+
+#[derive(Debug, Clone)]
+enum ViewWatchKind {
+    Folder {
+        left: PathBuf,
+        right: PathBuf,
+    },
+    Text {
+        left: Option<ExternalDocument>,
+        right: Option<ExternalDocument>,
+    },
+    Binary {
+        left: Option<PathBuf>,
+        right: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug)]
+pub enum ViewWatchAction {
+    FolderChanged {
+        root: PathBuf,
+        subtree: PathBuf,
+    },
+    TextReload {
+        side: crate::diff::model::DiffSide,
+        loaded: LoadedTextFile,
+    },
+    TextConflict {
+        side: crate::diff::model::DiffSide,
+        path: PathBuf,
+    },
+    BinaryRefresh,
+}
+
+impl ViewWatchRuntime {
+    const DEBOUNCE: Duration = Duration::from_millis(120);
+
+    pub fn folder(tag: WatchTag, left: PathBuf, right: PathBuf) -> Self {
+        let watcher = WatchSet::roots(tag, [left.clone(), right.clone()]).ok();
+        Self {
+            tag,
+            watcher,
+            coalescer: EventCoalescer::new(Self::DEBOUNCE),
+            kind: ViewWatchKind::Folder {
+                left: normalize_absolute(&left),
+                right: normalize_absolute(&right),
+            },
+        }
+    }
+    pub fn text(tag: WatchTag, left: Option<PathBuf>, right: Option<PathBuf>) -> Self {
+        let paths = left.iter().chain(right.iter()).cloned().collect::<Vec<_>>();
+        let watcher = (!paths.is_empty())
+            .then(|| WatchSet::files(tag, paths).ok())
+            .flatten();
+        let document = |path: Option<PathBuf>| {
+            path.map(|p| ExternalDocument::new(p.clone(), stat_identity(&p).ok(), 0, tag))
+        };
+        Self {
+            tag,
+            watcher,
+            coalescer: EventCoalescer::new(Self::DEBOUNCE),
+            kind: ViewWatchKind::Text {
+                left: document(left),
+                right: document(right),
+            },
+        }
+    }
+    pub fn binary(tag: WatchTag, left: Option<PathBuf>, right: Option<PathBuf>) -> Self {
+        let paths = left.iter().chain(right.iter()).cloned().collect::<Vec<_>>();
+        let watcher = (!paths.is_empty())
+            .then(|| WatchSet::files(tag, paths).ok())
+            .flatten();
+        Self {
+            tag,
+            watcher,
+            coalescer: EventCoalescer::new(Self::DEBOUNCE),
+            kind: ViewWatchKind::Binary {
+                left: left.map(|p| normalize_absolute(&p)),
+                right: right.map(|p| normalize_absolute(&p)),
+            },
+        }
+    }
+    /// Test/back-end injection boundary. Events are still checked at drain time.
+    pub fn inject(&mut self, now: Instant, event: WatchEvent) {
+        self.coalescer.push(now, event);
+    }
+    pub fn poll(&mut self, now: Instant, dirty: [bool; 2]) -> Vec<ViewWatchAction> {
+        if let Some(watcher) = &self.watcher {
+            for event in watcher.try_events().into_iter().flatten() {
+                self.coalescer.push(now, event);
+            }
+        }
+        let events = self.coalescer.drain_ready(now, self.tag);
+        let mut out = Vec::new();
+        for event in events {
+            match &mut self.kind {
+                ViewWatchKind::Folder { left, right } => {
+                    if &event.identity_path != left && &event.identity_path != right {
+                        continue;
+                    }
+                    if let Some(subtree) = affected_subtree(&event.identity_path, &event.paths) {
+                        out.push(ViewWatchAction::FolderChanged {
+                            root: event.identity_path,
+                            subtree,
+                        });
+                    }
+                }
+                ViewWatchKind::Text { left, right } => {
+                    for (index, document) in [left, right].into_iter().enumerate() {
+                        let Some(document) = document else { continue };
+                        if event.identity_path != document.path {
+                            continue;
+                        }
+                        document.dirty = dirty[index];
+                        let side = if index == 0 {
+                            crate::diff::model::DiffSide::Left
+                        } else {
+                            crate::diff::model::DiffSide::Right
+                        };
+                        if let Some(ticket) = document.observe() {
+                            match ExternalDocument::load(&ticket) {
+                                Ok(loaded) if document.accept_reload(&ticket, &loaded) => {
+                                    out.push(ViewWatchAction::TextReload { side, loaded })
+                                }
+                                Err(error) => {
+                                    document.state = ExternalState::Missing(error.to_string())
+                                }
+                                _ => {}
+                            }
+                        } else if document.state == ExternalState::Conflict {
+                            out.push(ViewWatchAction::TextConflict {
+                                side,
+                                path: document.path.clone(),
+                            });
+                        }
+                    }
+                }
+                ViewWatchKind::Binary { left, right } => {
+                    if left.as_ref() == Some(&event.identity_path)
+                        || right.as_ref() == Some(&event.identity_path)
+                    {
+                        out.push(ViewWatchAction::BinaryRefresh);
+                    }
+                }
+            }
+        }
+        out
+    }
+    pub fn resolve_text_conflict(
+        &mut self,
+        side: crate::diff::model::DiffSide,
+        reload: bool,
+    ) -> Option<LoadedTextFile> {
+        let ViewWatchKind::Text { left, right } = &mut self.kind else {
+            return None;
+        };
+        let document = match side {
+            crate::diff::model::DiffSide::Left => left,
+            crate::diff::model::DiffSide::Right => right,
+        }
+        .as_mut()?;
+        if !reload {
+            document.keep_buffer();
+            return None;
+        }
+        let loaded = load_text_file(&document.path).ok()?;
+        document.dirty = false;
+        document.identity = Some(loaded.identity.clone());
+        document.revision = document.revision.wrapping_add(1);
+        document.state = ExternalState::Current;
+        Some(loaded)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WatchTag {
     pub workspace: u64,
@@ -93,11 +275,18 @@ impl WatchSet {
         let registration = self
             .registrations
             .iter()
-            .find(|(watched, scope)| match scope {
-                WatchScope::File => normalized
+            .find(|(watched, scope)| {
+                *scope == WatchScope::File && normalized.iter().any(|p| p == watched)
+            })
+            .or_else(|| {
+                self.registrations
                     .iter()
-                    .any(|p| p == watched || p.parent() == watched.parent()),
-                WatchScope::Root => normalized.iter().any(|p| p.starts_with(watched)),
+                    .find(|(watched, scope)| match scope {
+                        WatchScope::File => normalized
+                            .iter()
+                            .any(|p| p == watched || p.parent() == watched.parent()),
+                        WatchScope::Root => normalized.iter().any(|p| p.starts_with(watched)),
+                    })
             })
             .or_else(|| self.registrations.first());
         let (identity_path, scope) = registration

--- a/src/diff/watch.rs
+++ b/src/diff/watch.rs
@@ -103,8 +103,14 @@ impl ViewWatchRuntime {
             },
         }
     }
-    /// Test/back-end injection boundary. Events are still checked at drain time.
+    /// Deterministic test/back-end injection boundary.
+    ///
+    /// The first injected event detaches the live OS watcher. Otherwise a real
+    /// notification for the same test write can arrive during `poll`, extend
+    /// the coalescing deadline, and make an injected-clock test nondeterministic.
+    /// Production code never calls this method.
     pub fn inject(&mut self, now: Instant, event: WatchEvent) {
+        self.watcher = None;
         self.coalescer.push(now, event);
     }
     pub fn poll(&mut self, now: Instant, dirty: [bool; 2]) -> Vec<ViewWatchAction> {

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -24,6 +24,7 @@ pub struct DiffDialogState {
     folder_runtimes: HashMap<u64, crate::diff::folder_runtime::FolderRuntime>,
     operation_preview: Option<operation_preview::OperationPreview>,
     binary_views: HashMap<u64, crate::diff::binary_compare::BinaryViewModel>,
+    watch_views: HashMap<u64, crate::diff::watch::ViewWatchRuntime>,
     close_prompt: bool,
     pub persistence: crate::diff::persistence::DiffPersistenceV1,
 }
@@ -47,12 +48,14 @@ impl DiffDialogState {
         self.text_views.retain(|id, _| retained.contains(id));
         self.folder_runtimes.retain(|id, _| retained.contains(id));
         self.binary_views.retain(|id, _| retained.contains(id));
+        self.watch_views.retain(|id, _| retained.contains(id));
     }
 
     fn clear_runtime_resources(&mut self) {
         self.text_views.clear();
         self.folder_runtimes.clear();
         self.binary_views.clear();
+        self.watch_views.clear();
     }
     pub fn ui(&mut self, ctx: &egui::Context) {
         if !self.open {
@@ -138,7 +141,34 @@ impl DiffDialogState {
                             }
                         }
                     }
+                    let tag = crate::diff::watch::WatchTag { workspace: workspace_id, view: view_id, generation: 1 };
+                    if self.watch_views.get(&view_id).is_none_or(|watch| watch.tag != tag) {
+                        self.watch_views.insert(view_id, crate::diff::watch::ViewWatchRuntime::text(tag, s.left.clone(), s.right.clone()));
+                    }
                     if let Some(m) = self.text_views.get_mut(&view_id) {
+                        let dirty = [m.left.is_dirty(), m.right.is_dirty()];
+                        let actions = self.watch_views.get_mut(&view_id).map(|w| w.poll(std::time::Instant::now(), dirty)).unwrap_or_default();
+                        for action in actions {
+                            match action {
+                                crate::diff::watch::ViewWatchAction::TextReload { side, loaded } => { if let Err(e) = m.reload_external(side, &loaded) { render_error = Some(e); } }
+                                crate::diff::watch::ViewWatchAction::TextConflict { side, .. } => m.external_conflict[if side == crate::diff::model::DiffSide::Left { 0 } else { 1 }] = true,
+                                _ => {}
+                            }
+                        }
+                        for (index, side, label) in [(0, crate::diff::model::DiffSide::Left, "Left"), (1, crate::diff::model::DiffSide::Right, "Right")] {
+                            if m.external_conflict[index] {
+                                ui.horizontal(|ui| {
+                                    ui.colored_label(egui::Color32::YELLOW, format!("{label} changed on disk; in-memory edits were preserved."));
+                                    if ui.button("Reload / discard edits").clicked() {
+                                        if let Some(loaded) = self.watch_views.get_mut(&view_id).and_then(|w| w.resolve_text_conflict(side, true)) { let _ = m.reload_external(side, &loaded); }
+                                    }
+                                    if ui.button("Keep current").clicked() {
+                                        if let Some(w) = self.watch_views.get_mut(&view_id) { w.resolve_text_conflict(side, false); }
+                                        m.external_conflict[index] = false;
+                                    }
+                                });
+                            }
+                        }
                         text_view::show(ui, workspace_id, view_id, m);
                     }
                     ui.label(format!(
@@ -162,6 +192,18 @@ impl DiffDialogState {
                             }
                         }
                     }
+                    let tag = crate::diff::watch::WatchTag { workspace: workspace_id, view: view_id, generation: 1 };
+                    if self.watch_views.get(&view_id).is_none_or(|watch| watch.tag != tag) {
+                        self.watch_views.insert(view_id, crate::diff::watch::ViewWatchRuntime::binary(tag, s.left.clone(), s.right.clone()));
+                    }
+                    let refresh = self.watch_views.get_mut(&view_id).is_some_and(|watch| watch.poll(std::time::Instant::now(), [false; 2]).into_iter().any(|a| matches!(a, crate::diff::watch::ViewWatchAction::BinaryRefresh)));
+                    if refresh {
+                        if let Some(model) = self.binary_views.get_mut(&view_id) {
+                            if let Err(error) = model.refresh_external(s) {
+                                render_error = Some(format!("Binary view is stale: {error}"));
+                            }
+                        }
+                    }
                     if let Some(model) = self.binary_views.get_mut(&view_id) {
                         binary_view::show(ui, workspace_id, view_id, model);
                     }
@@ -169,6 +211,21 @@ impl DiffDialogState {
                 DiffView::FolderCompare(s) => {
                     let runtime = self.folder_runtimes.entry(view_id).or_default();
                     poll_folder_runtime(s, runtime);
+                    let tag = crate::diff::watch::WatchTag { workspace: workspace_id, view: view_id, generation: runtime.generation };
+                    if self.watch_views.get(&view_id).is_none_or(|watch| watch.tag != tag) {
+                        self.watch_views.insert(view_id, crate::diff::watch::ViewWatchRuntime::folder(tag, s.left_root.clone(), s.right_root.clone()));
+                    }
+                    let changes = self.watch_views.get_mut(&view_id).map(|w| w.poll(std::time::Instant::now(), [false; 2])).unwrap_or_default();
+                    for change in changes {
+                        if let crate::diff::watch::ViewWatchAction::FolderChanged { subtree, .. } = change {
+                            for entry in s.model.entries.values() {
+                                if entry.relative_path.starts_with(&subtree) { s.stale_paths.insert(entry.relative_path.clone()); }
+                            }
+                            // A bounded replacement scan discovers additions/removals; it
+                            // never performs synchronization or filesystem mutation.
+                            runtime.prepare_rescan();
+                        }
+                    }
                     if runtime.is_active() {
                         ctx.request_repaint();
                     }
@@ -727,6 +784,18 @@ mod tests {
     fn replacing_comparison_removes_obsolete_runtime() {
         let mut dialog = folder_dialog(51);
         dialog.folder_runtimes.insert(51, Default::default());
+        dialog.watch_views.insert(
+            51,
+            crate::diff::watch::ViewWatchRuntime::folder(
+                crate::diff::watch::WatchTag {
+                    workspace: dialog.workspace.workspace_id,
+                    view: 51,
+                    generation: 1,
+                },
+                tempfile::tempdir().unwrap().path().into(),
+                tempfile::tempdir().unwrap().path().into(),
+            ),
+        );
         let dirs = (tempfile::tempdir().unwrap(), tempfile::tempdir().unwrap());
         dialog
             .workspace
@@ -737,6 +806,28 @@ mod tests {
             .unwrap();
         dialog.reconcile_runtime_resources();
         assert!(!dialog.folder_runtimes.contains_key(&51));
+        assert!(!dialog.watch_views.contains_key(&51));
+    }
+
+    #[test]
+    fn closing_dialog_drops_all_watchers() {
+        let mut dialog = folder_dialog(52);
+        let left = tempfile::tempdir().unwrap();
+        let right = tempfile::tempdir().unwrap();
+        dialog.watch_views.insert(
+            52,
+            crate::diff::watch::ViewWatchRuntime::folder(
+                crate::diff::watch::WatchTag {
+                    workspace: dialog.workspace.workspace_id,
+                    view: 52,
+                    generation: 1,
+                },
+                left.path().into(),
+                right.path().into(),
+            ),
+        );
+        dialog.clear_runtime_resources();
+        assert!(dialog.watch_views.is_empty());
     }
 
     #[test]

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -219,7 +219,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
                     let y = rect.top() + pixel as f32;
                     ui.painter().line_segment(
                         [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
-                        egui::Stroke::new(1.0, color),
+                        egui::Stroke::new(1.0_f32, color),
                     );
                 }
             }
@@ -227,7 +227,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
                 let y = rect.top() + rect.height() * row as f32 / c.rows.len().max(1) as f32;
                 ui.painter().line_segment(
                     [egui::pos2(rect.left(), y), egui::pos2(rect.right(), y)],
-                    egui::Stroke::new(2.0, Color32::WHITE),
+                    egui::Stroke::new(2.0_f32, Color32::WHITE),
                 );
             }
         }
@@ -369,7 +369,7 @@ fn pane(
                                 format.background =
                                     Color32::from_rgba_unmultiplied(255, 190, 40, 75);
                                 format.underline =
-                                    egui::Stroke::new(1.5, Color32::from_rgb(255, 210, 80));
+                                    egui::Stroke::new(1.5_f32, Color32::from_rgb(255, 210, 80));
                             }
                             job.append(&fragment.text, 0.0, format);
                         }

--- a/tests/diff_watch.rs
+++ b/tests/diff_watch.rs
@@ -97,3 +97,115 @@ fn stale_reload_and_smallest_subtree() {
         Some("a".into())
     );
 }
+
+#[test]
+fn injected_folder_event_invalidates_smallest_affected_subtree() {
+    let d = tempfile::tempdir().unwrap();
+    let other = tempfile::tempdir().unwrap();
+    let now = Instant::now();
+    let mut runtime = ViewWatchRuntime::folder(tag(4), d.path().into(), other.path().into());
+    runtime.inject(
+        now,
+        WatchEvent {
+            tag: tag(4),
+            identity_path: d.path().into(),
+            paths: vec![
+                d.path().join("src/a.txt"),
+                d.path().join("src/nested/b.txt"),
+            ],
+            scope: WatchScope::Root,
+        },
+    );
+    assert!(
+        runtime
+            .poll(now + Duration::from_millis(119), [false; 2])
+            .is_empty()
+    );
+    let actions = runtime.poll(now + Duration::from_millis(120), [false; 2]);
+    assert!(
+        matches!(&actions[..], [ViewWatchAction::FolderChanged { subtree, .. }] if subtree == &PathBuf::from("src"))
+    );
+}
+
+#[test]
+fn injected_clean_and_dirty_text_changes_are_arbitrated_without_data_loss() {
+    let d = tempfile::tempdir().unwrap();
+    let p = d.path().join("left.txt");
+    std::fs::write(&p, "before").unwrap();
+    let now = Instant::now();
+    let mut clean = ViewWatchRuntime::text(tag(5), Some(p.clone()), None);
+    std::fs::write(&p, "after, externally").unwrap();
+    clean.inject(
+        now,
+        WatchEvent {
+            tag: tag(5),
+            identity_path: p.clone(),
+            paths: vec![p.clone()],
+            scope: WatchScope::File,
+        },
+    );
+    let actions = clean.poll(now + Duration::from_secs(1), [false; 2]);
+    assert!(
+        matches!(&actions[..], [ViewWatchAction::TextReload { side: multi_launcher::diff::model::DiffSide::Left, loaded }] if loaded.text() == Some("after, externally"))
+    );
+
+    let mut dirty = ViewWatchRuntime::text(tag(6), Some(p.clone()), None);
+    std::fs::write(&p, "a second external version").unwrap();
+    dirty.inject(
+        now,
+        WatchEvent {
+            tag: tag(6),
+            identity_path: p.clone(),
+            paths: vec![p.clone()],
+            scope: WatchScope::File,
+        },
+    );
+    let actions = dirty.poll(now + Duration::from_secs(1), [true, false]);
+    assert!(matches!(
+        &actions[..],
+        [ViewWatchAction::TextConflict { .. }]
+    ));
+}
+
+#[test]
+fn obsolete_root_and_generation_events_are_ignored_and_binary_refreshes_once() {
+    let d = tempfile::tempdir().unwrap();
+    let p = d.path().join("a.bin");
+    std::fs::write(&p, [0, 1]).unwrap();
+    let now = Instant::now();
+    let mut binary = ViewWatchRuntime::binary(tag(8), Some(p.clone()), None);
+    for event in [
+        WatchEvent {
+            tag: tag(7),
+            identity_path: p.clone(),
+            paths: vec![p.clone()],
+            scope: WatchScope::File,
+        },
+        WatchEvent {
+            tag: tag(8),
+            identity_path: d.path().join("obsolete.bin"),
+            paths: vec![p.clone()],
+            scope: WatchScope::File,
+        },
+    ] {
+        binary.inject(now, event);
+    }
+    assert!(
+        binary
+            .poll(now + Duration::from_secs(1), [false; 2])
+            .is_empty()
+    );
+    binary.inject(
+        now,
+        WatchEvent {
+            tag: tag(8),
+            identity_path: p.clone(),
+            paths: vec![p],
+            scope: WatchScope::File,
+        },
+    );
+    assert!(matches!(
+        &binary.poll(now + Duration::from_secs(1), [false; 2])[..],
+        [ViewWatchAction::BinaryRefresh]
+    ));
+}


### PR DESCRIPTION
### Motivation

- Keep OS watcher handles out of persisted models and owned only by ephemeral dialog/runtime state so replacing or closing views reliably cancels watches.
- Debounce and generation-check events for folder comparisons, mark affected entries/subtrees stale, and schedule bounded refreshes rather than performing automatic syncs.
- Reload clean text sides, preserve dirty in-memory buffers on external changes and surface explicit conflict choices, and mark binary views stale and rebuild their difference indexes in a generation-safe manner.

### Description

- Added an ephemeral per-view watcher controller `ViewWatchRuntime` with `ViewWatchKind` and `ViewWatchAction` that owns a `WatchSet`, coalesces/debounces events, supports test injection, and exposes `poll` and `resolve_text_conflict` APIs (`src/diff/watch.rs`).
- Integrated watcher runtimes into the dialog runtime by storing them in `DiffDialogState::watch_views` and wiring watchers for all three two-way view types (text, folder, binary) in the UI loop; watchers are created when views are first retained and are retained/dropped along with other runtime resources (`src/gui/diff_dialog/mod.rs`).
- Folder handling: watch both roots, map debounced events to the smallest affected subtree via `affected_subtree`, mark model entries/subtrees stale, and call `FolderRuntime::prepare_rescan()` to perform a bounded, generation-safe refresh rather than automatic synchronization (`src/diff/watch.rs`, `src/gui/diff_dialog/mod.rs`).
- Clean text handling: introduced `TextViewModel::reload_external` to install a clean reload while advancing document revisions so stale comparison results are rejected; `ViewWatchRuntime` arbitrates `ExternalDocument` state (reload vs. conflict) and emits `TextReload` or `TextConflict` actions; UI surfaces explicit `Reload / discard edits` and `Keep current` choices and preserves dirty buffers (`src/diff/model.rs`, `src/diff/watch.rs`, `src/gui/diff_dialog/mod.rs`).
- Binary handling: added `BinaryViewModel::refresh_external` which atomically reopens files and rebuilds the binary difference index and advances its `generation` only after successful rebuild; UI triggers the refresh only when `ViewWatchAction::BinaryRefresh` is emitted (`src/diff/binary_compare.rs`, `src/gui/diff_dialog/mod.rs`).
- Minor improvement to `WatchSet::map_event` path-to-registration matching to prefer exact-file registrations before root matches (`src/diff/watch.rs`).
- Added unit tests (injectable/mock events) covering debouncing, folder subtree invalidation, clean-text reload, dirty-text conflict preservation, obsolete root/generation rejection, binary refresh rebuild, and watcher cleanup on view replacement/close (`tests/diff_watch.rs`).

### Testing

- Ran `cargo fmt --all` (success). 
- Ran `cargo check --tests --target x86_64-pc-windows-gnu` to type-check the test builds for the Windows target (success).
- Ran `git diff --check` (success).
- Added unit tests under `tests/diff_watch.rs` that exercise injected watcher events: `injected_folder_event_invalidates_smallest_affected_subtree`, `injected_clean_and_dirty_text_changes_are_arbitrated_without_data_loss`, `obsolete_root_and_generation_events_are_ignored_and_binary_refreshes_once`, and related existing `Watch` unit cases; these tests are deterministic and use the injected `ViewWatchRuntime::inject` boundary.
- Note: running the full native test suite on Linux is constrained by platform-specific dependencies (crate imports Win32/Linux system libs), so local execution used cross/target type-checking and the injected-event tests are present for deterministic unit coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78e13befdc833285744fbce0609a5d)