### PR TITLE
Build injectable worker-owned macro runtime and executor with fake backends

### DIFF
--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1,0 +1,854 @@
+//! Platform-neutral plan executor and injectable effect boundaries.
+use super::{
+    Jump, MkAction, MkCompareOp, MkCondition, MkCoordinateTarget, MkExecutionPlan, MkImagePayload,
+    MkKey, MkMouseButton, MkPoint, MkProcessPayload, MkTextPayload, MkUiPayload, MkValue,
+    MkWaitOptions, MkWindowMatcher, MkWindowPayload, RuntimeVariables,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    sync::{Arc, Condvar, Mutex},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticKind {
+    TargetNotFound,
+    AmbiguousTarget,
+    Timeout,
+    UnsupportedOperation,
+    InputRejected,
+    InvalidTarget,
+    InvalidPlan,
+    InvalidSelection,
+    Backend,
+    Cancelled,
+    Panic,
+    RuntimeUnavailable,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionDiagnostic {
+    pub kind: DiagnosticKind,
+    pub message: String,
+    pub context: BTreeMap<String, String>,
+}
+impl ExecutionDiagnostic {
+    pub fn new(kind: DiagnosticKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            context: BTreeMap::new(),
+        }
+    }
+    pub fn context(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.context.insert(key.into(), value.into());
+        self
+    }
+}
+impl fmt::Display for ExecutionDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+impl std::error::Error for ExecutionDiagnostic {}
+pub type ExecResult<T = ()> = Result<T, ExecutionDiagnostic>;
+
+pub trait InputBackend: Send + Sync {
+    fn key_down(&self, key: &MkKey) -> ExecResult;
+    fn key_up(&self, key: &MkKey) -> ExecResult;
+    fn button_down(&self, button: MkMouseButton) -> ExecResult;
+    fn button_up(&self, button: MkMouseButton) -> ExecResult;
+    fn move_mouse(&self, point: MkPoint) -> ExecResult;
+    fn scroll(&self, delta: i32) -> ExecResult;
+    fn text(&self, payload: &MkTextPayload) -> ExecResult;
+}
+pub trait WindowBackend: Send + Sync {
+    fn exists(&self, m: &MkWindowMatcher) -> ExecResult<bool>;
+    fn is_active(&self, m: &MkWindowMatcher) -> ExecResult<bool>;
+    fn activate(&self, p: &MkWindowPayload) -> ExecResult;
+    fn close(&self, m: &MkWindowMatcher) -> ExecResult;
+}
+pub trait ScreenBackend: Send + Sync {
+    fn resolve(
+        &self,
+        target: &MkCoordinateTarget,
+        variables: &RuntimeVariables,
+    ) -> ExecResult<MkPoint>;
+    fn image_found(&self, asset_id: u64, confidence: f32) -> ExecResult<Option<MkPoint>>;
+    fn pixel_matches(
+        &self,
+        target: &MkCoordinateTarget,
+        color: &str,
+        tolerance: u8,
+        variables: &RuntimeVariables,
+    ) -> ExecResult<bool>;
+}
+pub trait UiAutomationBackend: Send + Sync {
+    fn exists(&self, p: &MkUiPayload) -> ExecResult<bool>;
+    fn invoke(&self, p: &MkUiPayload) -> ExecResult;
+    fn set_value(&self, p: &MkUiPayload, value: &str) -> ExecResult;
+}
+pub trait LauncherBackend: Send + Sync {
+    fn launch_process(&self, p: &MkProcessPayload) -> ExecResult;
+    fn command(&self, command: &str, args: Option<&str>) -> ExecResult;
+}
+
+#[derive(Clone)]
+pub struct Backends {
+    pub input: Arc<dyn InputBackend>,
+    pub window: Arc<dyn WindowBackend>,
+    pub screen: Arc<dyn ScreenBackend>,
+    pub uia: Arc<dyn UiAutomationBackend>,
+    pub launcher: Arc<dyn LauncherBackend>,
+}
+impl Backends {
+    pub fn unsupported() -> Self {
+        let u = Arc::new(Unsupported);
+        Self {
+            input: u.clone(),
+            window: u.clone(),
+            screen: u.clone(),
+            uia: u.clone(),
+            launcher: u,
+        }
+    }
+}
+struct Unsupported;
+fn unsupported<T>() -> ExecResult<T> {
+    Err(ExecutionDiagnostic::new(
+        DiagnosticKind::UnsupportedOperation,
+        "automation backend is unavailable on this platform",
+    ))
+}
+impl InputBackend for Unsupported {
+    fn key_down(&self, _: &MkKey) -> ExecResult {
+        unsupported()
+    }
+    fn key_up(&self, _: &MkKey) -> ExecResult {
+        unsupported()
+    }
+    fn button_down(&self, _: MkMouseButton) -> ExecResult {
+        unsupported()
+    }
+    fn button_up(&self, _: MkMouseButton) -> ExecResult {
+        unsupported()
+    }
+    fn move_mouse(&self, _: MkPoint) -> ExecResult {
+        unsupported()
+    }
+    fn scroll(&self, _: i32) -> ExecResult {
+        unsupported()
+    }
+    fn text(&self, _: &MkTextPayload) -> ExecResult {
+        unsupported()
+    }
+}
+impl WindowBackend for Unsupported {
+    fn exists(&self, _: &MkWindowMatcher) -> ExecResult<bool> {
+        unsupported()
+    }
+    fn is_active(&self, _: &MkWindowMatcher) -> ExecResult<bool> {
+        unsupported()
+    }
+    fn activate(&self, _: &MkWindowPayload) -> ExecResult {
+        unsupported()
+    }
+    fn close(&self, _: &MkWindowMatcher) -> ExecResult {
+        unsupported()
+    }
+}
+impl ScreenBackend for Unsupported {
+    fn resolve(&self, _: &MkCoordinateTarget, _: &RuntimeVariables) -> ExecResult<MkPoint> {
+        unsupported()
+    }
+    fn image_found(&self, _: u64, _: f32) -> ExecResult<Option<MkPoint>> {
+        unsupported()
+    }
+    fn pixel_matches(
+        &self,
+        _: &MkCoordinateTarget,
+        _: &str,
+        _: u8,
+        _: &RuntimeVariables,
+    ) -> ExecResult<bool> {
+        unsupported()
+    }
+}
+impl UiAutomationBackend for Unsupported {
+    fn exists(&self, _: &MkUiPayload) -> ExecResult<bool> {
+        unsupported()
+    }
+    fn invoke(&self, _: &MkUiPayload) -> ExecResult {
+        unsupported()
+    }
+    fn set_value(&self, _: &MkUiPayload, _: &str) -> ExecResult {
+        unsupported()
+    }
+}
+impl LauncherBackend for Unsupported {
+    fn launch_process(&self, _: &MkProcessPayload) -> ExecResult {
+        unsupported()
+    }
+    fn command(&self, _: &str, _: Option<&str>) -> ExecResult {
+        unsupported()
+    }
+}
+
+#[derive(Default)]
+struct ControlState {
+    paused: bool,
+    stopped: bool,
+    active: bool,
+}
+#[derive(Default)]
+pub struct RunControl {
+    state: Mutex<ControlState>,
+    wake: Condvar,
+}
+impl RunControl {
+    pub fn reset(&self) {
+        let mut s = self.state.lock().unwrap();
+        *s = ControlState {
+            active: true,
+            ..Default::default()
+        };
+        self.wake.notify_all()
+    }
+    pub fn pause(&self) {
+        self.state.lock().unwrap().paused = true;
+        self.wake.notify_all()
+    }
+    pub fn resume(&self) {
+        self.state.lock().unwrap().paused = false;
+        self.wake.notify_all()
+    }
+    pub fn stop(&self) {
+        self.state.lock().unwrap().stopped = true;
+        self.wake.notify_all()
+    }
+    pub fn is_active(&self) -> bool {
+        self.state.lock().unwrap().active
+    }
+    pub fn checkpoint(&self) -> ExecResult {
+        let mut s = self.state.lock().unwrap();
+        while s.paused && !s.stopped {
+            s = self.wake.wait(s).unwrap()
+        }
+        if s.stopped {
+            Err(ExecutionDiagnostic::new(
+                DiagnosticKind::Cancelled,
+                "automation stopped",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+    pub fn wait(&self, duration: Duration) -> ExecResult {
+        let mut remaining = duration;
+        loop {
+            self.checkpoint()?;
+            if remaining.is_zero() {
+                return Ok(());
+            }
+            let start = Instant::now();
+            let s = self.state.lock().unwrap();
+            let (s, timeout) = self.wake.wait_timeout(s, remaining).unwrap();
+            let elapsed = start.elapsed();
+            if !s.paused {
+                remaining = remaining.saturating_sub(elapsed)
+            }
+            if s.stopped {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::Cancelled,
+                    "automation stopped",
+                ));
+            }
+            if timeout.timed_out() && !s.paused {
+                return Ok(());
+            }
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub enum ExecutionEvent {
+    StepStarted(u64),
+    StepFinished(u64),
+    StepSkipped(u64),
+    StepFailed(u64, ExecutionDiagnostic),
+    Paused,
+    Resumed,
+}
+
+pub struct InputCleanupGuard {
+    backend: Arc<dyn InputBackend>,
+    keys: Vec<MkKey>,
+    buttons: Vec<MkMouseButton>,
+}
+impl InputCleanupGuard {
+    pub fn new(backend: Arc<dyn InputBackend>) -> Self {
+        Self {
+            backend,
+            keys: vec![],
+            buttons: vec![],
+        }
+    }
+    fn down_key(&mut self, k: &MkKey) -> ExecResult {
+        self.backend.key_down(k)?;
+        self.keys.push(k.clone());
+        Ok(())
+    }
+    fn up_key(&mut self, k: &MkKey) -> ExecResult {
+        self.backend.key_up(k)?;
+        if let Some(i) = self.keys.iter().rposition(|x| x == k) {
+            self.keys.remove(i);
+        }
+        Ok(())
+    }
+    fn down_button(&mut self, b: MkMouseButton) -> ExecResult {
+        self.backend.button_down(b.clone())?;
+        self.buttons.push(b);
+        Ok(())
+    }
+    fn up_button(&mut self, b: MkMouseButton) -> ExecResult {
+        self.backend.button_up(b.clone())?;
+        if let Some(i) = self.buttons.iter().rposition(|x| x == &b) {
+            self.buttons.remove(i);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fake::FakeBackend, *};
+    use crate::mkmacro::{MkErrorPolicy, MkMacro, MkPlayback, MkStep, compile};
+
+    fn step(id: u64, action: MkAction) -> MkStep {
+        MkStep {
+            id,
+            enabled: true,
+            repeat: 1,
+            delay_after_ms: 0,
+            on_error: MkErrorPolicy::Stop,
+            action,
+        }
+    }
+    fn plan(steps: Vec<MkStep>) -> MkExecutionPlan {
+        compile(&MkMacro {
+            id: 7,
+            name: "test".into(),
+            description: String::new(),
+            enabled: true,
+            hotkey: None,
+            playback: MkPlayback::default(),
+            steps,
+        })
+        .unwrap()
+    }
+    #[test]
+    fn sequential_order_and_owned_input_cleanup() {
+        let fake = Arc::new(FakeBackend::default());
+        let control = Arc::new(RunControl::default());
+        control.reset();
+        let p = plan(vec![
+            step(1, MkAction::KeyDown(MkKey::Control)),
+            step(
+                2,
+                MkAction::Text(MkTextPayload {
+                    text: "hello".into(),
+                    mode: crate::mkmacro::MkTextMode::Type,
+                }),
+            ),
+        ]);
+        Executor::new(fake.clone().backends(), control)
+            .execute(&p, &|_| {})
+            .unwrap();
+        assert_eq!(
+            fake.events(),
+            vec!["key_down:Control", "text:hello", "key_up:Control"]
+        );
+    }
+    #[test]
+    fn never_releases_unowned_input() {
+        let fake = Arc::new(FakeBackend::default());
+        {
+            let _guard = InputCleanupGuard::new(fake.clone());
+        }
+        assert!(fake.events().is_empty());
+    }
+    #[test]
+    fn stop_wakes_a_long_wait() {
+        let control = Arc::new(RunControl::default());
+        control.reset();
+        let c = control.clone();
+        let worker = std::thread::spawn(move || c.wait(Duration::from_secs(60)));
+        std::thread::sleep(Duration::from_millis(10));
+        control.stop();
+        assert_eq!(
+            worker.join().unwrap().unwrap_err().kind,
+            DiagnosticKind::Cancelled
+        );
+    }
+}
+impl Drop for InputCleanupGuard {
+    fn drop(&mut self) {
+        for b in self.buttons.drain(..).rev() {
+            if let Err(e) = self.backend.button_up(b) {
+                tracing::error!(error=%e,"failed to release owned mouse button")
+            }
+        }
+        for k in self.keys.drain(..).rev() {
+            if let Err(e) = self.backend.key_up(&k) {
+                tracing::error!(error=%e,"failed to release owned key")
+            }
+        }
+    }
+}
+
+pub struct Executor {
+    backends: Backends,
+    control: Arc<RunControl>,
+}
+impl Executor {
+    pub fn new(backends: Backends, control: Arc<RunControl>) -> Self {
+        Self { backends, control }
+    }
+    pub fn execute(&self, plan: &MkExecutionPlan, observe: &dyn Fn(ExecutionEvent)) -> ExecResult {
+        let mut guard = InputCleanupGuard::new(self.backends.input.clone());
+        let mut vars = RuntimeVariables::new();
+        let mut pc = 0;
+        let mut loops: HashMap<usize, u32> = HashMap::new();
+        while pc < plan.instructions.len() {
+            self.control.checkpoint()?;
+            let ins = &plan.instructions[pc];
+            let step = &ins.step;
+            if !step.enabled {
+                observe(ExecutionEvent::StepSkipped(step.id));
+                pc += 1;
+                continue;
+            }
+            observe(ExecutionEvent::StepStarted(step.id));
+            let mut final_error = None;
+            for repetition in 0..step.repeat {
+                vars.insert("iteration".into(), MkValue::Number(repetition as f64));
+                let attempts = match &step.on_error {
+                    super::MkErrorPolicy::Retry(r) => r.attempts.max(1),
+                    _ => 1,
+                };
+                for attempt in 1..=attempts {
+                    tracing::debug!(
+                        macro_id = plan.macro_id,
+                        step_id = step.id,
+                        attempt,
+                        "executing macro step"
+                    );
+                    match self.action(&step.action, &mut vars, &mut guard) {
+                        Ok(()) => {
+                            final_error = None;
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::warn!(macro_id=plan.macro_id,step_id=step.id,attempt,error=%e,"macro step attempt failed");
+                            final_error = Some(e);
+                            if attempt < attempts {
+                                if let super::MkErrorPolicy::Retry(r) = &step.on_error {
+                                    self.control.wait(Duration::from_millis(r.delay_ms))?
+                                }
+                            }
+                        }
+                    }
+                }
+                if final_error.is_some() {
+                    break;
+                }
+                if step.delay_after_ms > 0 {
+                    self.control
+                        .wait(Duration::from_millis(step.delay_after_ms))?
+                }
+            }
+            if let Some(e) = final_error {
+                observe(ExecutionEvent::StepFailed(step.id, e.clone()));
+                if !matches!(step.on_error, super::MkErrorPolicy::Continue) {
+                    return Err(e);
+                }
+            } else {
+                observe(ExecutionEvent::StepFinished(step.id))
+            }
+            pc = match (&step.action, &ins.jump) {
+                (MkAction::If(c) | MkAction::WhileStart { condition: c }, Jump::IfFalse(to)) => {
+                    if self.condition(c, &vars)? {
+                        pc + 1
+                    } else {
+                        *to
+                    }
+                }
+                (_, Jump::To(to) | Jump::Break(to) | Jump::Continue(to)) => *to,
+                (MkAction::RepeatStart { count }, _) => {
+                    loops.insert(pc, *count);
+                    pc + 1
+                }
+                (_, Jump::RepeatEnd { start, exit }) => {
+                    let entry = loops.entry(start.saturating_sub(1)).or_default();
+                    if *entry > 1 {
+                        *entry -= 1;
+                        *start
+                    } else {
+                        loops.remove(&start.saturating_sub(1));
+                        *exit
+                    }
+                }
+                (_, Jump::WhileEnd { condition }) => *condition,
+                _ => pc + 1,
+            };
+        }
+        self.control.state.lock().unwrap().active = false;
+        Ok(())
+    }
+    fn action(
+        &self,
+        a: &MkAction,
+        v: &mut RuntimeVariables,
+        g: &mut InputCleanupGuard,
+    ) -> ExecResult {
+        match a {
+            MkAction::KeyDown(k) => g.down_key(k),
+            MkAction::KeyUp(k) => g.up_key(k),
+            MkAction::KeyPress(k) => {
+                g.down_key(k)?;
+                g.up_key(k)
+            }
+            MkAction::Hotkey(keys) => {
+                for k in keys {
+                    g.down_key(k)?
+                }
+                for k in keys.iter().rev() {
+                    g.up_key(k)?
+                }
+                Ok(())
+            }
+            MkAction::Text(p) => self.backends.input.text(p),
+            MkAction::MouseMove(t) => self
+                .backends
+                .input
+                .move_mouse(self.backends.screen.resolve(t, v)?),
+            MkAction::MouseClick(p) => {
+                let point = self.backends.screen.resolve(&p.target, v)?;
+                self.backends.input.move_mouse(point)?;
+                for _ in 0..p.clicks {
+                    g.down_button(p.button.clone())?;
+                    g.up_button(p.button.clone())?
+                }
+                Ok(())
+            }
+            MkAction::MouseDown(b) => g.down_button(b.clone()),
+            MkAction::MouseUp(b) => g.up_button(b.clone()),
+            MkAction::MouseScroll { i32_delta } => self.backends.input.scroll(*i32_delta),
+            MkAction::Delay { milliseconds } => {
+                self.control.wait(Duration::from_millis(*milliseconds))
+            }
+            MkAction::Process(p) => self.backends.launcher.launch_process(p),
+            MkAction::LauncherCommand { command, args } => {
+                self.backends.launcher.command(command, args.as_deref())
+            }
+            MkAction::WindowActivate(p) => self.backends.window.activate(p),
+            MkAction::WindowClose(m) => self.backends.window.close(m),
+            MkAction::WindowWait(p) => self.wait_until(
+                p.wait.as_ref().unwrap_or(&MkWaitOptions {
+                    timeout_ms: 0,
+                    poll_interval_ms: 10,
+                }),
+                || self.backends.window.exists(&p.matcher),
+            ),
+            MkAction::SetVariable { name, value } => {
+                v.insert(name.clone(), value.clone());
+                Ok(())
+            }
+            MkAction::UnsetVariable { name } => {
+                v.remove(name);
+                Ok(())
+            }
+            MkAction::ImageFind(p) => self.wait_image(p).map(|_| ()),
+            MkAction::ImageClick(p) => {
+                let pt = self.wait_image(p)?;
+                self.backends.input.move_mouse(pt)?;
+                g.down_button(MkMouseButton::Left)?;
+                g.up_button(MkMouseButton::Left)
+            }
+            MkAction::PixelCheck {
+                target,
+                color,
+                tolerance,
+            } => {
+                if self
+                    .backends
+                    .screen
+                    .pixel_matches(target, color, *tolerance, v)?
+                {
+                    Ok(())
+                } else {
+                    Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::TargetNotFound,
+                        "pixel did not match",
+                    ))
+                }
+            }
+            MkAction::UiInvoke(p) => self.backends.uia.invoke(p),
+            MkAction::UiSetValue { target, value } => self.backends.uia.set_value(target, value),
+            MkAction::UiWait(p) => self.wait_until(
+                p.wait.as_ref().unwrap_or(&MkWaitOptions {
+                    timeout_ms: 0,
+                    poll_interval_ms: 10,
+                }),
+                || self.backends.uia.exists(p),
+            ),
+            _ => Ok(()),
+        }
+    }
+    fn wait_image(&self, p: &MkImagePayload) -> ExecResult<MkPoint> {
+        let mut found = None;
+        self.wait_until(&p.wait, || {
+            found = self.backends.screen.image_found(p.asset_id, p.confidence)?;
+            Ok(found.is_some())
+        })?;
+        found.ok_or_else(|| {
+            ExecutionDiagnostic::new(DiagnosticKind::TargetNotFound, "image not found")
+        })
+    }
+    fn wait_until(
+        &self,
+        o: &MkWaitOptions,
+        mut poll: impl FnMut() -> ExecResult<bool>,
+    ) -> ExecResult {
+        let start = Instant::now();
+        loop {
+            self.control.checkpoint()?;
+            if poll()? {
+                return Ok(());
+            }
+            if start.elapsed() >= Duration::from_millis(o.timeout_ms) {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::Timeout,
+                    format!("condition timed out after {} ms", o.timeout_ms),
+                ));
+            }
+            self.control
+                .wait(Duration::from_millis(o.poll_interval_ms.max(1)))?
+        }
+    }
+    fn condition(&self, c: &MkCondition, v: &RuntimeVariables) -> ExecResult<bool> {
+        match c {
+            MkCondition::Variable { name, op, value } => {
+                Ok(compare(v.get(name).unwrap_or(&MkValue::Null), op, value))
+            }
+            MkCondition::WindowExists { matcher } => self.backends.window.exists(matcher),
+            MkCondition::WindowActive { matcher } => self.backends.window.is_active(matcher),
+            MkCondition::ImageResult { asset_id, found } => {
+                Ok(self.backends.screen.image_found(*asset_id, 0.0)?.is_some() == *found)
+            }
+            MkCondition::PixelResult {
+                target,
+                color,
+                tolerance,
+            } => self
+                .backends
+                .screen
+                .pixel_matches(target, color, *tolerance, v),
+            MkCondition::All { conditions } => {
+                for c in conditions {
+                    if !self.condition(c, v)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            MkCondition::Any { conditions } => {
+                for c in conditions {
+                    if self.condition(c, v)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            MkCondition::Not { condition } => Ok(!self.condition(condition, v)?),
+        }
+    }
+}
+fn compare(a: &MkValue, op: &MkCompareOp, b: &MkValue) -> bool {
+    match op {
+        MkCompareOp::Eq => a == b,
+        MkCompareOp::NotEq => a != b,
+        MkCompareOp::Less
+        | MkCompareOp::LessOrEq
+        | MkCompareOp::Greater
+        | MkCompareOp::GreaterOrEq => {
+            let (MkValue::Number(a), MkValue::Number(b)) = (a, b) else {
+                return false;
+            };
+            match op {
+                MkCompareOp::Less => a < b,
+                MkCompareOp::LessOrEq => a <= b,
+                MkCompareOp::Greater => a > b,
+                _ => a >= b,
+            }
+        }
+        MkCompareOp::Contains
+        | MkCompareOp::StartsWith
+        | MkCompareOp::EndsWith
+        | MkCompareOp::Regex => {
+            let (MkValue::String(a), MkValue::String(b)) = (a, b) else {
+                return false;
+            };
+            match op {
+                MkCompareOp::Contains => a.contains(b),
+                MkCompareOp::StartsWith => a.starts_with(b),
+                MkCompareOp::EndsWith => a.ends_with(b),
+                _ => regex::Regex::new(b).is_ok_and(|r| r.is_match(a)),
+            }
+        }
+    }
+}
+
+/// Configurable synchronized fake implementing every effect boundary.
+pub mod fake {
+    use super::*;
+    #[derive(Default)]
+    pub struct FakeBackend {
+        pub events: Mutex<Vec<String>>,
+        pub failures: Mutex<HashMap<String, ExecutionDiagnostic>>,
+        pub conditions: Mutex<HashMap<String, bool>>,
+    }
+    impl FakeBackend {
+        pub fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+        pub fn fail(&self, name: &str, d: ExecutionDiagnostic) {
+            self.failures.lock().unwrap().insert(name.into(), d);
+        }
+        fn event(&self, e: String) -> ExecResult {
+            self.events.lock().unwrap().push(e.clone());
+            if let Some(d) = self.failures.lock().unwrap().get(&e).cloned() {
+                Err(d)
+            } else {
+                Ok(())
+            }
+        }
+        pub fn backends(self: Arc<Self>) -> Backends {
+            Backends {
+                input: self.clone(),
+                window: self.clone(),
+                screen: self.clone(),
+                uia: self.clone(),
+                launcher: self,
+            }
+        }
+    }
+    impl InputBackend for FakeBackend {
+        fn key_down(&self, k: &MkKey) -> ExecResult {
+            self.event(format!("key_down:{k:?}"))
+        }
+        fn key_up(&self, k: &MkKey) -> ExecResult {
+            self.event(format!("key_up:{k:?}"))
+        }
+        fn button_down(&self, b: MkMouseButton) -> ExecResult {
+            self.event(format!("button_down:{b:?}"))
+        }
+        fn button_up(&self, b: MkMouseButton) -> ExecResult {
+            self.event(format!("button_up:{b:?}"))
+        }
+        fn move_mouse(&self, p: MkPoint) -> ExecResult {
+            self.event(format!("move:{},{}", p.x, p.y))
+        }
+        fn scroll(&self, d: i32) -> ExecResult {
+            self.event(format!("scroll:{d}"))
+        }
+        fn text(&self, p: &MkTextPayload) -> ExecResult {
+            self.event(format!("text:{}", p.text))
+        }
+    }
+    impl WindowBackend for FakeBackend {
+        fn exists(&self, _: &MkWindowMatcher) -> ExecResult<bool> {
+            Ok(*self
+                .conditions
+                .lock()
+                .unwrap()
+                .get("window_exists")
+                .unwrap_or(&false))
+        }
+        fn is_active(&self, _: &MkWindowMatcher) -> ExecResult<bool> {
+            Ok(*self
+                .conditions
+                .lock()
+                .unwrap()
+                .get("window_active")
+                .unwrap_or(&false))
+        }
+        fn activate(&self, _: &MkWindowPayload) -> ExecResult {
+            self.event("window_activate".into())
+        }
+        fn close(&self, _: &MkWindowMatcher) -> ExecResult {
+            self.event("window_close".into())
+        }
+    }
+    impl ScreenBackend for FakeBackend {
+        fn resolve(&self, t: &MkCoordinateTarget, v: &RuntimeVariables) -> ExecResult<MkPoint> {
+            match t {
+                MkCoordinateTarget::Screen { point }
+                | MkCoordinateTarget::ActiveWindow { point } => Ok(*point),
+                MkCoordinateTarget::Variable { name } => match v.get(name) {
+                    Some(MkValue::Point(p)) => Ok(*p),
+                    _ => Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::InvalidTarget,
+                        "point variable is missing",
+                    )),
+                },
+                _ => Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::TargetNotFound,
+                    "image target not found",
+                )),
+            }
+        }
+        fn image_found(&self, _: u64, _: f32) -> ExecResult<Option<MkPoint>> {
+            Ok(self
+                .conditions
+                .lock()
+                .unwrap()
+                .get("image")
+                .copied()
+                .unwrap_or(false)
+                .then_some(MkPoint { x: 1, y: 1 }))
+        }
+        fn pixel_matches(
+            &self,
+            _: &MkCoordinateTarget,
+            _: &str,
+            _: u8,
+            _: &RuntimeVariables,
+        ) -> ExecResult<bool> {
+            Ok(*self
+                .conditions
+                .lock()
+                .unwrap()
+                .get("pixel")
+                .unwrap_or(&false))
+        }
+    }
+    impl UiAutomationBackend for FakeBackend {
+        fn exists(&self, _: &MkUiPayload) -> ExecResult<bool> {
+            Ok(*self.conditions.lock().unwrap().get("uia").unwrap_or(&false))
+        }
+        fn invoke(&self, _: &MkUiPayload) -> ExecResult {
+            self.event("uia_invoke".into())
+        }
+        fn set_value(&self, _: &MkUiPayload, v: &str) -> ExecResult {
+            self.event(format!("uia_value:{v}"))
+        }
+    }
+    impl LauncherBackend for FakeBackend {
+        fn launch_process(&self, p: &MkProcessPayload) -> ExecResult {
+            self.event(format!("process:{}", p.program))
+        }
+        fn command(&self, c: &str, _: Option<&str>) -> ExecResult {
+            self.event(format!("command:{c}"))
+        }
+    }
+}

--- a/src/mkmacro/mod.rs
+++ b/src/mkmacro/mod.rs
@@ -1,5 +1,6 @@
 //! Versioned model, validation, compilation, and persistence for the new macro system.
 pub mod compiler;
+pub mod executor;
 pub mod model;
 pub mod runtime;
 pub mod store;
@@ -7,7 +8,11 @@ pub mod validation;
 pub mod variables;
 
 pub use compiler::*;
+pub use executor::*;
 pub use model::*;
+pub use runtime::{
+    CommandResult, MacroRuntime, RuntimeCommand, RuntimeSnapshot, RuntimeState, StepState,
+};
 pub use store::*;
 pub use validation::*;
 pub use variables::*;

--- a/src/mkmacro/runtime.rs
+++ b/src/mkmacro/runtime.rs
@@ -1,49 +1,423 @@
-use super::MkMacroStore;
-use anyhow::{Result, bail};
+//! Worker-owned macro runtime.  The public methods only exchange messages and snapshots;
+//! action execution and all waits live on the worker.
+use super::{MkMacroStore, compile, executor::*};
+use anyhow::{Result, anyhow};
 use once_cell::sync::Lazy;
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::{Arc, Mutex, RwLock, mpsc},
+    thread::{self, JoinHandle},
+    time::SystemTime,
+};
 
-static STORE: Lazy<RwLock<Option<Arc<MkMacroStore>>>> = Lazy::new(|| RwLock::new(None));
-pub fn set_shared_store(store: Arc<MkMacroStore>) {
-    *STORE.write().unwrap() = Some(store);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCommand {
+    Run(u64),
+    RunFrom(u64, u64),
+    RunSelection(u64, Vec<u64>),
+    Pause,
+    Resume,
+    Stop,
+    Shutdown,
 }
-fn store() -> Result<Arc<MkMacroStore>> {
-    STORE
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeState {
+    Idle,
+    Running,
+    Paused,
+    Stopping,
+    Completed,
+    Stopped,
+    Failed,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepState {
+    Pending,
+    Running,
+    Success,
+    Skipped,
+    Failed,
+}
+#[derive(Debug, Clone)]
+pub struct RuntimeSnapshot {
+    pub state: RuntimeState,
+    pub macro_id: Option<u64>,
+    pub step_id: Option<u64>,
+    pub completed_steps: usize,
+    pub total_steps: usize,
+    pub started_at: Option<SystemTime>,
+    pub finished_at: Option<SystemTime>,
+    pub latest_failure: Option<ExecutionDiagnostic>,
+    pub steps: Arc<BTreeMap<u64, StepState>>,
+    pub revision: u64,
+}
+impl Default for RuntimeSnapshot {
+    fn default() -> Self {
+        Self {
+            state: RuntimeState::Idle,
+            macro_id: None,
+            step_id: None,
+            completed_steps: 0,
+            total_steps: 0,
+            started_at: None,
+            finished_at: None,
+            latest_failure: None,
+            steps: Arc::new(BTreeMap::new()),
+            revision: 0,
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandResult {
+    Accepted,
+    AlreadyRunning { active_macro_id: u64 },
+    Rejected(ExecutionDiagnostic),
+}
+
+struct Shared {
+    snapshot: RwLock<Arc<RuntimeSnapshot>>,
+    control: Arc<RunControl>,
+    admission: Mutex<Option<u64>>,
+}
+pub struct MacroRuntime {
+    tx: mpsc::Sender<RuntimeCommand>,
+    shared: Arc<Shared>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+impl MacroRuntime {
+    pub fn new(store: Arc<MkMacroStore>, backends: Backends) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let shared = Arc::new(Shared {
+            snapshot: RwLock::new(Arc::new(RuntimeSnapshot::default())),
+            control: Arc::new(RunControl::default()),
+            admission: Mutex::new(None),
+        });
+        let s = shared.clone();
+        let worker = thread::Builder::new()
+            .name("mkmacro-runtime".into())
+            .spawn(move || worker_loop(store, backends, rx, s))
+            .expect("spawn macro runtime");
+        Self {
+            tx,
+            shared,
+            worker: Mutex::new(Some(worker)),
+        }
+    }
+    pub fn command(&self, c: RuntimeCommand) -> CommandResult {
+        if let RuntimeCommand::Run(id)
+        | RuntimeCommand::RunFrom(id, _)
+        | RuntimeCommand::RunSelection(id, _) = &c
+        {
+            let mut active = self.shared.admission.lock().unwrap();
+            if let Some(a) = *active {
+                return CommandResult::AlreadyRunning { active_macro_id: a };
+            }
+            *active = Some(*id);
+        }
+        match c {
+            RuntimeCommand::Pause => {
+                self.shared.control.pause();
+                if self.shared.admission.lock().unwrap().is_some() {
+                    publish(&self.shared, |snapshot| {
+                        snapshot.state = RuntimeState::Paused
+                    });
+                }
+            }
+            RuntimeCommand::Resume => {
+                self.shared.control.resume();
+                if self.shared.admission.lock().unwrap().is_some() {
+                    publish(&self.shared, |snapshot| {
+                        snapshot.state = RuntimeState::Running
+                    });
+                }
+            }
+            RuntimeCommand::Stop => {
+                self.shared.control.stop();
+                if self.shared.admission.lock().unwrap().is_some() {
+                    publish(&self.shared, |snapshot| {
+                        snapshot.state = RuntimeState::Stopping
+                    });
+                }
+            }
+            _ => {}
+        }
+        if self.tx.send(c).is_err() {
+            *self.shared.admission.lock().unwrap() = None;
+            return CommandResult::Rejected(ExecutionDiagnostic::new(
+                DiagnosticKind::RuntimeUnavailable,
+                "macro worker is shut down",
+            ));
+        }
+        CommandResult::Accepted
+    }
+    pub fn snapshot(&self) -> Arc<RuntimeSnapshot> {
+        self.shared.snapshot.read().unwrap().clone()
+    }
+    pub fn shutdown(&self) {
+        self.shared.control.stop();
+        let _ = self.tx.send(RuntimeCommand::Shutdown);
+        if let Some(h) = self.worker.lock().unwrap().take() {
+            let _ = h.join();
+        }
+    }
+}
+impl Drop for MacroRuntime {
+    fn drop(&mut self) {
+        self.shutdown()
+    }
+}
+
+fn publish(shared: &Shared, f: impl FnOnce(&mut RuntimeSnapshot)) {
+    let old = shared.snapshot.read().unwrap().as_ref().clone();
+    let mut n = old;
+    f(&mut n);
+    n.revision += 1;
+    *shared.snapshot.write().unwrap() = Arc::new(n)
+}
+fn worker_loop(
+    store: Arc<MkMacroStore>,
+    backends: Backends,
+    rx: mpsc::Receiver<RuntimeCommand>,
+    shared: Arc<Shared>,
+) {
+    while let Ok(cmd) = rx.recv() {
+        match cmd {
+            RuntimeCommand::Shutdown => break,
+            RuntimeCommand::Pause => {
+                if shared.control.is_active() {
+                    publish(&shared, |s| s.state = RuntimeState::Paused)
+                }
+            }
+            RuntimeCommand::Resume => {
+                if shared.control.is_active() {
+                    publish(&shared, |s| s.state = RuntimeState::Running)
+                }
+            }
+            RuntimeCommand::Stop => {}
+            RuntimeCommand::Run(mid) | RuntimeCommand::RunFrom(mid, 0) => {
+                run_one(&store, &backends, &shared, mid, None, None)
+            }
+            RuntimeCommand::RunFrom(mid, sid) => {
+                run_one(&store, &backends, &shared, mid, Some(sid), None)
+            }
+            RuntimeCommand::RunSelection(mid, ids) => {
+                run_one(&store, &backends, &shared, mid, None, Some(ids))
+            }
+        }
+    }
+    shared.control.stop();
+    *shared.admission.lock().unwrap() = None;
+}
+fn run_one(
+    store: &MkMacroStore,
+    backends: &Backends,
+    shared: &Shared,
+    mid: u64,
+    from: Option<u64>,
+    selection: Option<Vec<u64>>,
+) {
+    shared.control.reset();
+    let result = (|| {
+        let doc = store.snapshot();
+        let m = doc.macros.iter().find(|m| m.id == mid).ok_or_else(|| {
+            ExecutionDiagnostic::new(
+                DiagnosticKind::TargetNotFound,
+                format!("macro {mid} was not found"),
+            )
+        })?;
+        if !m.enabled {
+            return Err(ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                "macro is disabled",
+            ));
+        }
+        let mut plan = compile(m).map_err(|d| {
+            ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidPlan,
+                format!(
+                    "macro validation failed: {}",
+                    d.first()
+                        .map(|x| x.message.as_str())
+                        .unwrap_or("invalid plan")
+                ),
+            )
+        })?;
+        if let Some(sid) = from {
+            if plan
+                .instructions
+                .iter()
+                .any(|instruction| instruction.step.action.is_structural())
+            {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::InvalidSelection,
+                    "run-from cannot enter a structured control-flow plan",
+                ));
+            }
+            let start = *plan.step_to_instruction.get(&sid).ok_or_else(|| {
+                ExecutionDiagnostic::new(
+                    DiagnosticKind::TargetNotFound,
+                    format!("step {sid} was not found"),
+                )
+            })?;
+            plan.instructions = plan.instructions[start..].to_vec().into();
+            plan.step_to_instruction = plan
+                .instructions
+                .iter()
+                .enumerate()
+                .map(|(i, x)| (x.step.id, i))
+                .collect();
+        }
+        if let Some(ids) = selection {
+            let wanted: HashSet<_> = ids.into_iter().collect();
+            if wanted
+                .iter()
+                .any(|id| !plan.step_to_instruction.contains_key(id))
+            {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::TargetNotFound,
+                    "selection contains an unknown step",
+                ));
+            }
+            if plan
+                .instructions
+                .iter()
+                .any(|x| x.step.action.is_structural() && !wanted.contains(&x.step.id))
+                || wanted.iter().any(|id| {
+                    plan.instructions[*plan.step_to_instruction.get(id).unwrap()]
+                        .step
+                        .action
+                        .is_structural()
+                })
+            {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::InvalidSelection,
+                    "structural selections must include a complete executable plan",
+                ));
+            }
+            plan.instructions = plan
+                .instructions
+                .iter()
+                .filter(|x| wanted.contains(&x.step.id))
+                .cloned()
+                .collect::<Vec<_>>()
+                .into();
+            plan.step_to_instruction = plan
+                .instructions
+                .iter()
+                .enumerate()
+                .map(|(i, x)| (x.step.id, i))
+                .collect();
+        }
+        let states = plan
+            .instructions
+            .iter()
+            .map(|x| {
+                (
+                    x.step.id,
+                    if x.step.enabled {
+                        StepState::Pending
+                    } else {
+                        StepState::Skipped
+                    },
+                )
+            })
+            .collect();
+        publish(shared, |s| {
+            s.state = RuntimeState::Running;
+            s.macro_id = Some(mid);
+            s.step_id = None;
+            s.completed_steps = 0;
+            s.total_steps = plan.instructions.iter().filter(|x| x.step.enabled).count();
+            s.started_at = Some(SystemTime::now());
+            s.finished_at = None;
+            s.latest_failure = None;
+            s.steps = Arc::new(states)
+        });
+        let observer = |ev: ExecutionEvent| {
+            publish(shared, |s| match ev {
+                ExecutionEvent::StepStarted(id) => {
+                    s.step_id = Some(id);
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Running)
+                }
+                ExecutionEvent::StepFinished(id) => {
+                    s.completed_steps += 1;
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Success)
+                }
+                ExecutionEvent::StepSkipped(id) => {
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Skipped)
+                }
+                ExecutionEvent::StepFailed(id, d) => {
+                    s.latest_failure = Some(d);
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Failed)
+                }
+                ExecutionEvent::Paused => s.state = RuntimeState::Paused,
+                ExecutionEvent::Resumed => s.state = RuntimeState::Running,
+            })
+        };
+        Executor::new(backends.clone(), shared.control.clone()).execute(&plan, &observer)
+    })();
+    match result {
+        Ok(()) => publish(shared, |s| {
+            s.state = RuntimeState::Completed;
+            s.step_id = None;
+            s.finished_at = Some(SystemTime::now())
+        }),
+        Err(d) => {
+            let stopped = d.kind == DiagnosticKind::Cancelled;
+            publish(shared, |s| {
+                s.state = if stopped {
+                    RuntimeState::Stopped
+                } else {
+                    RuntimeState::Failed
+                };
+                s.latest_failure = if stopped {
+                    s.latest_failure.clone()
+                } else {
+                    Some(d)
+                };
+                s.step_id = None;
+                s.finished_at = Some(SystemTime::now())
+            })
+        }
+    };
+    *shared.admission.lock().unwrap() = None;
+}
+
+static RUNTIME: Lazy<RwLock<Option<Arc<MacroRuntime>>>> = Lazy::new(|| RwLock::new(None));
+pub fn set_shared_store(store: Arc<MkMacroStore>) {
+    if let Some(old) = RUNTIME.write().unwrap().take() {
+        old.shutdown()
+    }
+    *RUNTIME.write().unwrap() = Some(Arc::new(MacroRuntime::new(store, Backends::unsupported())))
+}
+fn global() -> Result<Arc<MacroRuntime>> {
+    RUNTIME
         .read()
         .unwrap()
         .clone()
-        .ok_or_else(|| anyhow::anyhow!("macro runtime is not initialized"))
+        .ok_or_else(|| anyhow!("macro runtime is not initialized"))
+}
+fn accepted(r: CommandResult) -> Result<()> {
+    match r {
+        CommandResult::Accepted => Ok(()),
+        x => Err(anyhow!("{x:?}")),
+    }
 }
 pub fn run(id: u64) -> Result<()> {
-    let s = store()?;
-    let doc = s.snapshot();
-    let m = doc
-        .macros
-        .iter()
-        .find(|m| m.id == id)
-        .ok_or_else(|| anyhow::anyhow!("unknown macro id {id}"))?;
-    if !m.enabled {
-        bail!("macro '{}' is disabled", m.name);
-    }
-    if !s.can_run() {
-        bail!("macro document has fatal validation errors");
-    }
-    let _ = crate::mkmacro::compile(m)
-        .map_err(|_| anyhow::anyhow!("macro has fatal validation errors"))?;
-    Ok(())
+    accepted(global()?.command(RuntimeCommand::Run(id)))
 }
 pub fn pause() -> Result<()> {
-    store().map(|_| ())
+    accepted(global()?.command(RuntimeCommand::Pause))
 }
 pub fn resume() -> Result<()> {
-    store().map(|_| ())
+    accepted(global()?.command(RuntimeCommand::Resume))
 }
 pub fn stop() -> Result<()> {
-    store().map(|_| ())
+    accepted(global()?.command(RuntimeCommand::Stop))
 }
 pub fn record() -> Result<()> {
-    store().map(|_| ())
+    Err(anyhow!("macro recording is not implemented"))
 }
 pub fn record_stop() -> Result<()> {
-    store().map(|_| ())
+    Err(anyhow!("macro recording is not implemented"))
 }

--- a/src/mkmacro/runtime.rs
+++ b/src/mkmacro/runtime.rs
@@ -337,18 +337,18 @@ fn run_one(
             publish(shared, |s| match ev {
                 ExecutionEvent::StepStarted(id) => {
                     s.step_id = Some(id);
-                    Arc::make_mut(&mut s.steps).insert(id, StepState::Running)
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Running);
                 }
                 ExecutionEvent::StepFinished(id) => {
                     s.completed_steps += 1;
-                    Arc::make_mut(&mut s.steps).insert(id, StepState::Success)
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Success);
                 }
                 ExecutionEvent::StepSkipped(id) => {
-                    Arc::make_mut(&mut s.steps).insert(id, StepState::Skipped)
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Skipped);
                 }
                 ExecutionEvent::StepFailed(id, d) => {
                     s.latest_failure = Some(d);
-                    Arc::make_mut(&mut s.steps).insert(id, StepState::Failed)
+                    Arc::make_mut(&mut s.steps).insert(id, StepState::Failed);
                 }
                 ExecutionEvent::Paused => s.state = RuntimeState::Paused,
                 ExecutionEvent::Resumed => s.state = RuntimeState::Running,


### PR DESCRIPTION
### Motivation

- Provide a worker-owned, testable macro runtime so the UI/launcher never executes effects or blocks on the egui thread. 
- Make all effect boundaries injectable so unit tests can run deterministically with fake backends instead of touching the real mouse/keyboard/OS.
- Expose stable run commands and immutable status snapshots to enable one-active-run enforcement, pause/stop semantics, and GUI-friendly state reads.

### Description

- Added a new platform-neutral executor in `src/mkmacro/executor.rs` that defines `InputBackend`, `WindowBackend`, `ScreenBackend`, `UiAutomationBackend`, and `LauncherBackend` traits, structured `ExecutionDiagnostic` kinds, and the `Executor` that runs compiled `MkExecutionPlan`s honoring precomputed jumps, repeats, delays, and error policies. 
- Implemented cancellation-aware control with `RunControl` (mutex + `Condvar`) supporting `checkpoint` and `wait` primitives that observe pause/stop and preserve remaining delay while paused.
- Added an RAII `InputCleanupGuard` that tracks only successfully acquired keys/buttons and deterministically releases owned inputs on error/stop/panic, and tests to ensure it never releases unowned inputs.
- Added synchronized `fake` backends in `executor.rs` that record high-level semantic events, can be configured to fail or satisfy conditions, and provide `Backends::unsupported()` for production defaults.
- Replaced the placeholder runtime with a worker-owned state machine in `src/mkmacro/runtime.rs` exposing `RuntimeCommand` variants (`Run`, `RunFrom`, `RunSelection`, `Pause`, `Resume`, `Stop`, `Shutdown`), `RuntimeState`/`StepState` enums, and `RuntimeSnapshot` immutable revisioned snapshots; the runtime runs on a dedicated thread and rejects a second run with `AlreadyRunning`.
- Added ID-based resolution for `run-from` and `run-selection`, explicit rejection for invalid structural selections, batched per-step state publication, progress/timestamps, and preservation of the latest diagnostic in final snapshots.
- Exported the new executor and runtime types through the `mkmacro` module and added unit tests colocated in `executor.rs` test module.

### Testing

- Ran `cargo fmt --all` and repository style checks: succeeded.
- Added and ran isolated unit tests via a small harness (`/tmp/mkcheck`) that builds `model`, `compiler`, `executor` and runs `cargo test --manifest-path /tmp/mkcheck/Cargo.toml`; all 7 unit tests passed (including sequential execution, owned-input cleanup, no release of unowned input, and cancellation of waits).
- Ran `cargo check` for the full repository: dependency platform build steps required installing native Linux dev packages (installed `libasound2-dev`, `libxi-dev`, `libxtst-dev`), after which the build still fails on unconditional Windows API imports in the repo (these are unrelated platform-specific symbols and mean the full project does not compile for `x86_64-unknown-linux-gnu` in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d12487b3c8332bf5e4206d1a0460e)