### PR TITLE
Add Phase C worker-side macro recorder with hook transport and normalization

### DIFF
--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1,5 +1,6 @@
 mod action_editor;
 mod macro_list;
+pub mod recorder_controller;
 mod step_table;
 mod toolbar;
 

--- a/src/gui/mkmacro_dialog/recorder_controller.rs
+++ b/src/gui/mkmacro_dialog/recorder_controller.rs
@@ -1,0 +1,149 @@
+//! Recorder orchestration and optional floating-controller boundary.
+use crate::mkmacro::{
+    HookCommand, MkMacroDocument, MkStep, RecordedStep, RuntimeSnapshot, to_macro_steps,
+};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecorderState {
+    Recording,
+    Paused,
+    Stopped,
+}
+#[derive(Debug, Clone)]
+pub struct RecorderStatusSnapshot {
+    pub state: RecorderState,
+    pub elapsed: Duration,
+    pub raw_event_count: u64,
+    pub produced_step_count: usize,
+}
+impl Default for RecorderStatusSnapshot {
+    fn default() -> Self {
+        Self {
+            state: RecorderState::Stopped,
+            elapsed: Duration::ZERO,
+            raw_event_count: 0,
+            produced_step_count: 0,
+        }
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerAction {
+    Record,
+    Pause,
+    Resume,
+    Stop,
+    Play,
+    StopPlayback,
+}
+
+/// Isolates secondary viewport/window creation from recorder state and commands.
+pub trait RecorderControllerView {
+    fn set_visible(&mut self, visible: bool);
+    fn show(
+        &mut self,
+        recorder: &RecorderStatusSnapshot,
+        runtime: Option<&RuntimeSnapshot>,
+    ) -> Option<ControllerAction>;
+    fn exclude_from_capture(&mut self) {}
+}
+
+#[derive(Debug, Default)]
+pub struct DraftTransaction {
+    pub macro_id: u64,
+    pub inserted: Vec<MkStep>,
+}
+impl DraftTransaction {
+    pub fn apply(self, draft: &mut MkMacroDocument) -> Result<(), String> {
+        let m = draft
+            .macros
+            .iter_mut()
+            .find(|m| m.id == self.macro_id)
+            .ok_or("selected macro no longer exists")?;
+        m.steps.extend(self.inserted);
+        Ok(())
+    }
+    pub fn undo(&self, draft: &mut MkMacroDocument) {
+        if let Some(m) = draft.macros.iter_mut().find(|m| m.id == self.macro_id) {
+            let ids: std::collections::HashSet<_> = self.inserted.iter().map(|s| s.id).collect();
+            m.steps.retain(|s| !ids.contains(&s.id));
+        }
+    }
+}
+
+pub struct RecorderController<V: RecorderControllerView> {
+    pub view: V,
+    pub status: RecorderStatusSnapshot,
+    pub show_floating: bool,
+    pub undo: Vec<DraftTransaction>,
+}
+impl<V: RecorderControllerView> RecorderController<V> {
+    pub fn new(view: V) -> Self {
+        Self {
+            view,
+            status: Default::default(),
+            show_floating: false,
+            undo: vec![],
+        }
+    }
+    pub fn hook_command(&mut self, c: HookCommand) {
+        match c {
+            HookCommand::Start => {
+                self.status = Default::default();
+                self.status.state = RecorderState::Recording
+            }
+            HookCommand::Pause => self.status.state = RecorderState::Paused,
+            HookCommand::Resume => self.status.state = RecorderState::Recording,
+            HookCommand::Stop | HookCommand::Shutdown => self.status.state = RecorderState::Stopped,
+        }
+    }
+    pub fn render(&mut self, runtime: Option<&RuntimeSnapshot>) -> Option<ControllerAction> {
+        self.view.set_visible(self.show_floating);
+        if self.show_floating {
+            self.view.exclude_from_capture();
+            self.view.show(&self.status, runtime)
+        } else {
+            None
+        }
+    }
+    /// One in-memory, undoable insertion; persistence remains the dialog's explicit Save operation.
+    pub fn insert_recording(
+        &mut self,
+        draft: &mut MkMacroDocument,
+        macro_id: u64,
+        recorded: &[RecordedStep],
+    ) -> Result<(), String> {
+        let next = draft
+            .macros
+            .iter()
+            .flat_map(|m| m.steps.iter())
+            .map(|s| s.id)
+            .max()
+            .unwrap_or(0);
+        let transaction = DraftTransaction {
+            macro_id,
+            inserted: to_macro_steps(recorded, next),
+        };
+        transaction.clone_apply(draft)?;
+        self.status.produced_step_count = transaction.inserted.len();
+        self.undo.push(transaction);
+        Ok(())
+    }
+}
+impl DraftTransaction {
+    fn clone_apply(&self, draft: &mut MkMacroDocument) -> Result<(), String> {
+        let m = draft
+            .macros
+            .iter_mut()
+            .find(|m| m.id == self.macro_id)
+            .ok_or("selected macro no longer exists")?;
+        m.steps.extend(self.inserted.clone());
+        Ok(())
+    }
+}
+
+/// Hotkeys/control windows are excluded by explicit commands rather than blanket input suppression;
+/// unrelated physical events continue through the hook channel.
+pub fn is_control_hotkey(vk: u32, configured: &[u32]) -> bool {
+    configured.contains(&vk)
+}

--- a/src/gui/mkmacro_dialog/toolbar.rs
+++ b/src/gui/mkmacro_dialog/toolbar.rs
@@ -8,7 +8,7 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, dialog: &mut MkMacroDialog) {
             ui.add_enabled(false, eframe::egui::Button::new("Run"))
                 .on_disabled_hover_text(reason);
         } else {
-            ui.button("Run");
+            let _ = ui.button("Run");
         }
         if dialog.dirty {
             ui.label("Unsaved changes");

--- a/src/mkmacro/mod.rs
+++ b/src/mkmacro/mod.rs
@@ -5,6 +5,8 @@ pub mod executor;
 pub mod hotkeys;
 pub mod input;
 pub mod model;
+pub mod recorder;
+pub mod recorder_hooks;
 pub mod runtime;
 pub mod store;
 pub mod validation;
@@ -15,6 +17,8 @@ pub use compiler::*;
 pub use coordinates::*;
 pub use executor::*;
 pub use model::*;
+pub use recorder::*;
+pub use recorder_hooks::*;
 pub use runtime::{
     CommandResult, MacroRuntime, RuntimeCommand, RuntimeSnapshot, RuntimeState, StepState,
 };

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -395,6 +395,7 @@ pub fn to_macro_steps(items: &[RecordedStep], mut next_id: u64) -> Vec<MkStep> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mkmacro::recorder_hooks::LLKHF_EXTENDED;
     fn mouse(t: u64, m: MouseMessage, x: i32, y: i32) -> RecordingBoundary {
         RecordingBoundary::Event(HookEvent::Mouse {
             timestamp_us: t,

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -1,0 +1,483 @@
+//! Worker-side, pure recording normalization. No OS, UI automation, or persistence is used here.
+use super::{
+    HookEvent, KeyTransition, MkAction, MkCoordinateTarget, MkErrorPolicy, MkKey, MkMouseButton,
+    MkMousePayload, MkPoint, MkStep, MouseButton, MouseMessage, should_record,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MovementMode {
+    Off,
+    ClicksOnly,
+    SampledMovement,
+    DetailedMovement,
+}
+#[derive(Debug, Clone)]
+pub struct NormalizationConfig {
+    pub movement_mode: MovementMode,
+    pub movement_distance_px: i32,
+    pub movement_interval_ms: u64,
+    pub click_max_ms: u64,
+    pub click_distance_px: i32,
+    pub multi_click_ms: u64,
+    pub record_injected_input: bool,
+}
+impl Default for NormalizationConfig {
+    fn default() -> Self {
+        Self {
+            movement_mode: MovementMode::SampledMovement,
+            movement_distance_px: 4,
+            movement_interval_ms: 25,
+            click_max_ms: 500,
+            click_distance_px: 4,
+            multi_click_ms: 500,
+            record_injected_input: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct WindowContext {
+    pub executable: String,
+    pub title: String,
+    pub class: String,
+    pub rect: Option<(i32, i32, i32, i32)>,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventContext {
+    pub foreground: WindowContext,
+    pub window_under_point: Option<WindowContext>,
+}
+pub trait EventEnricher: Send {
+    fn enrich(&mut self, event: &HookEvent) -> Option<EventContext>;
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordingBoundary {
+    Event(HookEvent),
+    Pause { timestamp_us: u64 },
+    Resume { timestamp_us: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordedAction {
+    Key {
+        down: bool,
+        vk: u32,
+        scan_code: u32,
+        extended: bool,
+        flags: u32,
+        extra_info: usize,
+    },
+    Move {
+        x: i32,
+        y: i32,
+    },
+    Down {
+        button: MouseButton,
+        x: i32,
+        y: i32,
+    },
+    Up {
+        button: MouseButton,
+        x: i32,
+        y: i32,
+    },
+    Click {
+        button: MouseButton,
+        x: i32,
+        y: i32,
+        count: u32,
+    },
+    Drag {
+        button: MouseButton,
+        from: (i32, i32),
+        to: (i32, i32),
+    },
+    Wheel {
+        delta: i32,
+        horizontal: bool,
+        x: i32,
+        y: i32,
+    },
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedStep {
+    pub timestamp_us: u64,
+    pub delay_after_ms: u64,
+    pub action: RecordedAction,
+    pub context: Option<EventContext>,
+}
+
+fn distance(a: (i32, i32), b: (i32, i32)) -> i32 {
+    (a.0 - b.0).abs().max((a.1 - b.1).abs())
+}
+pub fn normalize(
+    input: &[RecordingBoundary],
+    cfg: &NormalizationConfig,
+    mut enricher: Option<&mut dyn EventEnricher>,
+) -> Vec<RecordedStep> {
+    let mut raw = Vec::new();
+    let mut paused = false;
+    let mut pause_at = 0;
+    let mut excluded = 0;
+    for item in input {
+        match *item {
+            RecordingBoundary::Pause { timestamp_us } => {
+                paused = true;
+                pause_at = timestamp_us;
+            }
+            RecordingBoundary::Resume { timestamp_us } => {
+                if paused {
+                    excluded += timestamp_us.saturating_sub(pause_at);
+                    paused = false;
+                }
+            }
+            RecordingBoundary::Event(e)
+                if !paused && should_record(&e, cfg.record_injected_input) =>
+            {
+                raw.push((e, e.timestamp_us().saturating_sub(excluded)))
+            }
+            _ => {}
+        }
+    }
+    let mut out: Vec<RecordedStep> = vec![];
+    let mut down: Option<(MouseButton, (i32, i32), u64, Option<EventContext>)> = None;
+    let mut last_move: Option<((i32, i32), u64)> = None;
+    for (e, t) in raw {
+        let context = enricher.as_deref_mut().and_then(|x| x.enrich(&e));
+        let action = match e {
+            HookEvent::Key {
+                transition,
+                vk,
+                scan_code,
+                flags,
+                extra_info,
+                ..
+            } => Some(RecordedAction::Key {
+                down: transition == KeyTransition::Down,
+                vk,
+                scan_code,
+                extended: flags & super::LLKHF_EXTENDED != 0,
+                flags,
+                extra_info,
+            }),
+            HookEvent::Mouse {
+                message: MouseMessage::Move,
+                x,
+                y,
+                ..
+            } => {
+                if let Some((_, start, _, _)) = down.as_mut() {
+                    *start = (start.0, start.1);
+                }
+                let keep = match cfg.movement_mode {
+                    MovementMode::Off | MovementMode::ClicksOnly => false,
+                    MovementMode::DetailedMovement => last_move.map_or(true, |(p, _)| p != (x, y)),
+                    MovementMode::SampledMovement => last_move.map_or(true, |(p, lt)| {
+                        distance(p, (x, y)) >= cfg.movement_distance_px
+                            || t.saturating_sub(lt) >= cfg.movement_interval_ms * 1000
+                    }),
+                };
+                if keep {
+                    last_move = Some(((x, y), t));
+                    Some(RecordedAction::Move { x, y })
+                } else {
+                    None
+                }
+            }
+            HookEvent::Mouse {
+                message: MouseMessage::Down(b),
+                x,
+                y,
+                ..
+            } => {
+                down = Some((b, (x, y), t, context.clone()));
+                None
+            }
+            HookEvent::Mouse {
+                message: MouseMessage::Up(b),
+                x,
+                y,
+                ..
+            } => {
+                if let Some((db, p, dt, dc)) = down.take() {
+                    if db == b
+                        && distance(p, (x, y)) <= cfg.click_distance_px
+                        && t - dt <= cfg.click_max_ms * 1000
+                    {
+                        Some(RecordedAction::Click {
+                            button: b,
+                            x,
+                            y,
+                            count: 1,
+                        })
+                    } else if db == b && distance(p, (x, y)) > cfg.click_distance_px {
+                        Some(RecordedAction::Drag {
+                            button: b,
+                            from: p,
+                            to: (x, y),
+                        })
+                    } else {
+                        out.push(RecordedStep {
+                            timestamp_us: dt,
+                            delay_after_ms: 0,
+                            action: RecordedAction::Down {
+                                button: db,
+                                x: p.0,
+                                y: p.1,
+                            },
+                            context: dc,
+                        });
+                        Some(RecordedAction::Up { button: b, x, y })
+                    }
+                } else {
+                    Some(RecordedAction::Up { button: b, x, y })
+                }
+            }
+            HookEvent::Mouse {
+                message: MouseMessage::Wheel(delta),
+                x,
+                y,
+                ..
+            } => Some(RecordedAction::Wheel {
+                delta,
+                horizontal: false,
+                x,
+                y,
+            }),
+            HookEvent::Mouse {
+                message: MouseMessage::HorizontalWheel(delta),
+                x,
+                y,
+                ..
+            } => Some(RecordedAction::Wheel {
+                delta,
+                horizontal: true,
+                x,
+                y,
+            }),
+        };
+        if let Some(action) = action {
+            if let (
+                Some(prev),
+                RecordedAction::Click {
+                    button,
+                    x,
+                    y,
+                    count,
+                },
+            ) = (out.last_mut(), &action)
+            {
+                if let RecordedAction::Click {
+                    button: pb,
+                    x: px,
+                    y: py,
+                    count: pc,
+                } = &mut prev.action
+                {
+                    if pb == button
+                        && distance((*px, *py), (*x, *y)) <= cfg.click_distance_px
+                        && t.saturating_sub(prev.timestamp_us) <= cfg.multi_click_ms * 1000
+                    {
+                        *pc += *count;
+                        prev.timestamp_us = t;
+                        prev.context = context;
+                        continue;
+                    }
+                }
+            }
+            out.push(RecordedStep {
+                timestamp_us: t,
+                delay_after_ms: 0,
+                action,
+                context,
+            });
+        }
+    }
+    if let Some((b, p, t, c)) = down {
+        out.push(RecordedStep {
+            timestamp_us: t,
+            delay_after_ms: 0,
+            action: RecordedAction::Down {
+                button: b,
+                x: p.0,
+                y: p.1,
+            },
+            context: c,
+        });
+    }
+    out.sort_by_key(|x| x.timestamp_us);
+    for i in 0..out.len().saturating_sub(1) {
+        out[i].delay_after_ms = out[i + 1].timestamp_us.saturating_sub(out[i].timestamp_us) / 1000;
+    }
+    out
+}
+
+fn key(vk: u32) -> MkKey {
+    match vk {
+        0x0D => MkKey::Enter,
+        0x09 => MkKey::Tab,
+        0x1B => MkKey::Escape,
+        0x20 => MkKey::Space,
+        0x25 => MkKey::Left,
+        0x26 => MkKey::Up,
+        0x27 => MkKey::Right,
+        0x28 => MkKey::Down,
+        0x70..=0x87 => MkKey::Function((vk - 0x6f) as u8),
+        _ => MkKey::Character(char::from_u32(vk).unwrap_or('?').to_string()),
+    }
+}
+fn button(b: MouseButton) -> MkMouseButton {
+    match b {
+        MouseButton::Left => MkMouseButton::Left,
+        MouseButton::Right => MkMouseButton::Right,
+        MouseButton::Middle => MkMouseButton::Middle,
+        MouseButton::X1 => MkMouseButton::X1,
+        MouseButton::X2 => MkMouseButton::X2,
+    }
+}
+/// Converts a normalized batch to draft steps. IDs are allocated only at insertion time.
+pub fn to_macro_steps(items: &[RecordedStep], mut next_id: u64) -> Vec<MkStep> {
+    let mut result = Vec::new();
+    for s in items {
+        let point = |x, y| MkCoordinateTarget::Screen {
+            point: MkPoint { x, y },
+        };
+        let actions: Vec<MkAction> = match s.action {
+            RecordedAction::Key { down: true, vk, .. } => vec![MkAction::KeyDown(key(vk))],
+            RecordedAction::Key {
+                down: false, vk, ..
+            } => vec![MkAction::KeyUp(key(vk))],
+            RecordedAction::Move { x, y } => vec![MkAction::MouseMove(point(x, y))],
+            RecordedAction::Click {
+                button: b,
+                x,
+                y,
+                count,
+            } => vec![MkAction::MouseClick(MkMousePayload {
+                target: point(x, y),
+                button: button(b),
+                clicks: count,
+            })],
+            RecordedAction::Down { button: b, .. } => vec![MkAction::MouseDown(button(b))],
+            RecordedAction::Up { button: b, .. } => vec![MkAction::MouseUp(button(b))],
+            RecordedAction::Drag {
+                button: b,
+                from,
+                to,
+            } => vec![
+                MkAction::MouseMove(point(from.0, from.1)),
+                MkAction::MouseDown(button(b)),
+                MkAction::MouseMove(point(to.0, to.1)),
+                MkAction::MouseUp(button(b)),
+            ],
+            RecordedAction::Wheel { delta, .. } => vec![MkAction::MouseScroll { i32_delta: delta }],
+        };
+        let action_count = actions.len();
+        for (i, action) in actions.into_iter().enumerate() {
+            next_id += 1;
+            result.push(MkStep {
+                id: next_id,
+                enabled: true,
+                repeat: 1,
+                delay_after_ms: if i + 1 == action_count {
+                    s.delay_after_ms
+                } else {
+                    0
+                },
+                on_error: MkErrorPolicy::Stop,
+                action,
+            });
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn mouse(t: u64, m: MouseMessage, x: i32, y: i32) -> RecordingBoundary {
+        RecordingBoundary::Event(HookEvent::Mouse {
+            timestamp_us: t,
+            message: m,
+            x,
+            y,
+            flags: 0,
+            extra_info: 0,
+        })
+    }
+    #[test]
+    fn clicks_repeats_drag_wheels_and_delay() {
+        let c = NormalizationConfig::default();
+        let v = normalize(
+            &[
+                mouse(0, MouseMessage::Down(MouseButton::Left), 0, 0),
+                mouse(10_000, MouseMessage::Up(MouseButton::Left), 0, 0),
+                mouse(20_000, MouseMessage::Down(MouseButton::Left), 0, 0),
+                mouse(30_000, MouseMessage::Up(MouseButton::Left), 0, 0),
+                mouse(50_000, MouseMessage::Down(MouseButton::Left), 0, 0),
+                mouse(60_000, MouseMessage::Move, 20, 0),
+                mouse(70_000, MouseMessage::Up(MouseButton::Left), 20, 0),
+                mouse(80_000, MouseMessage::Wheel(120), 20, 0),
+                mouse(90_000, MouseMessage::HorizontalWheel(-120), 20, 0),
+            ],
+            &c,
+            None,
+        );
+        assert!(matches!(
+            v[0].action,
+            RecordedAction::Click { count: 2, .. }
+        ));
+        assert!(
+            v.iter()
+                .any(|x| matches!(x.action, RecordedAction::Drag { .. }))
+        );
+        assert!(v.iter().any(|x| matches!(
+            x.action,
+            RecordedAction::Wheel {
+                horizontal: true,
+                ..
+            }
+        )));
+        assert!(v[0].delay_after_ms > 0);
+    }
+    #[test]
+    fn sampling_pause_and_key_fidelity() {
+        let mut c = NormalizationConfig::default();
+        c.movement_distance_px = 10;
+        let k = HookEvent::Key {
+            timestamp_us: 200_000,
+            transition: KeyTransition::Up,
+            vk: 65,
+            scan_code: 30,
+            flags: LLKHF_EXTENDED,
+            extra_info: 7,
+        };
+        let v = normalize(
+            &[
+                mouse(0, MouseMessage::Move, 0, 0),
+                mouse(1_000, MouseMessage::Move, 2, 2),
+                RecordingBoundary::Pause {
+                    timestamp_us: 2_000,
+                },
+                mouse(4_000, MouseMessage::Move, 30, 30),
+                RecordingBoundary::Resume {
+                    timestamp_us: 102_000,
+                },
+                RecordingBoundary::Event(k),
+            ],
+            &c,
+            None,
+        );
+        assert_eq!(v.len(), 2);
+        assert!(matches!(
+            v[1].action,
+            RecordedAction::Key {
+                down: false,
+                scan_code: 30,
+                extended: true,
+                ..
+            }
+        ));
+        assert_eq!(v[0].delay_after_ms, 100);
+    }
+}

--- a/src/mkmacro/recorder_hooks.rs
+++ b/src/mkmacro/recorder_hooks.rs
@@ -1,0 +1,405 @@
+//! Low-level hook transport. Hook callbacks are deliberately limited to copying POD data,
+//! reading the monotonic clock, a `try_send`, and chaining the hook.
+use crate::mkmacro::input::MKMACRO_EXTRA_INFO;
+use std::{
+    sync::{
+        Arc, Mutex,
+        mpsc::{self, SyncSender, TrySendError},
+    },
+    thread::{self, JoinHandle},
+};
+
+pub const LLKHF_EXTENDED: u32 = 0x01;
+pub const LLKHF_INJECTED: u32 = 0x10;
+pub const LLMHF_INJECTED: u32 = 0x01;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyTransition {
+    Down,
+    Up,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseMessage {
+    Move,
+    Down(MouseButton),
+    Up(MouseButton),
+    Wheel(i32),
+    HorizontalWheel(i32),
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+    X1,
+    X2,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookEvent {
+    Key {
+        timestamp_us: u64,
+        transition: KeyTransition,
+        vk: u32,
+        scan_code: u32,
+        flags: u32,
+        extra_info: usize,
+    },
+    Mouse {
+        timestamp_us: u64,
+        message: MouseMessage,
+        x: i32,
+        y: i32,
+        flags: u32,
+        extra_info: usize,
+    },
+}
+impl HookEvent {
+    pub fn timestamp_us(&self) -> u64 {
+        match self {
+            Self::Key { timestamp_us, .. } | Self::Mouse { timestamp_us, .. } => *timestamp_us,
+        }
+    }
+    pub fn is_injected(&self) -> bool {
+        match self {
+            Self::Key { flags, .. } => flags & LLKHF_INJECTED != 0,
+            Self::Mouse { flags, .. } => flags & LLMHF_INJECTED != 0,
+        }
+    }
+    pub fn extra_info(&self) -> usize {
+        match self {
+            Self::Key { extra_info, .. } | Self::Mouse { extra_info, .. } => *extra_info,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookCommand {
+    Start,
+    Pause,
+    Resume,
+    Stop,
+    Shutdown,
+}
+pub trait HookLoopAdapter: Send + 'static {
+    /// Runs on the hook thread. Implementations install/uninstall hooks and own their message loop.
+    fn run(self, commands: mpsc::Receiver<HookCommand>, callback: CallbackSender);
+}
+
+#[derive(Clone)]
+pub struct CallbackSender {
+    tx: SyncSender<HookEvent>,
+    dropped: Arc<std::sync::atomic::AtomicU64>,
+}
+impl CallbackSender {
+    /// Bounded and nonblocking; safe for direct use by a hook callback.
+    pub fn submit(&self, event: HookEvent) {
+        if let Err(TrySendError::Full(_)) = self.tx.try_send(event) {
+            self.dropped
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+}
+
+pub struct HookService {
+    commands: mpsc::Sender<HookCommand>,
+    events: Mutex<mpsc::Receiver<HookEvent>>,
+    dropped: Arc<std::sync::atomic::AtomicU64>,
+    thread: Mutex<Option<JoinHandle<()>>>,
+}
+impl HookService {
+    pub fn with_adapter<A: HookLoopAdapter>(adapter: A, capacity: usize) -> Self {
+        let (commands, rx) = mpsc::channel();
+        let (tx, events) = mpsc::sync_channel(capacity.max(1));
+        let dropped = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let callback = CallbackSender {
+            tx,
+            dropped: dropped.clone(),
+        };
+        let thread = thread::Builder::new()
+            .name("mkmacro-hooks".into())
+            .spawn(move || adapter.run(rx, callback))
+            .expect("spawn hook loop");
+        Self {
+            commands,
+            events: Mutex::new(events),
+            dropped,
+            thread: Mutex::new(Some(thread)),
+        }
+    }
+    pub fn command(&self, command: HookCommand) -> bool {
+        self.commands.send(command).is_ok()
+    }
+    pub fn start(&self) -> bool {
+        self.command(HookCommand::Start)
+    }
+    pub fn pause(&self) -> bool {
+        self.command(HookCommand::Pause)
+    }
+    pub fn resume(&self) -> bool {
+        self.command(HookCommand::Resume)
+    }
+    pub fn stop(&self) -> bool {
+        self.command(HookCommand::Stop)
+    }
+    pub fn try_event(&self) -> Option<HookEvent> {
+        self.events.lock().unwrap().try_recv().ok()
+    }
+    pub fn dropped_events(&self) -> u64 {
+        self.dropped.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    pub fn shutdown(&self) {
+        let _ = self.commands.send(HookCommand::Shutdown);
+        if let Some(t) = self.thread.lock().unwrap().take() {
+            let _ = t.join();
+        }
+    }
+}
+impl Drop for HookService {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+pub fn should_record(event: &HookEvent, record_injected_input: bool) -> bool {
+    event.extra_info() != MKMACRO_EXTRA_INFO && (record_injected_input || !event.is_injected())
+}
+
+/// Portable no-op adapter; the Windows implementation is selected by the application on Windows.
+pub struct NoopHookLoop;
+impl HookLoopAdapter for NoopHookLoop {
+    fn run(self, commands: mpsc::Receiver<HookCommand>, _: CallbackSender) {
+        while let Ok(c) = commands.recv() {
+            if c == HookCommand::Shutdown {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+mod win32 {
+    use super::*;
+    use std::{
+        sync::OnceLock,
+        time::{Duration, Instant},
+    };
+    use windows::Win32::{
+        Foundation::{HINSTANCE, LPARAM, LRESULT, POINT, WPARAM},
+        System::LibraryLoader::GetModuleHandleW,
+        UI::WindowsAndMessaging::*,
+    };
+    static CALLBACK: OnceLock<Mutex<Option<CallbackSender>>> = OnceLock::new();
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    fn now() -> u64 {
+        EPOCH.get_or_init(Instant::now).elapsed().as_micros() as u64
+    }
+    unsafe extern "system" fn keyboard(code: i32, w: WPARAM, l: LPARAM) -> LRESULT {
+        if code >= 0 {
+            let d = &*(l.0 as *const KBDLLHOOKSTRUCT);
+            let transition = if w.0 as u32 == WM_KEYUP || w.0 as u32 == WM_SYSKEYUP {
+                KeyTransition::Up
+            } else {
+                KeyTransition::Down
+            };
+            if let Some(tx) = CALLBACK
+                .get()
+                .and_then(|x| x.lock().ok())
+                .and_then(|x| x.clone())
+            {
+                tx.submit(HookEvent::Key {
+                    timestamp_us: now(),
+                    transition,
+                    vk: d.vkCode,
+                    scan_code: d.scanCode,
+                    flags: d.flags.0,
+                    extra_info: d.dwExtraInfo,
+                });
+            }
+        }
+        CallNextHookEx(None, code, w, l)
+    }
+    unsafe extern "system" fn mouse(code: i32, w: WPARAM, l: LPARAM) -> LRESULT {
+        if code >= 0 {
+            let d = &*(l.0 as *const MSLLHOOKSTRUCT);
+            let hi = ((d.mouseData >> 16) & 0xffff) as u16;
+            let delta = hi as i16 as i32;
+            let message = match w.0 as u32 {
+                WM_MOUSEMOVE => Some(MouseMessage::Move),
+                WM_LBUTTONDOWN => Some(MouseMessage::Down(MouseButton::Left)),
+                WM_LBUTTONUP => Some(MouseMessage::Up(MouseButton::Left)),
+                WM_RBUTTONDOWN => Some(MouseMessage::Down(MouseButton::Right)),
+                WM_RBUTTONUP => Some(MouseMessage::Up(MouseButton::Right)),
+                WM_MBUTTONDOWN => Some(MouseMessage::Down(MouseButton::Middle)),
+                WM_MBUTTONUP => Some(MouseMessage::Up(MouseButton::Middle)),
+                WM_XBUTTONDOWN => Some(MouseMessage::Down(if hi == 1 {
+                    MouseButton::X1
+                } else {
+                    MouseButton::X2
+                })),
+                WM_XBUTTONUP => Some(MouseMessage::Up(if hi == 1 {
+                    MouseButton::X1
+                } else {
+                    MouseButton::X2
+                })),
+                WM_MOUSEWHEEL => Some(MouseMessage::Wheel(delta)),
+                WM_MOUSEHWHEEL => Some(MouseMessage::HorizontalWheel(delta)),
+                _ => None,
+            };
+            if let (Some(message), Some(tx)) = (
+                message,
+                CALLBACK
+                    .get()
+                    .and_then(|x| x.lock().ok())
+                    .and_then(|x| x.clone()),
+            ) {
+                tx.submit(HookEvent::Mouse {
+                    timestamp_us: now(),
+                    message,
+                    x: d.pt.x,
+                    y: d.pt.y,
+                    flags: d.flags.0,
+                    extra_info: d.dwExtraInfo,
+                });
+            }
+        }
+        CallNextHookEx(None, code, w, l)
+    }
+    /// Dedicated low-level-hook thread. Commands are polled beside its Windows message queue;
+    /// shutdown always unhooks both handles before returning and allowing the owner to join.
+    pub struct WindowsHookLoop;
+    impl HookLoopAdapter for WindowsHookLoop {
+        fn run(self, commands: mpsc::Receiver<HookCommand>, callback: CallbackSender) {
+            unsafe {
+                *CALLBACK.get_or_init(|| Mutex::new(None)).lock().unwrap() = Some(callback.clone());
+                let module = GetModuleHandleW(None).ok().map(|x| HINSTANCE(x.0));
+                let mut keyboard_hook = None;
+                let mut mouse_hook = None;
+                let mut enabled = false;
+                'outer: loop {
+                    while let Ok(c) = commands.try_recv() {
+                        match c {
+                            HookCommand::Start => {
+                                if keyboard_hook.is_none() {
+                                    keyboard_hook = SetWindowsHookExW(
+                                        WH_KEYBOARD_LL,
+                                        Some(keyboard),
+                                        module,
+                                        0,
+                                    )
+                                    .ok();
+                                    mouse_hook =
+                                        SetWindowsHookExW(WH_MOUSE_LL, Some(mouse), module, 0).ok();
+                                }
+                                enabled = true
+                            }
+                            HookCommand::Pause | HookCommand::Stop => enabled = false,
+                            HookCommand::Resume => enabled = true,
+                            HookCommand::Shutdown => break 'outer,
+                        }
+                    }
+                    if !enabled {
+                        *CALLBACK.get().unwrap().lock().unwrap() = None;
+                    } // paused callbacks still chain, but do not enqueue
+                    let mut msg = MSG::default();
+                    while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+                        TranslateMessage(&msg);
+                        DispatchMessageW(&msg);
+                    }
+                    std::thread::sleep(Duration::from_millis(2));
+                    if enabled && CALLBACK.get().unwrap().lock().unwrap().is_none() {
+                        *CALLBACK.get().unwrap().lock().unwrap() = Some(callback.clone());
+                    }
+                }
+                *CALLBACK.get().unwrap().lock().unwrap() = None;
+                if let Some(h) = keyboard_hook {
+                    let _ = UnhookWindowsHookEx(h);
+                }
+                if let Some(h) = mouse_hook {
+                    let _ = UnhookWindowsHookEx(h);
+                }
+            }
+        }
+    }
+}
+#[cfg(windows)]
+pub use win32::WindowsHookLoop;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    struct Fake {
+        unhooked: Arc<AtomicUsize>,
+        event: HookEvent,
+    }
+    impl HookLoopAdapter for Fake {
+        fn run(self, rx: mpsc::Receiver<HookCommand>, cb: CallbackSender) {
+            let mut active = false;
+            while let Ok(c) = rx.recv() {
+                match c {
+                    HookCommand::Start => {
+                        active = true;
+                        cb.submit(self.event);
+                        cb.submit(self.event);
+                    }
+                    HookCommand::Stop => active = false,
+                    HookCommand::Shutdown => {
+                        if active {
+                            active = false;
+                        }
+                        self.unhooked.fetch_add(1, Ordering::SeqCst);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            let _ = active;
+        }
+    }
+    fn key(flags: u32, extra_info: usize) -> HookEvent {
+        HookEvent::Key {
+            timestamp_us: 1,
+            transition: KeyTransition::Down,
+            vk: 65,
+            scan_code: 30,
+            flags,
+            extra_info,
+        }
+    }
+    #[test]
+    fn filtering_and_overflow_are_callback_local() {
+        assert!(!should_record(&key(LLKHF_INJECTED, 0), false));
+        assert!(!should_record(&key(0, MKMACRO_EXTRA_INFO), true));
+        let u = Arc::new(AtomicUsize::new(0));
+        let s = HookService::with_adapter(
+            Fake {
+                unhooked: u.clone(),
+                event: key(0, 0),
+            },
+            1,
+        );
+        s.start();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert_eq!(s.dropped_events(), 1);
+        s.shutdown();
+        assert_eq!(u.load(Ordering::SeqCst), 1);
+    }
+    #[test]
+    fn start_stop_are_idempotent_and_shutdown_joins() {
+        let u = Arc::new(AtomicUsize::new(0));
+        let s = HookService::with_adapter(
+            Fake {
+                unhooked: u.clone(),
+                event: key(0, 0),
+            },
+            8,
+        );
+        assert!(s.start());
+        assert!(s.start());
+        assert!(s.stop());
+        assert!(s.stop());
+        s.shutdown();
+        s.shutdown();
+        assert_eq!(u.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/mkmacro/recorder_hooks.rs
+++ b/src/mkmacro/recorder_hooks.rs
@@ -184,7 +184,7 @@ mod win32 {
         time::{Duration, Instant},
     };
     use windows::Win32::{
-        Foundation::{HINSTANCE, LPARAM, LRESULT, POINT, WPARAM},
+        Foundation::{LPARAM, LRESULT, WPARAM},
         System::LibraryLoader::GetModuleHandleW,
         UI::WindowsAndMessaging::*,
     };
@@ -195,7 +195,9 @@ mod win32 {
     }
     unsafe extern "system" fn keyboard(code: i32, w: WPARAM, l: LPARAM) -> LRESULT {
         if code >= 0 {
-            let d = &*(l.0 as *const KBDLLHOOKSTRUCT);
+            // SAFETY: Windows supplies a valid KBDLLHOOKSTRUCT pointer for non-negative
+            // low-level keyboard hook codes, and the value is copied before returning.
+            let d = unsafe { &*(l.0 as *const KBDLLHOOKSTRUCT) };
             let transition = if w.0 as u32 == WM_KEYUP || w.0 as u32 == WM_SYSKEYUP {
                 KeyTransition::Up
             } else {
@@ -216,11 +218,14 @@ mod win32 {
                 });
             }
         }
-        CallNextHookEx(None, code, w, l)
+        // SAFETY: Forward the hook parameters unchanged as required by the hook contract.
+        unsafe { CallNextHookEx(None, code, w, l) }
     }
     unsafe extern "system" fn mouse(code: i32, w: WPARAM, l: LPARAM) -> LRESULT {
         if code >= 0 {
-            let d = &*(l.0 as *const MSLLHOOKSTRUCT);
+            // SAFETY: Windows supplies a valid MSLLHOOKSTRUCT pointer for non-negative
+            // low-level mouse hook codes, and the value is copied before returning.
+            let d = unsafe { &*(l.0 as *const MSLLHOOKSTRUCT) };
             let hi = ((d.mouseData >> 16) & 0xffff) as u16;
             let delta = hi as i16 as i32;
             let message = match w.0 as u32 {
@@ -257,12 +262,13 @@ mod win32 {
                     message,
                     x: d.pt.x,
                     y: d.pt.y,
-                    flags: d.flags.0,
+                    flags: d.flags,
                     extra_info: d.dwExtraInfo,
                 });
             }
         }
-        CallNextHookEx(None, code, w, l)
+        // SAFETY: Forward the hook parameters unchanged as required by the hook contract.
+        unsafe { CallNextHookEx(None, code, w, l) }
     }
     /// Dedicated low-level-hook thread. Commands are polled beside its Windows message queue;
     /// shutdown always unhooks both handles before returning and allowing the owner to join.
@@ -271,7 +277,10 @@ mod win32 {
         fn run(self, commands: mpsc::Receiver<HookCommand>, callback: CallbackSender) {
             unsafe {
                 *CALLBACK.get_or_init(|| Mutex::new(None)).lock().unwrap() = Some(callback.clone());
-                let module = GetModuleHandleW(None).ok().map(|x| HINSTANCE(x.0));
+                // HMODULE implements the windows crate's HINSTANCE parameter conversion.
+                // Passing it directly also avoids wrapping the parameter in Option, which
+                // SetWindowsHookExW does not accept in windows 0.58.
+                let module = GetModuleHandleW(None).unwrap_or_default();
                 let mut keyboard_hook = None;
                 let mut mouse_hook = None;
                 let mut enabled = false;
@@ -302,7 +311,7 @@ mod win32 {
                     } // paused callbacks still chain, but do not enqueue
                     let mut msg = MSG::default();
                     while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
-                        TranslateMessage(&msg);
+                        let _ = TranslateMessage(&msg);
                         DispatchMessageW(&msg);
                     }
                     std::thread::sleep(Duration::from_millis(2));


### PR DESCRIPTION
### Motivation

- Provide a safe, low-overhead Phase C recorder that installs global hooks on a dedicated thread while keeping hook callbacks minimal and nonblocking. 
- Move normalization and semantic conversion out of callbacks into a pure worker component to allow robust coalescing, click/drag recognition, and timestamp-to-delay derivation. 
- Expose a small recorder controller abstraction and one-transaction insertion into the macro draft so recorded data is never saved directly from callbacks. 

### Description

- Add a bounded, nonblocking hook transport and lifecycle service in `src/mkmacro/recorder_hooks.rs` with a `HookLoopAdapter` abstraction and a Windows-specific `WindowsHookLoop` adapter guarded by `#[cfg(windows)]`, monotonic timestamps, overflow accounting, and reliable shutdown/join behavior. 【F:src/mkmacro/recorder_hooks.rs†L1-L20】【F:src/mkmacro/recorder_hooks.rs†L320-L344】
- Implement a pure worker-side normalization pipeline in `src/mkmacro/recorder.rs` that filters injected/internal marker events, removes paused intervals from timing, samples/coalesces movement, compresses down/up pairs into clicks (including multi-click merging), recognizes drags, preserves raw fidelity when needed, and converts timestamps into preceding-step `delay_after_ms`. 【F:src/mkmacro/recorder.rs†L1-L20】【F:src/mkmacro/recorder.rs†L110-L140】
- Provide conversion from normalized recorded events to macro steps (`to_macro_steps`) that allocates fresh IDs at insertion time and uses `MkAction` variants for mouse/keyboard/wheel actions. 【F:src/mkmacro/recorder.rs†L300-L360】
- Add an abstract `RecorderControllerView` and `RecorderController` in `src/gui/mkmacro_dialog/recorder_controller.rs` to host an optional always-on-top controller, expose recorder status snapshots (state, elapsed, raw count, produced steps), and perform a single undoable in-memory insertion into the selected macro draft. 【F:src/gui/mkmacro_dialog/recorder_controller.rs†L1-L20】【F:src/gui/mkmacro_dialog/recorder_controller.rs†L100-L130】
- Wire new modules into `src/mkmacro/mod.rs` and expose them for use by the rest of the mkmacro subsystem; add unit tests that exercise pure-normalization logic and the hook-service behavior via a fake adapter (no real global hooks invoked). 【F:src/mkmacro/mod.rs†L1-L28】【F:src/mkmacro/recorder.rs†L400-L483】

### Testing

- Ran `cargo fmt --all`, which completed successfully. 
- Ran `git diff --check`, which showed no whitespace/merge errors. 
- Built a minimal smoke binary with `rustc /tmp/recorder_smoke.rs` to verify syntax of added modules, which succeeded. 
- Attempted `cargo check --lib` and `cargo test -q mkmacro::recorder --lib`, but full repository build/tests are blocked in this environment by pre-existing non-Windows build-resolution and platform dependency issues (the repo contains many Windows-API-guarded modules and the local toolchain/platform produced unrelated Win32 resolution errors), so recorder unit tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e287ffcf88332b26a9b88be20ce25)