### PR TITLE
Add folder alignment overrides and ‘Align With…’ interaction for folder compare

### DIFF
--- a/src/diff/folder_compare.rs
+++ b/src/diff/folder_compare.rs
@@ -78,6 +78,41 @@ pub struct FolderEntry {
     pub effective_status: FolderStatus,
     pub content_checked: bool,
 }
+
+/// A durable, presentation-only pairing between two paths below the compared
+/// roots. It never changes either path on disk or the scanner's raw entries.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FolderAlignmentOverride {
+    pub left_relative: PathBuf,
+    pub right_relative: PathBuf,
+}
+
+pub fn validate_alignment_overrides(
+    values: &[FolderAlignmentOverride],
+) -> Result<Vec<FolderAlignmentOverride>, String> {
+    let mut left = BTreeSet::new();
+    let mut right = BTreeSet::new();
+    values
+        .iter()
+        .map(|value| {
+            let l = normalized_relative(&value.left_relative)?;
+            let r = normalized_relative(&value.right_relative)?;
+            if l.as_os_str().is_empty() || r.as_os_str().is_empty() {
+                return Err("alignment paths cannot be empty".into());
+            }
+            if !left.insert(l.clone()) {
+                return Err(format!("duplicate left alignment: {}", l.display()));
+            }
+            if !right.insert(r.clone()) {
+                return Err(format!("duplicate right alignment: {}", r.display()));
+            }
+            Ok(FolderAlignmentOverride {
+                left_relative: l,
+                right_relative: r,
+            })
+        })
+        .collect()
+}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathKeyPolicy {
     Platform,
@@ -165,6 +200,54 @@ pub struct FolderModel {
     pub revision: u64,
 }
 impl FolderModel {
+    /// Builds the derived alignment model. The retained scan model is untouched;
+    /// missing endpoints are represented as harmless one-sided/error rows.
+    pub fn with_alignment_overrides(&self, overrides: &[FolderAlignmentOverride]) -> Self {
+        let Ok(overrides) = validate_alignment_overrides(overrides) else {
+            return self.clone();
+        };
+        let mut result = self.clone();
+        for mapping in overrides {
+            let left_key = result
+                .entries
+                .iter()
+                .find(|(_, e)| e.relative_path == mapping.left_relative)
+                .map(|(k, _)| k.clone());
+            let right_key = result
+                .entries
+                .iter()
+                .find(|(_, e)| e.relative_path == mapping.right_relative)
+                .map(|(k, _)| k.clone());
+            let left = left_key
+                .as_ref()
+                .and_then(|k| result.entries.get(k))
+                .and_then(|e| e.left.clone());
+            let right = right_key
+                .as_ref()
+                .and_then(|k| result.entries.get(k))
+                .and_then(|e| e.right.clone());
+            if let Some(k) = left_key {
+                result.entries.remove(&k);
+            }
+            if let Some(k) = right_key {
+                result.entries.remove(&k);
+            }
+            let metadata_status =
+                fast_status(left.as_ref(), right.as_ref(), Duration::from_secs(2));
+            result.entries.insert(
+                format!("override:{}", mapping.left_relative.display()),
+                FolderEntry {
+                    relative_path: mapping.left_relative.clone(),
+                    left,
+                    right,
+                    metadata_status,
+                    effective_status: metadata_status,
+                    content_checked: false,
+                },
+            );
+        }
+        result
+    }
     pub fn upsert(
         &mut self,
         relative: &Path,
@@ -572,5 +655,67 @@ mod tests {
                 .len(),
             10_001
         );
+    }
+
+    #[test]
+    fn alignment_validation_rejects_bad_and_duplicate_endpoints() {
+        let ov = |l: &str, r: &str| FolderAlignmentOverride {
+            left_relative: l.into(),
+            right_relative: r.into(),
+        };
+        assert!(validate_alignment_overrides(&[ov("/absolute", "b")]).is_err());
+        assert!(validate_alignment_overrides(&[ov("../outside", "b")]).is_err());
+        assert!(validate_alignment_overrides(&[ov("a", "x"), ov("a", "y")]).is_err());
+        assert!(validate_alignment_overrides(&[ov("a", "x"), ov("b", "x")]).is_err());
+    }
+
+    #[test]
+    fn alignment_pairs_different_names_without_mutating_scan_or_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let lp = dir.path().join("left-name.txt");
+        let rp = dir.path().join("right-name.txt");
+        fs::write(&lp, "same bytes").unwrap();
+        fs::write(&rp, "same bytes").unwrap();
+        let mut model = FolderModel::default();
+        model
+            .upsert(
+                Path::new("left-name.txt"),
+                EntrySide {
+                    path: lp.clone(),
+                    metadata: None,
+                    error: None,
+                },
+                true,
+                PathKeyPolicy::Sensitive,
+                Duration::ZERO,
+            )
+            .unwrap();
+        model
+            .upsert(
+                Path::new("right-name.txt"),
+                EntrySide {
+                    path: rp.clone(),
+                    metadata: None,
+                    error: None,
+                },
+                false,
+                PathKeyPolicy::Sensitive,
+                Duration::ZERO,
+            )
+            .unwrap();
+        let original = model.clone();
+        let mapping = FolderAlignmentOverride {
+            left_relative: "left-name.txt".into(),
+            right_relative: "right-name.txt".into(),
+        };
+        let aligned = model.with_alignment_overrides(std::slice::from_ref(&mapping));
+        assert_eq!(aligned.entries.len(), 1);
+        let row = aligned.entries.values().next().unwrap();
+        assert!(row.left.is_some() && row.right.is_some());
+        assert_eq!(model, original);
+        assert_eq!(fs::read_to_string(lp).unwrap(), "same bytes");
+        assert_eq!(fs::read_to_string(rp).unwrap(), "same bytes");
+        let missing = FolderModel::default().with_alignment_overrides(&[mapping]);
+        assert_eq!(missing.entries.len(), 1);
     }
 }

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -1,4 +1,4 @@
-use crate::diff::folder_compare::FolderModel;
+use crate::diff::folder_compare::{FolderAlignmentOverride, FolderModel};
 use crate::diff::folder_scan::ScanRules;
 use crate::diff::settings::{DiffConfigV1, FolderColumnWidthsV1, FolderSortColumn};
 use crate::diff::text_compare::{
@@ -150,6 +150,9 @@ pub struct FolderCompareState {
     pub right_scan_complete: bool,
     /// Children changed by an editor and awaiting a targeted metadata refresh.
     pub stale_paths: BTreeSet<PathBuf>,
+    pub alignment_overrides: Vec<FolderAlignmentOverride>,
+    /// First endpoint selected by the two-step `Align With…` interaction.
+    pub pending_alignment: Option<(bool, PathBuf)>,
 }
 impl Default for FolderCompareState {
     fn default() -> Self {
@@ -181,6 +184,8 @@ impl Default for FolderCompareState {
             left_scan_complete: false,
             right_scan_complete: false,
             stale_paths: BTreeSet::new(),
+            alignment_overrides: vec![],
+            pending_alignment: None,
         }
     }
 }

--- a/src/diff/persistence.rs
+++ b/src/diff/persistence.rs
@@ -10,7 +10,30 @@ use crate::diff::settings::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FolderAlignmentOverrideV1 {
+    pub left_relative: PathBuf,
+    pub right_relative: PathBuf,
+}
+
+impl From<&crate::diff::folder_compare::FolderAlignmentOverride> for FolderAlignmentOverrideV1 {
+    fn from(v: &crate::diff::folder_compare::FolderAlignmentOverride) -> Self {
+        Self {
+            left_relative: v.left_relative.clone(),
+            right_relative: v.right_relative.clone(),
+        }
+    }
+}
+impl From<&FolderAlignmentOverrideV1> for crate::diff::folder_compare::FolderAlignmentOverride {
+    fn from(v: &FolderAlignmentOverrideV1) -> Self {
+        Self {
+            left_relative: v.left_relative.clone(),
+            right_relative: v.right_relative.clone(),
+        }
+    }
+}
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
@@ -67,6 +90,8 @@ pub struct SavedDiffSessionV1 {
     pub folder_display_filter: String,
     #[serde(default)]
     pub content_comparison: ContentComparisonModeV1,
+    #[serde(default)]
+    pub folder_alignment_overrides: Vec<FolderAlignmentOverrideV1>,
 }
 impl Default for SavedDiffSessionV1 {
     fn default() -> Self {
@@ -88,6 +113,7 @@ impl Default for SavedDiffSessionV1 {
             folder_excludes: vec![],
             folder_display_filter: "all".into(),
             content_comparison: Default::default(),
+            folder_alignment_overrides: vec![],
         }
     }
 }
@@ -406,5 +432,23 @@ mod tests {
         ] {
             assert!(!json.contains(runtime_field), "serialized {runtime_field}");
         }
+    }
+    #[test]
+    fn old_session_defaults_alignment_and_new_session_roundtrips_it() {
+        let old = r#"{"id":"1","name":"old","left":"l","right":"r","pane_split":0.5,"wrap_text":false,"syntax_highlighting":true,"syntax_theme":"x"}"#;
+        let parsed: SavedDiffSessionV1 = serde_json::from_str(old).unwrap();
+        assert!(parsed.folder_alignment_overrides.is_empty());
+        let mut session = SavedDiffSessionV1::default();
+        session
+            .folder_alignment_overrides
+            .push(FolderAlignmentOverrideV1 {
+                left_relative: "old.txt".into(),
+                right_relative: "new.txt".into(),
+            });
+        let json = serde_json::to_string(&session).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SavedDiffSessionV1>(&json).unwrap(),
+            session
+        );
     }
 }

--- a/src/gui/diff_dialog/folder_table.rs
+++ b/src/gui/diff_dialog/folder_table.rs
@@ -70,8 +70,10 @@ pub(super) fn show(
 
     state.column_widths = state.column_widths.validated();
     let layout = table_layout(state.column_widths);
-    let entry_keys: HashMap<PathBuf, String> = state
+    let aligned_model = state
         .model
+        .with_alignment_overrides(&state.alignment_overrides);
+    let entry_keys: HashMap<PathBuf, String> = aligned_model
         .entries
         .iter()
         .map(|(key, entry)| (entry.relative_path.clone(), key.clone()))
@@ -116,6 +118,7 @@ pub(super) fn show(
                         row_rect,
                         layout,
                         state,
+                        &aligned_model,
                         paths,
                         &rows[index],
                         entry_keys.get(&rows[index].path),
@@ -228,6 +231,7 @@ fn render_row(
     rect: egui::Rect,
     layout: TableLayout,
     state: &mut FolderCompareState,
+    aligned_model: &crate::diff::folder_compare::FolderModel,
     paths: &[PathBuf],
     row: &FolderProjectionRow,
     entry_key: Option<&String>,
@@ -236,7 +240,7 @@ fn render_row(
     index: usize,
 ) {
     let Some(entry) = entry_key
-        .and_then(|key| state.model.entries.get(key))
+        .and_then(|key| aligned_model.entries.get(key))
         .cloned()
     else {
         return;
@@ -368,15 +372,82 @@ fn render_path_cell(
     } else {
         entry.right.is_some()
     };
-    let text = present
-        .then(|| row.path.display().to_string())
-        .unwrap_or_default();
+    let mapping = state
+        .alignment_overrides
+        .iter()
+        .find(|m| m.left_relative == row.path);
+    let side_relative = mapping
+        .map(|m| {
+            if left {
+                &m.left_relative
+            } else {
+                &m.right_relative
+            }
+        })
+        .cloned()
+        .unwrap_or_else(|| row.path.clone());
+    let text = if present {
+        format!(
+            "{}{}",
+            if mapping.is_some() { "⛓ " } else { "" },
+            side_relative.display()
+        )
+    } else if mapping.is_some() {
+        format!("⚠ missing: {}", side_relative.display())
+    } else {
+        String::new()
+    };
     cell.style_mut().wrap = Some(false);
     let response = cell.add(egui::SelectableLabel::new(
         state.selected_paths.contains(&row.path),
         text,
     ));
-    response.context_menu(|ui| folder_view::mutation_menu(ui, state, operation_active, action));
+    response.clone().context_menu(|ui| {
+        if present && ui.button("Align With…").clicked() {
+            state.pending_alignment = Some((left, side_relative.clone()));
+            ui.close_menu();
+        }
+        if let Some(index) = state
+            .alignment_overrides
+            .iter()
+            .position(|m| m.left_relative == row.path)
+        {
+            if ui.button("Remove alignment override").clicked() {
+                state.alignment_overrides.remove(index);
+                state.pending_alignment = None;
+                ui.close_menu();
+            }
+        }
+        if let Some((source_left, source)) = state.pending_alignment.clone() {
+            if source_left != left
+                && present
+                && ui
+                    .button(format!("Confirm alignment with {}", source.display()))
+                    .clicked()
+            {
+                let value = if source_left {
+                    crate::diff::folder_compare::FolderAlignmentOverride {
+                        left_relative: source,
+                        right_relative: side_relative.clone(),
+                    }
+                } else {
+                    crate::diff::folder_compare::FolderAlignmentOverride {
+                        left_relative: side_relative.clone(),
+                        right_relative: source,
+                    }
+                };
+                let mut candidate = state.alignment_overrides.clone();
+                candidate.push(value);
+                if crate::diff::folder_compare::validate_alignment_overrides(&candidate).is_ok() {
+                    state.alignment_overrides = candidate;
+                }
+                state.pending_alignment = None;
+                ui.close_menu();
+            }
+        }
+        ui.separator();
+        folder_view::mutation_menu(ui, state, operation_active, action);
+    });
     if response.clicked() {
         let modifiers = cell.input(|i| i.modifiers);
         folder_view::apply_selection(

--- a/src/gui/diff_dialog/folder_view.rs
+++ b/src/gui/diff_dialog/folder_view.rs
@@ -622,8 +622,11 @@ pub(super) fn status_label(status: FolderStatus) -> &'static str {
     }
 }
 pub(crate) fn projected_rows(state: &FolderCompareState) -> Vec<FolderProjectionRow> {
+    let aligned = state
+        .model
+        .with_alignment_overrides(&state.alignment_overrides);
     project_folder_rows(
-        &state.model,
+        &aligned,
         state.display_filter.clone(),
         &state.path_filter,
         &state.expanded_nodes,

--- a/src/gui/diff_dialog/mod.rs
+++ b/src/gui/diff_dialog/mod.rs
@@ -214,6 +214,12 @@ impl DiffDialogState {
             folder_excludes: excludes,
             folder_display_filter: display,
             content_comparison: content,
+            folder_alignment_overrides: match &self.workspace.current_view.view {
+                DiffView::FolderCompare(folder) => {
+                    folder.alignment_overrides.iter().map(Into::into).collect()
+                }
+                _ => vec![],
+            },
         })
     }
 
@@ -233,6 +239,14 @@ impl DiffDialogState {
         self.persistence.unimportant_section_rules = session.unimportant_section_rules.clone();
         self.open_and_record(left, right)?;
         if let DiffView::FolderCompare(folder) = &mut self.workspace.current_view.view {
+            folder.alignment_overrides = crate::diff::folder_compare::validate_alignment_overrides(
+                &session
+                    .folder_alignment_overrides
+                    .iter()
+                    .map(Into::into)
+                    .collect::<Vec<_>>(),
+            )
+            .map_err(|e| format!("invalid folder alignment override: {e}"))?;
             folder.draft_rules.include_rules = session.folder_includes.join("\n");
             folder.draft_rules.exclude_rules = session.folder_excludes.join("\n");
             folder.applied_scan_rules = crate::diff::folder_scan::ScanRules::validated(


### PR DESCRIPTION
### Motivation

- Provide a durable, domain-level way to override folder alignment so differently named items can be presented as one logical row without mutating scan results or filesystem state.
- Persist and restore these overrides with named sessions while remaining backward-compatible with older saved session JSON.
- Expose a two-step `Align With…` interaction in the folder table to let users create, preview/confirm, and remove overrides and visibly mark overridden/missing rows.

### Description

- Added domain type `FolderAlignmentOverride` and validation via `validate_alignment_overrides` which normalizes paths (`normalized_relative`) and rejects absolute/traversal/empty paths and duplicate left/right endpoints (file: `src/diff/folder_compare.rs`).
- Implemented a non-mutating projection `FolderModel::with_alignment_overrides` that applies overrides to a cloned model so paired left/right items share one logical row and status is recomputed; raw scan model and filesystem are not modified (file: `src/diff/folder_compare.rs`).
- Added persistence type `FolderAlignmentOverrideV1` and extended `SavedDiffSessionV1` with `#[serde(default)] folder_alignment_overrides` to keep older JSON backward-compatible and to round-trip new sessions (file: `src/diff/persistence.rs`).
- Restore and validate overrides on session reopen (file: `src/gui/diff_dialog/mod.rs`) and apply overrides before projection is built by changing `projected_rows` to operate on `state.model.with_alignment_overrides(...)` (files: `src/gui/diff_dialog/folder_view.rs`, `src/gui/diff_dialog/folder_table.rs`).
- UI: added a two-step context-menu flow on folder rows: choose `Align With…` from a row, select a compatible opposite-side row, preview and confirm the mapping, and allow removal of existing overrides; overridden and missing rows are clearly marked in the table (file: `src/gui/diff_dialog/folder_table.rs`).
- Added domain and persistence unit tests that exercise validation, round-trip serialization, creation of an aligned row from differently named files without mutating the model or filesystem, and old-session compatibility (files: `src/diff/folder_compare.rs`, `src/diff/persistence.rs`).

### Testing

- Ran `cargo fmt` which completed successfully.
- Ran repository checks (`git diff --check`) which passed locally in this environment.
- Attempted `cargo check` and targeted unit tests, but full compilation/test runs were blocked by unrelated, repository-wide native platform/dependency issues (missing system pkg-config packages and Windows-only `windows::Win32` APIs present in the tree), so the newly added unit tests were not executed to completion in this environment; the tests are present and expect to run under normal developer CI/local setups.
- Manual verification: code compiles locally up to platform-dependent phases and the changes were committed (local commit message: add folder alignment overrides).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a75ac240c8332820516593113aa9c)