### PR TITLE
Folder table: typed sort state, column widths, interactive headers, and stable sorting

### DIFF
--- a/src/diff/folder_compare.rs
+++ b/src/diff/folder_compare.rs
@@ -226,7 +226,7 @@ pub fn project_folder_rows(
     filter: crate::diff::model::FolderDisplayFilter,
     path_filter: &str,
     expanded: &BTreeSet<PathBuf>,
-    descending: bool,
+    sort: crate::diff::model::FolderSortState,
 ) -> Vec<FolderProjectionRow> {
     use crate::diff::model::FolderDisplayFilter as F;
     let query = path_filter.replace('\\', "/").to_lowercase();
@@ -253,16 +253,46 @@ pub fn project_folder_rows(
         expanded: &BTreeSet<PathBuf>,
         filter: F,
         query: &str,
-        descending: bool,
+        sort: crate::diff::model::FolderSortState,
         out: &mut Vec<FolderProjectionRow>,
     ) {
         let key = parent.map(Path::to_path_buf);
         let mut paths = children.get(&key).cloned().unwrap_or_default();
-        // Sorting siblings keeps a directory immediately before its subtree.
-        paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
-        if descending {
-            paths.reverse();
-        }
+        // Sort siblings only: a directory remains immediately before its subtree.
+        use crate::diff::settings::FolderSortColumn as C;
+        let metadata = |e: &FolderEntry, left: bool| {
+            (if left { &e.left } else { &e.right })
+                .as_ref()
+                .and_then(|s| s.metadata.as_ref())
+        };
+        let normalized = |p: &PathBuf| p.to_string_lossy().replace('\\', "/").to_lowercase();
+        paths.sort_by(|a, b| {
+            let (ea, eb) = (by_path[a], by_path[b]);
+            let primary = match sort.column {
+                C::Path => normalized(a).cmp(&normalized(b)),
+                C::Status => {
+                    status_rank(ea.effective_status).cmp(&status_rank(eb.effective_status))
+                }
+                C::LeftSize => metadata(ea, true)
+                    .map(|m| m.size)
+                    .cmp(&metadata(eb, true).map(|m| m.size)),
+                C::RightSize => metadata(ea, false)
+                    .map(|m| m.size)
+                    .cmp(&metadata(eb, false).map(|m| m.size)),
+                C::LeftModified => metadata(ea, true)
+                    .and_then(|m| m.modified)
+                    .cmp(&metadata(eb, true).and_then(|m| m.modified)),
+                C::RightModified => metadata(ea, false)
+                    .and_then(|m| m.modified)
+                    .cmp(&metadata(eb, false).and_then(|m| m.modified)),
+            };
+            let primary = if sort.descending {
+                primary.reverse()
+            } else {
+                primary
+            };
+            primary.then_with(|| normalized(a).cmp(&normalized(b)))
+        });
         for path in paths {
             let entry = by_path[&path];
             let has_children = children.contains_key(&Some(path.clone()));
@@ -287,7 +317,7 @@ pub fn project_folder_rows(
                     expanded,
                     filter.clone(),
                     query,
-                    descending,
+                    sort.clone(),
                     out,
                 );
             }
@@ -295,9 +325,23 @@ pub fn project_folder_rows(
     }
     let mut rows = Vec::new();
     walk(
-        None, 0, &by_path, &children, expanded, filter, &query, descending, &mut rows,
+        None, 0, &by_path, &children, expanded, filter, &query, sort, &mut rows,
     );
     rows
+}
+
+fn status_rank(status: FolderStatus) -> u8 {
+    match status {
+        FolderStatus::Identical => 0,
+        FolderStatus::Different => 1,
+        FolderStatus::LeftOnly => 2,
+        FolderStatus::RightOnly => 3,
+        FolderStatus::LeftNewer => 4,
+        FolderStatus::RightNewer => 5,
+        FolderStatus::PendingContentComparison => 6,
+        FolderStatus::Unreadable => 7,
+        FolderStatus::Error => 8,
+    }
 }
 
 /// Expands every retained directory entry above `target`.

--- a/src/diff/folder_compare.rs
+++ b/src/diff/folder_compare.rs
@@ -260,11 +260,10 @@ pub fn project_folder_rows(
         let mut paths = children.get(&key).cloned().unwrap_or_default();
         // Sort siblings only: a directory remains immediately before its subtree.
         use crate::diff::settings::FolderSortColumn as C;
-        let metadata = |e: &FolderEntry, left: bool| {
-            (if left { &e.left } else { &e.right })
-                .as_ref()
-                .and_then(|s| s.metadata.as_ref())
-        };
+        fn metadata(entry: &FolderEntry, left: bool) -> Option<&EntryMetadata> {
+            let side = if left { &entry.left } else { &entry.right };
+            side.as_ref().and_then(|side| side.metadata.as_ref())
+        }
         let normalized = |p: &PathBuf| p.to_string_lossy().replace('\\', "/").to_lowercase();
         paths.sort_by(|a, b| {
             let (ea, eb) = (by_path[a], by_path[b]);

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -1,6 +1,6 @@
 use crate::diff::folder_compare::FolderModel;
 use crate::diff::folder_scan::ScanRules;
-use crate::diff::settings::DiffConfigV1;
+use crate::diff::settings::{DiffConfigV1, FolderColumnWidthsV1, FolderSortColumn};
 use crate::diff::text_compare::{
     self, AlignedDiffRow, CompiledRules, FindMatch, FindScope, NavigationDirection,
     RowProjectionMode, TextComparisonResult, TextComparisonRules,
@@ -79,7 +79,7 @@ impl FolderDisplayFilter {
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FolderSortState {
-    pub column: String,
+    pub column: FolderSortColumn,
     pub descending: bool,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -133,6 +133,7 @@ pub struct FolderCompareState {
     pub display_filter: FolderDisplayFilter,
     pub path_filter: String,
     pub sort: FolderSortState,
+    pub column_widths: FolderColumnWidthsV1,
     /// Rules that produced `model`; drafts never mutate these implicitly.
     pub applied_scan_rules: ScanRules,
     pub draft_rules: FolderRulesDraft,
@@ -163,9 +164,10 @@ impl Default for FolderCompareState {
             display_filter: FolderDisplayFilter::All,
             path_filter: String::new(),
             sort: FolderSortState {
-                column: "path".into(),
+                column: FolderSortColumn::Path,
                 descending: false,
             },
+            column_widths: FolderColumnWidthsV1::default(),
             applied_scan_rules: ScanRules::default(),
             draft_rules: FolderRulesDraft::default(),
             text_rules: TextComparisonRules::default(),
@@ -184,6 +186,13 @@ impl Default for FolderCompareState {
 }
 
 impl FolderCompareState {
+    pub fn apply_table_preferences(&mut self, settings: &DiffConfigV1) {
+        self.sort = FolderSortState {
+            column: settings.folder_sort.column,
+            descending: settings.folder_sort.descending,
+        };
+        self.column_widths = settings.folder_column_widths.validated();
+    }
     fn draft_lines(value: &str) -> Vec<String> {
         value
             .lines()
@@ -408,11 +417,13 @@ impl DiffWorkspace {
                 })
             }
         } else if lm.is_dir() && rm.is_dir() {
-            DiffView::FolderCompare(FolderCompareState {
+            let mut folder = FolderCompareState {
                 left_root: lp,
                 right_root: rp,
                 ..FolderCompareState::default()
-            })
+            };
+            folder.apply_table_preferences(&self.settings);
+            DiffView::FolderCompare(folder)
         } else {
             let msg = "Left and right paths must both be files or both be directories".to_string();
             self.error = Some(msg.clone());
@@ -1505,7 +1516,7 @@ mod tests {
             path_filter: "needle".into(),
             display_filter: FolderDisplayFilter::RightOnly,
             sort: FolderSortState {
-                column: "size".into(),
+                column: FolderSortColumn::LeftSize,
                 descending: true,
             },
             ..Default::default()

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -121,7 +121,7 @@ impl Default for FolderRulesDraft {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FolderCompareState {
     pub left_root: PathBuf,
     pub right_root: PathBuf,

--- a/src/diff/settings.rs
+++ b/src/diff/settings.rs
@@ -1,5 +1,189 @@
 use serde::{Deserialize, Serialize};
 
+pub const FOLDER_COLUMN_MIN: f32 = 56.0;
+pub const FOLDER_COLUMN_MAX: f32 = 1200.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FolderSortColumn {
+    #[default]
+    #[serde(alias = "relative_path", alias = "left_path", alias = "right_path")]
+    Path,
+    Status,
+    #[serde(alias = "size")]
+    LeftSize,
+    RightSize,
+    #[serde(alias = "left_modified_time")]
+    #[serde(alias = "modified", alias = "mtime")]
+    LeftModified,
+    #[serde(alias = "right_modified_time")]
+    RightModified,
+}
+
+#[cfg(test)]
+mod folder_table_settings_tests {
+    use super::*;
+    #[test]
+    fn migrates_legacy_sort_names_and_round_trips_typed_state() {
+        for (name, expected) in [
+            ("path", FolderSortColumn::Path),
+            ("relative_path", FolderSortColumn::Path),
+            ("size", FolderSortColumn::LeftSize),
+            ("modified", FolderSortColumn::LeftModified),
+        ] {
+            let value: FolderSortStateV1 =
+                serde_json::from_str(&format!(r#"{{"column":"{name}","descending":true}}"#))
+                    .unwrap();
+            assert_eq!(value.column, expected);
+            assert_eq!(
+                serde_json::from_str::<FolderSortStateV1>(&serde_json::to_string(&value).unwrap())
+                    .unwrap(),
+                value
+            );
+        }
+    }
+    #[test]
+    fn invalid_widths_clamp_and_defaults_are_deterministic() {
+        let invalid = FolderColumnWidthsV1 {
+            left_path: f32::NAN,
+            right_path: f32::INFINITY,
+            left_size: -4.0,
+            ..Default::default()
+        }
+        .validated();
+        assert!(
+            invalid
+                .as_array()
+                .iter()
+                .all(|x| x.is_finite() && *x >= FOLDER_COLUMN_MIN && *x <= FOLDER_COLUMN_MAX)
+        );
+        assert_eq!(
+            FolderColumnWidthsV1::for_viewport(800.0),
+            FolderColumnWidthsV1::for_viewport(800.0)
+        );
+        let mut dragged = invalid;
+        dragged.set(0, 99_999.0);
+        assert_eq!(dragged.left_path, FOLDER_COLUMN_MAX);
+    }
+    #[test]
+    fn config_persistence_round_trip_keeps_table_preferences() {
+        let mut config = DiffConfigV1::default();
+        config.folder_sort = FolderSortStateV1 {
+            column: FolderSortColumn::RightModified,
+            descending: true,
+        };
+        config.folder_column_widths.left_path = 333.0;
+        let decoded: DiffConfigV1 =
+            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+        assert_eq!(decoded, config);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FolderSortStateV1 {
+    pub column: FolderSortColumn,
+    pub descending: bool,
+}
+impl Default for FolderSortStateV1 {
+    fn default() -> Self {
+        Self {
+            column: FolderSortColumn::Path,
+            descending: false,
+        }
+    }
+}
+
+/// Durable widths for the eight table columns. Values are validated after load.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FolderColumnWidthsV1 {
+    pub left_path: f32,
+    pub left_size: f32,
+    pub left_modified: f32,
+    pub status: f32,
+    pub right_path: f32,
+    pub right_size: f32,
+    pub right_modified: f32,
+    pub action: f32,
+}
+impl Default for FolderColumnWidthsV1 {
+    fn default() -> Self {
+        Self::for_viewport(900.0)
+    }
+}
+impl FolderColumnWidthsV1 {
+    pub fn for_viewport(viewport: f32) -> Self {
+        let fixed = 110.0 * 2.0 + 170.0 * 2.0 + 130.0 + 72.0 + 7.0 * 8.0;
+        let path = ((if viewport.is_finite() {
+            viewport.max(0.0)
+        } else {
+            900.0
+        } - fixed)
+            / 2.0)
+            .max(190.0);
+        Self {
+            left_path: path,
+            left_size: 110.0,
+            left_modified: 170.0,
+            status: 130.0,
+            right_path: path,
+            right_size: 110.0,
+            right_modified: 170.0,
+            action: 72.0,
+        }
+    }
+    pub fn validated(self) -> Self {
+        fn v(x: f32) -> f32 {
+            if x.is_finite() {
+                x.clamp(FOLDER_COLUMN_MIN, FOLDER_COLUMN_MAX)
+            } else {
+                FOLDER_COLUMN_MIN
+            }
+        }
+        Self {
+            left_path: v(self.left_path),
+            left_size: v(self.left_size),
+            left_modified: v(self.left_modified),
+            status: v(self.status),
+            right_path: v(self.right_path),
+            right_size: v(self.right_size),
+            right_modified: v(self.right_modified),
+            action: v(self.action),
+        }
+    }
+    pub fn as_array(self) -> [f32; 8] {
+        [
+            self.left_path,
+            self.left_size,
+            self.left_modified,
+            self.status,
+            self.right_path,
+            self.right_size,
+            self.right_modified,
+            self.action,
+        ]
+    }
+    pub fn set(&mut self, index: usize, value: f32) {
+        let value = if value.is_finite() {
+            value.clamp(FOLDER_COLUMN_MIN, FOLDER_COLUMN_MAX)
+        } else {
+            FOLDER_COLUMN_MIN
+        };
+        match index {
+            0 => self.left_path = value,
+            1 => self.left_size = value,
+            2 => self.left_modified = value,
+            3 => self.status = value,
+            4 => self.right_path = value,
+            5 => self.right_size = value,
+            6 => self.right_modified = value,
+            7 => self.action = value,
+            _ => {}
+        }
+    }
+}
+
 pub const DIFF_CONFIG_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -19,6 +203,8 @@ pub struct DiffConfigV1 {
     pub extreme_file_bytes: u64,
     pub large_file_estimated_rows: u64,
     pub extreme_file_estimated_rows: u64,
+    pub folder_sort: FolderSortStateV1,
+    pub folder_column_widths: FolderColumnWidthsV1,
 }
 
 impl Default for DiffConfigV1 {
@@ -36,6 +222,8 @@ impl Default for DiffConfigV1 {
             extreme_file_bytes: 128 * 1024 * 1024,
             large_file_estimated_rows: 200_000,
             extreme_file_estimated_rows: 2_000_000,
+            folder_sort: FolderSortStateV1::default(),
+            folder_column_widths: FolderColumnWidthsV1::default(),
         }
     }
 }

--- a/src/gui/diff_dialog/folder_table.rs
+++ b/src/gui/diff_dialog/folder_table.rs
@@ -1,7 +1,8 @@
 //! Bounded, virtualized viewport for Folder Compare results.
 use super::folder_view::{self, FolderViewAction, SelectionGesture};
 use crate::diff::folder_compare::{FolderEntry, FolderProjectionRow};
-use crate::diff::model::FolderCompareState;
+use crate::diff::model::{FolderCompareState, FolderSortState};
+use crate::diff::settings::{FolderColumnWidthsV1, FolderSortColumn};
 use eframe::egui;
 use std::collections::HashMap;
 use std::ops::Range;
@@ -14,39 +15,18 @@ pub(crate) const FOLDER_ROW_HEIGHT: f32 = 24.0;
 const FOLDER_HEADER_HEIGHT: f32 = 26.0;
 const OVERSCAN_ROWS: usize = 4;
 const GAP: f32 = 8.0;
-const PATH_MIN: f32 = 190.0;
-const METADATA_WIDTH: f32 = 150.0;
-const STATUS_WIDTH: f32 = 130.0;
-const ACTION_WIDTH: f32 = 58.0;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct TableLayout {
-    widths: [f32; 6],
+    widths: [f32; 8],
     total_width: f32,
 }
 
-fn path_extent<'a>(paths: impl Iterator<Item = &'a Path>) -> f32 {
-    // A stable font-independent estimate is sufficient to establish horizontal
-    // canvas extent; text itself is clipped and never participates in layout.
-    paths
-        .map(|path| path.to_string_lossy().chars().count() as f32 * 7.0 + 42.0)
-        .fold(PATH_MIN, f32::max)
-}
-
-fn table_layout(viewport_width: f32, left_extent: f32, right_extent: f32) -> TableLayout {
-    let fixed = METADATA_WIDTH * 2.0 + STATUS_WIDTH + ACTION_WIDTH + GAP * 5.0;
-    let normal_path = ((viewport_width.max(0.0) - fixed) / 2.0).max(PATH_MIN);
-    let widths = [
-        normal_path.max(left_extent),
-        METADATA_WIDTH,
-        STATUS_WIDTH,
-        normal_path.max(right_extent),
-        METADATA_WIDTH,
-        ACTION_WIDTH,
-    ];
+fn table_layout(widths: FolderColumnWidthsV1) -> TableLayout {
+    let widths = widths.validated().as_array();
     TableLayout {
         widths,
-        total_width: widths.iter().sum::<f32>() + GAP * 5.0,
+        total_width: widths.iter().sum::<f32>() + GAP * 7.0,
     }
 }
 
@@ -88,21 +68,8 @@ pub(super) fn show(
     let mut viewport_ui = ui.child_ui(outer, egui::Layout::top_down(egui::Align::Min));
     viewport_ui.set_clip_rect(viewport_ui.clip_rect().intersect(outer));
 
-    let left_extent = path_extent(
-        state
-            .model
-            .entries
-            .values()
-            .filter_map(|entry| entry.left.as_ref().map(|_| entry.relative_path.as_path())),
-    );
-    let right_extent = path_extent(
-        state
-            .model
-            .entries
-            .values()
-            .filter_map(|entry| entry.right.as_ref().map(|_| entry.relative_path.as_path())),
-    );
-    let layout = table_layout(available.x, left_extent, right_extent);
+    state.column_widths = state.column_widths.validated();
+    let layout = table_layout(state.column_widths);
     let entry_keys: HashMap<PathBuf, String> = state
         .model
         .entries
@@ -120,7 +87,7 @@ pub(super) fn show(
         .auto_shrink([false, false])
         .show(&mut viewport_ui, |ui| {
             ui.set_min_width(layout.total_width);
-            render_header(ui, layout);
+            render_header(ui, layout, state, available.x);
             let mut scroll = egui::ScrollArea::vertical()
                 .id_source("folder-results-vertical")
                 .auto_shrink([false, false])
@@ -169,18 +136,25 @@ fn cell_rect(row: egui::Rect, layout: TableLayout, column: usize) -> egui::Rect 
     )
 }
 
-fn render_header(ui: &mut egui::Ui, layout: TableLayout) {
+fn render_header(
+    ui: &mut egui::Ui,
+    layout: TableLayout,
+    state: &mut FolderCompareState,
+    viewport: f32,
+) {
     let (rect, _) = ui.allocate_exact_size(
         egui::vec2(layout.total_width, FOLDER_HEADER_HEIGHT),
         egui::Sense::hover(),
     );
-    for (column, title) in [
-        "Left path",
-        "Left size / modified",
-        "Status",
-        "Right path",
-        "Right size / modified",
-        "",
+    for (column, (title, sort_column)) in [
+        ("Left path", Some(FolderSortColumn::Path)),
+        ("Left size", Some(FolderSortColumn::LeftSize)),
+        ("Left modified", Some(FolderSortColumn::LeftModified)),
+        ("Status", Some(FolderSortColumn::Status)),
+        ("Right path", Some(FolderSortColumn::Path)),
+        ("Right size", Some(FolderSortColumn::RightSize)),
+        ("Right modified", Some(FolderSortColumn::RightModified)),
+        ("", None),
     ]
     .iter()
     .enumerate()
@@ -189,7 +163,57 @@ fn render_header(ui: &mut egui::Ui, layout: TableLayout) {
             cell_rect(rect, layout, column),
             egui::Layout::left_to_right(egui::Align::Center),
         );
-        cell.add(egui::Label::new(egui::RichText::new(*title).strong()).wrap(false));
+        if column == 7 {
+            if cell.small_button("Reset Columns").clicked() {
+                state.column_widths = FolderColumnWidthsV1::for_viewport(viewport).validated();
+            }
+            continue;
+        }
+        let active = sort_column == Some(state.sort.column);
+        let indicator = if active {
+            if state.sort.descending {
+                " ▼"
+            } else {
+                " ▲"
+            }
+        } else {
+            ""
+        };
+        if cell
+            .add(
+                egui::Button::new(egui::RichText::new(format!("{title}{indicator}")).strong())
+                    .frame(false),
+            )
+            .clicked()
+        {
+            if let Some(column) = sort_column {
+                if state.sort.column == column {
+                    state.sort.descending = !state.sort.descending;
+                } else {
+                    state.sort = FolderSortState {
+                        column,
+                        descending: false,
+                    };
+                }
+            }
+        }
+        if column < 7 {
+            let separator = egui::Rect::from_center_size(
+                egui::pos2(cell.max_rect().right() + GAP / 2.0, rect.center().y),
+                egui::vec2(8.0, rect.height()),
+            );
+            let response = ui.interact(
+                separator,
+                ui.id().with(("folder-column-separator", column)),
+                egui::Sense::drag(),
+            );
+            if response.dragged() {
+                state
+                    .column_widths
+                    .set(column, layout.widths[column] + response.drag_delta().x);
+            }
+            response.on_hover_cursor(egui::CursorIcon::ResizeHorizontal);
+        }
     }
     ui.painter().hline(
         rect.x_range(),
@@ -235,16 +259,32 @@ fn render_row(
     label_cell(
         ui,
         cell_rect(rect, layout, 1),
-        folder_view::side_details(entry.left.as_ref()),
+        entry
+            .left
+            .as_ref()
+            .and_then(|s| s.metadata.as_ref())
+            .map(|m| folder_view::format_size(m.size))
+            .unwrap_or_else(|| "—".into()),
     );
     label_cell(
         ui,
         cell_rect(rect, layout, 2),
+        entry
+            .left
+            .as_ref()
+            .and_then(|s| s.metadata.as_ref())
+            .and_then(|m| m.modified)
+            .map(folder_view::format_modified)
+            .unwrap_or_else(|| "—".into()),
+    );
+    label_cell(
+        ui,
+        cell_rect(rect, layout, 3),
         folder_view::status_label(entry.effective_status),
     );
     render_path_cell(
         ui,
-        cell_rect(rect, layout, 3),
+        cell_rect(rect, layout, 4),
         state,
         paths,
         row,
@@ -255,11 +295,27 @@ fn render_row(
     );
     label_cell(
         ui,
-        cell_rect(rect, layout, 4),
-        folder_view::side_details(entry.right.as_ref()),
+        cell_rect(rect, layout, 5),
+        entry
+            .right
+            .as_ref()
+            .and_then(|s| s.metadata.as_ref())
+            .map(|m| folder_view::format_size(m.size))
+            .unwrap_or_else(|| "—".into()),
+    );
+    label_cell(
+        ui,
+        cell_rect(rect, layout, 6),
+        entry
+            .right
+            .as_ref()
+            .and_then(|s| s.metadata.as_ref())
+            .and_then(|m| m.modified)
+            .map(folder_view::format_modified)
+            .unwrap_or_else(|| "—".into()),
     );
     let mut cell = ui.child_ui(
-        cell_rect(rect, layout, 5),
+        cell_rect(rect, layout, 7),
         egui::Layout::left_to_right(egui::Align::Center),
     );
     if cell
@@ -383,22 +439,19 @@ mod tests {
                     })
                     .collect();
                 for width in [500.0, 900.0, 1_600.0] {
-                    let extent = path_extent(rows.iter().map(|row| row.path.as_path()));
-                    let layout = table_layout(width, extent, PATH_MIN);
+                    let layout = table_layout(FolderColumnWidthsV1::for_viewport(width));
                     assert!(layout.total_width >= width);
-                    assert!(layout.widths[0] >= layout.widths[3]);
-                    assert!(layout.widths[0] >= PATH_MIN);
+                    assert_eq!(layout.widths[0], layout.widths[4]);
+                    assert!(layout.widths[0] >= 190.0);
                 }
                 let rendered = visible_row_range(1_000.0, 360.0, count, OVERSCAN_ROWS).len();
                 assert!(rendered <= 24);
             }
         }
-        let wide = 260.0 * 7.0 + 42.0;
-        let wide_left = table_layout(900.0, wide, PATH_MIN);
-        assert!(wide_left.widths[0] > wide_left.widths[3]);
-        let both_wide = table_layout(900.0, wide, wide);
-        assert_eq!(both_wide.widths[0], both_wide.widths[3]);
-        assert!(both_wide.total_width > wide_left.total_width);
+        let narrow = table_layout(FolderColumnWidthsV1::for_viewport(100.0));
+        let wide = table_layout(FolderColumnWidthsV1::for_viewport(1600.0));
+        assert!(narrow.total_width > 100.0); // inner overflow, never parent growth
+        assert!(wide.total_width >= 1600.0);
     }
 
     #[test]

--- a/src/gui/diff_dialog/folder_table.rs
+++ b/src/gui/diff_dialog/folder_table.rs
@@ -156,7 +156,7 @@ fn render_header(
         ("Right modified", Some(FolderSortColumn::RightModified)),
         ("", None),
     ]
-    .iter()
+    .into_iter()
     .enumerate()
     {
         let mut cell = ui.child_ui(

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -3,7 +3,8 @@ use crate::diff::folder_compare::{
     EntryKind, FolderEntry, FolderProjectionRow, FolderStatus, expand_ancestors,
     project_folder_rows,
 };
-use crate::diff::model::{FolderCompareState, FolderDisplayFilter};
+use crate::diff::model::{FolderCompareState, FolderDisplayFilter, FolderSortState};
+use crate::diff::settings::FolderSortColumn;
 use eframe::egui;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -574,14 +575,36 @@ pub(super) fn activate_entry(
 }
 pub(super) fn side_details(side: Option<&crate::diff::folder_compare::EntrySide>) -> String {
     let Some(metadata) = side.and_then(|s| s.metadata.as_ref()) else {
-        return String::new();
+        return "—".into();
     };
     let modified = metadata
         .modified
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs().to_string())
+        .map(|t| {
+            chrono::DateTime::<chrono::Local>::from(t)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string()
+        })
         .unwrap_or_else(|| "—".into());
-    format!("{} B / {}", metadata.size, modified)
+    format!("{} / {}", format_size(metadata.size), modified)
+}
+pub(super) fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+pub(super) fn format_modified(time: std::time::SystemTime) -> String {
+    chrono::DateTime::<chrono::Local>::from(time)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
 }
 fn complete(value: bool) -> &'static str {
     if value { "complete" } else { "running" }
@@ -604,7 +627,7 @@ pub(crate) fn projected_rows(state: &FolderCompareState) -> Vec<FolderProjection
         state.display_filter.clone(),
         &state.path_filter,
         &state.expanded_nodes,
-        state.sort.descending,
+        state.sort.clone(),
     )
 }
 pub(crate) fn ordered_visible(state: &FolderCompareState) -> Vec<PathBuf> {
@@ -757,6 +780,68 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn every_raw_sort_column_works_both_directions_with_stable_missing_ties() {
+        fn rich(path: &str, size: u64, modified: u64, status: FolderStatus) -> FolderEntry {
+            let mut e = entry(path, Some(path), Some(path), EntryKind::File);
+            for side in [&mut e.left, &mut e.right] {
+                let m = side.as_mut().unwrap().metadata.as_mut().unwrap();
+                m.size = size;
+                m.modified =
+                    Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(modified));
+            }
+            e.effective_status = status;
+            e
+        }
+        let mut s = FolderCompareState::default();
+        s.model
+            .entries
+            .insert("b".into(), rich("b", 20, 200, FolderStatus::RightOnly));
+        s.model
+            .entries
+            .insert("a".into(), rich("a", 10, 100, FolderStatus::Identical));
+        s.model.entries.insert(
+            "missing".into(),
+            FolderEntry {
+                relative_path: "missing".into(),
+                left: None,
+                right: None,
+                metadata_status: FolderStatus::Error,
+                effective_status: FolderStatus::Error,
+                content_checked: false,
+            },
+        );
+        let original = s.model.clone();
+        for column in [
+            FolderSortColumn::Path,
+            FolderSortColumn::Status,
+            FolderSortColumn::LeftSize,
+            FolderSortColumn::RightSize,
+            FolderSortColumn::LeftModified,
+            FolderSortColumn::RightModified,
+        ] {
+            s.sort = FolderSortState {
+                column,
+                descending: false,
+            };
+            let asc = paths(&s);
+            s.sort.descending = true;
+            let desc = paths(&s);
+            assert_eq!(asc.len(), 3);
+            assert_eq!(desc.len(), 3);
+            assert_ne!(asc, desc, "{column:?}");
+        }
+        assert_eq!(
+            s.model, original,
+            "sorting must only reorder projection rows"
+        );
+        s.sort = FolderSortState {
+            column: FolderSortColumn::LeftSize,
+            descending: false,
+        };
+        assert_eq!(paths(&s)[0], PathBuf::from("missing"));
     }
 
     #[test]

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -674,6 +674,14 @@ impl DiffDialogState {
                     );
                 }
                 action = render_retained_folder(s, |state| folder_view::show(ui, state, runtime));
+                let sort = crate::diff::settings::FolderSortStateV1 {
+                    column: s.sort.column,
+                    descending: s.sort.descending,
+                };
+                self.workspace.settings.folder_sort = sort;
+                self.workspace.settings.folder_column_widths = s.column_widths.validated();
+                self.persistence.config.folder_sort = sort;
+                self.persistence.config.folder_column_widths = s.column_widths.validated();
             }
         }
         WorkspaceRenderOutcome {


### PR DESCRIPTION
### Motivation

- Replace the ad-hoc string sort key and fragile header layout with a typed sort model and durable, validated column widths so sorting, resizing and formatting live in the new folder table UI rather than being layered on `egui::Grid`.
- Make sorting predictable and accessible by sorting only the projected rows, providing stable tie-breakers, and preserving parent/child grouping so rows do not visibly shuffle between frames.
- Improve readability of metadata by formatting sizes and timestamps consistently and providing deterministic defaults, clamping and a user-reset action.

### Description

- Introduced a typed `FolderSortColumn` and versioned `FolderSortStateV1` and `FolderColumnWidthsV1` in `src/diff/settings.rs` with legacy aliases for migration and min/max clamping via `validated()` and `for_viewport()` defaults.
- Replaced the old `FolderSortState.column: String` with a typed `FolderSortColumn` in `src/diff/model.rs` and added `column_widths: FolderColumnWidthsV1` plus `apply_table_preferences()` to initialize per-view preferences.
- Implemented sorting inside the projection in `project_folder_rows` (`src/diff/folder_compare.rs`) accepting the typed `FolderSortState`, sorting only sibling entries, using raw numeric/time/status values, and ending with a normalized relative-path tie-breaker; introduced `status_rank()` for stable status ordering.
- Reworked the folder table rendering (`src/gui/diff_dialog/folder_table.rs`) to eight independent columns driven by `FolderColumnWidthsV1`, added interactive clickable headers with ascending/descending indicator, draggable column separators that clamp via `set()`, and a `Reset Columns` control that restores deterministic defaults for the viewport.
- Consistently format sizes and modified times in `src/gui/diff_dialog/folder_view.rs` with `format_size()` (binary units) and `format_modified()` (local timestamp with seconds) and use a single em dash (`"—"`) for missing metadata while preserving raw values for sorting.
- Persist and restore folder sort state and validated column widths into `DiffConfigV1` via `src/gui/diff_dialog/mod.rs` so user adjustments are preserved in workspace/session config.
- Added unit tests covering migration and width validation in `settings` and projection/sort behavior tests for each sort column plus missing metadata stability in `folder_view` (new tests included in the diff).

### Testing

- Ran formatting and static checks: `cargo fmt` and `cargo fmt -- --check` passed and `git diff --check` returned no formatting errors.
- Attempted compilation and test builds (`cargo check --all-targets`, `cargo test --lib --no-run`, `cargo test --all-features --no-run`) to exercise added unit tests; the build steps progressed but ultimately the repository fails to fully compile in this Linux CI environment due to existing platform-specific native dependencies and unconditional Windows/X11 `windows::Win32` imports elsewhere in the project, which are unrelated to the folder-table changes and prevented running the new unit tests end-to-end here.
- The folder-table unit tests and `settings` migration tests are present and are expected to run successfully once platform-specific build blockers are resolved in the CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a6d17e65083329ba0a50d600c2cc6)