### PR TITLE
Consolidate macro keyboard capture into shared module

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -462,11 +462,11 @@ fn mouse(b: &MkMouseButton) -> &'static str {
 pub fn action_details(a: &MkAction) -> String {
     match a {
         MkAction::KeyDown(k) | MkAction::KeyUp(k) | MkAction::KeyPress(k) => {
-            super::macro_properties::key_name(k)
+            super::key_capture::key_name(k)
         }
         MkAction::Hotkey(k) => k
             .iter()
-            .map(super::macro_properties::key_name)
+            .map(super::key_capture::key_name)
             .collect::<Vec<_>>()
             .join(" + "),
         MkAction::Text(p) => format!("{} characters", p.text.chars().count()),

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2,7 +2,10 @@
 //!
 //! The editor owns a complete `MkStep` clone.  No document field is borrowed by
 //! the modal, which makes closing/cancelling it a genuinely lossless operation.
-use super::MkMacroDialog;
+use super::{
+    MkMacroDialog,
+    key_capture::{CapturedChord, captured_chord, key_name},
+};
 use crate::mkmacro::variables::MkPoint;
 use crate::mkmacro::*;
 use eframe::egui;
@@ -190,62 +193,6 @@ pub fn apply_picked_window(payload: &mut MkWindowPayload, picked: &PickedWindow)
     payload.matcher = picked.matcher.clone();
 }
 
-fn key_name(k: &MkKey) -> String {
-    super::macro_properties::key_name(k)
-}
-fn egui_key(k: egui::Key) -> Option<MkKey> {
-    Some(match k {
-        egui::Key::Enter => MkKey::Enter,
-        egui::Key::Tab => MkKey::Tab,
-        egui::Key::Escape => MkKey::Escape,
-        egui::Key::Space => MkKey::Space,
-        egui::Key::Backspace => MkKey::Backspace,
-        egui::Key::Delete => MkKey::Delete,
-        egui::Key::ArrowUp => MkKey::Up,
-        egui::Key::ArrowDown => MkKey::Down,
-        egui::Key::ArrowLeft => MkKey::Left,
-        egui::Key::ArrowRight => MkKey::Right,
-        egui::Key::Home => MkKey::Home,
-        egui::Key::End => MkKey::End,
-        egui::Key::PageUp => MkKey::PageUp,
-        egui::Key::PageDown => MkKey::PageDown,
-        k if format!("{k:?}").len() == 1 => MkKey::Character(format!("{k:?}")),
-        _ => return None,
-    })
-}
-pub(super) fn captured_from_input(i: &egui::InputState) -> Option<Vec<MkKey>> {
-    for e in &i.events {
-        if let egui::Event::Key {
-            key,
-            pressed: true,
-            modifiers,
-            ..
-        } = e
-        {
-            if *key == egui::Key::Escape {
-                return Some(vec![]);
-            }
-            let mut v = vec![];
-            if modifiers.ctrl {
-                v.push(MkKey::Control)
-            }
-            if modifiers.alt {
-                v.push(MkKey::Alt)
-            }
-            if modifiers.shift {
-                v.push(MkKey::Shift)
-            }
-            if modifiers.mac_cmd {
-                v.push(MkKey::Meta)
-            }
-            if let Some(k) = egui_key(*key) {
-                v.push(k);
-                return Some(v);
-            }
-        }
-    }
-    None
-}
 fn optional_field(ui: &mut egui::Ui, label: &str, value: &mut Option<String>) {
     let v = value.get_or_insert_with(String::new);
     ui.horizontal(|ui| {
@@ -467,11 +414,10 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     egui::Color32::YELLOW,
                     "Press the next real key or chord. Escape cancels capture.",
                 );
-                if let Some(keys) = ui.input(captured_from_input) {
-                    if keys.is_empty() {
-                        state.capture_keys = false
-                    } else {
-                        captured = Some(keys);
+                if let Some(result) = ui.input(captured_chord) {
+                    match result {
+                        CapturedChord::Cancelled => state.capture_keys = false,
+                        CapturedChord::Keys(keys) => captured = Some(keys),
                     }
                 }
             }

--- a/src/gui/mkmacro_dialog/key_capture.rs
+++ b/src/gui/mkmacro_dialog/key_capture.rs
@@ -1,0 +1,291 @@
+//! Shared conversion of egui key events into platform-independent macro keys.
+
+use crate::mkmacro::{MkHotkey, MkKey};
+use eframe::egui;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CapturedChord {
+    Cancelled,
+    /// Modifiers are ordered Control, Alt, Shift, Meta, followed by the primary key.
+    Keys(Vec<MkKey>),
+}
+
+pub(crate) fn mk_key_from_egui(key: egui::Key) -> Option<MkKey> {
+    use egui::Key::*;
+    let character = match key {
+        A => "A",
+        B => "B",
+        C => "C",
+        D => "D",
+        E => "E",
+        F => "F",
+        G => "G",
+        H => "H",
+        I => "I",
+        J => "J",
+        K => "K",
+        L => "L",
+        M => "M",
+        N => "N",
+        O => "O",
+        P => "P",
+        Q => "Q",
+        R => "R",
+        S => "S",
+        T => "T",
+        U => "U",
+        V => "V",
+        W => "W",
+        X => "X",
+        Y => "Y",
+        Z => "Z",
+        Num0 => "0",
+        Num1 => "1",
+        Num2 => "2",
+        Num3 => "3",
+        Num4 => "4",
+        Num5 => "5",
+        Num6 => "6",
+        Num7 => "7",
+        Num8 => "8",
+        Num9 => "9",
+        _ => "",
+    };
+    if !character.is_empty() {
+        return Some(MkKey::Character(character.into()));
+    }
+    Some(match key {
+        Enter => MkKey::Enter,
+        Tab => MkKey::Tab,
+        Escape => MkKey::Escape,
+        Space => MkKey::Space,
+        Backspace => MkKey::Backspace,
+        Delete => MkKey::Delete,
+        ArrowUp => MkKey::Up,
+        ArrowDown => MkKey::Down,
+        ArrowLeft => MkKey::Left,
+        ArrowRight => MkKey::Right,
+        Home => MkKey::Home,
+        End => MkKey::End,
+        PageUp => MkKey::PageUp,
+        PageDown => MkKey::PageDown,
+        F1 => MkKey::Function(1),
+        F2 => MkKey::Function(2),
+        F3 => MkKey::Function(3),
+        F4 => MkKey::Function(4),
+        F5 => MkKey::Function(5),
+        F6 => MkKey::Function(6),
+        F7 => MkKey::Function(7),
+        F8 => MkKey::Function(8),
+        F9 => MkKey::Function(9),
+        F10 => MkKey::Function(10),
+        F11 => MkKey::Function(11),
+        F12 => MkKey::Function(12),
+        F13 => MkKey::Function(13),
+        F14 => MkKey::Function(14),
+        F15 => MkKey::Function(15),
+        F16 => MkKey::Function(16),
+        F17 => MkKey::Function(17),
+        F18 => MkKey::Function(18),
+        F19 => MkKey::Function(19),
+        F20 => MkKey::Function(20),
+        F21 => MkKey::Function(21),
+        F22 => MkKey::Function(22),
+        F23 => MkKey::Function(23),
+        F24 => MkKey::Function(24),
+        F25 => MkKey::Function(25),
+        F26 => MkKey::Function(26),
+        F27 => MkKey::Function(27),
+        F28 => MkKey::Function(28),
+        F29 => MkKey::Function(29),
+        F30 => MkKey::Function(30),
+        F31 => MkKey::Function(31),
+        F32 => MkKey::Function(32),
+        F33 => MkKey::Function(33),
+        F34 => MkKey::Function(34),
+        F35 => MkKey::Function(35),
+        _ => return None,
+    })
+}
+
+pub(crate) fn captured_chord(input: &egui::InputState) -> Option<CapturedChord> {
+    input.events.iter().find_map(|event| {
+        let egui::Event::Key {
+            key,
+            pressed: true,
+            modifiers,
+            ..
+        } = event
+        else {
+            return None;
+        };
+        if *key == egui::Key::Escape {
+            return Some(CapturedChord::Cancelled);
+        }
+        let primary = mk_key_from_egui(*key)?;
+        let mut keys = Vec::with_capacity(5);
+        if modifiers.ctrl {
+            keys.push(MkKey::Control);
+        }
+        if modifiers.alt {
+            keys.push(MkKey::Alt);
+        }
+        if modifiers.shift {
+            keys.push(MkKey::Shift);
+        }
+        // `command` aliases Ctrl off macOS; mac_cmd uniquely identifies the Meta/Command key.
+        if modifiers.mac_cmd {
+            keys.push(MkKey::Meta);
+        }
+        if !keys.contains(&primary) {
+            keys.push(primary);
+        }
+        Some(CapturedChord::Keys(keys))
+    })
+}
+
+pub(crate) fn key_name(key: &MkKey) -> String {
+    match key {
+        MkKey::Character(v) => v.to_uppercase(),
+        MkKey::Function(n) => format!("F{n}"),
+        MkKey::PageUp => "Page Up".into(),
+        MkKey::PageDown => "Page Down".into(),
+        MkKey::LeftControl | MkKey::RightControl | MkKey::Control => "Ctrl".into(),
+        MkKey::LeftAlt | MkKey::RightAlt | MkKey::Alt => "Alt".into(),
+        MkKey::LeftShift | MkKey::RightShift | MkKey::Shift => "Shift".into(),
+        MkKey::LeftMeta | MkKey::RightMeta | MkKey::Meta => "Meta".into(),
+        other => format!("{other:?}"),
+    }
+}
+
+pub(crate) fn hotkey_name(h: &MkHotkey) -> String {
+    h.modifiers
+        .iter()
+        .chain(std::iter::once(&h.key))
+        .map(key_name)
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_supported_keys_are_explicitly_translated() {
+        let letters = [
+            A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+        ];
+        for (key, expected) in letters.into_iter().zip('A'..='Z') {
+            assert_eq!(
+                mk_key_from_egui(key),
+                Some(MkKey::Character(expected.to_string()))
+            );
+        }
+        let digits = [Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9];
+        for (key, expected) in digits.into_iter().zip('0'..='9') {
+            assert_eq!(
+                mk_key_from_egui(key),
+                Some(MkKey::Character(expected.to_string()))
+            );
+        }
+        let named = [
+            (Enter, MkKey::Enter),
+            (Tab, MkKey::Tab),
+            (Space, MkKey::Space),
+            (Backspace, MkKey::Backspace),
+            (Delete, MkKey::Delete),
+            (Escape, MkKey::Escape),
+            (Home, MkKey::Home),
+            (End, MkKey::End),
+            (PageUp, MkKey::PageUp),
+            (PageDown, MkKey::PageDown),
+            (ArrowUp, MkKey::Up),
+            (ArrowDown, MkKey::Down),
+            (ArrowLeft, MkKey::Left),
+            (ArrowRight, MkKey::Right),
+        ];
+        for (key, expected) in named {
+            assert_eq!(mk_key_from_egui(key), Some(expected));
+        }
+        let functions = [
+            F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16, F17, F18, F19,
+            F20, F21, F22, F23, F24, F25, F26, F27, F28, F29, F30, F31, F32, F33, F34, F35,
+        ];
+        for (number, key) in functions.into_iter().enumerate() {
+            assert_eq!(
+                mk_key_from_egui(key),
+                Some(MkKey::Function(number as u8 + 1))
+            );
+        }
+        assert_eq!(mk_key_from_egui(Insert), None);
+    }
+
+    fn capture(key: egui::Key, modifiers: egui::Modifiers) -> CapturedChord {
+        let ctx = egui::Context::default();
+        ctx.begin_frame(egui::RawInput {
+            events: vec![egui::Event::Key {
+                key,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers,
+            }],
+            ..Default::default()
+        });
+        ctx.input(|i| captured_chord(i).unwrap())
+    }
+
+    #[test]
+    fn chords_have_stable_modifiers_and_special_keys_are_not_clear() {
+        assert_eq!(
+            capture(
+                M,
+                egui::Modifiers {
+                    ctrl: true,
+                    alt: true,
+                    ..Default::default()
+                }
+            ),
+            CapturedChord::Keys(vec![
+                MkKey::Control,
+                MkKey::Alt,
+                MkKey::Character("M".into())
+            ])
+        );
+        assert_eq!(
+            capture(
+                Num2,
+                egui::Modifiers {
+                    shift: true,
+                    ..Default::default()
+                }
+            ),
+            CapturedChord::Keys(vec![MkKey::Shift, MkKey::Character("2".into())])
+        );
+        assert_eq!(
+            capture(
+                A,
+                egui::Modifiers {
+                    mac_cmd: true,
+                    command: true,
+                    ..Default::default()
+                }
+            ),
+            CapturedChord::Keys(vec![MkKey::Meta, MkKey::Character("A".into())])
+        );
+        assert_eq!(
+            capture(Backspace, Default::default()),
+            CapturedChord::Keys(vec![MkKey::Backspace])
+        );
+        assert_eq!(
+            capture(Delete, Default::default()),
+            CapturedChord::Keys(vec![MkKey::Delete])
+        );
+        assert_eq!(
+            capture(Escape, Default::default()),
+            CapturedChord::Cancelled
+        );
+    }
+    use egui::Key::*;
+}

--- a/src/gui/mkmacro_dialog/macro_properties.rs
+++ b/src/gui/mkmacro_dialog/macro_properties.rs
@@ -1,68 +1,11 @@
 use super::MkMacroDialog;
-use crate::mkmacro::{MkHotkey, MkKey};
+use super::key_capture::{CapturedChord, captured_chord, hotkey_name};
 use eframe::egui;
 
-pub fn key_name(key: &MkKey) -> String {
-    match key {
-        MkKey::Character(v) => v.to_uppercase(),
-        MkKey::Function(n) => format!("F{n}"),
-        MkKey::PageUp => "Page Up".into(),
-        MkKey::PageDown => "Page Down".into(),
-        MkKey::LeftControl | MkKey::RightControl | MkKey::Control => "Ctrl".into(),
-        MkKey::LeftAlt | MkKey::RightAlt | MkKey::Alt => "Alt".into(),
-        MkKey::LeftShift | MkKey::RightShift | MkKey::Shift => "Shift".into(),
-        MkKey::LeftMeta | MkKey::RightMeta | MkKey::Meta => "Meta".into(),
-        MkKey::Enter => "Enter".into(),
-        MkKey::Tab => "Tab".into(),
-        MkKey::Escape => "Escape".into(),
-        MkKey::Space => "Space".into(),
-        MkKey::Backspace => "Backspace".into(),
-        MkKey::Delete => "Delete".into(),
-        MkKey::Up => "Up".into(),
-        MkKey::Down => "Down".into(),
-        MkKey::Left => "Left".into(),
-        MkKey::Right => "Right".into(),
-        MkKey::Home => "Home".into(),
-        MkKey::End => "End".into(),
-    }
+fn clear_hotkey(hotkey: &mut Option<crate::mkmacro::MkHotkey>) -> bool {
+    hotkey.take().is_some()
 }
-pub fn hotkey_name(h: &MkHotkey) -> String {
-    h.modifiers
-        .iter()
-        .chain(std::iter::once(&h.key))
-        .map(key_name)
-        .collect::<Vec<_>>()
-        .join(" + ")
-}
-fn egui_key(k: egui::Key) -> Option<MkKey> {
-    use egui::Key::*;
-    Some(match k {
-        Enter => MkKey::Enter,
-        Tab => MkKey::Tab,
-        Space => MkKey::Space,
-        ArrowUp => MkKey::Up,
-        ArrowDown => MkKey::Down,
-        ArrowLeft => MkKey::Left,
-        ArrowRight => MkKey::Right,
-        Home => MkKey::Home,
-        End => MkKey::End,
-        PageUp => MkKey::PageUp,
-        PageDown => MkKey::PageDown,
-        F1 => MkKey::Function(1),
-        F2 => MkKey::Function(2),
-        F3 => MkKey::Function(3),
-        F4 => MkKey::Function(4),
-        F5 => MkKey::Function(5),
-        F6 => MkKey::Function(6),
-        F7 => MkKey::Function(7),
-        F8 => MkKey::Function(8),
-        F9 => MkKey::Function(9),
-        F10 => MkKey::Function(10),
-        F11 => MkKey::Function(11),
-        F12 => MkKey::Function(12),
-        _ => return None,
-    })
-}
+
 pub(super) fn show(ui: &mut egui::Ui, d: &mut MkMacroDialog) {
     let capturing = d.hotkey_capture;
     let mut changed = false;
@@ -119,58 +62,27 @@ pub(super) fn show(ui: &mut egui::Ui, d: &mut MkMacroDialog) {
             .changed();
     });
     if clear {
-        m.hotkey = None;
-        changed = true;
+        changed |= clear_hotkey(&mut m.hotkey);
     }
     let _ = m;
     if capture == Some(true) {
         d.hotkey_capture = true;
     }
     if capturing {
-        let events = ui.input(|i| i.events.clone());
-        for event in events {
-            if let egui::Event::Key {
-                key,
-                pressed: true,
-                modifiers,
-                ..
-            } = event
-            {
-                if key == egui::Key::Escape {
-                    d.hotkey_capture = false;
-                    break;
-                }
-                if matches!(key, egui::Key::Backspace | egui::Key::Delete) {
+        if let Some(result) = ui.input(captured_chord) {
+            d.hotkey_capture = false;
+            if let CapturedChord::Keys(mut keys) = result {
+                if let Some(key) = keys.pop() {
+                    let hotkey = crate::mkmacro::MkHotkey {
+                        key,
+                        modifiers: keys,
+                    };
                     if let Some(m) = d.selected_macro_mut() {
-                        m.hotkey = None;
+                        if m.hotkey.as_ref() != Some(&hotkey) {
+                            m.hotkey = Some(hotkey);
+                            changed = true;
+                        }
                     }
-                    changed = true;
-                    d.hotkey_capture = false;
-                    break;
-                }
-                if let Some(key) = egui_key(key) {
-                    let mut mods = vec![];
-                    if modifiers.ctrl {
-                        mods.push(MkKey::Control)
-                    }
-                    if modifiers.shift {
-                        mods.push(MkKey::Shift)
-                    }
-                    if modifiers.alt {
-                        mods.push(MkKey::Alt)
-                    }
-                    if modifiers.mac_cmd {
-                        mods.push(MkKey::Meta)
-                    }
-                    if let Some(m) = d.selected_macro_mut() {
-                        m.hotkey = Some(MkHotkey {
-                            key,
-                            modifiers: mods,
-                        });
-                    }
-                    changed = true;
-                    d.hotkey_capture = false;
-                    break;
                 }
             }
         }
@@ -183,5 +95,22 @@ pub(super) fn show(ui: &mut egui::Ui, d: &mut MkMacroDialog) {
     }
     if changed {
         d.mark_dirty();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mkmacro::{MkHotkey, MkKey};
+
+    #[test]
+    fn clear_removes_an_assigned_hotkey_and_reports_a_change() {
+        let mut hotkey = Some(MkHotkey {
+            key: MkKey::Delete,
+            modifiers: vec![],
+        });
+        assert!(clear_hotkey(&mut hotkey));
+        assert!(hotkey.is_none());
+        assert!(!clear_hotkey(&mut hotkey));
     }
 }

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1,6 +1,7 @@
 pub mod action_catalog;
 pub mod action_editor;
 pub mod image_search_editor;
+mod key_capture;
 mod macro_list;
 mod macro_properties;
 pub mod recorder_controller;

--- a/src/gui/mkmacro_dialog/step_table.rs
+++ b/src/gui/mkmacro_dialog/step_table.rs
@@ -404,7 +404,7 @@ fn quick_insert(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
         d.quick_insert
             .keys
             .iter()
-            .map(super::macro_properties::key_name)
+            .map(super::key_capture::key_name)
             .collect::<Vec<_>>()
             .join(" + ")
     };
@@ -423,9 +423,11 @@ fn quick_insert(ui: &mut eframe::egui::Ui, d: &mut MkMacroDialog) {
     });
     if d.quick_insert.capturing {
         ui.label("Press a key or combination; Escape cancels capture.");
-        if let Some(keys) = ui.input(super::action_editor::captured_from_input) {
+        if let Some(result) = ui.input(super::key_capture::captured_chord) {
             d.quick_insert.capturing = false;
-            d.quick_insert.keys = keys;
+            if let super::key_capture::CapturedChord::Keys(keys) = result {
+                d.quick_insert.keys = keys;
+            }
         }
     }
     let enabled = d.quick_insert.action().is_some();

--- a/src/mkmacro/hotkeys.rs
+++ b/src/mkmacro/hotkeys.rs
@@ -9,6 +9,10 @@ pub struct HotkeyDiagnostic {
 fn key_name(k: &MkKey) -> String {
     match k {
         MkKey::Character(s) => s.to_ascii_uppercase(),
+        MkKey::Control | MkKey::LeftControl | MkKey::RightControl => "CONTROL".into(),
+        MkKey::Alt | MkKey::LeftAlt | MkKey::RightAlt => "ALT".into(),
+        MkKey::Shift | MkKey::LeftShift | MkKey::RightShift => "SHIFT".into(),
+        MkKey::Meta | MkKey::LeftMeta | MkKey::RightMeta => "META".into(),
         x => format!("{x:?}").to_ascii_uppercase(),
     }
 }
@@ -100,5 +104,18 @@ mod tests {
             validate_hotkeys(&d, &[("emergency stop", "CONTROL+K")]).len(),
             1
         )
+    }
+    #[test]
+    fn canonical_modifier_order_sides_and_duplicates_are_equivalent() {
+        let key = MkKey::Character("m".into());
+        let a = MkHotkey {
+            key: key.clone(),
+            modifiers: vec![MkKey::Alt, MkKey::Control],
+        };
+        let b = MkHotkey {
+            key,
+            modifiers: vec![MkKey::RightControl, MkKey::LeftAlt, MkKey::Control],
+        };
+        assert_eq!(canonical_hotkey(&a), canonical_hotkey(&b));
     }
 }


### PR DESCRIPTION
### Motivation

- Remove duplicated egui→MkKey translation and capture logic spread across the macro dialog and action editor and provide a single authoritative implementation. 
- Provide explicit, exhaustively matched egui key mappings and a clear capture result type so cancellation and modifier-only cases are unambiguous. 
- Normalize modifier representation and canonicalization to make conflict detection deterministic and consistent across UI surfaces. 

### Description

- Add a new module `src/gui/mkmacro_dialog/key_capture.rs` that implements `mk_key_from_egui`, `captured_chord`, `key_name`, `hotkey_name`, and the `CapturedChord` result enum (`Cancelled` | `Keys(Vec<MkKey>)`).
- Register the module from `src/gui/mkmacro_dialog/mod.rs` by adding `mod key_capture;`.
- Replace local ad-hoc capture/translation in `macro_properties.rs`, `action_editor.rs`, and `step_table.rs` to use the shared helpers (`captured_chord`, `mk_key_from_egui`, and `key_name`/`hotkey_name`) and route all captures through the unified handling.
- Change macro properties behavior so `Escape` cancels capture without mutating the hotkey, `Backspace`/`Delete` remain assignable, only the visible `Clear` button removes the hotkey, and the dialog is marked dirty only when an actual change occurs.
- Update `action_editor.rs` to accept `CapturedChord::Cancelled` vs `CapturedChord::Keys(...)` and preserve `ActionEditorState::set_captured_keys` semantics (KeyPress/KeyDown/KeyUp vs Hotkey conversion) unchanged.
- Normalize modifier naming and canonicalization in `src/mkmacro/hotkeys.rs` by mapping left/right variants to generic names and sorting/deduping modifiers for `canonical_hotkey` to make ordering/duplicates equivalent for conflict detection.
- Add focused unit tests for the new translation and capture behavior in `key_capture.rs`, a small test for hotkey clearing in `macro_properties.rs`, and a canonicalization test in `hotkeys.rs`.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `git diff --check` which succeeded and committed the refactor on the working branch.
- Attempted `cargo test --lib` but the full test run on the Linux CI environment is blocked/failing due to unrelated, unconditional Windows API imports and platform-specific dependencies in the repository (the changes themselves are platform independent); as a result the repository-wide test run could not complete here.
- Added focused tests for the capture module and hotkey canonicalization (`key_capture` tests, hotkeys canonicalization test, and a `clear_hotkey` test) which can be run as unit tests in a platform-appropriate environment once platform dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8059d42ddc833292daba756f6d4d92)