### PR TITLE
Wire production macro runtime and editor controls

### DIFF
--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -33,6 +33,7 @@ pub struct MkMacroDialog {
     pub uia_editor: uia_editor::UiaEditorState,
     pub action_editor: action_editor::ActionEditorState,
     pub quick_insert: action_editor::QuickInsertState,
+    pub command_error: Option<String>,
 }
 
 #[cfg(test)]
@@ -125,6 +126,7 @@ impl MkMacroDialog {
                 repeat: 1,
                 ..Default::default()
             },
+            command_error: None,
         }
     }
     pub fn open(&mut self) {
@@ -215,10 +217,85 @@ impl MkMacroDialog {
         self.mark_dirty();
     }
     pub fn playback_block_reason(&self) -> Option<String> {
+        let Some(m) = self.selected_macro() else {
+            return Some("Select a macro".into());
+        };
+        if !m.enabled {
+            return Some("The selected macro is disabled".into());
+        }
+        if crate::mkmacro::runtime::snapshot().is_some_and(|s| {
+            matches!(
+                s.state,
+                crate::mkmacro::RuntimeState::Running
+                    | crate::mkmacro::RuntimeState::Paused
+                    | crate::mkmacro::RuntimeState::Stopping
+            )
+        }) {
+            return Some("Another playback operation is active".into());
+        }
         let d = validate_document(&self.draft, None);
         d.iter()
             .find(|x| x.severity == DiagnosticSeverity::Fatal)
             .map(|x| x.message.clone())
+    }
+
+    fn prepare_execution(&mut self) -> anyhow::Result<u64> {
+        if self.dirty {
+            self.save()?;
+        }
+        self.selected_macro_id
+            .ok_or_else(|| anyhow::anyhow!("Select a macro"))
+    }
+    pub fn run_selected_macro(&mut self) -> anyhow::Result<()> {
+        if let Some(reason) = self.playback_block_reason() {
+            anyhow::bail!(reason);
+        }
+        let id = self.prepare_execution()?;
+        crate::mkmacro::runtime::run(id)
+    }
+    pub fn run_from_step(&mut self, original_step_id: u64) -> anyhow::Result<()> {
+        if let Some(reason) = self.playback_block_reason() {
+            anyhow::bail!(reason);
+        }
+        let index = self
+            .selected_macro()
+            .and_then(|m| m.steps.iter().position(|s| s.id == original_step_id))
+            .ok_or_else(|| anyhow::anyhow!("Selected step no longer exists"))?;
+        let id = self.prepare_execution()?;
+        let step = self
+            .selected_macro()
+            .and_then(|m| m.steps.get(index))
+            .ok_or_else(|| anyhow::anyhow!("Selected step no longer exists after save"))?
+            .id;
+        crate::mkmacro::runtime::run_from(id, step)
+    }
+    pub fn run_selected_steps(&mut self) -> anyhow::Result<()> {
+        if let Some(reason) = self.playback_block_reason() {
+            anyhow::bail!(reason);
+        }
+        let positions: Vec<usize> = self
+            .selected_macro()
+            .map(|m| {
+                m.steps
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, s)| self.selection.ids.contains(&s.id).then_some(i))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if positions.is_empty() {
+            anyhow::bail!("Select one or more steps");
+        }
+        let id = self.prepare_execution()?;
+        let ids = positions
+            .into_iter()
+            .filter_map(|i| {
+                self.selected_macro()
+                    .and_then(|m| m.steps.get(i))
+                    .map(|s| s.id)
+            })
+            .collect();
+        crate::mkmacro::runtime::run_selection(id, ids)
     }
     pub fn ui(&mut self, ctx: &eframe::egui::Context) {
         self.sync_external();

--- a/src/gui/mkmacro_dialog/step_table.rs
+++ b/src/gui/mkmacro_dialog/step_table.rs
@@ -185,14 +185,14 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
                         if let Some(state) = runtime.as_ref().and_then(|run| {
                             (run.macro_id == Some(mid)).then(|| run.steps.get(&s.id)).flatten()
                         }) {
-                            let (label, color) = match state {
-                                crate::mkmacro::StepState::Pending => ("pending", eframe::egui::Color32::GRAY),
-                                crate::mkmacro::StepState::Running => ("running", eframe::egui::Color32::YELLOW),
-                                crate::mkmacro::StepState::Success => ("success", eframe::egui::Color32::GREEN),
-                                crate::mkmacro::StepState::Skipped => ("skipped", eframe::egui::Color32::GRAY),
-                                crate::mkmacro::StepState::Failed => ("failed", eframe::egui::Color32::RED),
+                            let (label, full, color) = match state {
+                                crate::mkmacro::StepState::Pending => ("○", "Pending", eframe::egui::Color32::GRAY),
+                                crate::mkmacro::StepState::Running => ("▶", "Running", eframe::egui::Color32::YELLOW),
+                                crate::mkmacro::StepState::Success => ("✓", "Success", eframe::egui::Color32::GREEN),
+                                crate::mkmacro::StepState::Skipped => ("–", "Skipped", eframe::egui::Color32::GRAY),
+                                crate::mkmacro::StepState::Failed => ("✕", "Failed", eframe::egui::Color32::RED),
                             };
-                            let response = ui.colored_label(color, label);
+                            let response = ui.colored_label(color, label).on_hover_text(full);
                             if let Some(run) = runtime.as_ref()
                                 && let Some(failure) = run.failures.get(&crate::mkmacro::DiagnosticKey { run_id: run.run_id, step_id: s.id })
                             {
@@ -283,8 +283,16 @@ fn apply_command(d: &mut MkMacroDialog, c: Command) {
         return;
     }
     if matches!(c, Command::RunOne | Command::RunFrom) {
+        let result = match (c, d.selection.ids.iter().next().copied()) {
+            (Command::RunOne, _) => d.run_selected_steps(),
+            (Command::RunFrom, Some(id)) => d.run_from_step(id),
+            _ => Err(anyhow::anyhow!("Select a step")),
+        };
+        if let Err(e) = result {
+            d.command_error = Some(e.to_string());
+        }
         return;
-    } // runtime commands are intentionally draft-only unsupported until a compiled slice API exists.
+    }
     let ids = d.selection.ids.clone();
     let unsafe_structure = d.selected_macro().is_some_and(|m| {
         m.steps

--- a/src/gui/mkmacro_dialog/toolbar.rs
+++ b/src/gui/mkmacro_dialog/toolbar.rs
@@ -1,8 +1,57 @@
 use super::MkMacroDialog;
+use crate::mkmacro::RuntimeState;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolbarState {
+    pub run: bool,
+    pub pause: bool,
+    pub resume: bool,
+    pub stop: bool,
+    pub run_from: bool,
+    pub run_selected: bool,
+    pub disabled_reason: Option<String>,
+}
+pub fn decide(
+    runtime: RuntimeState,
+    disabled_reason: Option<String>,
+    selected_rows: usize,
+) -> ToolbarState {
+    let idle = !matches!(
+        runtime,
+        RuntimeState::Running | RuntimeState::Paused | RuntimeState::Stopping
+    );
+    let run = idle && disabled_reason.is_none();
+    ToolbarState {
+        run,
+        pause: runtime == RuntimeState::Running,
+        resume: runtime == RuntimeState::Paused,
+        stop: matches!(runtime, RuntimeState::Running | RuntimeState::Paused),
+        run_from: run && selected_rows == 1,
+        run_selected: run && selected_rows != 0,
+        disabled_reason,
+    }
+}
+pub fn state(dialog: &MkMacroDialog) -> ToolbarState {
+    let runtime = crate::mkmacro::runtime::snapshot()
+        .map(|s| s.state)
+        .unwrap_or(RuntimeState::Idle);
+    decide(
+        runtime,
+        dialog.playback_block_reason(),
+        dialog.selection.ids.len(),
+    )
+}
+fn report(dialog: &mut MkMacroDialog, result: anyhow::Result<()>) {
+    if let Err(e) = result {
+        dialog.command_error = Some(e.to_string());
+    }
+}
 pub(super) fn show(ui: &mut eframe::egui::Ui, dialog: &mut MkMacroDialog) {
+    let state = state(dialog);
     ui.horizontal(|ui| {
         if ui.button("Save").clicked() {
-            let _ = dialog.save();
+            let result = dialog.save();
+            report(dialog, result);
         }
         if ui
             .add_enabled(
@@ -13,11 +62,54 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, dialog: &mut MkMacroDialog) {
         {
             dialog.action_catalog_visible = true;
         }
-        if let Some(reason) = dialog.playback_block_reason() {
+        if !state.run {
             ui.add_enabled(false, eframe::egui::Button::new("Run"))
-                .on_disabled_hover_text(reason);
-        } else {
-            let _ = ui.button("Run");
+                .on_disabled_hover_text(
+                    state
+                        .disabled_reason
+                        .clone()
+                        .unwrap_or_else(|| "Playback is active".into()),
+                );
+        } else if ui.button("Run").clicked() {
+            let result = dialog.run_selected_macro();
+            report(dialog, result);
+        }
+        if ui
+            .add_enabled(state.pause, eframe::egui::Button::new("Pause"))
+            .clicked()
+        {
+            report(dialog, crate::mkmacro::runtime::pause());
+        }
+        if ui
+            .add_enabled(state.resume, eframe::egui::Button::new("Resume"))
+            .clicked()
+        {
+            report(dialog, crate::mkmacro::runtime::resume());
+        }
+        if ui
+            .add_enabled(state.stop, eframe::egui::Button::new("Stop"))
+            .clicked()
+        {
+            report(dialog, crate::mkmacro::runtime::stop());
+        }
+        if ui
+            .add_enabled(state.run_from, eframe::egui::Button::new("Run From Here"))
+            .clicked()
+        {
+            if let Some(id) = dialog.selection.ids.iter().next().copied() {
+                let result = dialog.run_from_step(id);
+                report(dialog, result)
+            }
+        }
+        if ui
+            .add_enabled(
+                state.run_selected,
+                eframe::egui::Button::new("Run Selected"),
+            )
+            .clicked()
+        {
+            let result = dialog.run_selected_steps();
+            report(dialog, result);
         }
         if dialog.dirty {
             ui.label("Unsaved changes");
@@ -29,4 +121,52 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, dialog: &mut MkMacroDialog) {
             );
         }
     });
+    if let Some(error) = &dialog.command_error {
+        ui.colored_label(eframe::egui::Color32::RED, error);
+    }
+    if let Some(run) = crate::mkmacro::runtime::snapshot().filter(|s| {
+        matches!(
+            s.state,
+            RuntimeState::Running | RuntimeState::Paused | RuntimeState::Failed
+        )
+    }) {
+        let name = run
+            .macro_id
+            .and_then(|id| dialog.draft.macros.iter().find(|m| m.id == id))
+            .map(|m| m.name.as_str())
+            .unwrap_or("Unknown macro");
+        ui.label(format!(
+            "{:?}: {} — step {}/{}",
+            run.state,
+            name,
+            run.completed_steps.saturating_add(1).min(run.total_steps),
+            run.total_steps
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn idle_controls_follow_eligibility_and_selection() {
+        let s = decide(RuntimeState::Idle, None, 1);
+        assert!(s.run && s.run_from && s.run_selected);
+        assert!(!s.pause && !s.resume && !s.stop);
+        let blocked = decide(RuntimeState::Idle, Some("macro is disabled".into()), 1);
+        assert!(!blocked.run);
+        assert_eq!(
+            blocked.disabled_reason.as_deref(),
+            Some("macro is disabled")
+        );
+    }
+    #[test]
+    fn running_and_paused_controls_are_deterministic() {
+        let running = decide(RuntimeState::Running, None, 1);
+        assert!(running.pause && running.stop);
+        assert!(!running.run && !running.resume);
+        let paused = decide(RuntimeState::Paused, None, 1);
+        assert!(paused.resume && paused.stop);
+        assert!(!paused.run && !paused.pause);
+    }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -237,7 +237,9 @@ pub fn set_execute_action_hook(
     }
 }
 
-fn execute_action(action: &Action) -> anyhow::Result<()> {
+/// Dispatch an already-resolved launcher action without performing another plugin search.
+/// This is also the canonical boundary used by macro playback.
+pub(crate) fn execute_action(action: &Action) -> anyhow::Result<()> {
     if let Ok(guard) = EXECUTE_ACTION_HOOK.lock()
         && let Some(ref hook) = *guard
     {

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -124,22 +124,43 @@ pub struct Backends {
 }
 impl Backends {
     pub fn unsupported() -> Self {
-        let u = Arc::new(Unsupported);
+        let input = Arc::new(Unsupported { backend: "input" });
+        let window = Arc::new(Unsupported { backend: "window" });
+        let screen = Arc::new(Unsupported { backend: "screen" });
+        let uia = Arc::new(Unsupported {
+            backend: "UI Automation",
+        });
+        let launcher = Arc::new(Unsupported {
+            backend: "launcher",
+        });
         Self {
-            input: u.clone(),
-            window: u.clone(),
-            screen: u.clone(),
-            uia: u.clone(),
-            launcher: u,
+            input,
+            window,
+            screen,
+            uia,
+            launcher,
         }
     }
+
+    /// Backends used by the installed application. Live input remains an explicit
+    /// production-only capability; tests should use [`MacroRuntime::new`] instead.
+    pub fn production() -> Self {
+        production_backends()
+    }
 }
-struct Unsupported;
-fn unsupported<T>() -> ExecResult<T> {
+struct Unsupported {
+    backend: &'static str,
+}
+fn unsupported_context<T>(backend: &'static str, action: &'static str) -> ExecResult<T> {
     Err(ExecutionDiagnostic::new(
         DiagnosticKind::UnsupportedOperation,
-        "automation backend is unavailable on this platform",
-    ))
+        "This action is not available yet",
+    )
+    .context("backend", backend)
+    .context("action", action))
+}
+fn unsupported<T>() -> ExecResult<T> {
+    unsupported_context("automation", "unknown")
 }
 impl InputBackend for Unsupported {
     fn key_down(&self, _: &MkKey) -> ExecResult {
@@ -180,10 +201,10 @@ impl WindowBackend for Unsupported {
 }
 impl ScreenBackend for Unsupported {
     fn resolve(&self, _: &MkCoordinateTarget, _: &RuntimeVariables) -> ExecResult<MkPoint> {
-        unsupported()
+        unsupported_context(self.backend, "resolve coordinates")
     }
     fn image_found(&self, _: u64, _: f32) -> ExecResult<Option<MkPoint>> {
-        unsupported()
+        unsupported_context(self.backend, "find image")
     }
     fn pixel_matches(
         &self,
@@ -192,30 +213,84 @@ impl ScreenBackend for Unsupported {
         _: u8,
         _: &RuntimeVariables,
     ) -> ExecResult<bool> {
-        unsupported()
+        unsupported_context(self.backend, "match pixel")
     }
 }
 impl UiAutomationBackend for Unsupported {
     fn exists(&self, _: &MkUiPayload) -> ExecResult<bool> {
-        unsupported()
+        unsupported_context(self.backend, "exists")
     }
     fn invoke(&self, _: &MkUiPayload) -> ExecResult {
-        unsupported()
+        unsupported_context(self.backend, "invoke")
     }
     fn set_value(&self, _: &MkUiPayload, _: &str) -> ExecResult {
-        unsupported()
+        unsupported_context(self.backend, "set value")
     }
     fn read_value(&self, _: &MkUiPayload) -> ExecResult<String> {
-        unsupported()
+        unsupported_context(self.backend, "read value")
     }
     fn toggle(&self, _: &MkUiPayload) -> ExecResult {
-        unsupported()
+        unsupported_context(self.backend, "toggle")
     }
     fn select(&self, _: &MkUiPayload) -> ExecResult {
-        unsupported()
+        unsupported_context(self.backend, "select")
     }
     fn focus(&self, _: &MkUiPayload) -> ExecResult {
-        unsupported()
+        unsupported_context(self.backend, "focus")
+    }
+}
+
+#[cfg(windows)]
+struct ProductionLauncher;
+#[cfg(windows)]
+impl LauncherBackend for ProductionLauncher {
+    fn launch_process(&self, p: &MkProcessPayload) -> ExecResult {
+        let action = crate::actions::Action {
+            label: p.program.clone(),
+            desc: "Macro".into(),
+            action: p.program.clone(),
+            args: (!p.arguments.is_empty()).then(|| p.arguments.join(" ")),
+        };
+        crate::gui::execute_action(&action).map_err(|e| {
+            ExecutionDiagnostic::new(DiagnosticKind::Backend, e.to_string())
+                .context("backend", "launcher")
+                .context("action", p.program.clone())
+        })
+    }
+    fn command(&self, command: &str, args: Option<&str>) -> ExecResult {
+        let action = crate::actions::Action {
+            label: command.to_owned(),
+            desc: "Macro".into(),
+            action: command.to_owned(),
+            args: args.map(str::to_owned),
+        };
+        crate::gui::execute_action(&action).map_err(|e| {
+            ExecutionDiagnostic::new(DiagnosticKind::Backend, e.to_string())
+                .context("backend", "launcher")
+                .context("action", command)
+        })
+    }
+}
+
+/// Constructs the application's effect boundaries without exposing an accidental
+/// live-input default.
+pub fn production_backends() -> Backends {
+    let unsupported = Backends::unsupported();
+    #[cfg(windows)]
+    {
+        Backends {
+            input: Arc::new(super::input::Win32InputBackend::system(
+                super::input::LiveInputOptIn::production(),
+            )),
+            window: Arc::new(super::windows::Win32WindowBackend),
+            screen: unsupported.screen,
+            uia: unsupported.uia,
+            launcher: Arc::new(ProductionLauncher),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        unsupported
     }
 }
 impl LauncherBackend for Unsupported {

--- a/src/mkmacro/input.rs
+++ b/src/mkmacro/input.rs
@@ -47,7 +47,12 @@ fn rejected(wanted: usize, sent: usize, detail: impl Into<String>) -> ExecutionD
     ExecutionDiagnostic::new(
         DiagnosticKind::InputRejected,
         format!(
-            "SendInput accepted {sent} of {wanted} event(s): {}",
+            "SendInput accepted {sent} of {wanted} event(s): {}{}",
+            if sent == 0 {
+                " likely integrity/UIPI restrictions; "
+            } else {
+                ""
+            },
             detail.into()
         ),
     )

--- a/src/mkmacro/runtime.rs
+++ b/src/mkmacro/runtime.rs
@@ -120,6 +120,26 @@ impl MacroRuntime {
         }
     }
     pub fn command(&self, c: RuntimeCommand) -> CommandResult {
+        if matches!(&c, RuntimeCommand::RunSelection(_, ids) if ids.is_empty()) {
+            return CommandResult::Rejected(ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidSelection,
+                "selection is empty",
+            ));
+        }
+        let active = self.shared.admission.lock().unwrap().is_some();
+        let state = self.snapshot().state;
+        let wrong_state = match &c {
+            RuntimeCommand::Pause => !active || state == RuntimeState::Paused,
+            RuntimeCommand::Resume => !active || state != RuntimeState::Paused,
+            RuntimeCommand::Stop => !active,
+            _ => false,
+        };
+        if wrong_state {
+            return CommandResult::Rejected(ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                format!("command {c:?} is not valid while runtime is {state:?}"),
+            ));
+        }
         if let RuntimeCommand::Run(id)
         | RuntimeCommand::RunFrom(id, _)
         | RuntimeCommand::RunSelection(id, _) = &c
@@ -210,9 +230,7 @@ fn worker_loop(
                 }
             }
             RuntimeCommand::Stop => {}
-            RuntimeCommand::Run(mid) | RuntimeCommand::RunFrom(mid, 0) => {
-                run_one(&store, &backends, &shared, mid, None, None)
-            }
+            RuntimeCommand::Run(mid) => run_one(&store, &backends, &shared, mid, None, None),
             RuntimeCommand::RunFrom(mid, sid) => {
                 run_one(&store, &backends, &shared, mid, Some(sid), None)
             }
@@ -411,10 +429,14 @@ fn run_one(
 
 static RUNTIME: Lazy<RwLock<Option<Arc<MacroRuntime>>>> = Lazy::new(|| RwLock::new(None));
 pub fn set_shared_store(store: Arc<MkMacroStore>) {
+    set_shared_store_with_backends(store, production_backends())
+}
+/// Installs a shared runtime with injected effects (intended for tests).
+pub fn set_shared_store_with_backends(store: Arc<MkMacroStore>, backends: Backends) {
     if let Some(old) = RUNTIME.write().unwrap().take() {
         old.shutdown()
     }
-    *RUNTIME.write().unwrap() = Some(Arc::new(MacroRuntime::new(store, Backends::unsupported())))
+    *RUNTIME.write().unwrap() = Some(Arc::new(MacroRuntime::new(store, backends)))
 }
 fn global() -> Result<Arc<MacroRuntime>> {
     RUNTIME
@@ -431,6 +453,12 @@ fn accepted(r: CommandResult) -> Result<()> {
 }
 pub fn run(id: u64) -> Result<()> {
     accepted(global()?.command(RuntimeCommand::Run(id)))
+}
+pub fn run_from(macro_id: u64, step_id: u64) -> Result<()> {
+    accepted(global()?.command(RuntimeCommand::RunFrom(macro_id, step_id)))
+}
+pub fn run_selection(macro_id: u64, ids: Vec<u64>) -> Result<()> {
+    accepted(global()?.command(RuntimeCommand::RunSelection(macro_id, ids)))
 }
 pub fn pause() -> Result<()> {
     accepted(global()?.command(RuntimeCommand::Pause))


### PR DESCRIPTION
### Motivation

- Provide a production `Backends` factory so the shipped application uses real platform effects while keeping tests able to inject fake backends. 
- Ensure live input is opt-in (no accidental default construction of `LiveInputOptIn::production()`), and connect macro-launched process requests into the launcher action dispatch path. 
- Make runtime commands and toolbar decisions deterministic and testable, require dirty-draft saves before run, and surface command/save errors to the UI. 
- Present compact, accessible runtime/step state and return actionable diagnostics for unsupported Screen/UIA operations and input rejections.

### Description

- Added a production effect factory: `production_backends()` and `Backends::production()` in `src/mkmacro/executor.rs`, with Windows-specific plumbing that constructs `Win32InputBackend::system(LiveInputOptIn::production())` and `Win32WindowBackend`, and a `ProductionLauncher` that routes `MkProcessPayload`/launcher commands through the app's canonical `gui::execute_action` boundary.
- Implemented richer unsupported diagnostics: replaced the single `Unsupported` placeholder with `unsupported_context(backend, action)` to return `ExecutionDiagnostic` with backend/action context and a clearer message; kept safe unsupported backends for non-Windows builds.
- Made shared runtime initialization select production backends by default via `set_shared_store` and added `set_shared_store_with_backends(store, backends)` to allow injected backends for tests in `src/mkmacro/runtime.rs`.
- Exposed facade functions `runtime::run_from(macro_id, step_id)` and `runtime::run_selection(macro_id, ids)` and hardened `MacroRuntime::command` to reject empty selections and invalid state transitions deterministically while preserving full `RuntimeCommand` payloads.
- Improved input diagnostics in `src/mkmacro/input.rs` so zero-event `SendInput` rejections mention likely integrity/UIPI restrictions.
- Added draft-save-before-run and selection ID repair logic in `src/gui/mkmacro_dialog/mod.rs` with `prepare_execution()`, `run_selected_macro()`, `run_from_step()`, and `run_selected_steps()`; these functions abort on save failure and re-resolve step IDs after save.
- Refactored toolbar command decision into a pure model: `ToolbarState` and `decide(runtime, disabled_reason, selected_rows)` in `src/gui/mkmacro_dialog/toolbar.rs`, wired UI buttons to `run`, `run from here`, `run selected`, `pause`, `resume`, and `stop`, and surfaced command/save errors to `dialog.command_error` instead of discarding them.
- Improved runtime presentation: toolbar shows a running/paused/failed summary with macro name and step progress, and `step_table` renders step states compactly as `○`, `▶`, `✓`, `–`, `✕` with hover text and failure diagnostic context preserved.
- Added small unit tests for the pure toolbar decision logic in `toolbar.rs`.

### Testing

- Ran `cargo fmt --all` and pre-check style validations successfully.
- Ran repository checks (`git diff --check`) with no style errors reported.
- Attempted `cargo check`; platform/system-specific compilation failed due to unrelated non-Windows build-time/system dependencies and `windows`-crate resolution errors in this Linux CI environment (the project contains Windows-targeted modules that shadow the external `windows` crate and require platform/system libs), so full compilation and runtime tests could not complete here.
- Existing added unit tests (pure `decide` tests) are local and deterministic; they are included and exercise the toolbar decision model but full `cargo test` could not be run to completion due to the same platform-specific compilation limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fa5bb627883328b7073aa9f1b69d7)