### PR TITLE
Unify Diff window geometry validation and persistence

### DIFF
--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -310,6 +310,20 @@ impl DiffWorkspace {
     }
 }
 
+/// Preferred and minimum Diff window sizes, before adapting them to the work area.
+pub const DIFF_DEFAULT_SIZE: [f32; 2] = [900.0, 650.0];
+pub const DIFF_MIN_SIZE: [f32; 2] = [400.0, 250.0];
+
+/// Returns the minimum Diff window size that fits in the current work area.
+pub fn diff_window_min_size(screen: [f32; 4]) -> [f32; 2] {
+    let screen_width = (screen[2] - screen[0]).max(1.0);
+    let screen_height = (screen[3] - screen[1]).max(1.0);
+    [
+        DIFF_MIN_SIZE[0].min(screen_width),
+        DIFF_MIN_SIZE[1].min(screen_height),
+    ]
+}
+
 /// Returns safe initial window geometry for the current work area.
 ///
 /// This is deliberately the only policy used when restoring a diff window.
@@ -321,8 +335,11 @@ pub fn validated_window_geometry(
 ) -> ([f32; 2], Option<[f32; 2]>) {
     let screen_width = (screen[2] - screen[0]).max(1.0);
     let screen_height = (screen[3] - screen[1]).max(1.0);
-    let effective_min = [400.0_f32.min(screen_width), 250.0_f32.min(screen_height)];
-    let default = [900.0_f32.min(screen_width), 650.0_f32.min(screen_height)];
+    let effective_min = diff_window_min_size(screen);
+    let default = [
+        DIFF_DEFAULT_SIZE[0].min(screen_width),
+        DIFF_DEFAULT_SIZE[1].min(screen_height),
+    ];
     let size = persistence
         .window_size
         .filter(|s| {
@@ -1041,7 +1058,7 @@ mod tests {
     #[test]
     fn geometry_accepts_nominal_minimum_and_rejects_invalid_dimensions() {
         let screen = [0.0, 0.0, 1920.0, 1080.0];
-        for size in [[400.0, 250.0], [1000.0, 700.0]] {
+        for size in [DIFF_MIN_SIZE, [800.0, 250.0], [1000.0, 700.0]] {
             let mut p = crate::diff::persistence::DiffPersistenceV1::default();
             p.window_size = Some(size);
             p.window_position = Some([30.0, 40.0]);
@@ -1055,10 +1072,27 @@ mod tests {
             [f32::INFINITY, 250.0],
             [0.0, 250.0],
             [-1.0, 250.0],
+            [800.0, 72.0],
+            [800.0, 249.0],
+            [399.0, 250.0],
         ] {
             let mut p = crate::diff::persistence::DiffPersistenceV1::default();
             p.window_size = Some(invalid);
-            assert_eq!(validated_window_geometry(&p, screen).0, [900.0, 650.0]);
+            assert_eq!(validated_window_geometry(&p, screen).0, DIFF_DEFAULT_SIZE);
+        }
+    }
+
+    #[test]
+    fn geometry_rejects_non_finite_positions_and_clamps_oversized_sizes() {
+        let screen = [10.0, 20.0, 1210.0, 820.0];
+        let mut persistence = crate::diff::persistence::DiffPersistenceV1::default();
+        persistence.window_size = Some([2000.0, 1000.0]);
+        for position in [[f32::NAN, 30.0], [30.0, f32::INFINITY]] {
+            persistence.window_position = Some(position);
+            assert_eq!(
+                validated_window_geometry(&persistence, screen),
+                ([1200.0, 800.0], None)
+            );
         }
     }
     #[test]
@@ -1066,6 +1100,12 @@ mod tests {
         let mut p = crate::diff::persistence::DiffPersistenceV1::default();
         p.window_size = Some([900.0, 650.0]);
         p.window_position = Some([5000.0, -5000.0]);
+        assert_eq!(
+            validated_window_geometry(&p, [10.0, 20.0, 310.0, 220.0]),
+            ([300.0, 200.0], Some([10.0, 20.0]))
+        );
+        p.window_size = Some([300.0, 200.0]);
+        p.window_position = Some([10.0, 20.0]);
         assert_eq!(
             validated_window_geometry(&p, [10.0, 20.0, 310.0, 220.0]),
             ([300.0, 200.0], Some([10.0, 20.0]))

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -10,6 +10,18 @@ mod operation_preview;
 mod rules_dialog;
 mod text_view;
 
+/// Captures a complete, persistable runtime rectangle or rejects it atomically.
+fn runtime_window_geometry(rect: egui::Rect, screen: [f32; 4]) -> Option<([f32; 2], [f32; 2])> {
+    let coordinates = [rect.min.x, rect.min.y, rect.max.x, rect.max.y];
+    let size = [rect.width(), rect.height()];
+    let minimum = crate::diff::model::diff_window_min_size(screen);
+    (coordinates.iter().all(|value| value.is_finite())
+        && size.iter().all(|value| value.is_finite())
+        && size[0] >= minimum[0]
+        && size[1] >= minimum[1])
+        .then_some((size, [rect.left(), rect.top()]))
+}
+
 fn render_retained_folder(
     state: &mut crate::diff::model::FolderCompareState,
     render: impl FnOnce(&mut crate::diff::model::FolderCompareState) -> folder_view::FolderViewAction,
@@ -250,16 +262,19 @@ impl DiffDialogState {
             &self.persistence,
             [screen.left(), screen.top(), screen.right(), screen.bottom()],
         );
+        let minimum_size = crate::diff::model::diff_window_min_size([
+            screen.left(),
+            screen.top(),
+            screen.right(),
+            screen.bottom(),
+        ]);
         let mut window = egui::Window::new("Diff")
             .id(egui::Id::new(("diff_window", self.workspace.workspace_id)))
             .open(&mut open)
             .collapsible(false)
             .resizable(true)
             .default_size(initial_size)
-            .min_size([
-                400.0_f32.min(screen.width()),
-                250.0_f32.min(screen.height()),
-            ]);
+            .min_size(minimum_size);
         if let Some(position) = initial_position {
             window = window.default_pos(position);
         }
@@ -332,8 +347,13 @@ impl DiffDialogState {
         self.show_operation_preview(ctx);
         if let Some(response) = response {
             let rect = response.response.rect;
-            self.persistence.window_size = Some([rect.width(), rect.height()]);
-            self.persistence.window_position = Some([rect.left(), rect.top()]);
+            if let Some((size, position)) = runtime_window_geometry(
+                rect,
+                [screen.left(), screen.top(), screen.right(), screen.bottom()],
+            ) {
+                self.persistence.window_size = Some(size);
+                self.persistence.window_position = Some(position);
+            }
         }
         if !open && self.text_views.values().any(|m| m.has_dirty()) {
             self.close_prompt = true;
@@ -1155,6 +1175,54 @@ mod tests {
             .0,
             [888.0, 666.0]
         );
+    }
+
+    #[test]
+    fn runtime_geometry_accepts_valid_and_effective_minimum_rectangles() {
+        let screen = [0.0, 0.0, 1920.0, 1080.0];
+        assert_eq!(
+            runtime_window_geometry(
+                egui::Rect::from_min_size(egui::pos2(12.0, 24.0), egui::vec2(1000.0, 700.0)),
+                screen,
+            ),
+            Some(([1000.0, 700.0], [12.0, 24.0]))
+        );
+        assert_eq!(
+            runtime_window_geometry(
+                egui::Rect::from_min_size(egui::pos2(3.0, 4.0), egui::vec2(400.0, 250.0)),
+                screen,
+            ),
+            Some((crate::diff::model::DIFF_MIN_SIZE, [3.0, 4.0]))
+        );
+        assert!(
+            runtime_window_geometry(
+                egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(300.0, 200.0)),
+                [0.0, 0.0, 300.0, 200.0],
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn runtime_geometry_rejects_incomplete_rectangles_without_partial_persistence() {
+        let screen = [0.0, 0.0, 1920.0, 1080.0];
+        let rejected = [
+            egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(900.0, 61.0)),
+            egui::Rect::from_min_max(egui::pos2(10.0, 10.0), egui::pos2(9.0, 260.0)),
+            egui::Rect::from_min_max(egui::pos2(f32::NAN, 0.0), egui::pos2(900.0, 650.0)),
+            egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(f32::INFINITY, 650.0)),
+        ];
+        let mut persistence = crate::diff::persistence::DiffPersistenceV1::default();
+        persistence.window_size = Some([1000.0, 700.0]);
+        persistence.window_position = Some([20.0, 30.0]);
+        for rect in rejected {
+            if let Some((size, position)) = runtime_window_geometry(rect, screen) {
+                persistence.window_size = Some(size);
+                persistence.window_position = Some(position);
+            }
+            assert_eq!(persistence.window_size, Some([1000.0, 700.0]));
+            assert_eq!(persistence.window_position, Some([20.0, 30.0]));
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Centralize the Diff window geometry policy so restoration, GUI configuration, and runtime persistence use the same named defaults and minimums.
- Prevent partial or corrupted runtime persistence updates by only storing a complete, validated rectangle atomically.
- Preserve existing small-monitor behavior and offscreen clamping while removing duplicated numeric literals.

### Description
- Introduce `DIFF_DEFAULT_SIZE` and `DIFF_MIN_SIZE` constants and a `diff_window_min_size(screen: [f32;4])` helper in `src/diff/model.rs`. 
- Update `validated_window_geometry()` to derive effective minimum and screen-clamped default sizes from those constants and to keep the existing small-monitor allowance. 
- Add a pure `runtime_window_geometry(rect, screen)` helper in `src/gui/diff_dialog/mod.rs` that accepts an egui rect and work-area and returns `Some((size, position))` only when all coordinates and dimensions are finite and each dimension meets the screen-adjusted minimum. 
- Change runtime persistence to update `persistence.window_size` and `persistence.window_position` only when `runtime_window_geometry` accepts the rectangle, ensuring atomic updates and preventing partial writes. 
- Replace duplicated min-size literals in the main Diff window `.min_size(...)` call to use the shared policy-derived minimum. 
- Expand unit tests in `src/diff/model.rs` and add unit tests covering runtime persistence validation in `src/gui/diff_dialog/mod.rs` to verify nominal minimums, edge cases, non-finite inputs, small-monitor behavior, oversized clamping, and that rejected runtime rectangles do not mutate persisted values.

### Testing
- `cargo fmt --check` passed.
- `git diff --check` passed.
- Attempted `cargo test diff::model::tests::geometry --lib` and `cargo test gui::diff_dialog::tests::runtime_geometry --lib`, but full test execution was blocked by platform-specific build issues (the repository contains unconditional Windows `windows::Win32` API imports that prevent successful compilation on this Linux environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a791ae157608332a2bc6bbb14962b3e)