### PR TITLE
Add macro authoring editor workflows

### DIFF
--- a/src/gui/confirmation_modal.rs
+++ b/src/gui/confirmation_modal.rs
@@ -21,6 +21,7 @@ pub enum DestructiveAction {
     ClearBrowserTabCache,
     EmptyRecycleBin,
     ResetWidgetSettings,
+    DeleteMacro,
 }
 
 impl DestructiveAction {
@@ -50,6 +51,7 @@ impl DestructiveAction {
             Self::ClearBrowserTabCache => "Clear browser tab cache",
             Self::EmptyRecycleBin => "Empty recycle bin",
             Self::ResetWidgetSettings => "Reset widget settings",
+            Self::DeleteMacro => "Delete macro",
         }
     }
 

--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -515,7 +515,7 @@ pub fn action_depths(m: &MkMacro) -> Vec<usize> {
     if let Ok(p) = crate::mkmacro::compile(m) {
         return p.instructions.iter().map(|i| i.depth).collect();
     }
-    let mut n = 0;
+    let mut n: usize = 0;
     let mut out = vec![];
     for s in &m.steps {
         if matches!(
@@ -559,32 +559,33 @@ pub fn insert_action(d: &mut MkMacroDialog, action: MkAction) {
         .filter_map(|(i, s)| ids.contains(&s.id).then_some(i))
         .collect();
     let pos = selected.last().map_or(m.steps.len(), |i| i + 1);
-    let structural = match action {
-        MkAction::If(_) => Some((action, MkAction::EndIf)),
-        MkAction::RepeatStart { .. } => Some((action, MkAction::RepeatEnd)),
-        MkAction::WhileStart { .. } => Some((action, MkAction::WhileEnd)),
+    let terminator = match &action {
+        MkAction::If(_) => Some(MkAction::EndIf),
+        MkAction::RepeatStart { .. } => Some(MkAction::RepeatEnd),
+        MkAction::WhileStart { .. } => Some(MkAction::WhileEnd),
         _ => None,
     };
-    let (start, count) = if let Some((a, z)) = structural {
+    let inserted_indices = if let Some(terminator) = terminator {
         if let (Some(first), Some(last)) = (selected.first(), selected.last()) {
             let first = *first;
             let last = *last;
-            m.steps.insert(first, step(a));
-            m.steps.insert(last + 2, step(z));
-            (first, 2)
+            let terminator_index = last + 2;
+            m.steps.insert(first, step(action));
+            m.steps.insert(terminator_index, step(terminator));
+            vec![first, terminator_index]
         } else {
-            m.steps.insert(pos, step(a));
-            m.steps.insert(pos + 1, step(z));
-            (pos, 2)
+            m.steps.insert(pos, step(action));
+            m.steps.insert(pos + 1, step(terminator));
+            vec![pos, pos + 1]
         }
     } else {
         m.steps.insert(pos, step(action));
-        (pos, 1)
+        vec![pos]
     };
     repair_ids(&mut d.draft);
-    let chosen = d.selected_macro().unwrap().steps[start..start + count]
+    let chosen = inserted_indices
         .iter()
-        .map(|s| s.id)
+        .map(|&index| d.selected_macro().unwrap().steps[index].id)
         .collect();
     d.selection.ids = chosen;
     d.mark_dirty()
@@ -603,10 +604,8 @@ pub(super) fn show_modal(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 .max_height(430.0)
                 .show(ui, |ui| {
                     let mut last = None;
-                    for x in descriptors()
-                        .into_iter()
-                        .filter(|x| matches(x, &d.action_search))
-                    {
+                    let query = d.action_search.clone();
+                    for x in descriptors().into_iter().filter(|x| matches(x, &query)) {
                         if last != Some(x.category) {
                             ui.heading(x.category.label());
                             last = Some(x.category)

--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -1,0 +1,622 @@
+use super::MkMacroDialog;
+use crate::mkmacro::variables::{MkPoint, MkValue};
+use crate::mkmacro::*;
+use eframe::egui;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ActionCategory {
+    KeyboardText,
+    Mouse,
+    Timing,
+    Windows,
+    ProgramsLauncher,
+    Logic,
+    Variables,
+    Visual,
+    UiAutomation,
+}
+impl ActionCategory {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::KeyboardText => "Keyboard & Text",
+            Self::Mouse => "Mouse",
+            Self::Timing => "Timing",
+            Self::Windows => "Windows",
+            Self::ProgramsLauncher => "Programs & Launcher",
+            Self::Logic => "Logic",
+            Self::Variables => "Variables",
+            Self::Visual => "Visual",
+            Self::UiAutomation => "UI Automation",
+        }
+    }
+}
+pub struct ActionDescriptor {
+    pub category: ActionCategory,
+    pub name: &'static str,
+    pub description: &'static str,
+    pub keywords: &'static [&'static str],
+    pub make_default: fn() -> MkAction,
+}
+#[derive(Clone, Copy)]
+pub enum StructuralInsertion {
+    If,
+    Repeat,
+    While,
+}
+fn point() -> MkCoordinateTarget {
+    MkCoordinateTarget::Screen {
+        point: MkPoint { x: 0, y: 0 },
+    }
+}
+fn cond() -> MkCondition {
+    MkCondition::All { conditions: vec![] }
+}
+fn wait() -> MkWaitOptions {
+    MkWaitOptions {
+        timeout_ms: 5000,
+        poll_interval_ms: 100,
+    }
+}
+fn matcher() -> MkWindowMatcher {
+    MkWindowMatcher {
+        title: Some(String::new()),
+        title_regex: None,
+        process: None,
+        class: None,
+    }
+}
+fn wp() -> MkWindowPayload {
+    MkWindowPayload {
+        matcher: matcher(),
+        wait: Some(wait()),
+    }
+}
+fn ip() -> MkImagePayload {
+    MkImagePayload {
+        asset_id: 0,
+        wait: wait(),
+        confidence: 0.8,
+    }
+}
+fn up() -> MkUiPayload {
+    MkUiPayload {
+        window: matcher(),
+        selector: MkUiSelector {
+            automation_id: None,
+            name: Some(String::new()),
+            control_type: None,
+            class_name: None,
+            framework_id: None,
+            ancestor_path: vec![],
+        },
+        wait: Some(wait()),
+    }
+}
+macro_rules! d {
+    ($c:ident,$n:literal,$desc:literal,$keys:expr,$a:expr) => {
+        ActionDescriptor {
+            category: ActionCategory::$c,
+            name: $n,
+            description: $desc,
+            keywords: $keys,
+            make_default: || $a,
+        }
+    };
+}
+pub fn descriptors() -> Vec<ActionDescriptor> {
+    vec![
+        d!(
+            KeyboardText,
+            "Key Press",
+            "Press and release a keyboard key",
+            &["keyboard", "send"],
+            MkAction::KeyPress(MkKey::Enter)
+        ),
+        d!(
+            KeyboardText,
+            "Key Down",
+            "Hold a keyboard key",
+            &["keyboard"],
+            MkAction::KeyDown(MkKey::Enter)
+        ),
+        d!(
+            KeyboardText,
+            "Key Up",
+            "Release a keyboard key",
+            &["keyboard"],
+            MkAction::KeyUp(MkKey::Enter)
+        ),
+        d!(
+            KeyboardText,
+            "Hotkey",
+            "Send a key combination",
+            &["keyboard", "send"],
+            MkAction::Hotkey(vec![MkKey::Control, MkKey::Character("C".into())])
+        ),
+        d!(
+            KeyboardText,
+            "Text",
+            "Type or paste text",
+            &["type", "send", "keyboard"],
+            MkAction::Text(MkTextPayload {
+                text: String::new(),
+                mode: MkTextMode::Type
+            })
+        ),
+        d!(
+            Mouse,
+            "Mouse Move",
+            "Move the pointer",
+            &["mouse"],
+            MkAction::MouseMove(point())
+        ),
+        d!(
+            Mouse,
+            "Mouse Click",
+            "Click a mouse button",
+            &["click", "mouse"],
+            MkAction::MouseClick(MkMousePayload {
+                target: point(),
+                button: MkMouseButton::Left,
+                clicks: 1
+            })
+        ),
+        d!(
+            Mouse,
+            "Mouse Down",
+            "Hold a mouse button",
+            &["mouse"],
+            MkAction::MouseDown(MkMouseButton::Left)
+        ),
+        d!(
+            Mouse,
+            "Mouse Up",
+            "Release a mouse button",
+            &["mouse"],
+            MkAction::MouseUp(MkMouseButton::Left)
+        ),
+        d!(
+            Mouse,
+            "Mouse Scroll",
+            "Scroll the mouse wheel",
+            &["mouse"],
+            MkAction::MouseScroll { i32_delta: -120 }
+        ),
+        d!(
+            Timing,
+            "Delay",
+            "Wait for a duration",
+            &["wait"],
+            MkAction::Delay { milliseconds: 1000 }
+        ),
+        d!(
+            Timing,
+            "Wait Until",
+            "Wait for a condition",
+            &["wait", "condition"],
+            MkAction::WaitUntil {
+                condition: cond(),
+                wait: wait()
+            }
+        ),
+        d!(
+            Windows,
+            "Activate Window",
+            "Activate a matching window",
+            &["window"],
+            MkAction::WindowActivate(wp())
+        ),
+        d!(
+            Windows,
+            "Close Window",
+            "Close a matching window",
+            &["window"],
+            MkAction::WindowClose(matcher())
+        ),
+        d!(
+            Windows,
+            "Wait for Window",
+            "Wait for a matching window",
+            &["window", "wait"],
+            MkAction::WindowWait(wp())
+        ),
+        d!(
+            ProgramsLauncher,
+            "Run Program",
+            "Start a program",
+            &["run", "launch"],
+            MkAction::Process(MkProcessPayload {
+                program: String::new(),
+                arguments: vec![],
+                working_directory: None,
+                wait: false
+            })
+        ),
+        d!(
+            ProgramsLauncher,
+            "Launcher Command",
+            "Run a launcher command",
+            &["run", "launch"],
+            MkAction::LauncherCommand {
+                command: String::new(),
+                args: None
+            }
+        ),
+        d!(
+            Variables,
+            "Set Variable",
+            "Store a value",
+            &["variable"],
+            MkAction::SetVariable {
+                name: "value".into(),
+                value: MkValue::Null
+            }
+        ),
+        d!(
+            Variables,
+            "Unset Variable",
+            "Remove a value",
+            &["variable"],
+            MkAction::UnsetVariable {
+                name: "value".into()
+            }
+        ),
+        d!(
+            Logic,
+            "If",
+            "Condition block",
+            &["condition"],
+            MkAction::If(cond())
+        ),
+        d!(
+            Logic,
+            "Else",
+            "Alternate condition branch",
+            &["condition"],
+            MkAction::Else
+        ),
+        d!(
+            Logic,
+            "End If",
+            "End condition block",
+            &["condition"],
+            MkAction::EndIf
+        ),
+        d!(
+            Logic,
+            "Repeat",
+            "Repeat block",
+            &["loop"],
+            MkAction::RepeatStart { count: 2 }
+        ),
+        d!(
+            Logic,
+            "End Repeat",
+            "End repeat block",
+            &["loop"],
+            MkAction::RepeatEnd
+        ),
+        d!(
+            Logic,
+            "While",
+            "Conditional loop",
+            &["loop", "condition"],
+            MkAction::WhileStart { condition: cond() }
+        ),
+        d!(
+            Logic,
+            "End While",
+            "End while loop",
+            &["loop"],
+            MkAction::WhileEnd
+        ),
+        d!(Logic, "Break", "Exit a loop", &["loop"], MkAction::Break),
+        d!(
+            Logic,
+            "Continue",
+            "Continue a loop",
+            &["loop"],
+            MkAction::Continue
+        ),
+        d!(
+            Visual,
+            "Find Image",
+            "Find an image",
+            &["image"],
+            MkAction::ImageFind(ip())
+        ),
+        d!(
+            Visual,
+            "Click Image",
+            "Find and click an image",
+            &["image", "click"],
+            MkAction::ImageClick(ip())
+        ),
+        d!(
+            Visual,
+            "Check Pixel",
+            "Check a pixel color",
+            &["pixel"],
+            MkAction::PixelCheck {
+                target: point(),
+                color: "#000000".into(),
+                tolerance: 0
+            }
+        ),
+        d!(
+            UiAutomation,
+            "Invoke UI Element",
+            "Invoke a UI element",
+            &["uia"],
+            MkAction::UiInvoke(up())
+        ),
+        d!(
+            UiAutomation,
+            "Set UI Value",
+            "Set an element value",
+            &["uia"],
+            MkAction::UiSetValue {
+                target: up(),
+                value: String::new()
+            }
+        ),
+        d!(
+            UiAutomation,
+            "Read UI Value",
+            "Read an element value",
+            &["uia"],
+            MkAction::UiReadValue {
+                target: up(),
+                variable: "value".into()
+            }
+        ),
+        d!(
+            UiAutomation,
+            "Toggle UI Element",
+            "Toggle an element",
+            &["uia"],
+            MkAction::UiToggle(up())
+        ),
+        d!(
+            UiAutomation,
+            "Select UI Element",
+            "Select an element",
+            &["uia"],
+            MkAction::UiSelect(up())
+        ),
+        d!(
+            UiAutomation,
+            "Focus UI Element",
+            "Focus an element",
+            &["uia"],
+            MkAction::UiFocus(up())
+        ),
+        d!(
+            UiAutomation,
+            "Wait for UI Element",
+            "Wait for an element",
+            &["uia", "wait"],
+            MkAction::UiWait(up())
+        ),
+    ]
+}
+pub fn matches(d: &ActionDescriptor, q: &str) -> bool {
+    let q = q.to_lowercase();
+    q.is_empty()
+        || d.name.to_lowercase().contains(&q)
+        || d.description.to_lowercase().contains(&q)
+        || d.category.label().to_lowercase().contains(&q)
+        || d.keywords.iter().any(|k| k.contains(&q))
+}
+pub fn action_name(a: &MkAction) -> &'static str {
+    match a {
+        MkAction::KeyDown(_) => "Key Down",
+        MkAction::KeyUp(_) => "Key Up",
+        MkAction::KeyPress(_) => "Key Press",
+        MkAction::Hotkey(_) => "Hotkey",
+        MkAction::Text(_) => "Text",
+        MkAction::MouseMove(_) => "Mouse Move",
+        MkAction::MouseClick(_) => "Mouse Click",
+        MkAction::MouseDown(_) => "Mouse Down",
+        MkAction::MouseUp(_) => "Mouse Up",
+        MkAction::MouseScroll { .. } => "Mouse Scroll",
+        MkAction::Delay { .. } => "Delay",
+        MkAction::Process(_) => "Run Program",
+        MkAction::LauncherCommand { .. } => "Launcher Command",
+        MkAction::WindowActivate(_) => "Activate Window",
+        MkAction::WindowClose(_) => "Close Window",
+        MkAction::WindowWait(_) => "Wait for Window",
+        MkAction::WaitUntil { .. } => "Wait Until",
+        MkAction::SetVariable { .. } => "Set Variable",
+        MkAction::UnsetVariable { .. } => "Unset Variable",
+        MkAction::If(_) => "If",
+        MkAction::Else => "Else",
+        MkAction::EndIf => "End If",
+        MkAction::RepeatStart { .. } => "Repeat",
+        MkAction::RepeatEnd => "End Repeat",
+        MkAction::WhileStart { .. } => "While",
+        MkAction::WhileEnd => "End While",
+        MkAction::Break => "Break",
+        MkAction::Continue => "Continue",
+        MkAction::ImageFind(_) => "Find Image",
+        MkAction::ImageClick(_) => "Click Image",
+        MkAction::PixelCheck { .. } => "Check Pixel",
+        MkAction::UiInvoke(_) => "Invoke UI Element",
+        MkAction::UiSetValue { .. } => "Set UI Value",
+        MkAction::UiReadValue { .. } => "Read UI Value",
+        MkAction::UiToggle(_) => "Toggle UI Element",
+        MkAction::UiSelect(_) => "Select UI Element",
+        MkAction::UiFocus(_) => "Focus UI Element",
+        MkAction::UiWait(_) => "Wait for UI Element",
+    }
+}
+fn mouse(b: &MkMouseButton) -> &'static str {
+    match b {
+        MkMouseButton::Left => "Left",
+        MkMouseButton::Right => "Right",
+        MkMouseButton::Middle => "Middle",
+        MkMouseButton::X1 => "X1",
+        MkMouseButton::X2 => "X2",
+    }
+}
+pub fn action_details(a: &MkAction) -> String {
+    match a {
+        MkAction::KeyDown(k) | MkAction::KeyUp(k) | MkAction::KeyPress(k) => {
+            super::macro_properties::key_name(k)
+        }
+        MkAction::Hotkey(k) => k
+            .iter()
+            .map(super::macro_properties::key_name)
+            .collect::<Vec<_>>()
+            .join(" + "),
+        MkAction::Text(p) => format!("{} characters", p.text.chars().count()),
+        MkAction::MouseClick(p) => format!("{} click ×{}", mouse(&p.button), p.clicks),
+        MkAction::MouseDown(b) | MkAction::MouseUp(b) => mouse(b).into(),
+        MkAction::MouseScroll { i32_delta } => format!("{i32_delta} wheel units"),
+        MkAction::Delay { milliseconds } => format!("{milliseconds} ms"),
+        MkAction::Process(p) => format!("{} {}", p.program, p.arguments.join(" ")),
+        MkAction::LauncherCommand { command, args } => {
+            format!("{} {}", command, args.as_deref().unwrap_or(""))
+        }
+        MkAction::SetVariable { name, .. } => format!("Set {name}"),
+        MkAction::UnsetVariable { name } => format!("Unset {name}"),
+        MkAction::RepeatStart { count } => format!("{count} times"),
+        MkAction::ImageFind(p) | MkAction::ImageClick(p) => format!(
+            "Image asset {} ({:.0}% confidence)",
+            p.asset_id,
+            p.confidence * 100.0
+        ),
+        MkAction::PixelCheck {
+            color, tolerance, ..
+        } => format!("Color {color}, tolerance {tolerance}"),
+        MkAction::UiSetValue { value, .. } => format!("Value: {value}"),
+        MkAction::UiReadValue { variable, .. } => format!("Store in {variable}"),
+        MkAction::MouseMove(_) => "Target coordinates".into(),
+        MkAction::WindowActivate(p) | MkAction::WindowWait(p) => {
+            format!("Window {}", p.matcher.title.as_deref().unwrap_or("match"))
+        }
+        MkAction::WindowClose(p) => format!("Window {}", p.title.as_deref().unwrap_or("match")),
+        MkAction::WaitUntil { wait, .. } => format!("Timeout {} ms", wait.timeout_ms),
+        MkAction::If(_) | MkAction::WhileStart { .. } => "Condition".into(),
+        MkAction::Else
+        | MkAction::EndIf
+        | MkAction::RepeatEnd
+        | MkAction::WhileEnd
+        | MkAction::Break
+        | MkAction::Continue => String::new(),
+        MkAction::UiInvoke(_)
+        | MkAction::UiToggle(_)
+        | MkAction::UiSelect(_)
+        | MkAction::UiFocus(_)
+        | MkAction::UiWait(_) => "UI Automation target".into(),
+    }
+}
+pub fn action_depths(m: &MkMacro) -> Vec<usize> {
+    if let Ok(p) = crate::mkmacro::compile(m) {
+        return p.instructions.iter().map(|i| i.depth).collect();
+    }
+    let mut n = 0;
+    let mut out = vec![];
+    for s in &m.steps {
+        if matches!(
+            s.action,
+            MkAction::Else | MkAction::EndIf | MkAction::RepeatEnd | MkAction::WhileEnd
+        ) {
+            n = n.saturating_sub(1)
+        }
+        out.push(n);
+        if matches!(
+            s.action,
+            MkAction::If(_)
+                | MkAction::Else
+                | MkAction::RepeatStart { .. }
+                | MkAction::WhileStart { .. }
+        ) {
+            n += 1
+        }
+    }
+    out
+}
+fn step(action: MkAction) -> MkStep {
+    MkStep {
+        id: 0,
+        enabled: true,
+        repeat: 1,
+        delay_after_ms: 0,
+        on_error: Default::default(),
+        action,
+    }
+}
+pub fn insert_action(d: &mut MkMacroDialog, action: MkAction) {
+    let ids = d.selection.ids.clone();
+    let Some(m) = d.selected_macro_mut() else {
+        return;
+    };
+    let selected: Vec<usize> = m
+        .steps
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| ids.contains(&s.id).then_some(i))
+        .collect();
+    let pos = selected.last().map_or(m.steps.len(), |i| i + 1);
+    let structural = match action {
+        MkAction::If(_) => Some((action, MkAction::EndIf)),
+        MkAction::RepeatStart { .. } => Some((action, MkAction::RepeatEnd)),
+        MkAction::WhileStart { .. } => Some((action, MkAction::WhileEnd)),
+        _ => None,
+    };
+    let (start, count) = if let Some((a, z)) = structural {
+        if let (Some(first), Some(last)) = (selected.first(), selected.last()) {
+            let first = *first;
+            let last = *last;
+            m.steps.insert(first, step(a));
+            m.steps.insert(last + 2, step(z));
+            (first, 2)
+        } else {
+            m.steps.insert(pos, step(a));
+            m.steps.insert(pos + 1, step(z));
+            (pos, 2)
+        }
+    } else {
+        m.steps.insert(pos, step(action));
+        (pos, 1)
+    };
+    repair_ids(&mut d.draft);
+    let chosen = d.selected_macro().unwrap().steps[start..start + count]
+        .iter()
+        .map(|s| s.id)
+        .collect();
+    d.selection.ids = chosen;
+    d.mark_dirty()
+}
+pub(super) fn show_modal(ctx: &egui::Context, d: &mut MkMacroDialog) {
+    if !d.action_catalog_visible {
+        return;
+    }
+    let mut open = true;
+    egui::Window::new("Add Action")
+        .open(&mut open)
+        .default_width(520.0)
+        .show(ctx, |ui| {
+            ui.add(egui::TextEdit::singleline(&mut d.action_search).hint_text("Search actions"));
+            egui::ScrollArea::vertical()
+                .max_height(430.0)
+                .show(ui, |ui| {
+                    let mut last = None;
+                    for x in descriptors()
+                        .into_iter()
+                        .filter(|x| matches(x, &d.action_search))
+                    {
+                        if last != Some(x.category) {
+                            ui.heading(x.category.label());
+                            last = Some(x.category)
+                        }
+                        if ui.button(x.name).on_hover_text(x.description).clicked() {
+                            insert_action(d, (x.make_default)());
+                            d.action_catalog_visible = false;
+                        }
+                    }
+                });
+        });
+    d.action_catalog_visible &= open
+}

--- a/src/gui/mkmacro_dialog/macro_list.rs
+++ b/src/gui/mkmacro_dialog/macro_list.rs
@@ -1,15 +1,54 @@
 use super::MkMacroDialog;
+pub const SIDEBAR_WIDTH: f32 = 220.0;
+pub(super) fn show_empty(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
+    ui.vertical_centered(|ui| {
+        ui.heading("Mouse/Keyboard Macros");
+        ui.label("Create reusable keyboard, mouse, window, and automation workflows.");
+        if ui
+            .add_sized([180.0, 36.0], eframe::egui::Button::new("+ Create Macro"))
+            .clicked()
+        {
+            d.create_macro();
+        }
+        ui.add_enabled(false, eframe::egui::Button::new("Record New Macro"))
+            .on_disabled_hover_text("Macro recording integration is coming soon.");
+    });
+}
 pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
     ui.heading("Macros");
-    ui.text_edit_singleline(&mut d.search);
-    for m in &d.draft.macros {
-        if (d.search.is_empty() || m.name.to_lowercase().contains(&d.search.to_lowercase()))
-            && ui
-                .selectable_label(d.selected_macro == Some(m.id), &m.name)
-                .clicked()
-        {
-            d.selected_macro = Some(m.id);
-            d.selection.clear();
+    ui.horizontal(|ui| {
+        if ui.button("New").clicked() {
+            d.create_macro();
         }
+        let selected = d.selected_macro().is_some();
+        if ui
+            .add_enabled(selected, eframe::egui::Button::new("Duplicate"))
+            .clicked()
+        {
+            d.duplicate_selected_macro();
+        }
+        if ui
+            .add_enabled(selected, eframe::egui::Button::new("Delete"))
+            .clicked()
+        {
+            d.request_delete_selected_macro();
+        }
+    });
+    ui.add(eframe::egui::TextEdit::singleline(&mut d.search).hint_text("Search"));
+    let mut clicked = None;
+    eframe::egui::ScrollArea::vertical().show(ui, |ui| {
+        for m in &d.draft.macros {
+            if (d.search.is_empty() || m.name.to_lowercase().contains(&d.search.to_lowercase()))
+                && ui
+                    .selectable_label(d.selected_macro_id == Some(m.id), &m.name)
+                    .clicked()
+            {
+                clicked = Some(m.id);
+            }
+        }
+    });
+    if let Some(id) = clicked {
+        d.selected_macro_id = Some(id);
+        d.selection.clear();
     }
 }

--- a/src/gui/mkmacro_dialog/macro_properties.rs
+++ b/src/gui/mkmacro_dialog/macro_properties.rs
@@ -1,0 +1,187 @@
+use super::MkMacroDialog;
+use crate::mkmacro::{MkHotkey, MkKey};
+use eframe::egui;
+
+pub fn key_name(key: &MkKey) -> String {
+    match key {
+        MkKey::Character(v) => v.to_uppercase(),
+        MkKey::Function(n) => format!("F{n}"),
+        MkKey::PageUp => "Page Up".into(),
+        MkKey::PageDown => "Page Down".into(),
+        MkKey::LeftControl | MkKey::RightControl | MkKey::Control => "Ctrl".into(),
+        MkKey::LeftAlt | MkKey::RightAlt | MkKey::Alt => "Alt".into(),
+        MkKey::LeftShift | MkKey::RightShift | MkKey::Shift => "Shift".into(),
+        MkKey::LeftMeta | MkKey::RightMeta | MkKey::Meta => "Meta".into(),
+        MkKey::Enter => "Enter".into(),
+        MkKey::Tab => "Tab".into(),
+        MkKey::Escape => "Escape".into(),
+        MkKey::Space => "Space".into(),
+        MkKey::Backspace => "Backspace".into(),
+        MkKey::Delete => "Delete".into(),
+        MkKey::Up => "Up".into(),
+        MkKey::Down => "Down".into(),
+        MkKey::Left => "Left".into(),
+        MkKey::Right => "Right".into(),
+        MkKey::Home => "Home".into(),
+        MkKey::End => "End".into(),
+    }
+}
+pub fn hotkey_name(h: &MkHotkey) -> String {
+    h.modifiers
+        .iter()
+        .chain(std::iter::once(&h.key))
+        .map(key_name)
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+fn egui_key(k: egui::Key) -> Option<MkKey> {
+    use egui::Key::*;
+    Some(match k {
+        Enter => MkKey::Enter,
+        Tab => MkKey::Tab,
+        Space => MkKey::Space,
+        ArrowUp => MkKey::Up,
+        ArrowDown => MkKey::Down,
+        ArrowLeft => MkKey::Left,
+        ArrowRight => MkKey::Right,
+        Home => MkKey::Home,
+        End => MkKey::End,
+        PageUp => MkKey::PageUp,
+        PageDown => MkKey::PageDown,
+        F1 => MkKey::Function(1),
+        F2 => MkKey::Function(2),
+        F3 => MkKey::Function(3),
+        F4 => MkKey::Function(4),
+        F5 => MkKey::Function(5),
+        F6 => MkKey::Function(6),
+        F7 => MkKey::Function(7),
+        F8 => MkKey::Function(8),
+        F9 => MkKey::Function(9),
+        F10 => MkKey::Function(10),
+        F11 => MkKey::Function(11),
+        F12 => MkKey::Function(12),
+        _ => return None,
+    })
+}
+pub(super) fn show(ui: &mut egui::Ui, d: &mut MkMacroDialog) {
+    let capturing = d.hotkey_capture;
+    let mut changed = false;
+    let mut capture = None;
+    let mut clear = false;
+    let Some(m) = d.selected_macro_mut() else {
+        ui.label("Select a macro");
+        return;
+    };
+    ui.heading("Macro Properties");
+    changed |= ui.text_edit_singleline(&mut m.name).changed();
+    changed |= ui
+        .add(
+            egui::TextEdit::multiline(&mut m.description)
+                .desired_rows(2)
+                .hint_text("Description"),
+        )
+        .changed();
+    changed |= ui.checkbox(&mut m.enabled, "Enabled").changed();
+    ui.horizontal(|ui| {
+        ui.label("Hotkey:");
+        let label = m
+            .hotkey
+            .as_ref()
+            .map(hotkey_name)
+            .unwrap_or_else(|| "None".into());
+        if ui
+            .button(if capturing { "Press a key…" } else { &label })
+            .clicked()
+        {
+            capture = Some(true);
+        }
+        if m.hotkey.is_some() && ui.small_button("Clear").clicked() {
+            clear = true;
+        }
+    });
+    egui::CollapsingHeader::new("Playback Settings").show(ui, |ui| {
+        changed |= ui
+            .add(egui::Slider::new(&mut m.playback.speed_percent, 1..=1000).text("Speed %"))
+            .changed();
+        changed |= ui
+            .add(
+                egui::DragValue::new(&mut m.playback.random_delay_ms)
+                    .clamp_range(0..=60_000)
+                    .suffix(" ms random delay"),
+            )
+            .changed();
+        changed |= ui
+            .add(
+                egui::DragValue::new(&mut m.playback.random_offset_px)
+                    .clamp_range(0..=10_000)
+                    .suffix(" px random offset"),
+            )
+            .changed();
+    });
+    if clear {
+        m.hotkey = None;
+        changed = true;
+    }
+    let _ = m;
+    if capture == Some(true) {
+        d.hotkey_capture = true;
+    }
+    if capturing {
+        let events = ui.input(|i| i.events.clone());
+        for event in events {
+            if let egui::Event::Key {
+                key,
+                pressed: true,
+                modifiers,
+                ..
+            } = event
+            {
+                if key == egui::Key::Escape {
+                    d.hotkey_capture = false;
+                    break;
+                }
+                if matches!(key, egui::Key::Backspace | egui::Key::Delete) {
+                    if let Some(m) = d.selected_macro_mut() {
+                        m.hotkey = None;
+                    }
+                    changed = true;
+                    d.hotkey_capture = false;
+                    break;
+                }
+                if let Some(key) = egui_key(key) {
+                    let mut mods = vec![];
+                    if modifiers.ctrl {
+                        mods.push(MkKey::Control)
+                    }
+                    if modifiers.shift {
+                        mods.push(MkKey::Shift)
+                    }
+                    if modifiers.alt {
+                        mods.push(MkKey::Alt)
+                    }
+                    if modifiers.mac_cmd {
+                        mods.push(MkKey::Meta)
+                    }
+                    if let Some(m) = d.selected_macro_mut() {
+                        m.hotkey = Some(MkHotkey {
+                            key,
+                            modifiers: mods,
+                        });
+                    }
+                    changed = true;
+                    d.hotkey_capture = false;
+                    break;
+                }
+            }
+        }
+    }
+    if let Some(w) = crate::mkmacro::hotkeys::validate_hotkeys(&d.draft, &[])
+        .into_iter()
+        .find(|x| Some(x.macro_id) == d.selected_macro_id)
+    {
+        ui.colored_label(egui::Color32::YELLOW, w.message);
+    }
+    if changed {
+        d.mark_dirty();
+    }
+}

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1,13 +1,16 @@
+pub mod action_catalog;
 mod action_editor;
 pub mod image_search_editor;
 mod macro_list;
+mod macro_properties;
 pub mod recorder_controller;
 mod step_table;
 mod toolbar;
 pub mod uia_editor;
 
+use crate::gui::confirmation_modal::{ConfirmationModal, ConfirmationResult, DestructiveAction};
 use crate::mkmacro::{
-    DiagnosticSeverity, MkMacroDocument, MkMacroStore, repair_ids, validate_document,
+    DiagnosticSeverity, MkMacro, MkMacroDocument, MkMacroStore, repair_ids, validate_document,
 };
 use std::sync::Arc;
 pub use step_table::{Selection, duplicate_steps, move_steps};
@@ -19,10 +22,82 @@ pub struct MkMacroDialog {
     baseline: Arc<MkMacroDocument>,
     pub dirty: bool,
     pub conflict: bool,
-    pub selected_macro: Option<u64>,
+    pub selected_macro_id: Option<u64>,
     pub selection: Selection,
     pub search: String,
+    pub delete_confirmation: ConfirmationModal,
+    pub hotkey_capture: bool,
+    pub action_catalog_visible: bool,
+    pub action_search: String,
+    pub structural_insertion: Option<action_catalog::StructuralInsertion>,
     pub uia_editor: uia_editor::UiaEditorState,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mkmacro::{MkAction, MkHotkey, MkKey, MkStep};
+    fn dialog() -> (tempfile::TempDir, MkMacroDialog) {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        (dir, MkMacroDialog::new(Arc::new(store)))
+    }
+    #[test]
+    fn create_duplicate_and_delete_are_draft_only() {
+        let (_dir, mut d) = dialog();
+        let baseline = d.store.snapshot();
+        d.create_macro();
+        let first = d.selected_macro_id.unwrap();
+        assert_ne!(first, 0);
+        d.selected_macro_mut().unwrap().hotkey = Some(MkHotkey {
+            key: MkKey::Function(8),
+            modifiers: vec![MkKey::Control],
+        });
+        d.selected_macro_mut().unwrap().steps.push(MkStep {
+            id: 0,
+            enabled: true,
+            repeat: 1,
+            delay_after_ms: 0,
+            on_error: Default::default(),
+            action: MkAction::Delay { milliseconds: 1 },
+        });
+        repair_ids(&mut d.draft);
+        d.duplicate_selected_macro();
+        let copy = d.selected_macro().unwrap();
+        assert_ne!(copy.id, first);
+        assert!(copy.hotkey.is_none());
+        assert_eq!(copy.name, "New Macro Copy");
+        assert!(copy.steps.iter().all(|s| s.id != 0));
+        d.delete_selected_macro();
+        assert_eq!(d.selected_macro_id, Some(first));
+        assert!(d.dirty);
+        assert!(Arc::ptr_eq(&baseline, &d.store.snapshot()));
+    }
+    #[test]
+    fn catalog_search_and_structures() {
+        let (_dir, mut d) = dialog();
+        d.create_macro();
+        assert!(
+            action_catalog::descriptors()
+                .iter()
+                .any(|x| action_catalog::matches(x, "launch"))
+        );
+        action_catalog::insert_action(
+            &mut d,
+            MkAction::If(crate::mkmacro::MkCondition::All { conditions: vec![] }),
+        );
+        assert!(crate::mkmacro::compile(d.selected_macro().unwrap()).is_ok());
+        action_catalog::insert_action(&mut d, MkAction::RepeatStart { count: 2 });
+        assert!(crate::mkmacro::compile(d.selected_macro().unwrap()).is_ok());
+    }
+    #[test]
+    fn names_and_details_cover_catalog() {
+        for x in action_catalog::descriptors() {
+            let a = (x.make_default)();
+            assert!(!action_catalog::action_name(&a).is_empty());
+            let _ = action_catalog::action_details(&a);
+        }
+    }
 }
 impl MkMacroDialog {
     pub fn new(store: Arc<MkMacroStore>) -> Self {
@@ -34,9 +109,14 @@ impl MkMacroDialog {
             store,
             dirty: false,
             conflict: false,
-            selected_macro: None,
+            selected_macro_id: None,
             selection: Default::default(),
             search: String::new(),
+            delete_confirmation: Default::default(),
+            hotkey_capture: false,
+            action_catalog_visible: false,
+            action_search: String::new(),
+            structural_insertion: None,
             uia_editor: Default::default(),
         }
     }
@@ -62,6 +142,71 @@ impl MkMacroDialog {
         self.conflict = false;
         Ok(())
     }
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+    pub fn selected_macro(&self) -> Option<&MkMacro> {
+        let id = self.selected_macro_id?;
+        self.draft.macros.iter().find(|m| m.id == id)
+    }
+    pub fn selected_macro_mut(&mut self) -> Option<&mut MkMacro> {
+        let id = self.selected_macro_id?;
+        self.draft.macros.iter_mut().find(|m| m.id == id)
+    }
+    pub fn create_macro(&mut self) {
+        self.draft.macros.push(MkMacro {
+            id: 0,
+            name: "New Macro".into(),
+            description: String::new(),
+            enabled: true,
+            hotkey: None,
+            playback: Default::default(),
+            steps: vec![],
+        });
+        repair_ids(&mut self.draft);
+        self.selected_macro_id = self.draft.macros.last().map(|m| m.id);
+        self.selection.clear();
+        self.mark_dirty();
+    }
+    pub fn duplicate_selected_macro(&mut self) {
+        let Some(mut copy) = self.selected_macro().cloned() else {
+            return;
+        };
+        copy.id = 0;
+        copy.name.push_str(" Copy");
+        copy.hotkey = None;
+        for step in &mut copy.steps {
+            step.id = 0;
+        }
+        self.draft.macros.push(copy);
+        repair_ids(&mut self.draft);
+        self.selected_macro_id = self.draft.macros.last().map(|m| m.id);
+        self.selection.clear();
+        self.mark_dirty();
+    }
+    pub fn request_delete_selected_macro(&mut self) {
+        if self.selected_macro().is_some() {
+            self.delete_confirmation
+                .open_for(DestructiveAction::DeleteMacro);
+        }
+    }
+    pub fn delete_selected_macro(&mut self) {
+        let Some(id) = self.selected_macro_id else {
+            return;
+        };
+        let Some(index) = self.draft.macros.iter().position(|m| m.id == id) else {
+            return;
+        };
+        self.draft.macros.remove(index);
+        self.selected_macro_id = self
+            .draft
+            .macros
+            .get(index)
+            .or_else(|| index.checked_sub(1).and_then(|i| self.draft.macros.get(i)))
+            .map(|m| m.id);
+        self.selection.clear();
+        self.mark_dirty();
+    }
     pub fn playback_block_reason(&self) -> Option<String> {
         let d = validate_document(&self.draft, None);
         d.iter()
@@ -80,16 +225,34 @@ impl MkMacroDialog {
             .min_size([680.0, 420.0])
             .resizable(true)
             .show(ctx, |ui| {
-                toolbar::show(ui, self);
-                ui.columns(2, |cols| {
-                    macro_list::show(&mut cols[0], self);
-                    step_table::show(&mut cols[1], self);
-                });
-                if !self.uia_editor.editor_hidden() {
-                    action_editor::show(ui, self);
-                }
-                uia_editor::show(ui, &mut self.uia_editor);
+                self.show_contents(ui);
             });
         self.open = open;
+    }
+    pub fn show_contents(&mut self, ui: &mut eframe::egui::Ui) {
+        toolbar::show(ui, self);
+        if self.draft.macros.is_empty() {
+            macro_list::show_empty(ui, self);
+        } else {
+            egui_extras::StripBuilder::new(ui)
+                .size(egui_extras::Size::exact(macro_list::SIDEBAR_WIDTH))
+                .size(egui_extras::Size::remainder())
+                .horizontal(|mut strip| {
+                    strip.cell(|ui| macro_list::show(ui, self));
+                    strip.cell(|ui| {
+                        macro_properties::show(ui, self);
+                        ui.separator();
+                        step_table::show(ui, self);
+                    });
+                });
+        }
+        action_catalog::show_modal(ui.ctx(), self);
+        if !self.uia_editor.editor_hidden() {
+            action_editor::show(ui, self);
+        }
+        uia_editor::show(ui, &mut self.uia_editor);
+        if self.delete_confirmation.ui(ui.ctx()) == ConfirmationResult::Confirmed {
+            self.delete_selected_macro();
+        }
     }
 }

--- a/src/gui/mkmacro_dialog/step_table.rs
+++ b/src/gui/mkmacro_dialog/step_table.rs
@@ -75,16 +75,20 @@ pub fn move_steps(steps: &mut [MkStep], ids: &BTreeSet<u64>, down: bool) {
     }
 }
 pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
-    let Some(mid) = d.selected_macro else {
+    let Some(mid) = d.selected_macro_id else {
         ui.label("Select a macro");
         return;
     };
     let diagnostics = validate_document(&d.draft, None);
     let runtime = crate::mkmacro::runtime::snapshot();
-    let Some(m) = d.draft.macros.iter_mut().find(|m| m.id == mid) else {
+    let Some(m) = d.draft.macros.iter().find(|m| m.id == mid) else {
         return;
     };
     let rows: Vec<u64> = m.steps.iter().map(|s| s.id).collect();
+    let depths = super::action_catalog::action_depths(m);
+    let mut clicked = None;
+    let mut changed = false;
+    let mut updates = Vec::new();
     egui_extras::TableBuilder::new(ui)
         .striped(true)
         .column(egui_extras::Column::exact(28.0))
@@ -104,7 +108,8 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
             }
         })
         .body(|mut body| {
-            for (i, s) in m.steps.iter_mut().enumerate() {
+            for (i, source) in m.steps.iter().enumerate() {
+                let mut s = source.clone();
                 body.row(22.0, |mut r| {
                     r.col(|ui| {
                         if ui
@@ -112,27 +117,28 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
                             .clicked()
                         {
                             let mods = ui.input(|x| x.modifiers);
-                            d.selection.click(&rows, i, mods.ctrl, mods.shift);
+                            clicked = Some((i, mods.ctrl, mods.shift));
                         }
                     });
                     r.col(|ui| {
-                        ui.add_enabled(
+                        changed |= ui.add_enabled(
                             s.action.can_be_disabled(),
                             eframe::egui::Checkbox::without_text(&mut s.enabled),
-                        );
+                        ).changed();
                     });
                     r.col(|ui| {
-                        ui.label(format!("{:?}", s.action));
+                        let structural = matches!(s.action, crate::mkmacro::MkAction::Else|crate::mkmacro::MkAction::EndIf|crate::mkmacro::MkAction::RepeatEnd|crate::mkmacro::MkAction::WhileEnd);
+                        let label = format!("{}{}", "  ".repeat(depths[i]), super::action_catalog::action_name(&s.action));
+                        if structural { ui.strong(label); } else { ui.label(label); }
                     });
                     r.col(|ui| {
-                        ui.label(format!("{:?}", s.action))
-                            .on_hover_text(format!("{:?}", s.action));
+                        let full=super::action_catalog::action_details(&s.action); let short=if full.chars().count()>80 {format!("{}…",full.chars().take(80).collect::<String>())}else{full.clone()}; ui.label(short).on_hover_text(full);
                     });
                     r.col(|ui| {
-                        ui.add(eframe::egui::DragValue::new(&mut s.repeat));
+                        changed |= ui.add(eframe::egui::DragValue::new(&mut s.repeat).clamp_range(1..=1_000_000)).changed();
                     });
                     r.col(|ui| {
-                        ui.add(eframe::egui::DragValue::new(&mut s.delay_after_ms));
+                        changed |= ui.add(eframe::egui::DragValue::new(&mut s.delay_after_ms).clamp_range(0..=86_400_000)).changed();
                     });
                     r.col(|ui| {
                         if let Some(state) = runtime.as_ref().and_then(|run| {
@@ -163,6 +169,22 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
                         }
                     });
                 });
+                updates.push((s.id,s.enabled,s.repeat,s.delay_after_ms));
             }
         });
+    if let Some((i, ctrl, shift)) = clicked {
+        d.selection.click(&rows, i, ctrl, shift);
+    }
+    if changed {
+        if let Some(m) = d.selected_macro_mut() {
+            for (id, en, repeat, delay) in updates {
+                if let Some(s) = m.steps.iter_mut().find(|s| s.id == id) {
+                    s.enabled = en;
+                    s.repeat = repeat;
+                    s.delay_after_ms = delay;
+                }
+            }
+        }
+        d.mark_dirty();
+    }
 }

--- a/src/gui/mkmacro_dialog/toolbar.rs
+++ b/src/gui/mkmacro_dialog/toolbar.rs
@@ -4,6 +4,15 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, dialog: &mut MkMacroDialog) {
         if ui.button("Save").clicked() {
             let _ = dialog.save();
         }
+        if ui
+            .add_enabled(
+                dialog.selected_macro().is_some(),
+                eframe::egui::Button::new("+ Action"),
+            )
+            .clicked()
+        {
+            dialog.action_catalog_visible = true;
+        }
         if let Some(reason) = dialog.playback_block_reason() {
             ui.add_enabled(false, eframe::egui::Button::new("Run"))
                 .on_disabled_hover_text(reason);


### PR DESCRIPTION
### Motivation

- Provide an explicit, testable editor API and state for Mouse/Keyboard macro authoring so widgets no longer mutate `draft` directly and baseline/draft/save semantics remain intact.
- Surface a focused authoring UX with a bounded sidebar, properties panel, and an action catalog so users can create, duplicate, edit, and compose macro steps reliably.
- Improve presentation and safety of step edits by avoiding overlapping mutable borrows and introducing human-friendly action names/details and hotkey UX.

### Description

- Added editor state and mutation APIs to `MkMacroDialog` including `create_macro`, `duplicate_selected_macro`, `request_delete_selected_macro`, `delete_selected_macro`, `selected_macro`, `selected_macro_mut`, and `mark_dirty`, plus transient state for delete confirmation, hotkey capture, action-catalog visibility/search, and structural insertion. (`src/gui/mkmacro_dialog/mod.rs`).
- Extracted UI rendering into `MkMacroDialog::show_contents` and replaced the old `ui.columns` layout with `egui_extras::StripBuilder` using a named sidebar width (`macro_list::SIDEBAR_WIDTH`) to host the macro list and the remainder workspace for properties and the step table. (`src/gui/mkmacro_dialog/mod.rs`, `src/gui/mkmacro_dialog/macro_list.rs`).
- Implemented the empty sidebar state with `+ Create Macro` and a disabled `Record New Macro` affordance, plus sidebar toolbar buttons for New/Duplicate/Delete and case-insensitive Search. (`src/gui/mkmacro_dialog/macro_list.rs`).
- Added a compact macro properties panel in `src/gui/mkmacro_dialog/macro_properties.rs` that binds Name, multiline Description, Enabled, Hotkey capture/clear, and a collapsed Playback Settings section to the selected draft macro, with a human-friendly key formatter and inline hotkey validation.
- Created `src/gui/mkmacro_dialog/action_catalog.rs` which defines `ActionCategory`, `ActionDescriptor`, a catalog of descriptors with safe default constructors, the `matches` search helper, `action_name`/`action_details` presentation helpers, a depth calculation fallback, and `insert_action` logic for ordinary and structural action insertion/wrapping.
- Implemented a searchable Add Action modal opened from the toolbar `+ Action` button that filters descriptors and inserts actions (including If/Repeat/While pairs or wrapping of selected ranges), runs `repair_ids`, selects inserted rows, and marks the draft dirty. (`src/gui/mkmacro_dialog/action_catalog.rs`, `src/gui/mkmacro_dialog/toolbar.rs`).
- Reworked the step table to avoid overlapping mutable borrows by cloning row data for UI, collecting edits to apply after the borrow ends, showing user-facing `action_name`/`action_details` (with truncation + hover text), visually indenting structural rows with compiler-derived depth fallback, and only marking dirty on real changes. (`src/gui/mkmacro_dialog/step_table.rs`).
- Small change to `confirmation_modal` to include a `DeleteMacro` destructive action so the dialog is reused for deletion confirmation. (`src/gui/confirmation_modal.rs`).
- Added focused unit tests (in-module) that exercise creation/duplication/deletion behavior, verify catalog search and structural insertion compile via the existing compiler, and exercise `action_name`/`action_details` coverage. (`src/gui/mkmacro_dialog/mod.rs` tests). All edits keep the baseline/draft/save semantics (no automatic persistence or asset deletion).

### Testing

- Ran `cargo fmt --all` and `git diff --check` (both succeeded) and committed the changes as `Add macro authoring editor workflows`.
- Attempted `cargo check`: the build progressed but ultimately failed on this Linux CI host due to platform-specific Windows API references (`windows::Win32` symbols) in the repository; installing missing native dev packages (ALSA/X11) addressed earlier native build failures but did not eliminate existing Windows-only platform compilation errors, so a full `cargo check` success is blocked by platform-specific code paths.
- Added unit tests alongside pure helpers; the tests were added to the repo but were not executed to completion because `cargo check`/`cargo test` cannot finish on this non-Windows environment due to platform bindings.  The tests exercise: `create_macro`/`duplicate_selected_macro`/`delete_selected_macro` draft semantics, catalog search/insertion/structural compilation, and presentation helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f9999e9048332ba4f42e553645563)