### PR TITLE
Add timed MouseMove/MouseDrag actions, schema v2 and migration

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -196,7 +196,22 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             "Mouse Move",
             "Move the pointer",
             &["mouse"],
-            MkAction::MouseMove(point())
+            MkAction::MouseMove(MkMouseMovePayload {
+                target: point(),
+                duration_ms: 0
+            })
+        ),
+        d!(
+            Mouse,
+            "Mouse Drag",
+            "Drag while holding a mouse button",
+            &["mouse", "drag"],
+            MkAction::MouseDrag(MkMouseDragPayload {
+                from: point(),
+                to: point(),
+                button: MkMouseButton::Left,
+                duration_ms: 400
+            })
         ),
         d!(
             Mouse,
@@ -518,6 +533,7 @@ pub fn action_name(a: &MkAction) -> &'static str {
         MkAction::Hotkey(_) => "Hotkey",
         MkAction::Text(_) => "Text",
         MkAction::MouseMove(_) => "Mouse Move",
+        MkAction::MouseDrag(_) => "Mouse Drag",
         MkAction::MouseClick(_) => "Mouse Click",
         MkAction::MouseDown(_) => "Mouse Down",
         MkAction::MouseUp(_) => "Mouse Up",
@@ -608,7 +624,22 @@ pub fn action_details(a: &MkAction) -> String {
         MkAction::UiReadValue { variable, .. } => {
             format!("Unavailable UI Automation action (read into {variable})")
         }
-        MkAction::MouseMove(target) => format_coordinate_target(target),
+        MkAction::MouseMove(p) => format!(
+            "{} · {}",
+            format_coordinate_target(&p.target),
+            if p.duration_ms == 0 {
+                "Instant".into()
+            } else {
+                format!("{} ms", p.duration_ms)
+            }
+        ),
+        MkAction::MouseDrag(p) => format!(
+            "{} → {} · {} · {} ms",
+            format_coordinate_target(&p.from),
+            format_coordinate_target(&p.to),
+            mouse(&p.button),
+            p.duration_ms
+        ),
         MkAction::WindowActivate(p) | MkAction::WindowWait(p) => {
             format!("Window {}", p.matcher.title.as_deref().unwrap_or("match"))
         }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -324,7 +324,36 @@ fn action_ui(ui: &mut egui::Ui, step: &mut MkStep, capture: &mut bool) {
                 p.mode = MkTextMode::Type;
             }
         }
-        MkAction::MouseMove(t) => target_ui(ui, t),
+        MkAction::MouseMove(p) => {
+            target_ui(ui, &mut p.target);
+            ui.horizontal(|ui| {
+                ui.label("Duration (ms)");
+                ui.add(egui::DragValue::new(&mut p.duration_ms));
+            });
+        }
+        MkAction::MouseDrag(p) => {
+            ui.label("Start");
+            target_ui(ui, &mut p.from);
+            ui.label("Destination");
+            target_ui(ui, &mut p.to);
+            egui::ComboBox::from_label("Button")
+                .selected_text(format!("{:?}", p.button))
+                .show_ui(ui, |ui| {
+                    for b in [
+                        MkMouseButton::Left,
+                        MkMouseButton::Right,
+                        MkMouseButton::Middle,
+                        MkMouseButton::X1,
+                        MkMouseButton::X2,
+                    ] {
+                        ui.selectable_value(&mut p.button, b.clone(), format!("{b:?}"));
+                    }
+                });
+            ui.horizontal(|ui| {
+                ui.label("Duration (ms)");
+                ui.add(egui::DragValue::new(&mut p.duration_ms));
+            });
+        }
         MkAction::MouseClick(p) => {
             target_ui(ui, &mut p.target);
             egui::ComboBox::from_label("Button")

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -186,8 +186,11 @@ mod tests {
             "Image asset 9 offset (-3, 5)"
         );
         assert_eq!(
-            action_catalog::action_details(&MkAction::MouseMove(screen.clone())),
-            "Screen (824, 446)"
+            action_catalog::action_details(&MkAction::MouseMove(MkMouseMovePayload {
+                target: screen.clone(),
+                duration_ms: 0
+            })),
+            "Screen (824, 446) · Instant"
         );
         for (clicks, expected) in [
             (1, "Left ×1 @ Screen (824, 446)"),
@@ -237,22 +240,29 @@ mod tests {
         for i in 0..500 {
             action_catalog::insert_action(
                 &mut dialog,
-                MkAction::MouseMove(MkCoordinateTarget::Screen {
-                    point: crate::mkmacro::variables::MkPoint {
-                        x: i - 250,
-                        y: 250 - i,
+                MkAction::MouseMove(MkMouseMovePayload {
+                    target: MkCoordinateTarget::Screen {
+                        point: crate::mkmacro::variables::MkPoint {
+                            x: i - 250,
+                            y: 250 - i,
+                        },
                     },
+                    duration_ms: 0,
                 }),
             );
         }
         let before = serde_json::to_vec(&dialog.draft).unwrap();
         for step in &dialog.selected_macro().unwrap().steps {
-            let MkAction::MouseMove(MkCoordinateTarget::Screen { point }) = &step.action else {
+            let MkAction::MouseMove(MkMouseMovePayload {
+                target: MkCoordinateTarget::Screen { point },
+                ..
+            }) = &step.action
+            else {
                 panic!("unexpected action")
             };
             assert_eq!(
                 action_catalog::action_details(&step.action),
-                format!("Screen ({}, {})", point.x, point.y)
+                format!("Screen ({}, {}) · Instant", point.x, point.y)
             );
         }
         assert_eq!(serde_json::to_vec(&dialog.draft).unwrap(), before);

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
     use crate::mkmacro::{
         MkAction, MkCoordinateTarget, MkHotkey, MkImagePayload, MkKey, MkMouseButton,
-        MkMousePayload, MkStep, MkWaitOptions,
+        MkMouseMovePayload, MkMousePayload, MkStep, MkWaitOptions,
     };
     fn dialog() -> (tempfile::TempDir, MkMacroDialog) {
         let dir = tempfile::tempdir().unwrap();

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -65,6 +65,7 @@ pub trait InputBackend: Send + Sync {
     fn button_down(&self, button: MkMouseButton) -> ExecResult;
     fn button_up(&self, button: MkMouseButton) -> ExecResult;
     fn move_mouse(&self, point: MkPoint) -> ExecResult;
+    fn cursor_position(&self) -> ExecResult<MkPoint>;
     fn scroll(&self, delta: i32) -> ExecResult;
     fn text(&self, payload: &MkTextPayload) -> ExecResult;
 }
@@ -176,6 +177,9 @@ impl InputBackend for Unsupported {
         unsupported()
     }
     fn move_mouse(&self, _: MkPoint) -> ExecResult {
+        unsupported()
+    }
+    fn cursor_position(&self) -> ExecResult<MkPoint> {
         unsupported()
     }
     fn scroll(&self, _: i32) -> ExecResult {
@@ -759,7 +763,22 @@ impl Executor {
                 Ok(())
             }
             MkAction::Text(p) => self.backends.input.text(p),
-            MkAction::MouseMove(t) => self.move_to(t, v),
+            MkAction::MouseMove(p) => self.move_to(p, v),
+            MkAction::MouseDrag(p) => {
+                let from = self.backends.screen.resolve(&p.from, v)?;
+                let to = self.backends.screen.resolve(&p.to, v)?;
+                super::input::drag(
+                    &*self.backends.input,
+                    &self.control,
+                    p.button.clone(),
+                    from,
+                    to,
+                    Duration::from_millis(p.duration_ms),
+                )?;
+                set_point(v, "mouse", to);
+                set_point(v, "last_point", to);
+                Ok(())
+            }
             MkAction::MouseClick(p) => {
                 let point = self.backends.screen.resolve(&p.target, v)?;
                 set_point(v, "last_point", point);
@@ -861,9 +880,20 @@ impl Executor {
             | MkAction::Continue => Ok(()),
         }
     }
-    fn move_to(&self, target: &MkCoordinateTarget, v: &mut RuntimeVariables) -> ExecResult {
-        let point = self.backends.screen.resolve(target, v)?;
-        self.backends.input.move_mouse(point)?;
+    fn move_to(&self, payload: &super::MkMouseMovePayload, v: &mut RuntimeVariables) -> ExecResult {
+        let point = self.backends.screen.resolve(&payload.target, v)?;
+        if payload.duration_ms == 0 {
+            self.backends.input.move_mouse(point)?;
+        } else {
+            let from = self.backends.input.cursor_position()?;
+            super::input::smooth_move(
+                &*self.backends.input,
+                &self.control,
+                from,
+                point,
+                Duration::from_millis(payload.duration_ms),
+            )?;
+        }
         set_point(v, "mouse", point);
         set_point(v, "last_point", point);
         Ok(())
@@ -1027,6 +1057,7 @@ pub fn has_runtime_support(action: &MkAction) -> bool {
         | MkAction::Hotkey(_)
         | MkAction::Text(_)
         | MkAction::MouseMove(_)
+        | MkAction::MouseDrag(_)
         | MkAction::MouseClick(_)
         | MkAction::MouseDown(_)
         | MkAction::MouseUp(_)
@@ -1069,6 +1100,7 @@ fn action_name(a: &MkAction) -> &'static str {
         | MkAction::Hotkey(_)
         | MkAction::Text(_) => "SendInput",
         MkAction::MouseMove(_)
+        | MkAction::MouseDrag(_)
         | MkAction::MouseClick(_)
         | MkAction::MouseDown(_)
         | MkAction::MouseUp(_)
@@ -1155,11 +1187,21 @@ pub fn compare(a: &MkValue, op: &MkCompareOp, b: &MkValue) -> ExecResult<bool> {
 /// Configurable synchronized fake implementing every effect boundary.
 pub mod fake {
     use super::*;
-    #[derive(Default)]
     pub struct FakeBackend {
         pub events: Mutex<Vec<String>>,
         pub failures: Mutex<HashMap<String, ExecutionDiagnostic>>,
         pub conditions: Mutex<HashMap<String, bool>>,
+        pub cursor: Mutex<MkPoint>,
+    }
+    impl Default for FakeBackend {
+        fn default() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+                failures: Mutex::new(HashMap::new()),
+                conditions: Mutex::new(HashMap::new()),
+                cursor: Mutex::new(MkPoint { x: 0, y: 0 }),
+            }
+        }
     }
     impl FakeBackend {
         pub fn events(&self) -> Vec<String> {
@@ -1201,6 +1243,10 @@ pub mod fake {
         }
         fn move_mouse(&self, p: MkPoint) -> ExecResult {
             self.event(format!("move:{},{}", p.x, p.y))
+        }
+        fn cursor_position(&self) -> ExecResult<MkPoint> {
+            self.event("cursor_position".into())?;
+            Ok(*self.cursor.lock().unwrap())
         }
         fn scroll(&self, d: i32) -> ExecResult {
             self.event(format!("scroll:{d}"))

--- a/src/mkmacro/input.rs
+++ b/src/mkmacro/input.rs
@@ -247,6 +247,9 @@ impl<S: InputSink> InputBackend for Win32InputBackend<S> {
             MOUSEEVENTF_MOVE_ | MOUSEEVENTF_ABSOLUTE_ | MOUSEEVENTF_VIRTUALDESK_,
         )
     }
+    fn cursor_position(&self) -> ExecResult<MkPoint> {
+        cursor_position()
+    }
     fn scroll(&self, d: i32) -> ExecResult {
         self.mouse(0, 0, d as u32, MOUSEEVENTF_WHEEL_)
     }
@@ -259,6 +262,25 @@ impl<S: InputSink> InputBackend for Win32InputBackend<S> {
             )),
         }
     }
+}
+#[cfg(windows)]
+fn cursor_position() -> ExecResult<MkPoint> {
+    use windows::Win32::{Foundation::POINT, UI::WindowsAndMessaging::GetCursorPos};
+    let mut point = POINT::default();
+    unsafe { GetCursorPos(&mut point) }.map_err(|e| {
+        ExecutionDiagnostic::new(DiagnosticKind::Backend, format!("GetCursorPos failed: {e}"))
+    })?;
+    Ok(MkPoint {
+        x: point.x,
+        y: point.y,
+    })
+}
+#[cfg(not(windows))]
+fn cursor_position() -> ExecResult<MkPoint> {
+    Err(ExecutionDiagnostic::new(
+        DiagnosticKind::UnsupportedOperation,
+        "GetCursorPos is available only on Windows",
+    ))
 }
 
 #[cfg(windows)]

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -2,7 +2,7 @@ use crate::mkmacro::variables::{MkPoint, MkValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 fn schema() -> u32 {
     SCHEMA_VERSION
 }
@@ -287,6 +287,20 @@ pub struct MkMousePayload {
     pub clicks: u32,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MkMouseMovePayload {
+    pub target: MkCoordinateTarget,
+    #[serde(default)]
+    pub duration_ms: u64,
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MkMouseDragPayload {
+    pub from: MkCoordinateTarget,
+    pub to: MkCoordinateTarget,
+    pub button: MkMouseButton,
+    #[serde(default)]
+    pub duration_ms: u64,
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkProcessPayload {
     pub program: String,
     #[serde(default)]
@@ -324,7 +338,8 @@ pub enum MkAction {
     KeyPress(MkKey),
     Hotkey(Vec<MkKey>),
     Text(MkTextPayload),
-    MouseMove(MkCoordinateTarget),
+    MouseMove(MkMouseMovePayload),
+    MouseDrag(MkMouseDragPayload),
     MouseClick(MkMousePayload),
     MouseDown(MkMouseButton),
     MouseUp(MkMouseButton),

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -1,7 +1,8 @@
 //! Worker-side, pure recording normalization. No OS, UI automation, or persistence is used here.
 use super::{
     HookEvent, KeyTransition, MkAction, MkCoordinateTarget, MkErrorPolicy, MkKey, MkMouseButton,
-    MkMousePayload, MkPoint, MkStep, MouseButton, MouseMessage, should_record,
+    MkMouseDragPayload, MkMouseMovePayload, MkMousePayload, MkPoint, MkStep, MouseButton,
+    MouseMessage, should_record,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -371,7 +372,10 @@ pub fn to_macro_steps(items: &[RecordedStep], mut next_id: u64) -> Vec<MkStep> {
             RecordedAction::Key {
                 down: false, vk, ..
             } => vec![MkAction::KeyUp(key(vk))],
-            RecordedAction::Move { x, y } => vec![MkAction::MouseMove(point(x, y))],
+            RecordedAction::Move { x, y } => vec![MkAction::MouseMove(MkMouseMovePayload {
+                target: point(x, y),
+                duration_ms: 0,
+            })],
             RecordedAction::Click {
                 button: b,
                 x,
@@ -388,12 +392,12 @@ pub fn to_macro_steps(items: &[RecordedStep], mut next_id: u64) -> Vec<MkStep> {
                 button: b,
                 from,
                 to,
-            } => vec![
-                MkAction::MouseMove(point(from.0, from.1)),
-                MkAction::MouseDown(button(b)),
-                MkAction::MouseMove(point(to.0, to.1)),
-                MkAction::MouseUp(button(b)),
-            ],
+            } => vec![MkAction::MouseDrag(MkMouseDragPayload {
+                from: point(from.0, from.1),
+                to: point(to.0, to.1),
+                button: button(b),
+                duration_ms: 0,
+            })],
             RecordedAction::Wheel { delta, .. } => vec![MkAction::MouseScroll { i32_delta: delta }],
         };
         let action_count = actions.len();
@@ -504,5 +508,37 @@ mod tests {
             }
         ));
         assert_eq!(v[0].delay_after_ms, 100);
+    }
+
+    #[test]
+    fn normalized_drag_becomes_one_drag_step() {
+        let recorded = RecordedStep {
+            action: RecordedAction::Drag {
+                button: MouseButton::Right,
+                from: (3, 4),
+                to: (30, 40),
+            },
+            delay_after_ms: 77,
+        };
+        let steps = to_macro_steps(&[recorded], 10);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].delay_after_ms, 77);
+        let MkAction::MouseDrag(payload) = &steps[0].action else {
+            panic!()
+        };
+        assert_eq!(payload.button, MkMouseButton::Right);
+        assert_eq!(payload.duration_ms, 0);
+        assert_eq!(
+            payload.from,
+            MkCoordinateTarget::Screen {
+                point: MkPoint { x: 3, y: 4 }
+            }
+        );
+        assert_eq!(
+            payload.to,
+            MkCoordinateTarget::Screen {
+                point: MkPoint { x: 30, y: 40 }
+            }
+        );
     }
 }

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -513,12 +513,14 @@ mod tests {
     #[test]
     fn normalized_drag_becomes_one_drag_step() {
         let recorded = RecordedStep {
+            timestamp_us: 0,
             action: RecordedAction::Drag {
                 button: MouseButton::Right,
                 from: (3, 4),
                 to: (30, 40),
             },
             delay_after_ms: 77,
+            context: None,
         };
         let steps = to_macro_steps(&[recorded], 10);
         assert_eq!(steps.len(), 1);

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -232,7 +232,7 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
     if text.trim().is_empty() {
         return Ok(None);
     };
-    let value: serde_json::Value = serde_json::from_str(&text)
+    let mut value: serde_json::Value = serde_json::from_str(&text)
         .context("mkmacros.json is malformed; keep it for recovery or correct the JSON")?;
     let version = value
         .get("schema_version")
@@ -243,8 +243,11 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
             "mkmacros.json schema version {version} is newer than supported version {SCHEMA_VERSION}; update Multi Launcher before opening it"
         )
     };
+    if version == 1 {
+        migrate_v1_to_v2(&mut value)?;
+    }
     let mut doc: MkMacroDocument = match version {
-        0 | 1 => serde_json::from_value(value)
+        0 | 1 | 2 => serde_json::from_value(value)
             .context("mkmacros.json does not match the macro schema")?,
         _ => unreachable!(),
     };
@@ -252,6 +255,46 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
     doc.schema_version = SCHEMA_VERSION;
     changed |= repair_ids(&mut doc);
     Ok(Some((doc, changed)))
+}
+fn migrate_v1_to_v2(value: &mut serde_json::Value) -> Result<()> {
+    let macros = value
+        .get_mut("macros")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or_else(|| anyhow::anyhow!("version 1 macro document has no macros array"))?;
+    for mac in macros {
+        let Some(steps) = mac
+            .get_mut("steps")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for step in steps {
+            let Some(action) = step
+                .get_mut("action")
+                .and_then(serde_json::Value::as_object_mut)
+            else {
+                continue;
+            };
+            if action.get("type").and_then(serde_json::Value::as_str) != Some("mouse_move") {
+                continue;
+            }
+            let already = action
+                .get("data")
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|data| data.contains_key("target"));
+            if !already {
+                let old = action
+                    .remove("data")
+                    .ok_or_else(|| anyhow::anyhow!("version 1 mouse_move has no data"))?;
+                action.insert(
+                    "data".into(),
+                    serde_json::json!({"target": old, "duration_ms": 0}),
+                );
+            }
+        }
+    }
+    value["schema_version"] = serde_json::json!(SCHEMA_VERSION);
+    Ok(())
 }
 pub fn repair_ids(d: &mut MkMacroDocument) -> bool {
     let mut used = HashSet::new();
@@ -358,6 +401,42 @@ mod tests {
         .unwrap();
         let (_, x) = MkMacroStore::open(d.path()).unwrap();
         assert!(matches!(x, LoadDisposition::NeedsUserRecovery { .. }))
+    }
+    #[test]
+    fn version_one_mouse_move_migrates_once_to_payload() {
+        let d = tempfile::tempdir().unwrap();
+        let p = d.path().join(MKMACROS_FILE);
+        fs::write(
+            &p,
+            r#"{
+          "schema_version": 1,
+          "macros": [{"id": 1, "name": "legacy", "steps": [{
+            "id": 2, "action": {"type": "mouse_move", "data": {
+              "kind": "screen", "point": {"x": 12, "y": -4}
+            }}
+          }]}]
+        }"#,
+        )
+        .unwrap();
+        let (doc, changed) = read_document(&p).unwrap().unwrap();
+        assert!(changed);
+        assert_eq!(doc.schema_version, 2);
+        let MkAction::MouseMove(payload) = &doc.macros[0].steps[0].action else {
+            panic!()
+        };
+        assert_eq!(payload.duration_ms, 0);
+        assert_eq!(
+            payload.target,
+            MkCoordinateTarget::Screen {
+                point: MkPoint { x: 12, y: -4 }
+            }
+        );
+        persist(&p, &doc).unwrap();
+        let text = fs::read_to_string(&p).unwrap();
+        assert!(text.contains("\"target\""));
+        let (again, changed_again) = read_document(&p).unwrap().unwrap();
+        assert!(!changed_again);
+        assert_eq!(again, doc);
     }
     #[test]
     fn repairs_zero_and_duplicates() {

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -340,6 +340,7 @@ pub fn repair_ids(d: &mut MkMacroDocument) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mkmacro::MkPoint;
     fn document() -> MkMacroDocument {
         MkMacroDocument {
             schema_version: SCHEMA_VERSION,

--- a/tests/mkmacro_runtime.rs
+++ b/tests/mkmacro_runtime.rs
@@ -61,8 +61,11 @@ fn fake_backed_end_to_end_has_exact_events_and_row_states() {
                     ),
                     s(
                         2,
-                        MkAction::MouseMove(MkCoordinateTarget::Screen {
-                            point: MkPoint { x: 10, y: -2 },
+                        MkAction::MouseMove(MkMouseMovePayload {
+                            target: MkCoordinateTarget::Screen {
+                                point: MkPoint { x: 10, y: -2 },
+                            },
+                            duration_ms: 0,
                         }),
                     ),
                     s(


### PR DESCRIPTION
### Motivation

- Introduce timed mouse movement and first-class mouse drag actions so macros can express duration-based pointer motion and single-step drags.
- Preserve backward compatibility by migrating legacy version-1 `mouse_move` tagged payloads to the new payload shape.
- Surface the new capabilities through the authoring UI and recorder so recorded input maps cleanly to the new model.
- Expose a cursor-position operation on the input boundary so the executor can compute smooth paths from the current pointer.

### Description

- Bumped macro schema to `SCHEMA_VERSION = 2` and added payload types `MkMouseMovePayload` and `MkMouseDragPayload` and the `MkAction::MouseDrag` variant, while changing `MouseMove` to carry `MkMouseMovePayload` (see `src/mkmacro/model.rs`).
- Implemented an explicit, deterministic, idempotent v1->v2 migration in `src/mkmacro/store.rs` that traverses every macro step and rewrites `mouse_move` actions so their `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80a56027b48332b3b9ae0f7d773309)