### PR TITLE
Add deterministic folder and text diff exports

### DIFF
--- a/src/diff/folder_export.rs
+++ b/src/diff/folder_export.rs
@@ -1,0 +1,324 @@
+//! Deterministic, UI-independent folder comparison exports.
+use crate::diff::folder_compare::{FolderEntry, FolderModel, FolderStatus};
+use crate::diff::model::FolderDisplayFilter;
+use chrono::{DateTime, Utc};
+use std::path::Path;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FolderExportFormat {
+    Csv,
+    Html,
+    PlainText,
+}
+
+/// An owned export input.  Constructing this value is the synchronization
+/// boundary: later scan/refinement changes to `FolderModel` cannot affect it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolderExportSnapshot {
+    pub rows: Vec<FolderExportRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolderExportRow {
+    pub relative_path: String,
+    pub status: FolderStatus,
+    pub left_size: Option<u64>,
+    pub right_size: Option<u64>,
+    pub left_modified: Option<SystemTime>,
+    pub right_modified: Option<SystemTime>,
+    pub content_checked: bool,
+}
+
+impl FolderExportSnapshot {
+    pub fn complete(model: &FolderModel) -> Self {
+        Self::from_entries(model.entries.values(), false)
+    }
+
+    pub fn filtered(
+        model: &FolderModel,
+        filter: FolderDisplayFilter,
+        path_filter: &str,
+        descending: bool,
+    ) -> Self {
+        let query = normalized_path_text(Path::new(path_filter)).to_lowercase();
+        let entries: Vec<_> = model
+            .entries
+            .values()
+            .filter(|entry| {
+                normalized_path_text(&entry.relative_path)
+                    .to_lowercase()
+                    .contains(&query)
+                    && status_matches(&filter, entry.effective_status)
+            })
+            .collect();
+        Self::from_entries(entries, descending)
+    }
+
+    fn from_entries<'a>(
+        entries: impl IntoIterator<Item = &'a FolderEntry>,
+        descending: bool,
+    ) -> Self {
+        let mut rows: Vec<_> = entries
+            .into_iter()
+            .map(|entry| FolderExportRow {
+                relative_path: normalized_path_text(&entry.relative_path),
+                status: entry.effective_status,
+                left_size: entry
+                    .left
+                    .as_ref()
+                    .and_then(|side| side.metadata.as_ref())
+                    .map(|m| m.size),
+                right_size: entry
+                    .right
+                    .as_ref()
+                    .and_then(|side| side.metadata.as_ref())
+                    .map(|m| m.size),
+                left_modified: entry
+                    .left
+                    .as_ref()
+                    .and_then(|side| side.metadata.as_ref())
+                    .and_then(|m| m.modified),
+                right_modified: entry
+                    .right
+                    .as_ref()
+                    .and_then(|side| side.metadata.as_ref())
+                    .and_then(|m| m.modified),
+                content_checked: entry.content_checked,
+            })
+            .collect();
+        rows.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        if descending {
+            rows.reverse();
+        }
+        Self { rows }
+    }
+
+    pub fn render(&self, format: FolderExportFormat) -> String {
+        match format {
+            FolderExportFormat::Csv => self.csv(),
+            FolderExportFormat::Html => self.html(),
+            FolderExportFormat::PlainText => self.plain_text(),
+        }
+    }
+
+    fn csv(&self) -> String {
+        let mut out = "relative path,status,left size,right size,left modified time,right modified time,content checked\r\n".to_owned();
+        for r in &self.rows {
+            let cells = [
+                csv_escape(&r.relative_path),
+                status(r.status).into(),
+                optional(r.left_size),
+                optional(r.right_size),
+                time(r.left_modified),
+                time(r.right_modified),
+                r.content_checked.to_string(),
+            ];
+            out.push_str(&cells.join(","));
+            out.push_str("\r\n");
+        }
+        out
+    }
+    fn plain_text(&self) -> String {
+        let mut out = "relative path\tstatus\tleft size\tright size\tleft modified time\tright modified time\tcontent checked\n".to_owned();
+        for r in &self.rows {
+            out.push_str(&format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+                text_escape(&r.relative_path),
+                status(r.status),
+                optional(r.left_size),
+                optional(r.right_size),
+                time(r.left_modified),
+                time(r.right_modified),
+                r.content_checked
+            ));
+        }
+        out
+    }
+    fn html(&self) -> String {
+        let mut out = "<!doctype html>\n<meta charset=\"utf-8\">\n<title>Folder comparison</title>\n<table>\n<thead><tr><th>Relative path</th><th>Status</th><th>Left size</th><th>Right size</th><th>Left modified time</th><th>Right modified time</th><th>Content checked</th></tr></thead>\n<tbody>\n".to_owned();
+        for r in &self.rows {
+            out.push_str(&format!("<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>\n", html_escape(&r.relative_path), status(r.status), optional(r.left_size), optional(r.right_size), time(r.left_modified), time(r.right_modified), r.content_checked));
+        }
+        out.push_str("</tbody>\n</table>\n");
+        out
+    }
+}
+
+fn normalized_path_text(path: &Path) -> String {
+    path.iter()
+        .map(|p| p.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+fn status(s: FolderStatus) -> &'static str {
+    match s {
+        FolderStatus::Identical => "identical",
+        FolderStatus::Different => "different",
+        FolderStatus::LeftOnly => "left only",
+        FolderStatus::RightOnly => "right only",
+        FolderStatus::LeftNewer => "left newer",
+        FolderStatus::RightNewer => "right newer",
+        FolderStatus::PendingContentComparison => "pending content comparison",
+        FolderStatus::Unreadable => "unreadable",
+        FolderStatus::Error => "error",
+    }
+}
+fn status_matches(f: &FolderDisplayFilter, s: FolderStatus) -> bool {
+    match f {
+        FolderDisplayFilter::All => true,
+        FolderDisplayFilter::Differences => s.is_different(),
+        FolderDisplayFilter::Identical => s == FolderStatus::Identical,
+        FolderDisplayFilter::LeftOnly => s == FolderStatus::LeftOnly,
+        FolderDisplayFilter::RightOnly => s == FolderStatus::RightOnly,
+        FolderDisplayFilter::LeftNewer => s == FolderStatus::LeftNewer,
+        FolderDisplayFilter::RightNewer => s == FolderStatus::RightNewer,
+        FolderDisplayFilter::Errors => matches!(s, FolderStatus::Unreadable | FolderStatus::Error),
+    }
+}
+fn optional(v: Option<u64>) -> String {
+    v.map(|x| x.to_string()).unwrap_or_default()
+}
+fn time(v: Option<SystemTime>) -> String {
+    v.map(|x| DateTime::<Utc>::from(x).to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_default()
+}
+fn csv_escape(v: &str) -> String {
+    if v.contains([',', '"', '\r', '\n']) {
+        format!("\"{}\"", v.replace('"', "\"\""))
+    } else {
+        v.into()
+    }
+}
+fn html_escape(v: &str) -> String {
+    let mut out = String::new();
+    for c in v.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+fn text_escape(v: &str) -> String {
+    v.replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::folder_compare::{EntryKind, EntryMetadata, EntrySide, FolderEntry};
+    use std::collections::BTreeMap;
+    fn entry(
+        path: &str,
+        status: FolderStatus,
+        left: Option<u64>,
+        right: Option<u64>,
+    ) -> FolderEntry {
+        let side = |size| EntrySide {
+            path: path.into(),
+            metadata: Some(EntryMetadata {
+                kind: EntryKind::File,
+                size,
+                modified: None,
+                identity: None,
+            }),
+            error: None,
+        };
+        FolderEntry {
+            relative_path: path.into(),
+            left: left.map(side),
+            right: right.map(side),
+            metadata_status: status,
+            effective_status: status,
+            content_checked: false,
+        }
+    }
+    #[test]
+    fn statuses_absent_metadata_and_stable_unicode_order() {
+        let statuses = [
+            FolderStatus::Identical,
+            FolderStatus::Different,
+            FolderStatus::LeftOnly,
+            FolderStatus::RightOnly,
+            FolderStatus::LeftNewer,
+            FolderStatus::RightNewer,
+            FolderStatus::PendingContentComparison,
+            FolderStatus::Unreadable,
+            FolderStatus::Error,
+        ];
+        let mut model = FolderModel {
+            entries: BTreeMap::new(),
+            revision: 1,
+        };
+        for (i, s) in statuses.into_iter().enumerate() {
+            let path = format!("é/{:02}", statuses.len() - i);
+            model.entries.insert(
+                format!("key{i}"),
+                entry(
+                    &path,
+                    s,
+                    (s != FolderStatus::RightOnly).then_some(i as u64),
+                    (s != FolderStatus::LeftOnly).then_some(i as u64),
+                ),
+            );
+        }
+        let snap = FolderExportSnapshot::complete(&model);
+        assert_eq!(snap.rows.len(), 9);
+        assert!(
+            snap.rows
+                .windows(2)
+                .all(|w| w[0].relative_path <= w[1].relative_path)
+        );
+        assert!(
+            snap.rows
+                .iter()
+                .find(|r| r.status == FolderStatus::LeftOnly)
+                .unwrap()
+                .right_size
+                .is_none()
+        );
+        assert!(
+            snap.rows
+                .iter()
+                .find(|r| r.status == FolderStatus::RightOnly)
+                .unwrap()
+                .left_size
+                .is_none()
+        );
+    }
+    #[test]
+    fn filtered_is_a_snapshot_and_not_the_complete_model() {
+        let mut m = FolderModel::default();
+        m.entries.insert(
+            "a".into(),
+            entry("a", FolderStatus::Identical, Some(1), Some(1)),
+        );
+        m.entries.insert(
+            "b".into(),
+            entry("b", FolderStatus::LeftOnly, Some(2), None),
+        );
+        let snap = FolderExportSnapshot::filtered(&m, FolderDisplayFilter::LeftOnly, "", false);
+        m.entries.clear();
+        assert_eq!(snap.rows.len(), 1);
+        assert_eq!(snap.rows[0].relative_path, "b");
+    }
+    #[test]
+    fn csv_quotes_and_html_escapes() {
+        let mut m = FolderModel::default();
+        m.entries.insert(
+            "x".into(),
+            entry("a,\"b\n<&>.txt", FolderStatus::Identical, None, None),
+        );
+        let s = FolderExportSnapshot::complete(&m);
+        assert!(s.csv().contains("\"a,\"\"b\n<&>.txt\""));
+        assert!(s.html().contains("&lt;&amp;&gt;"));
+    }
+}

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -7,6 +7,7 @@
 pub mod binary_compare;
 pub mod file_ops;
 pub mod folder_compare;
+pub mod folder_export;
 pub mod folder_runtime;
 pub mod folder_scan;
 pub mod model;
@@ -15,6 +16,7 @@ pub mod query;
 pub mod settings;
 pub mod syntax;
 pub mod text_compare;
+pub mod text_export;
 pub mod text_file;
 pub mod watch;
 pub mod worker;

--- a/src/diff/text_export.rs
+++ b/src/diff/text_export.rs
@@ -1,0 +1,211 @@
+//! UI-independent exports for text comparisons. Binary bytes are never stored
+//! in or emitted by this module.
+use similar::{ChangeTag, TextDiff};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextExportFormat {
+    UnifiedDiff,
+    PlainTextSummary,
+    HtmlSideBySide,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExportContent {
+    Text(String),
+    Binary { size: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextExportSnapshot {
+    pub left_name: String,
+    pub right_name: String,
+    pub left: ExportContent,
+    pub right: ExportContent,
+}
+
+impl TextExportSnapshot {
+    pub fn text(
+        left_name: impl Into<String>,
+        right_name: impl Into<String>,
+        left: &str,
+        right: &str,
+    ) -> Self {
+        Self {
+            left_name: left_name.into(),
+            right_name: right_name.into(),
+            left: ExportContent::Text(left.into()),
+            right: ExportContent::Text(right.into()),
+        }
+    }
+    pub fn render(&self, format: TextExportFormat) -> String {
+        match format {
+            TextExportFormat::UnifiedDiff => self.unified(),
+            TextExportFormat::PlainTextSummary => self.summary(),
+            TextExportFormat::HtmlSideBySide => self.html(),
+        }
+    }
+    fn texts(&self) -> Option<(&str, &str)> {
+        match (&self.left, &self.right) {
+            (ExportContent::Text(l), ExportContent::Text(r)) => Some((l, r)),
+            _ => None,
+        }
+    }
+    fn unified(&self) -> String {
+        let Some((left, right)) = self.texts() else {
+            return self.summary();
+        };
+        if left == right {
+            return String::new();
+        }
+        TextDiff::from_lines(left, right)
+            .unified_diff()
+            .header(
+                &safe_header(&self.left_name),
+                &safe_header(&self.right_name),
+            )
+            .to_string()
+            .replace("\r\n", "\n")
+    }
+    fn summary(&self) -> String {
+        let mut out = format!(
+            "Left: {} ({})\nRight: {} ({})\n",
+            text_escape(&self.left_name),
+            description(&self.left),
+            text_escape(&self.right_name),
+            description(&self.right)
+        );
+        if let Some((l, r)) = self.texts() {
+            let mut add = 0;
+            let mut del = 0;
+            for c in TextDiff::from_lines(l, r).iter_all_changes() {
+                match c.tag() {
+                    ChangeTag::Insert => add += 1,
+                    ChangeTag::Delete => del += 1,
+                    ChangeTag::Equal => {}
+                }
+            }
+            out.push_str(&format!(
+                "Added lines: {add}\nDeleted lines: {del}\nDifferent: {}\n",
+                l != r
+            ));
+        } else {
+            out.push_str("Binary content omitted.\n");
+        }
+        out
+    }
+    fn html(&self) -> String {
+        let mut out = format!(
+            "<!doctype html>\n<meta charset=\"utf-8\">\n<title>Text comparison</title>\n<h1>{} ↔ {}</h1>\n<table><thead><tr><th>Left</th><th>Right</th></tr></thead><tbody>\n",
+            html(&self.left_name),
+            html(&self.right_name)
+        );
+        if let Some((l, r)) = self.texts() {
+            let diff = TextDiff::from_lines(l, r);
+            for op in diff.ops() {
+                for change in diff.iter_changes(op) {
+                    let value = html(change.value().trim_end_matches(['\r', '\n']));
+                    match change.tag() {
+                        ChangeTag::Equal => {
+                            out.push_str(&format!("<tr><td>{0}</td><td>{0}</td></tr>\n", value))
+                        }
+                        ChangeTag::Delete => out.push_str(&format!(
+                            "<tr class=\"deleted\"><td>{}</td><td></td></tr>\n",
+                            value
+                        )),
+                        ChangeTag::Insert => out.push_str(&format!(
+                            "<tr class=\"inserted\"><td></td><td>{}</td></tr>\n",
+                            value
+                        )),
+                    }
+                }
+            }
+        } else {
+            out.push_str(&format!(
+                "<tr><td>{}</td><td>{}</td></tr>\n",
+                html(&description(&self.left)),
+                html(&description(&self.right))
+            ));
+        }
+        out.push_str("</tbody></table>\n");
+        out
+    }
+}
+fn description(c: &ExportContent) -> String {
+    match c {
+        ExportContent::Text(s) => format!("text, {} bytes", s.len()),
+        ExportContent::Binary { size } => format!("binary, {size} bytes; content omitted"),
+    }
+}
+fn safe_header(v: &str) -> String {
+    v.replace(['\r', '\n', '\t'], " ")
+}
+fn text_escape(v: &str) -> String {
+    v.replace('\\', "\\\\")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n")
+}
+fn html(v: &str) -> String {
+    let mut out = String::new();
+    for c in v.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn unified_add_delete_modify_empty_and_equal() {
+        let changed = TextExportSnapshot::text("左/a", "右/b", "old\ndelete\n", "new\n追加\n")
+            .render(TextExportFormat::UnifiedDiff);
+        assert!(changed.contains("-old"));
+        assert!(changed.contains("-delete"));
+        assert!(changed.contains("+new"));
+        assert!(changed.contains("+追加"));
+        assert!(
+            !TextExportSnapshot::text("a", "b", "same\n", "same\n")
+                .render(TextExportFormat::UnifiedDiff)
+                .contains("@@")
+        );
+        assert!(
+            TextExportSnapshot::text("a", "b", "", "one\n")
+                .render(TextExportFormat::UnifiedDiff)
+                .contains("+one")
+        );
+        assert!(
+            TextExportSnapshot::text("a", "b", "one\n", "")
+                .render(TextExportFormat::UnifiedDiff)
+                .contains("-one")
+        );
+    }
+    #[test]
+    fn html_escapes_paths_and_source() {
+        let value = TextExportSnapshot::text("<&", "\"right", "雪 <&>", "雪")
+            .render(TextExportFormat::HtmlSideBySide);
+        assert!(value.contains("&lt;&amp;"));
+        assert!(value.contains("&quot;right"));
+        assert!(!value.contains("雪 <&>"));
+    }
+    #[test]
+    fn binary_is_summary_only() {
+        let snapshot = TextExportSnapshot {
+            left_name: "a".into(),
+            right_name: "b".into(),
+            left: ExportContent::Binary { size: 42 },
+            right: ExportContent::Binary { size: 7 },
+        };
+        assert!(
+            snapshot
+                .render(TextExportFormat::UnifiedDiff)
+                .contains("Binary content omitted")
+        );
+    }
+}

--- a/src/gui/diff_dialog/export.rs
+++ b/src/gui/diff_dialog/export.rs
@@ -1,0 +1,93 @@
+//! Save-dialog glue only; report construction lives in `crate::diff`.
+use crate::diff::folder_export::{FolderExportFormat, FolderExportSnapshot};
+use crate::diff::model::{FolderCompareState, TextViewModel};
+use crate::diff::text_export::{TextExportFormat, TextExportSnapshot};
+use eframe::egui;
+
+pub(super) fn folder_menu(ui: &mut egui::Ui, state: &FolderCompareState) {
+    ui.menu_button("Export…", |ui| {
+        for (label, format, extension) in [
+            ("CSV", FolderExportFormat::Csv, "csv"),
+            ("HTML", FolderExportFormat::Html, "html"),
+            ("Plain text", FolderExportFormat::PlainText, "txt"),
+        ] {
+            ui.menu_button(label, |ui| {
+                if ui.button("Complete model").clicked() {
+                    save_folder(state, format, extension, false);
+                    ui.close_menu();
+                }
+                if ui.button("Current filter").clicked() {
+                    save_folder(state, format, extension, true);
+                    ui.close_menu();
+                }
+            });
+        }
+    });
+}
+fn save_folder(
+    state: &FolderCompareState,
+    format: FolderExportFormat,
+    extension: &str,
+    filtered: bool,
+) {
+    // Clone all scalar metadata before opening the native (blocking) dialog.
+    let snapshot = if filtered {
+        FolderExportSnapshot::filtered(
+            &state.model,
+            state.display_filter.clone(),
+            &state.path_filter,
+            state.sort.descending,
+        )
+    } else {
+        FolderExportSnapshot::complete(&state.model)
+    };
+    if let Some(path) = rfd::FileDialog::new()
+        .add_filter(extension, &[extension])
+        .set_file_name(format!("folder-comparison.{extension}"))
+        .save_file()
+    {
+        if let Err(e) = std::fs::write(&path, snapshot.render(format)) {
+            tracing::error!("could not export {}: {e}", path.display());
+        }
+    }
+}
+pub(super) fn text_menu(ui: &mut egui::Ui, model: &TextViewModel) {
+    ui.menu_button("Export…", |ui| {
+        for (label, format, ext) in [
+            ("Unified diff", TextExportFormat::UnifiedDiff, "diff"),
+            ("Summary", TextExportFormat::PlainTextSummary, "txt"),
+            (
+                "HTML side-by-side",
+                TextExportFormat::HtmlSideBySide,
+                "html",
+            ),
+        ] {
+            if ui.button(label).clicked() {
+                let left = model
+                    .left_path
+                    .as_ref()
+                    .map_or_else(|| "left".into(), |p| p.to_string_lossy().into_owned());
+                let right = model
+                    .right_path
+                    .as_ref()
+                    .map_or_else(|| "right".into(), |p| p.to_string_lossy().into_owned());
+                let snapshot = TextExportSnapshot::text(
+                    left,
+                    right,
+                    model.left.source(),
+                    model.right.source(),
+                );
+                if let Some(path) = rfd::FileDialog::new()
+                    .add_filter(ext, &[ext])
+                    .set_file_name(format!("comparison.{ext}"))
+                    .save_file()
+                {
+                    if let Err(e) = std::fs::write(&path, snapshot.render(format)) {
+                        tracing::error!("could not export {}: {e}", path.display());
+                    }
+                }
+                ui.close_menu();
+            }
+        }
+    });
+}

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -203,6 +203,7 @@ pub(super) fn show(
     ));
     let mut action = FolderViewAction::Noop;
     ui.horizontal_wrapped(|ui| {
+        super::export::folder_menu(ui, state);
         for (label, filter) in [
             ("All", FolderDisplayFilter::All),
             ("Differences", FolderDisplayFilter::Differences),

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -4,6 +4,7 @@ use eframe::egui;
 use std::collections::HashMap;
 use std::collections::HashSet;
 mod binary_view;
+mod export;
 mod folder_view;
 mod operation_preview;
 mod rules_dialog;

--- a/src/gui/diff_dialog/text_view.rs
+++ b/src/gui/diff_dialog/text_view.rs
@@ -8,6 +8,7 @@ pub fn show(ui: &mut egui::Ui, workspace: u64, view: u64, model: &mut TextViewMo
     model.poll();
     shortcuts(ui, model);
     ui.horizontal_wrapped(|ui| {
+        super::export::text_menu(ui, model);
         if ui
             .button("Rules…")
             .on_hover_text("Comparison rules")


### PR DESCRIPTION
### Motivation

- Provide deterministic, egui-independent export facilities for folder and text comparisons so reports can be generated, saved, and unit-tested outside the UI.
- Support common export formats (CSV, HTML, plain text, unified diff, side-by-side HTML) while avoiding binary content leakage and ensuring stable ordering and platform-independent line endings.

### Description

- Added snapshot-based folder export with CSV/HTML/plain-text renderers and stable, normalized relative paths in `src/diff/folder_export.rs`, including per-row: status, left/right size, left/right modified time, and `content_checked` flag.
- Added snapshot-based text exports in `src/diff/text_export.rs` implementing unified diffs, plain-text summaries, and HTML side-by-side reports while omitting binary bytes and escaping paths/source text.
- Integrated thin save-dialog menu options under `src/gui/diff_dialog/export.rs` and plumbed them into the existing folder/text UIs so users can export either the complete model or the current filtered projection; snapshots are taken before opening blocking dialogs to avoid inconsistent reports.
- Implemented format-specific escaping and line-ending policies (CSV quoting and CRLF, HTML escaping, LF for text/HTML where applicable) and stable ordering of exported rows.
- Kept export generation independent from egui to make the logic directly unit-testable and added unit tests covering status/absent-side metadata, complete vs filtered snapshots, CSV quoting, HTML escaping, stable ordering, unified diff cases, Unicode, and binary omission.
- Public API additions: `FolderExportSnapshot`, `FolderExportFormat`, `TextExportSnapshot`, and `TextExportFormat`; modules registered in `src/diff/mod.rs`.

### Testing

- Ran `cargo fmt --check`; the formatting check passed.
- Ran `git diff --check`; no whitespace/diff warnings were reported.
- Attempted `cargo test diff::folder_export && cargo test diff::text_export`; the new export modules include unit tests and were authored to be testable, but an overall `cargo test` run in the Linux CI environment was blocked by unrelated platform-specific compilation failures (unconditional `windows::Win32` and `windows::core` usages elsewhere in the repository), preventing a complete test-run across the whole crate. The export modules themselves compile and their tests are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78efb65300833283b539b88950a615)