### PR TITLE
Update quinn-proto to 0.11.15 and add lockfile regression test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",

--- a/tests/dependency_security.rs
+++ b/tests/dependency_security.rs
@@ -1,0 +1,99 @@
+use std::fs;
+use std::path::Path;
+
+const MINIMUM_SAFE_QUINN_PROTO: Version = Version {
+    major: 0,
+    minor: 11,
+    patch: 15,
+};
+const NEXT_INCOMPATIBLE_QUINN_PROTO: Version = Version {
+    major: 0,
+    minor: 12,
+    patch: 0,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct Version {
+    major: u64,
+    minor: u64,
+    patch: u64,
+}
+
+fn parse_version(version: &str) -> Result<Version, String> {
+    let components: Vec<_> = version.split('.').collect();
+    if components.len() != 3 {
+        return Err(format!(
+            "expected exactly three numeric components, found `{version}`"
+        ));
+    }
+
+    let parse_component = |component: &str, name: &str| {
+        if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(format!(
+                "{name} component must contain only decimal digits in `{version}`"
+            ));
+        }
+        component
+            .parse::<u64>()
+            .map_err(|error| format!("invalid {name} component in `{version}`: {error}"))
+    };
+
+    Ok(Version {
+        major: parse_component(components[0], "major")?,
+        minor: parse_component(components[1], "minor")?,
+        patch: parse_component(components[2], "patch")?,
+    })
+}
+
+fn is_safe_quinn_proto(version: &str) -> Result<bool, String> {
+    let version = parse_version(version)?;
+    Ok(version >= MINIMUM_SAFE_QUINN_PROTO && version < NEXT_INCOMPATIBLE_QUINN_PROTO)
+}
+
+fn package_field<'a>(record: &'a str, field: &str) -> Option<&'a str> {
+    let prefix = format!("{field} = \"");
+    record
+        .lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix(&prefix)?.strip_suffix('"'))
+}
+
+#[test]
+fn resolved_quinn_proto_versions_are_not_vulnerable() {
+    let lockfile_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock");
+    let lockfile = fs::read_to_string(&lockfile_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", lockfile_path.display()));
+
+    let versions: Vec<_> = lockfile
+        .split("[[package]]")
+        .filter(|record| package_field(record, "name") == Some("quinn-proto"))
+        .map(|record| {
+            package_field(record, "version")
+                .unwrap_or_else(|| panic!("quinn-proto package record has no version: {record}"))
+        })
+        .collect();
+
+    assert!(
+        !versions.is_empty(),
+        "Cargo.lock contains no exact quinn-proto package record; dependency removal or lockfile parser breakage must be reviewed explicitly"
+    );
+
+    for discovered in versions {
+        let safe = is_safe_quinn_proto(discovered).unwrap_or_else(|error| {
+            panic!("invalid resolved quinn-proto version `{discovered}`: {error}")
+        });
+        assert!(
+            safe,
+            "resolved quinn-proto version `{discovered}` is outside the explicitly supported secure range >= 0.11.15 and < 0.12.0; versions before 0.11.15 are vulnerable to fragmented-stream assembler memory exhaustion"
+        );
+    }
+}
+
+#[test]
+fn quinn_proto_security_range_cases() {
+    assert_eq!(is_safe_quinn_proto("0.11.14"), Ok(false));
+    assert_eq!(is_safe_quinn_proto("0.11.15"), Ok(true));
+    assert_eq!(is_safe_quinn_proto("0.11.99"), Ok(true));
+    assert!(is_safe_quinn_proto("0.11.15-rc.1").is_err());
+    assert_eq!(is_safe_quinn_proto("0.12.0"), Ok(false));
+}


### PR DESCRIPTION
### Motivation

- Close a known vulnerability by upgrading the transitive `quinn-proto` lockfile entry to a patched 0.11.x release and prevent regressions with an automated test.

### Description

- Updated `Cargo.lock` to move `quinn-proto` from `0.11.14` to `0.11.15` and recorded the new Cargo checksum generated by `cargo update -p quinn-proto --precise 0.11.15` without adding a direct `quinn-proto` dependency in `Cargo.toml`.
- Preserved the existing `reqwest -> quinn -> quinn-proto` transitive relationship and did not alter `reqwest` or `quinn` declarations.
- Added `tests/dependency_security.rs`, a lockfile regression test that reads the workspace `Cargo.lock` via `env!("CARGO_MANIFEST_DIR")`, finds exact `[[package]]` records named `quinn-proto`, parses strict `major.minor.patch` numeric versions, requires at least one record, and enforces the secure range `>= 0.11.15` and `< 0.12.0`.
- Included focused unit cases in the test for rejecting `0.11.14`, accepting `0.11.15` and later 0.11.x patches, rejecting malformed/pre-release values, and rejecting an unexpected major/minor bump to `0.12.x`.

### Testing

- Ran `cargo update -p quinn-proto --precise 0.11.15`, which completed successfully and updated `Cargo.lock` with the new checksum.
- Compiled and executed the new test directly with `rustc` (`CARGO_MANIFEST_DIR="$PWD" rustc --edition=2024 --test tests/dependency_security.rs -o /tmp/dependency_security_test && /tmp/dependency_security_test`) and observed both tests passing (`2 passed`).
- Attempting `cargo test --locked --test dependency_security` and `cargo build --locked --all-targets` in the CI-like environment was blocked by missing system ALSA development metadata required by `alsa-sys` (build failure), preventing a full workspace run; the regression test itself passed when run standalone.
- `cargo tree -i quinn-proto --locked` reported no second vulnerable `quinn-proto` version in the active resolution for the tested targets, and `cargo nextest` could not be executed in the environment because `cargo-nextest` was not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cf88977b8833288e6c02a5bb6d9dd)