### PR TITLE
mkmacro: add Phase B production backends (Win32 input, coordinates, windows, hotkeys)

### DIFF
--- a/src/mkmacro/coordinates.rs
+++ b/src/mkmacro/coordinates.rs
@@ -1,0 +1,168 @@
+//! Pure coordinate resolution and Win32 absolute-coordinate normalization.
+use super::{DiagnosticKind, ExecResult, ExecutionDiagnostic, MkPoint};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtualDesktop {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+/// Converts a desktop pixel into SendInput's inclusive 0..=65535 coordinate space.
+/// Points outside the virtual desktop are clamped to its nearest pixel.
+pub fn normalize_absolute(point: MkPoint, desktop: VirtualDesktop) -> ExecResult<(i32, i32)> {
+    if desktop.width <= 0 || desktop.height <= 0 {
+        return Err(ExecutionDiagnostic::new(
+            DiagnosticKind::InvalidTarget,
+            "virtual desktop has zero or negative dimensions",
+        ));
+    }
+    let max_x = desktop.x.saturating_add(desktop.width - 1);
+    let max_y = desktop.y.saturating_add(desktop.height - 1);
+    let x = point.x.clamp(desktop.x, max_x) as i64 - desktop.x as i64;
+    let y = point.y.clamp(desktop.y, max_y) as i64 - desktop.y as i64;
+    let nx = if desktop.width == 1 {
+        0
+    } else {
+        x * 65_535 / (desktop.width - 1) as i64
+    };
+    let ny = if desktop.height == 1 {
+        0
+    } else {
+        y * 65_535 / (desktop.height - 1) as i64
+    };
+    Ok((nx as i32, ny as i32))
+}
+
+pub trait CoordinateData {
+    fn virtual_desktop(&self) -> ExecResult<VirtualDesktop>;
+    fn active_window_rect(&self) -> ExecResult<Rect>;
+    fn active_client_origin(&self) -> ExecResult<MkPoint>;
+    fn mouse_position(&self) -> ExecResult<MkPoint>;
+    fn image_result(&self, id: u64) -> ExecResult<MkPoint>;
+    fn uia_result(&self, id: &str) -> ExecResult<MkPoint>;
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoordinateBase {
+    Screen(MkPoint),
+    Window(MkPoint),
+    Client(MkPoint),
+    RelativeMouse(MkPoint),
+    ImageResult { id: u64, offset: MkPoint },
+    UiAutomationElement { id: String, offset: MkPoint },
+}
+pub trait OffsetRng {
+    fn inclusive(&mut self, low: i32, high: i32) -> i32;
+}
+/// Resolves the base before applying an inclusive random offset. The final point is
+/// clamped to the virtual desktop, which is the documented out-of-bounds policy.
+pub fn resolve_coordinate(
+    data: &dyn CoordinateData,
+    target: &CoordinateBase,
+    radius: u32,
+    rng: &mut dyn OffsetRng,
+) -> ExecResult<MkPoint> {
+    let add = |a: MkPoint, b: MkPoint| MkPoint {
+        x: a.x.saturating_add(b.x),
+        y: a.y.saturating_add(b.y),
+    };
+    let mut p = match target {
+        CoordinateBase::Screen(p) => *p,
+        CoordinateBase::Window(p) => {
+            let r = data.active_window_rect()?;
+            add(MkPoint { x: r.x, y: r.y }, *p)
+        }
+        CoordinateBase::Client(p) => add(data.active_client_origin()?, *p),
+        CoordinateBase::RelativeMouse(p) => add(data.mouse_position()?, *p),
+        CoordinateBase::ImageResult { id, offset } => add(data.image_result(*id)?, *offset),
+        CoordinateBase::UiAutomationElement { id, offset } => add(data.uia_result(id)?, *offset),
+    };
+    let r = radius.min(i32::MAX as u32) as i32;
+    if r > 0 {
+        p.x = p.x.saturating_add(rng.inclusive(-r, r));
+        p.y = p.y.saturating_add(rng.inclusive(-r, r));
+    }
+    let d = data.virtual_desktop()?;
+    if d.width <= 0 || d.height <= 0 {
+        return Err(ExecutionDiagnostic::new(
+            DiagnosticKind::InvalidTarget,
+            "virtual desktop has zero or negative dimensions",
+        ));
+    }
+    p.x = p.x.clamp(d.x, d.x.saturating_add(d.width - 1));
+    p.y = p.y.clamp(d.y, d.y.saturating_add(d.height - 1));
+    Ok(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn normalization_handles_negative_origins() {
+        assert_eq!(
+            normalize_absolute(
+                MkPoint { x: -1920, y: 0 },
+                VirtualDesktop {
+                    x: -1920,
+                    y: 0,
+                    width: 3840,
+                    height: 1080
+                }
+            )
+            .unwrap(),
+            (0, 0)
+        );
+        assert_eq!(
+            normalize_absolute(
+                MkPoint { x: 1919, y: 1079 },
+                VirtualDesktop {
+                    x: -1920,
+                    y: 0,
+                    width: 3840,
+                    height: 1080
+                }
+            )
+            .unwrap(),
+            (65535, 65535)
+        );
+    }
+    #[test]
+    fn above_primary() {
+        assert_eq!(
+            normalize_absolute(
+                MkPoint { x: 0, y: -1080 },
+                VirtualDesktop {
+                    x: 0,
+                    y: -1080,
+                    width: 1920,
+                    height: 2160
+                }
+            )
+            .unwrap(),
+            (0, 0)
+        );
+    }
+    #[test]
+    fn invalid_desktop() {
+        assert!(
+            normalize_absolute(
+                MkPoint { x: 0, y: 0 },
+                VirtualDesktop {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 1
+                }
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/mkmacro/hotkeys.rs
+++ b/src/mkmacro/hotkeys.rs
@@ -1,0 +1,104 @@
+//! Macro-hotkey validation and stable ID mapping.
+use super::{MkHotkey, MkKey, MkMacroDocument};
+use std::collections::{BTreeMap, HashMap};
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotkeyDiagnostic {
+    pub macro_id: u64,
+    pub message: String,
+}
+fn key_name(k: &MkKey) -> String {
+    match k {
+        MkKey::Character(s) => s.to_ascii_uppercase(),
+        x => format!("{x:?}").to_ascii_uppercase(),
+    }
+}
+pub fn canonical_hotkey(h: &MkHotkey) -> String {
+    let mut mods = h.modifiers.iter().map(key_name).collect::<Vec<_>>();
+    mods.sort();
+    mods.dedup();
+    mods.push(key_name(&h.key));
+    mods.join("+")
+}
+pub fn validate_hotkeys(doc: &MkMacroDocument, reserved: &[(&str, &str)]) -> Vec<HotkeyDiagnostic> {
+    let mut seen = HashMap::new();
+    let reserved = reserved
+        .iter()
+        .map(|(n, h)| (h.to_ascii_uppercase().replace(' ', ""), *n))
+        .collect::<HashMap<_, _>>();
+    let mut out = Vec::new();
+    for m in doc.macros.iter().filter(|m| m.enabled) {
+        let Some(h) = &m.hotkey else { continue };
+        let c = canonical_hotkey(h);
+        if let Some(other) = seen.insert(c.clone(), m.id) {
+            out.push(HotkeyDiagnostic {
+                macro_id: m.id,
+                message: format!("hotkey duplicates macro {other}"),
+            })
+        }
+        if let Some(name) = reserved.get(&c) {
+            out.push(HotkeyDiagnostic {
+                macro_id: m.id,
+                message: format!("hotkey conflicts with {name}"),
+            })
+        }
+    }
+    out
+}
+/// Rebuilt after every store update; IDs are deterministic and disabled macros are absent.
+pub fn rebuild_hotkey_map(doc: &MkMacroDocument, first_registration_id: i32) -> BTreeMap<i32, u64> {
+    let mut ids = doc
+        .macros
+        .iter()
+        .filter(|m| m.enabled && m.hotkey.is_some())
+        .map(|m| m.id)
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.into_iter()
+        .enumerate()
+        .map(|(i, id)| (first_registration_id + i as i32, id))
+        .collect()
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mkmacro::{MkMacro, MkPlayback};
+    fn mac(id: u64, on: bool) -> MkMacro {
+        MkMacro {
+            id,
+            name: id.to_string(),
+            description: String::new(),
+            enabled: on,
+            hotkey: Some(MkHotkey {
+                key: MkKey::Character("K".into()),
+                modifiers: vec![MkKey::Control],
+            }),
+            playback: MkPlayback::default(),
+            steps: vec![],
+        }
+    }
+    #[test]
+    fn duplicates_disabled_and_stable_reload() {
+        let d = MkMacroDocument {
+            schema_version: 1,
+            macros: vec![mac(9, true), mac(2, true), mac(1, false)],
+        };
+        assert_eq!(validate_hotkeys(&d, &[]).len(), 1);
+        assert_eq!(
+            rebuild_hotkey_map(&d, 100)
+                .into_values()
+                .collect::<Vec<_>>(),
+            vec![2, 9]
+        );
+    }
+    #[test]
+    fn reserved_conflict() {
+        let d = MkMacroDocument {
+            schema_version: 1,
+            macros: vec![mac(1, true)],
+        };
+        assert_eq!(
+            validate_hotkeys(&d, &[("emergency stop", "CONTROL+K")]).len(),
+            1
+        )
+    }
+}

--- a/src/mkmacro/input.rs
+++ b/src/mkmacro/input.rs
@@ -1,0 +1,432 @@
+//! Production input synthesis. This is intentionally independent of legacy `actions::keys`.
+use super::{
+    DiagnosticKind, ExecResult, ExecutionDiagnostic, InputBackend, MkKey, MkMouseButton, MkPoint,
+    MkTextMode, MkTextPayload,
+};
+use std::time::{Duration, Instant};
+
+/// Stable marker used to identify (and ignore while recording) mkmacro input.
+pub const MKMACRO_EXTRA_INFO: usize = 0x4D4B_4D41_4352_4F01;
+pub const KEYEVENTF_EXTENDEDKEY_: u32 = 0x0001;
+pub const KEYEVENTF_KEYUP_: u32 = 0x0002;
+pub const KEYEVENTF_UNICODE_: u32 = 0x0004;
+pub const KEYEVENTF_SCANCODE_: u32 = 0x0008;
+pub const MOUSEEVENTF_MOVE_: u32 = 0x0001;
+pub const MOUSEEVENTF_LEFTDOWN_: u32 = 0x0002;
+pub const MOUSEEVENTF_LEFTUP_: u32 = 0x0004;
+pub const MOUSEEVENTF_RIGHTDOWN_: u32 = 0x0008;
+pub const MOUSEEVENTF_RIGHTUP_: u32 = 0x0010;
+pub const MOUSEEVENTF_MIDDLEDOWN_: u32 = 0x0020;
+pub const MOUSEEVENTF_MIDDLEUP_: u32 = 0x0040;
+pub const MOUSEEVENTF_XDOWN_: u32 = 0x0080;
+pub const MOUSEEVENTF_XUP_: u32 = 0x0100;
+pub const MOUSEEVENTF_WHEEL_: u32 = 0x0800;
+pub const MOUSEEVENTF_HWHEEL_: u32 = 0x1000;
+pub const MOUSEEVENTF_VIRTUALDESK_: u32 = 0x4000;
+pub const MOUSEEVENTF_ABSOLUTE_: u32 = 0x8000;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawInputEvent {
+    Keyboard {
+        vk: u16,
+        scan: u16,
+        flags: u32,
+        extra: usize,
+    },
+    Mouse {
+        dx: i32,
+        dy: i32,
+        data: u32,
+        flags: u32,
+        extra: usize,
+    },
+}
+pub trait InputSink: Send + Sync {
+    fn send(&self, events: &[RawInputEvent]) -> Result<usize, String>;
+}
+fn rejected(wanted: usize, sent: usize, detail: impl Into<String>) -> ExecutionDiagnostic {
+    ExecutionDiagnostic::new(
+        DiagnosticKind::InputRejected,
+        format!(
+            "SendInput accepted {sent} of {wanted} event(s): {}",
+            detail.into()
+        ),
+    )
+    .context("requested", wanted.to_string())
+    .context("sent", sent.to_string())
+}
+#[derive(Clone)]
+pub struct Win32InputBackend<S = SystemInputSink> {
+    sink: S,
+}
+impl Default for Win32InputBackend<SystemInputSink> {
+    fn default() -> Self {
+        Self {
+            sink: SystemInputSink,
+        }
+    }
+}
+impl<S> Win32InputBackend<S> {
+    pub fn with_sink(sink: S) -> Self {
+        Self { sink }
+    }
+}
+impl<S: InputSink> Win32InputBackend<S> {
+    fn emit(&self, e: &[RawInputEvent]) -> ExecResult {
+        let n = self.sink.send(e).map_err(|x| rejected(e.len(), 0, x))?;
+        if n != e.len() {
+            Err(rejected(e.len(), n, "the operating system rejected input"))
+        } else {
+            Ok(())
+        }
+    }
+    fn key_event(&self, key: &MkKey, up: bool) -> ExecResult {
+        let (vk, scan, extended) = key_metadata(key)?;
+        let mut flags = if up { KEYEVENTF_KEYUP_ } else { 0 };
+        if scan != 0 {
+            flags |= KEYEVENTF_SCANCODE_
+        }
+        if extended {
+            flags |= KEYEVENTF_EXTENDEDKEY_
+        }
+        self.emit(&[RawInputEvent::Keyboard {
+            vk,
+            scan,
+            flags,
+            extra: MKMACRO_EXTRA_INFO,
+        }])
+    }
+    pub fn unicode_text(&self, text: &str) -> ExecResult {
+        let mut e = Vec::new();
+        for unit in text.encode_utf16() {
+            e.push(RawInputEvent::Keyboard {
+                vk: 0,
+                scan: unit,
+                flags: KEYEVENTF_UNICODE_,
+                extra: MKMACRO_EXTRA_INFO,
+            });
+            e.push(RawInputEvent::Keyboard {
+                vk: 0,
+                scan: unit,
+                flags: KEYEVENTF_UNICODE_ | KEYEVENTF_KEYUP_,
+                extra: MKMACRO_EXTRA_INFO,
+            });
+        }
+        self.emit(&e)
+    }
+    pub fn key_press(&self, key: &MkKey) -> ExecResult {
+        self.key_event(key, false)?;
+        self.key_event(key, true)
+    }
+    pub fn chord(&self, keys: &[MkKey]) -> ExecResult {
+        let mut down = Vec::new();
+        for key in keys {
+            if let Err(primary) = self.key_event(key, false) {
+                for owned in down.iter().rev() {
+                    let _ = self.key_event(owned, true);
+                }
+                return Err(primary);
+            }
+            down.push(key);
+        }
+        let mut primary = None;
+        for key in down.into_iter().rev() {
+            if let Err(e) = self.key_event(key, true) {
+                if primary.is_none() {
+                    primary = Some(e);
+                }
+            }
+        }
+        primary.map_or(Ok(()), Err)
+    }
+    pub fn horizontal_scroll(&self, delta: i32) -> ExecResult {
+        self.mouse(0, 0, delta as u32, MOUSEEVENTF_HWHEEL_)
+    }
+    fn mouse(&self, dx: i32, dy: i32, data: u32, flags: u32) -> ExecResult {
+        self.emit(&[RawInputEvent::Mouse {
+            dx,
+            dy,
+            data,
+            flags,
+            extra: MKMACRO_EXTRA_INFO,
+        }])
+    }
+}
+fn key_metadata(k: &MkKey) -> ExecResult<(u16, u16, bool)> {
+    let v = match k {
+        MkKey::Character(s) if s.len() == 1 => s.as_bytes()[0].to_ascii_uppercase() as u16,
+        MkKey::Enter => 0x0D,
+        MkKey::Tab => 9,
+        MkKey::Escape => 0x1B,
+        MkKey::Space => 0x20,
+        MkKey::Backspace => 8,
+        MkKey::Delete => 0x2E,
+        MkKey::Up => 0x26,
+        MkKey::Down => 0x28,
+        MkKey::Left => 0x25,
+        MkKey::Right => 0x27,
+        MkKey::Home => 0x24,
+        MkKey::End => 0x23,
+        MkKey::PageUp => 0x21,
+        MkKey::PageDown => 0x22,
+        MkKey::Control => 0x11,
+        MkKey::LeftControl => 0xA2,
+        MkKey::RightControl => 0xA3,
+        MkKey::Alt => 0x12,
+        MkKey::LeftAlt => 0xA4,
+        MkKey::RightAlt => 0xA5,
+        MkKey::Shift => 0x10,
+        MkKey::LeftShift => 0xA0,
+        MkKey::RightShift => 0xA1,
+        MkKey::Meta | MkKey::LeftMeta => 0x5B,
+        MkKey::RightMeta => 0x5C,
+        MkKey::Function(n @ 1..=24) => 0x6F + *n as u16,
+        _ => {
+            return Err(ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                "key has no virtual-key representation",
+            ));
+        }
+    };
+    let ext = matches!(
+        k,
+        MkKey::Delete
+            | MkKey::Up
+            | MkKey::Down
+            | MkKey::Left
+            | MkKey::Right
+            | MkKey::Home
+            | MkKey::End
+            | MkKey::PageUp
+            | MkKey::PageDown
+            | MkKey::Meta
+            | MkKey::LeftMeta
+            | MkKey::RightMeta
+            | MkKey::RightControl
+            | MkKey::RightAlt
+    );
+    Ok((v, 0, ext))
+}
+impl<S: InputSink> InputBackend for Win32InputBackend<S> {
+    fn key_down(&self, k: &MkKey) -> ExecResult {
+        self.key_event(k, false)
+    }
+    fn key_up(&self, k: &MkKey) -> ExecResult {
+        self.key_event(k, true)
+    }
+    fn button_down(&self, b: MkMouseButton) -> ExecResult {
+        let (f, d) = button(b, false);
+        self.mouse(0, 0, d, f)
+    }
+    fn button_up(&self, b: MkMouseButton) -> ExecResult {
+        let (f, d) = button(b, true);
+        self.mouse(0, 0, d, f)
+    }
+    fn move_mouse(&self, p: MkPoint) -> ExecResult {
+        let (x, y) = super::normalize_absolute(p, system_virtual_desktop()?)?;
+        self.mouse(
+            x,
+            y,
+            0,
+            MOUSEEVENTF_MOVE_ | MOUSEEVENTF_ABSOLUTE_ | MOUSEEVENTF_VIRTUALDESK_,
+        )
+    }
+    fn scroll(&self, d: i32) -> ExecResult {
+        self.mouse(0, 0, d as u32, MOUSEEVENTF_WHEEL_)
+    }
+    fn text(&self, p: &MkTextPayload) -> ExecResult {
+        match p.mode {
+            MkTextMode::Type => self.unicode_text(&p.text),
+            MkTextMode::Paste => Err(ExecutionDiagnostic::new(
+                DiagnosticKind::UnsupportedOperation,
+                "clipboard paste mode is not enabled; use Unicode text",
+            )),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn system_virtual_desktop() -> ExecResult<super::VirtualDesktop> {
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+        SM_YVIRTUALSCREEN,
+    };
+    Ok(super::VirtualDesktop {
+        x: unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) },
+        y: unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) },
+        width: unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) },
+        height: unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) },
+    })
+}
+#[cfg(not(windows))]
+fn system_virtual_desktop() -> ExecResult<super::VirtualDesktop> {
+    Ok(super::VirtualDesktop {
+        x: 0,
+        y: 0,
+        width: 65_536,
+        height: 65_536,
+    })
+}
+fn button(b: MkMouseButton, up: bool) -> (u32, u32) {
+    match (b, up) {
+        (MkMouseButton::Left, false) => (MOUSEEVENTF_LEFTDOWN_, 0),
+        (MkMouseButton::Left, true) => (MOUSEEVENTF_LEFTUP_, 0),
+        (MkMouseButton::Right, false) => (MOUSEEVENTF_RIGHTDOWN_, 0),
+        (MkMouseButton::Right, true) => (MOUSEEVENTF_RIGHTUP_, 0),
+        (MkMouseButton::Middle, false) => (MOUSEEVENTF_MIDDLEDOWN_, 0),
+        (MkMouseButton::Middle, true) => (MOUSEEVENTF_MIDDLEUP_, 0),
+        (MkMouseButton::X1, false) => (MOUSEEVENTF_XDOWN_, 1),
+        (MkMouseButton::X1, true) => (MOUSEEVENTF_XUP_, 1),
+        (MkMouseButton::X2, false) => (MOUSEEVENTF_XDOWN_, 2),
+        (MkMouseButton::X2, true) => (MOUSEEVENTF_XUP_, 2),
+    }
+}
+
+/// Time-based movement capped at 120 updates/second. Cancellation is checked
+/// before every update; the number of events depends on time, not pixel count.
+pub fn smooth_move(
+    backend: &dyn InputBackend,
+    control: &super::RunControl,
+    from: MkPoint,
+    to: MkPoint,
+    duration: Duration,
+) -> ExecResult {
+    if duration.is_zero() {
+        return backend.move_mouse(to);
+    }
+    let started = Instant::now();
+    let tick = Duration::from_micros(8_333);
+    loop {
+        control.checkpoint()?;
+        let elapsed = started.elapsed();
+        let t = (elapsed.as_secs_f64() / duration.as_secs_f64()).min(1.0);
+        backend.move_mouse(MkPoint {
+            x: (from.x as f64 + (to.x - from.x) as f64 * t).round() as i32,
+            y: (from.y as f64 + (to.y - from.y) as f64 * t).round() as i32,
+        })?;
+        if t >= 1.0 {
+            return Ok(());
+        }
+        control.wait(tick.min(duration.saturating_sub(elapsed)))?;
+    }
+}
+
+/// Holds a button during smooth movement and always attempts release. A release
+/// failure is returned only when it is the primary error, so it cannot hide a
+/// movement/cancellation error.
+pub fn drag(
+    backend: &dyn InputBackend,
+    control: &super::RunControl,
+    button: MkMouseButton,
+    from: MkPoint,
+    to: MkPoint,
+    duration: Duration,
+) -> ExecResult {
+    backend.move_mouse(from)?;
+    backend.button_down(button.clone())?;
+    let primary = smooth_move(backend, control, from, to, duration);
+    let release = backend.button_up(button);
+    match (primary, release) {
+        (Err(e), _) => Err(e),
+        (Ok(()), result) => result,
+    }
+}
+#[derive(Clone, Copy)]
+pub struct SystemInputSink;
+#[cfg(not(windows))]
+impl InputSink for SystemInputSink {
+    fn send(&self, _: &[RawInputEvent]) -> Result<usize, String> {
+        Err("SendInput is available only on Windows".into())
+    }
+}
+#[cfg(windows)]
+impl InputSink for SystemInputSink {
+    fn send(&self, events: &[RawInputEvent]) -> Result<usize, String> {
+        use windows::Win32::UI::Input::KeyboardAndMouse::*;
+        let native: Vec<INPUT> = events
+            .iter()
+            .map(|e| match *e {
+                RawInputEvent::Keyboard {
+                    vk,
+                    scan,
+                    flags,
+                    extra,
+                } => INPUT {
+                    r#type: INPUT_KEYBOARD,
+                    Anonymous: INPUT_0 {
+                        ki: KEYBDINPUT {
+                            wVk: windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY(vk),
+                            wScan: scan,
+                            dwFlags: KEYBD_EVENT_FLAGS(flags),
+                            time: 0,
+                            dwExtraInfo: extra,
+                        },
+                    },
+                },
+                RawInputEvent::Mouse {
+                    dx,
+                    dy,
+                    data,
+                    flags,
+                    extra,
+                } => INPUT {
+                    r#type: INPUT_MOUSE,
+                    Anonymous: INPUT_0 {
+                        mi: MOUSEINPUT {
+                            dx,
+                            dy,
+                            mouseData: data,
+                            dwFlags: MOUSE_EVENT_FLAGS(flags),
+                            time: 0,
+                            dwExtraInfo: extra,
+                        },
+                    },
+                },
+            })
+            .collect();
+        let n = unsafe { SendInput(&native, std::mem::size_of::<INPUT>() as i32) } as usize;
+        if n == 0 {
+            Err(windows::core::Error::from_win32().to_string())
+        } else {
+            Ok(n)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    #[derive(Default)]
+    struct Sink(Mutex<Vec<RawInputEvent>>);
+    impl InputSink for &Sink {
+        fn send(&self, e: &[RawInputEvent]) -> Result<usize, String> {
+            self.0.lock().unwrap().extend_from_slice(e);
+            Ok(e.len())
+        }
+    }
+    #[test]
+    fn unicode_surrogates_have_down_up() {
+        let s = Sink::default();
+        Win32InputBackend::with_sink(&s).unicode_text("😀").unwrap();
+        let e = s.0.lock().unwrap();
+        assert_eq!(e.len(), 4);
+        assert!(e.iter().all(|x| match x {
+            RawInputEvent::Keyboard { extra, .. } => *extra == MKMACRO_EXTRA_INFO,
+            _ => false,
+        }));
+    }
+    #[test]
+    fn x2_data_and_flags() {
+        let s = Sink::default();
+        let b = Win32InputBackend::with_sink(&s);
+        b.button_down(MkMouseButton::X2).unwrap();
+        assert!(matches!(
+            s.0.lock().unwrap()[0],
+            RawInputEvent::Mouse {
+                data: 2,
+                flags: MOUSEEVENTF_XDOWN_,
+                ..
+            }
+        ));
+    }
+}

--- a/src/mkmacro/input.rs
+++ b/src/mkmacro/input.rs
@@ -118,7 +118,7 @@ impl<S: InputSink> Win32InputBackend<S> {
         self.key_event(key, true)
     }
     pub fn chord(&self, keys: &[MkKey]) -> ExecResult {
-        let mut down = Vec::new();
+        let mut down: Vec<&MkKey> = Vec::new();
         for key in keys {
             if let Err(primary) = self.key_event(key, false) {
                 for owned in down.iter().rev() {

--- a/src/mkmacro/mod.rs
+++ b/src/mkmacro/mod.rs
@@ -1,13 +1,18 @@
 //! Versioned model, validation, compilation, and persistence for the new macro system.
 pub mod compiler;
+pub mod coordinates;
 pub mod executor;
+pub mod hotkeys;
+pub mod input;
 pub mod model;
 pub mod runtime;
 pub mod store;
 pub mod validation;
 pub mod variables;
+pub mod windows;
 
 pub use compiler::*;
+pub use coordinates::*;
 pub use executor::*;
 pub use model::*;
 pub use runtime::{
@@ -16,3 +21,4 @@ pub use runtime::{
 pub use store::*;
 pub use validation::*;
 pub use variables::*;
+pub use windows::*;

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -117,9 +117,17 @@ pub enum MkKey {
     PageUp,
     PageDown,
     Control,
+    LeftControl,
+    RightControl,
     Alt,
+    LeftAlt,
+    RightAlt,
     Shift,
+    LeftShift,
+    RightShift,
     Meta,
+    LeftMeta,
+    RightMeta,
     Function(u8),
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/mkmacro/variables.rs
+++ b/src/mkmacro/variables.rs
@@ -10,7 +10,7 @@ pub enum MkValue {
     Point(MkPoint),
     Null,
 }
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MkPoint {
     pub x: i32,
     pub y: i32,

--- a/src/mkmacro/windows.rs
+++ b/src/mkmacro/windows.rs
@@ -17,8 +17,8 @@ pub enum AmbiguityPolicy {
     First,
 }
 fn same_path(a: &str, b: &str) -> bool {
-    a.replace('/', '\\')
-        .eq_ignore_ascii_case(&b.replace('/', '\\'))
+    a.replace('/', "\\")
+        .eq_ignore_ascii_case(&b.replace('/', "\\"))
 }
 fn basename(s: &str) -> &str {
     s.rsplit(['/', '\\']).next().unwrap_or(s)

--- a/src/mkmacro/windows.rs
+++ b/src/mkmacro/windows.rs
@@ -1,0 +1,243 @@
+//! Window discovery and matching. Persist matchers, never native handles.
+use super::{
+    DiagnosticKind, ExecResult, ExecutionDiagnostic, MkWindowMatcher, MkWindowPayload,
+    WindowBackend,
+};
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowCandidate {
+    pub handle: usize,
+    pub title: String,
+    pub executable: String,
+    pub process_path: String,
+    pub class_name: String,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AmbiguityPolicy {
+    Error,
+    First,
+}
+fn same_path(a: &str, b: &str) -> bool {
+    a.replace('/', '\\')
+        .eq_ignore_ascii_case(&b.replace('/', '\\'))
+}
+fn basename(s: &str) -> &str {
+    s.rsplit(['/', '\\']).next().unwrap_or(s)
+}
+pub fn candidate_matches(m: &MkWindowMatcher, c: &WindowCandidate) -> ExecResult<bool> {
+    if let Some(p) = m.process.as_deref() {
+        let yes = if p.contains(['/', '\\']) {
+            same_path(p, &c.process_path)
+        } else {
+            basename(p).eq_ignore_ascii_case(&c.executable)
+                || basename(p).eq_ignore_ascii_case(basename(&c.process_path))
+        };
+        if !yes {
+            return Ok(false);
+        }
+    }
+    if let Some(class) = m.class.as_deref() {
+        if !class.eq_ignore_ascii_case(&c.class_name) {
+            return Ok(false);
+        }
+    }
+    if let Some(pattern) = m.title_regex.as_deref() {
+        let r = regex::Regex::new(pattern).map_err(|e| {
+            ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                format!("invalid window title regex: {e}"),
+            )
+        })?;
+        if !r.is_match(&c.title) {
+            return Ok(false);
+        }
+    } else if let Some(title) = m.title.as_deref() {
+        if !c.title.contains(title) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+pub fn resolve_window(
+    m: &MkWindowMatcher,
+    candidates: &[WindowCandidate],
+    policy: AmbiguityPolicy,
+) -> ExecResult<WindowCandidate> {
+    let mut found = Vec::new();
+    for c in candidates {
+        if candidate_matches(m, c)? {
+            found.push(c.clone())
+        }
+    }
+    match found.len() {
+        0 => Err(ExecutionDiagnostic::new(
+            DiagnosticKind::TargetNotFound,
+            "matching window is missing",
+        )),
+        1 => Ok(found.remove(0)),
+        _ if policy == AmbiguityPolicy::First => Ok(found.remove(0)),
+        _ => {
+            let summary = found
+                .iter()
+                .take(4)
+                .map(|c| format!("{} ({})", c.title, c.executable))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(ExecutionDiagnostic::new(
+                DiagnosticKind::AmbiguousTarget,
+                format!("window matcher is ambiguous: {summary}"),
+            )
+            .context("candidate_count", found.len().to_string()))
+        }
+    }
+}
+#[derive(Default)]
+pub struct Win32WindowBackend;
+impl Win32WindowBackend {
+    fn candidates(&self) -> ExecResult<Vec<WindowCandidate>> {
+        crate::multi_manager::win::enumerate_top_level_windows()
+            .map(|v| {
+                v.into_iter()
+                    .map(|w| WindowCandidate {
+                        handle: w.hwnd,
+                        title: w.title,
+                        executable: w.executable,
+                        process_path: w.process_path,
+                        class_name: w.class_name,
+                    })
+                    .collect()
+            })
+            .map_err(|e| {
+                ExecutionDiagnostic::new(
+                    DiagnosticKind::Backend,
+                    format!("window enumeration failed: {e}"),
+                )
+            })
+    }
+    fn one(&self, m: &MkWindowMatcher) -> ExecResult<WindowCandidate> {
+        resolve_window(m, &self.candidates()?, AmbiguityPolicy::Error)
+    }
+}
+impl WindowBackend for Win32WindowBackend {
+    fn exists(&self, m: &MkWindowMatcher) -> ExecResult<bool> {
+        let c = self.candidates()?;
+        for x in &c {
+            if candidate_matches(m, x)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+    fn is_active(&self, m: &MkWindowMatcher) -> ExecResult<bool> {
+        let Some(w) = crate::multi_manager::win::active_window() else {
+            return Ok(false);
+        };
+        candidate_matches(
+            m,
+            &WindowCandidate {
+                handle: w.hwnd,
+                title: w.title,
+                executable: w.executable,
+                process_path: w.process_path,
+                class_name: w.class_name,
+            },
+        )
+    }
+    fn activate(&self, p: &MkWindowPayload) -> ExecResult {
+        activate_handle(self.one(&p.matcher)?.handle)
+    }
+    fn close(&self, m: &MkWindowMatcher) -> ExecResult {
+        close_handle(self.one(m)?.handle)
+    }
+}
+#[cfg(not(windows))]
+fn activate_handle(_: usize) -> ExecResult {
+    Err(ExecutionDiagnostic::new(
+        DiagnosticKind::UnsupportedOperation,
+        "window activation is available only on Windows",
+    ))
+}
+#[cfg(not(windows))]
+fn close_handle(_: usize) -> ExecResult {
+    Err(ExecutionDiagnostic::new(
+        DiagnosticKind::UnsupportedOperation,
+        "window close is available only on Windows",
+    ))
+}
+#[cfg(windows)]
+fn activate_handle(h: usize) -> ExecResult {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, SetForegroundWindow};
+    let hwnd = HWND(h as *mut _);
+    if !unsafe { SetForegroundWindow(hwnd) }.as_bool() || unsafe { GetForegroundWindow() } != hwnd {
+        return Err(ExecutionDiagnostic::new(
+            DiagnosticKind::Backend,
+            "Windows foreground-activation policy denied the request",
+        ));
+    }
+    Ok(())
+}
+#[cfg(windows)]
+fn close_handle(h: usize) -> ExecResult {
+    use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+    unsafe { PostMessageW(HWND(h as *mut _), WM_CLOSE, WPARAM(0), LPARAM(0)) }.map_err(|e| {
+        ExecutionDiagnostic::new(
+            DiagnosticKind::Backend,
+            format!("failed to close window: {e}"),
+        )
+    })
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn c(t: &str, e: &str) -> WindowCandidate {
+        WindowCandidate {
+            handle: 1,
+            title: t.into(),
+            executable: e.into(),
+            process_path: format!("C:\\bin\\{e}"),
+            class_name: "Class".into(),
+        }
+    }
+    #[test]
+    fn matching_and_ambiguity() {
+        let m = MkWindowMatcher {
+            title: Some("Doc".into()),
+            title_regex: None,
+            process: Some("app.exe".into()),
+            class: Some("class".into()),
+        };
+        assert!(candidate_matches(&m, &c("Document", "app.exe")).unwrap());
+        assert_eq!(
+            resolve_window(
+                &m,
+                &[c("Document", "app.exe"), c("Doc 2", "app.exe")],
+                AmbiguityPolicy::Error
+            )
+            .unwrap_err()
+            .kind,
+            DiagnosticKind::AmbiguousTarget
+        );
+        assert!(
+            resolve_window(
+                &m,
+                &[c("Document", "app.exe"), c("Doc 2", "app.exe")],
+                AmbiguityPolicy::First
+            )
+            .is_ok()
+        )
+    }
+    #[test]
+    fn invalid_regex() {
+        let m = MkWindowMatcher {
+            title: None,
+            title_regex: Some("[".into()),
+            process: None,
+            class: None,
+        };
+        assert_eq!(
+            candidate_matches(&m, &c("x", "x")).unwrap_err().kind,
+            DiagnosticKind::InvalidTarget
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the fake-backed runtime with production-ready Phase B backends to enable real Win32 input synthesis, coordinate resolution, window operations, and macro hotkey management.
- Preserve existing macro model and executor boundaries while adding a production InputBackend and window/screen resolvers that integrate with existing Multi Manager helpers.

### Description
- Added new Phase B modules and exports: `src/mkmacro/coordinates.rs`, `src/mkmacro/input.rs`, `src/mkmacro/windows.rs`, and `src/mkmacro/hotkeys.rs`, plus `mkmacro::input`, `mkmacro::coordinates`, `mkmacro::windows`, and `mkmacro::hotkeys` re-exports in `src/mkmacro/mod.rs`.
- Implemented `Win32InputBackend` with a small `InputSink` abstraction (default `SystemInputSink`) to emit `SendInput`-style events, supporting Unicode UTF-16 text, `key_press`, `key_down`/`key_up`, chords, left/right modifier distinctions, `dwExtraInfo` tagging via a stable `MKMACRO_EXTRA_INFO` marker, mouse buttons (Left, Right, Middle, X1, X2), vertical/horizontal wheel, and absolute virtual-desktop movement using `MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK`.
- Added time-based `smooth_move` interpolation and `drag` helper with cancellation checkpoints integrated with the runtime `RunControl`, plus deterministic absolute-coordinate normalization (including negative virtual-desktop origins) and a `system_virtual_desktop()` helper.
- Implemented pure coordinate resolver abstractions in `coordinates.rs` for Screen, Window, Client, RelativeMouse, ImageResult, and UI Automation bases with a small `OffsetRng` for deterministic/randomized offsets and documented clamping policy.
- Implemented window candidate matching and a `Win32WindowBackend` in `windows.rs` that resolves matchers against `multi_manager::win` enumerations, supports executable basename/path, title Any/Contains/Regex and class matching, returns Missing/Ambiguous diagnostics, and exposes checked activate/close operations.
- Added hotkey canonicalization, duplicate/reserved conflict diagnostics, and a stable registration ID map in `hotkeys.rs`, and extended the macro model to persist left/right modifier variants in `src/mkmacro/model.rs`.

### Testing
- Ran `cargo fmt --all -- --check` and repository style checks which passed.
- Verified repository diff checks (`git diff --check`) and ensured new files staged cleanly with no whitespace errors.
- Attempted `cargo test mkmacro --lib`; the build progressed after installing missing native dev packages (alsa/x11 input libraries) but ultimately failed to run the test harness because other parts of the repository import Windows-only `windows::Win32` APIs unconditionally on non-Windows CI, causing compilation errors before the `mkmacro` tests executed.
- Included unit tests in the new modules (pure Rust tests for normalization, hotkey validation, input sink behavior) that compile on Windows; their execution could not be validated in this Linux environment due to the cross-platform Windows API build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e16d4efa083329c7b5780dbd2cde8)