### PR TITLE
Add recursive condition editor, typed value editor, and configurable action editors

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -55,7 +55,10 @@ pub enum EditorKind {
     Launcher,
     Image,
     Pixel,
-    Structural,
+    Condition,
+    Repeat,
+    Variable,
+    General,
     DirectInsert,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -364,7 +367,7 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             "Repeat",
             "Repeat block",
             &["loop"],
-            MkAction::RepeatStart { count: 2 }
+            MkAction::RepeatStart { count: 5 }
         ),
         d!(
             direct,
@@ -493,17 +496,6 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             MkAction::UiWait(up())
         ),
     ];
-    for descriptor in &mut entries {
-        let action = (descriptor.make_default)();
-        if matches!(
-            action,
-            MkAction::WaitUntil { .. }
-                | MkAction::SetVariable { .. }
-                | MkAction::UnsetVariable { .. }
-        ) {
-            descriptor.availability = ActionAvailability::Hidden;
-        }
-    }
     entries
 }
 /// The editor capability for every model variant. This exhaustive match is the
@@ -525,9 +517,11 @@ pub fn editor_for_action(action: &MkAction) -> EditorKind {
         MkAction::WindowActivate(_) | MkAction::WindowClose(_) | MkAction::WindowWait(_) => {
             EditorKind::Window
         }
-        MkAction::If(_) | MkAction::RepeatStart { .. } | MkAction::WhileStart { .. } => {
-            EditorKind::Structural
+        MkAction::If(_) | MkAction::WhileStart { .. } | MkAction::WaitUntil { .. } => {
+            EditorKind::Condition
         }
+        MkAction::RepeatStart { .. } => EditorKind::Repeat,
+        MkAction::SetVariable { .. } | MkAction::UnsetVariable { .. } => EditorKind::Variable,
         MkAction::Else
         | MkAction::EndIf
         | MkAction::RepeatEnd
@@ -536,16 +530,13 @@ pub fn editor_for_action(action: &MkAction) -> EditorKind {
         | MkAction::Continue => EditorKind::DirectInsert,
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => EditorKind::Image,
         MkAction::PixelCheck { .. } => EditorKind::Pixel,
-        MkAction::WaitUntil { .. }
-        | MkAction::SetVariable { .. }
-        | MkAction::UnsetVariable { .. }
-        | MkAction::UiInvoke(_)
+        MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }
         | MkAction::UiToggle(_)
         | MkAction::UiSelect(_)
         | MkAction::UiFocus(_)
-        | MkAction::UiWait(_) => EditorKind::Structural,
+        | MkAction::UiWait(_) => EditorKind::General,
     }
 }
 
@@ -558,14 +549,17 @@ pub fn editor_route_recognizes(action: &MkAction, editor: EditorKind) -> bool {
 /// accessibility tooling). Zero means the strategy is deliberately insertion-only.
 pub fn editable_field_count(editor: EditorKind) -> usize {
     match editor {
-        EditorKind::DirectInsert | EditorKind::Structural => 0,
+        EditorKind::DirectInsert | EditorKind::General => 0,
         EditorKind::Keyboard
         | EditorKind::Text
         | EditorKind::Timing
         | EditorKind::MouseButton
         | EditorKind::MouseScroll
         | EditorKind::Process
-        | EditorKind::Launcher => 1,
+        | EditorKind::Launcher
+        | EditorKind::Condition
+        | EditorKind::Repeat
+        | EditorKind::Variable => 1,
         EditorKind::MouseMove | EditorKind::MouseClick | EditorKind::Image | EditorKind::Pixel => 2,
         EditorKind::MouseDrag | EditorKind::Window => 3,
     }
@@ -821,7 +815,7 @@ pub fn select_descriptor(d: &mut MkMacroDialog, descriptor: &ActionDescriptor) -
         descriptor.name
     );
     match descriptor.editor {
-        EditorKind::DirectInsert | EditorKind::Structural => insert_action(d, action),
+        EditorKind::DirectInsert => insert_action(d, action),
         kind => d.action_editor.begin_new_with_editor(action, kind),
     }
     true

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -6,7 +6,7 @@ use super::{
     MkMacroDialog,
     key_capture::{CapturedChord, captured_chord, key_name},
 };
-use crate::mkmacro::variables::MkPoint;
+use crate::mkmacro::variables::{MkPoint, MkValue};
 use crate::mkmacro::*;
 use eframe::egui;
 
@@ -161,6 +161,42 @@ impl ActionEditorState {
         let mut step = self.draft.take()?;
         let edit = self.editing_id.take();
         self.editor = None;
+        // New block openers are inserted together with their mandatory closing
+        // marker, while the configured step settings remain on the opener.
+        if edit.is_none()
+            && matches!(
+                &step.action,
+                MkAction::If(_) | MkAction::RepeatStart { .. } | MkAction::WhileStart { .. }
+            )
+        {
+            let action = step.action.clone();
+            super::action_catalog::insert_action(dialog, action);
+            let selected = dialog.selection.ids.clone();
+            let opening_id = dialog
+                .selected_macro()?
+                .steps
+                .iter()
+                .find(|candidate| {
+                    selected.contains(&candidate.id)
+                        && matches!(
+                            (&candidate.action, &step.action),
+                            (MkAction::If(_), MkAction::If(_))
+                                | (MkAction::RepeatStart { .. }, MkAction::RepeatStart { .. })
+                                | (MkAction::WhileStart { .. }, MkAction::WhileStart { .. })
+                        )
+                })?
+                .id;
+            step.id = opening_id;
+            let opening = dialog
+                .selected_macro_mut()?
+                .steps
+                .iter_mut()
+                .find(|candidate| candidate.id == opening_id)?;
+            *opening = step;
+            dialog.selection.ids.clear();
+            dialog.selection.ids.insert(opening_id);
+            return Some(opening_id);
+        }
         let selected = dialog.selection.ids.clone();
         let m = dialog.selected_macro_mut()?;
         let index = if let Some(id) = edit {
@@ -436,17 +472,17 @@ fn optional_field(ui: &mut egui::Ui, label: &str, value: &mut Option<String>) {
         *value = None;
     }
 }
-fn matcher_ui(ui: &mut egui::Ui, m: &mut MkWindowMatcher) {
-    optional_field(ui, "Executable/process", &mut m.process);
+pub(super) fn matcher_ui(ui: &mut egui::Ui, m: &mut MkWindowMatcher) {
+    optional_field(ui, "Executable", &mut m.process);
     optional_field(ui, "Title contains", &mut m.title);
     optional_field(ui, "Title regex", &mut m.title_regex);
-    optional_field(ui, "Window class", &mut m.class);
+    optional_field(ui, "Class", &mut m.class);
     ui.add_enabled(
         false,
         egui::Button::new("Pick window (unavailable on this platform/session)"),
     );
 }
-fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> bool {
+pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> bool {
     let kind = match target {
         MkCoordinateTarget::Screen { .. } => 0,
         MkCoordinateTarget::ActiveWindow { .. } => 1,
@@ -513,6 +549,66 @@ fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> bool {
         }
     }
     false
+}
+
+/// A shared typed editor. Switching type constructs a fresh value rather than
+/// interpreting text belonging to the previous type.
+pub(super) fn value_ui(ui: &mut egui::Ui, value: &mut MkValue) {
+    let kind = match value {
+        MkValue::String(_) => 0,
+        MkValue::Number(_) => 1,
+        MkValue::Boolean(_) => 2,
+        MkValue::Point(_) => 3,
+        MkValue::Null => 4,
+    };
+    let mut next = kind;
+    egui::ComboBox::from_label("Type")
+        .selected_text(["String", "Number", "Boolean", "Point", "Null"][kind])
+        .show_ui(ui, |ui| {
+            for (index, label) in ["String", "Number", "Boolean", "Point", "Null"]
+                .iter()
+                .enumerate()
+            {
+                ui.selectable_value(&mut next, index, *label);
+            }
+        });
+    if next != kind {
+        *value = match next {
+            0 => MkValue::String(String::new()),
+            1 => MkValue::Number(0.0),
+            2 => MkValue::Boolean(false),
+            3 => MkValue::Point(MkPoint { x: 0, y: 0 }),
+            _ => MkValue::Null,
+        };
+    }
+    match value {
+        MkValue::String(text) => {
+            ui.horizontal(|ui| {
+                ui.label("Value");
+                ui.text_edit_singleline(text);
+            });
+        }
+        MkValue::Number(number) => {
+            ui.horizontal(|ui| {
+                ui.label("Value");
+                ui.add(egui::DragValue::new(number));
+            });
+        }
+        MkValue::Boolean(boolean) => {
+            ui.checkbox(boolean, "Value");
+        }
+        MkValue::Point(point) => {
+            ui.horizontal(|ui| {
+                ui.label("X");
+                ui.add(egui::DragValue::new(&mut point.x));
+                ui.label("Y");
+                ui.add(egui::DragValue::new(&mut point.y));
+            });
+        }
+        MkValue::Null => {
+            ui.small("Null has no value.");
+        }
+    }
 }
 
 fn action_ui(
@@ -717,6 +813,39 @@ fn action_ui(
             }
         }
         MkAction::WindowClose(m) => matcher_ui(ui, m),
+        MkAction::SetVariable { name, value } => {
+            ui.horizontal(|ui| {
+                ui.label("Name");
+                ui.text_edit_singleline(name);
+            });
+            value_ui(ui, value);
+        }
+        MkAction::UnsetVariable { name } => {
+            ui.horizontal(|ui| {
+                ui.label("Name");
+                ui.text_edit_singleline(name);
+            });
+        }
+        MkAction::RepeatStart { count } => {
+            ui.horizontal(|ui| {
+                ui.label("Repeat count");
+                ui.add(egui::DragValue::new(count).clamp_range(1..=1_000_000));
+            });
+        }
+        MkAction::If(condition) | MkAction::WhileStart { condition } => {
+            super::condition_editor::condition_ui(ui, condition);
+        }
+        MkAction::WaitUntil { condition, wait } => {
+            super::condition_editor::condition_ui(ui, condition);
+            ui.horizontal(|ui| {
+                ui.label("Timeout (ms)");
+                ui.add(egui::DragValue::new(&mut wait.timeout_ms).clamp_range(0..=86_400_000));
+                ui.label("Poll (ms)");
+                ui.add(
+                    egui::DragValue::new(&mut wait.poll_interval_ms).clamp_range(1..=86_400_000),
+                );
+            });
+        }
         MkAction::LauncherCommand { command, args } => {
             ui.horizontal(|ui| {
                 ui.label("Canonical action");

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -1,0 +1,287 @@
+//! Recursive editor and pure mutation operations for macro conditions.
+
+use super::action_editor::{matcher_ui, target_ui, value_ui};
+use crate::mkmacro::variables::{MkPoint, MkValue};
+use crate::mkmacro::{MkCompareOp, MkCondition, MkCoordinateTarget, MkWindowMatcher};
+use eframe::egui;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConditionKind {
+    Variable,
+    WindowExists,
+    WindowActive,
+    ImageResult,
+    PixelResult,
+    All,
+    Any,
+    Not,
+}
+
+pub fn default_condition(kind: ConditionKind) -> MkCondition {
+    match kind {
+        ConditionKind::Variable => MkCondition::Variable {
+            name: "value".into(),
+            op: MkCompareOp::Eq,
+            value: MkValue::String(String::new()),
+        },
+        ConditionKind::WindowExists => MkCondition::WindowExists {
+            matcher: default_matcher(),
+        },
+        ConditionKind::WindowActive => MkCondition::WindowActive {
+            matcher: default_matcher(),
+        },
+        ConditionKind::ImageResult => MkCondition::ImageResult {
+            asset_id: 1,
+            found: true,
+        },
+        ConditionKind::PixelResult => MkCondition::PixelResult {
+            target: MkCoordinateTarget::Screen {
+                point: MkPoint { x: 0, y: 0 },
+            },
+            color: "#000000".into(),
+            tolerance: 0,
+        },
+        ConditionKind::All => MkCondition::All { conditions: vec![] },
+        ConditionKind::Any => MkCondition::Any { conditions: vec![] },
+        ConditionKind::Not => MkCondition::Not {
+            condition: Box::new(default_condition(ConditionKind::Variable)),
+        },
+    }
+}
+fn default_matcher() -> MkWindowMatcher {
+    MkWindowMatcher {
+        title: Some("Window".into()),
+        title_regex: None,
+        process: None,
+        class: None,
+    }
+}
+pub fn condition_kind(c: &MkCondition) -> ConditionKind {
+    match c {
+        MkCondition::Variable { .. } => ConditionKind::Variable,
+        MkCondition::WindowExists { .. } => ConditionKind::WindowExists,
+        MkCondition::WindowActive { .. } => ConditionKind::WindowActive,
+        MkCondition::ImageResult { .. } => ConditionKind::ImageResult,
+        MkCondition::PixelResult { .. } => ConditionKind::PixelResult,
+        MkCondition::All { .. } => ConditionKind::All,
+        MkCondition::Any { .. } => ConditionKind::Any,
+        MkCondition::Not { .. } => ConditionKind::Not,
+    }
+}
+pub fn replace_condition(c: &mut MkCondition, kind: ConditionKind) {
+    *c = default_condition(kind);
+}
+pub fn append_child(c: &mut MkCondition) -> bool {
+    match c {
+        MkCondition::All { conditions } | MkCondition::Any { conditions } => {
+            conditions.push(default_condition(ConditionKind::Variable));
+            true
+        }
+        _ => false,
+    }
+}
+pub fn remove_child(c: &mut MkCondition, index: usize) -> bool {
+    match c {
+        MkCondition::All { conditions } | MkCondition::Any { conditions }
+            if index < conditions.len() =>
+        {
+            conditions.remove(index);
+            true
+        }
+        _ => false,
+    }
+}
+
+pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) {
+    ui.group(|ui| {
+        let kind = condition_kind(condition);
+        let mut next = kind;
+        egui::ComboBox::from_label("Condition type")
+            .selected_text(kind_label(kind))
+            .show_ui(ui, |ui| {
+                for k in [
+                    ConditionKind::Variable,
+                    ConditionKind::WindowExists,
+                    ConditionKind::WindowActive,
+                    ConditionKind::ImageResult,
+                    ConditionKind::PixelResult,
+                    ConditionKind::All,
+                    ConditionKind::Any,
+                    ConditionKind::Not,
+                ] {
+                    ui.selectable_value(&mut next, k, kind_label(k));
+                }
+            });
+        if next != kind {
+            replace_condition(condition, next);
+        }
+        match condition {
+            MkCondition::Variable { name, op, value } => {
+                ui.horizontal(|ui| {
+                    ui.label("Variable name");
+                    ui.text_edit_singleline(name);
+                });
+                egui::ComboBox::from_label("Comparison")
+                    .selected_text(op_label(op))
+                    .show_ui(ui, |ui| {
+                        for candidate in [
+                            MkCompareOp::Eq,
+                            MkCompareOp::NotEq,
+                            MkCompareOp::Less,
+                            MkCompareOp::LessOrEq,
+                            MkCompareOp::Greater,
+                            MkCompareOp::GreaterOrEq,
+                            MkCompareOp::Contains,
+                            MkCompareOp::StartsWith,
+                            MkCompareOp::EndsWith,
+                            MkCompareOp::Regex,
+                        ] {
+                            let label = op_label(&candidate);
+                            ui.selectable_value(op, candidate, label);
+                        }
+                    });
+                value_ui(ui, value);
+            }
+            MkCondition::WindowExists { matcher } | MkCondition::WindowActive { matcher } => {
+                matcher_ui(ui, matcher)
+            }
+            MkCondition::ImageResult { asset_id, found } => {
+                ui.horizontal(|ui| {
+                    ui.label("Image asset ID");
+                    ui.add(egui::DragValue::new(asset_id));
+                });
+                egui::ComboBox::from_label("Result")
+                    .selected_text(if *found { "Found" } else { "Not found" })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(found, true, "Found");
+                        ui.selectable_value(found, false, "Not found");
+                    });
+            }
+            MkCondition::PixelResult {
+                target,
+                color,
+                tolerance,
+            } => {
+                let _ = target_ui(ui, target);
+                ui.horizontal(|ui| {
+                    ui.label("Color");
+                    ui.text_edit_singleline(color);
+                    ui.label("Tolerance");
+                    ui.add(egui::DragValue::new(tolerance));
+                });
+            }
+            MkCondition::All { conditions } | MkCondition::Any { conditions } => {
+                group_ui(ui, conditions)
+            }
+            MkCondition::Not { condition } => {
+                ui.indent("not-child", |ui| condition_ui(ui, condition));
+            }
+        }
+    });
+}
+fn group_ui(ui: &mut egui::Ui, conditions: &mut Vec<MkCondition>) {
+    let mut remove = None;
+    for (index, child) in conditions.iter_mut().enumerate() {
+        ui.indent(index, |ui| {
+            condition_ui(ui, child);
+            if ui.button("Remove").clicked() {
+                remove = Some(index);
+            }
+        });
+    }
+    if let Some(index) = remove {
+        conditions.remove(index);
+    }
+    if ui.button("+ Add Condition").clicked() {
+        conditions.push(default_condition(ConditionKind::Variable));
+    }
+}
+fn kind_label(k: ConditionKind) -> &'static str {
+    match k {
+        ConditionKind::Variable => "Variable comparison",
+        ConditionKind::WindowExists => "Window exists",
+        ConditionKind::WindowActive => "Window active",
+        ConditionKind::ImageResult => "Image found / not found",
+        ConditionKind::PixelResult => "Pixel matches",
+        ConditionKind::All => "ALL",
+        ConditionKind::Any => "ANY",
+        ConditionKind::Not => "NOT",
+    }
+}
+fn op_label(op: &MkCompareOp) -> &'static str {
+    match op {
+        MkCompareOp::Eq => "Equals",
+        MkCompareOp::NotEq => "Not equal",
+        MkCompareOp::Less => "Less than",
+        MkCompareOp::LessOrEq => "Less than or equal",
+        MkCompareOp::Greater => "Greater than",
+        MkCompareOp::GreaterOrEq => "Greater than or equal",
+        MkCompareOp::Contains => "Contains",
+        MkCompareOp::StartsWith => "Starts with",
+        MkCompareOp::EndsWith => "Ends with",
+        MkCompareOp::Regex => "Regex",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn mutations_are_recursive_and_groups_are_editable() {
+        let mut c = default_condition(ConditionKind::All);
+        assert!(append_child(&mut c));
+        if let MkCondition::All { conditions } = &mut c {
+            replace_condition(&mut conditions[0], ConditionKind::Not);
+            if let MkCondition::Not { condition } = &mut conditions[0] {
+                replace_condition(condition, ConditionKind::PixelResult);
+            }
+        }
+        assert!(remove_child(&mut c, 0));
+        assert!(matches!(c, MkCondition::All { conditions } if conditions.is_empty()));
+    }
+
+    #[test]
+    fn nested_condition_data_survives_recursive_mutation_helpers() {
+        let nested = MkCondition::All {
+            conditions: vec![
+                MkCondition::Any {
+                    conditions: vec![
+                        MkCondition::WindowExists {
+                            matcher: default_matcher(),
+                        },
+                        MkCondition::ImageResult {
+                            asset_id: 42,
+                            found: false,
+                        },
+                    ],
+                },
+                MkCondition::Not {
+                    condition: Box::new(MkCondition::PixelResult {
+                        target: MkCoordinateTarget::ActiveWindow {
+                            point: MkPoint { x: -2, y: 9 },
+                        },
+                        color: "#12abEF".into(),
+                        tolerance: 17,
+                    }),
+                },
+                MkCondition::WindowActive {
+                    matcher: MkWindowMatcher {
+                        title: Some("Editor".into()),
+                        title_regex: Some("^Edit".into()),
+                        process: Some("app.exe".into()),
+                        class: Some("Main".into()),
+                    },
+                },
+                MkCondition::Variable {
+                    name: "score".into(),
+                    op: MkCompareOp::GreaterOrEq,
+                    value: MkValue::Number(3.25),
+                },
+            ],
+        };
+        let mut edited = nested.clone();
+        assert!(append_child(&mut edited));
+        assert!(remove_child(&mut edited, 4));
+        assert_eq!(edited, nested);
+    }
+}

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1,5 +1,6 @@
 pub mod action_catalog;
 pub mod action_editor;
+pub mod condition_editor;
 pub mod image_search_editor;
 mod key_capture;
 mod macro_list;


### PR DESCRIPTION
### Motivation

- Provide a full, recursive UI for editing `MkCondition` nodes so users can author complex conditions (Variable, WindowExists, WindowActive, ImageResult, PixelResult, All, Any, Not) interactively. 
- Reuse existing window matcher and coordinate editors and centralize typed value editing to avoid duplicate UI and parsing surprises when switching types. 
- Replace the overloaded `Structural` editor route with explicit editor strategies so configurable actions open an editor draft transaction instead of inserting unconfigured defaults. 
- Preserve the editor transaction model so selecting/configuring actions does not mutate the macro until `Apply` and `Cancel`/window-close discard drafts.

### Description

- Added a new recursive condition editor in `src/gui/mkmacro_dialog/condition_editor.rs` and exported it from `src/gui/mkmacro_dialog/mod.rs`, including pure mutation helpers `replace_condition`, `append_child`, and `remove_child` and stable group rendering with deferred removals. 
- Introduced a shared typed `MkValue` editor as `value_ui` in `src/gui/mkmacro_dialog/action_editor.rs` and made `matcher_ui`/`target_ui` available as reusable helpers, updating matcher field labels to `Executable` and `Class`. 
- Implemented real editors for `MkAction::SetVariable`, `MkAction::UnsetVariable`, `MkAction::RepeatStart` (default count changed to 5), `MkAction::If`, `MkAction::WhileStart`, and `MkAction::WaitUntil` (including timeout and polling controls) inside `action_editor.rs`, invoking the recursive condition UI where appropriate. 
- Reworked the action catalog in `src/gui/mkmacro_dialog/action_catalog.rs` to replace `EditorKind::Structural` with `EditorKind::Condition`, `EditorKind::Repeat`, `EditorKind::Variable`, and `EditorKind::General`, removed the previous hiding loop for certain descriptors, and changed `select_descriptor` to open an editor transaction for configurable actions. 
- Preserved transactional behavior by ensuring `ActionEditorState::apply` inserts block-openers with their required terminators when creating new structural blocks and replaces the opener's step settings with the configured draft on apply. 
- Added unit tests in `src/gui/mkmacro_dialog/condition_editor.rs` to exercise recursive mutation helpers and a nested round-trip case covering `ALL`, `ANY`, `NOT`, window/image/pixel/variable nodes.

### Testing

- Ran `cargo fmt --all -- --check` which completed successfully. 
- Attempted `cargo test -q`, but the test run could not complete because the repository build pulls platform-specific system libraries and Windows API bindings: initial failures reported missing `alsa`/`x11` pkg-config entries which were resolved by installing dev packages, after which compilation failed on Windows-only `windows::Win32` bindings that are not available on the Linux build host, preventing the unit test suite from executing to completion. 
- Ran `cargo check` which likewise failed due to unresolved `windows::Win32` and `windows::core` symbols on the non-Windows CI/host, so the new UI unit tests were added but could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80b6ca0fe083329f8926c4474b1ca1)