### PR TITLE
Implement desktop pixel color checks and editor

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -478,9 +478,9 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
         ),
         d!(
             Visual,
-            "Check Pixel",
-            "Check a pixel color",
-            &["pixel"],
+            "Check Pixel Color",
+            "Check the color at one pixel coordinate",
+            &["pixel", "color", "screen"],
             Pixel,
             MkAction::PixelCheck {
                 target: point(),
@@ -691,7 +691,7 @@ pub fn action_name(a: &MkAction) -> &'static str {
         MkAction::Continue => "Continue",
         MkAction::ImageFind(_) => "Find Image",
         MkAction::ImageClick(_) => "Click Image",
-        MkAction::PixelCheck { .. } => "Check Pixel",
+        MkAction::PixelCheck { .. } => "Check Pixel Color",
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -39,6 +39,8 @@ enum PositionCaptureSlot {
     ClickTarget,
     DragFrom,
     DragTo,
+    PixelPosition,
+    PixelColor,
 }
 #[derive(Clone, Debug)]
 struct PositionCaptureState {
@@ -259,6 +261,9 @@ impl ActionEditorState {
             (PositionCaptureSlot::ClickTarget, MkAction::MouseClick(p)) => Some(&mut p.target),
             (PositionCaptureSlot::DragFrom, MkAction::MouseDrag(p)) => Some(&mut p.from),
             (PositionCaptureSlot::DragTo, MkAction::MouseDrag(p)) => Some(&mut p.to),
+            (PositionCaptureSlot::PixelPosition, MkAction::PixelCheck { target, .. }) => {
+                Some(target)
+            }
             _ => None,
         }
     }
@@ -295,10 +300,31 @@ impl ActionEditorState {
     }
 
     fn confirm_position(&mut self, capture: PositionCaptureState) {
+        self.confirm_position_with(capture, read_live_desktop_pixel);
+    }
+
+    fn confirm_position_with(
+        &mut self,
+        capture: PositionCaptureState,
+        read_pixel: impl FnOnce(MkPoint) -> Result<[u8; 3], String>,
+    ) {
         let Some(screen) = capture.last_screen_position else {
             self.capture_message = Some("Unable to read the current pointer position".into());
             return;
         };
+        if capture.slot == PositionCaptureSlot::PixelColor {
+            let result = read_pixel(screen).map(|rgb| {
+                if let Some(MkStep {
+                    action: MkAction::PixelCheck { color, .. },
+                    ..
+                }) = self.draft.as_mut()
+                {
+                    *color = crate::mkmacro::screen::format_rgb(rgb);
+                }
+            });
+            self.capture_message = result.err();
+            return;
+        }
         let window = picked_foreground_window(&capture);
         let result = match self.target_mut(capture.slot) {
             Some(target @ MkCoordinateTarget::ActiveWindow { .. }) => {
@@ -331,6 +357,18 @@ impl ActionEditorState {
         self.capture_keys = false;
         true
     }
+}
+
+#[cfg(windows)]
+fn read_live_desktop_pixel(point: MkPoint) -> Result<[u8; 3], String> {
+    let rgba = WindowsScreenCaptureBackend::system()
+        .read_pixel(point)
+        .map_err(|e| e.to_string())?;
+    Ok([rgba[0], rgba[1], rgba[2]])
+}
+#[cfg(not(windows))]
+fn read_live_desktop_pixel(_: MkPoint) -> Result<[u8; 3], String> {
+    Err("Desktop color picking is available only on Windows".into())
 }
 
 fn is_modifier(k: &MkKey) -> bool {
@@ -929,12 +967,38 @@ fn action_ui(
             color,
             tolerance,
         } => {
-            let _ = target_ui(ui, target);
+            ui.heading("Coordinate");
+            if target_ui(ui, target) {
+                pick = Some(PositionCaptureSlot::PixelPosition);
+            }
+            ui.separator();
+            ui.heading("Color");
             ui.horizontal(|ui| {
                 ui.label("Color");
-                ui.text_edit_singleline(color);
+                let response = ui.text_edit_singleline(color);
+                if response.lost_focus() {
+                    if let Ok(rgb) = crate::mkmacro::screen::parse_rgb(color) {
+                        *color = crate::mkmacro::screen::format_rgb(rgb);
+                    }
+                }
+                match crate::mkmacro::screen::parse_rgb(color) {
+                    Ok(rgb) => {
+                        let swatch = egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]);
+                        let (rect, _) =
+                            ui.allocate_exact_size(egui::vec2(28.0, 20.0), egui::Sense::hover());
+                        ui.painter().rect_filled(rect, 3.0, swatch);
+                    }
+                    Err(error) => {
+                        ui.colored_label(egui::Color32::RED, error.to_string());
+                    }
+                }
+                if ui.button("Pick Color").clicked() {
+                    pick = Some(PositionCaptureSlot::PixelColor);
+                }
+            });
+            ui.horizontal(|ui| {
                 ui.label("Tolerance");
-                ui.add(egui::DragValue::new(tolerance));
+                ui.add(egui::DragValue::new(tolerance).clamp_range(0..=255));
             });
         }
         _ => {
@@ -1047,6 +1111,19 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         d.action_editor.set_captured_keys(keys);
     }
     if apply {
+        if let Some(MkStep {
+            action: MkAction::PixelCheck { color, .. },
+            ..
+        }) = d.action_editor.draft.as_mut()
+        {
+            match crate::mkmacro::screen::parse_rgb(color) {
+                Ok(rgb) => *color = crate::mkmacro::screen::format_rgb(rgb),
+                Err(error) => {
+                    d.action_editor.capture_message = Some(error.to_string());
+                    return;
+                }
+            }
+        }
         let mut state = std::mem::take(&mut d.action_editor);
         state.apply(d);
         d.action_editor = state;
@@ -1141,6 +1218,37 @@ mod tests {
         e.position_capture = Some(capture(PositionCaptureSlot::ClickTarget));
         e.cancel();
         assert!(e.position_capture.is_none());
+    }
+
+    #[test]
+    fn desktop_color_pick_updates_only_after_confirmation_and_escape_preserves_draft() {
+        let source = step(MkAction::PixelCheck {
+            target: MkCoordinateTarget::Screen {
+                point: MkPoint { x: -8, y: 4 },
+            },
+            color: "#112233".into(),
+            tolerance: 0,
+        });
+        let mut editor = ActionEditorState::default();
+        editor.begin_edit(&source);
+        editor.draft_generation = 1;
+        let mut pending = capture(PositionCaptureSlot::PixelColor);
+        pending.last_screen_position = Some(MkPoint { x: -8, y: 4 });
+        editor.confirm_position_with(pending, |point| {
+            assert_eq!(point, MkPoint { x: -8, y: 4 });
+            Ok([0xab, 0, 0xff])
+        });
+        let MkAction::PixelCheck { color, .. } = &editor.draft.as_ref().unwrap().action else {
+            panic!()
+        };
+        assert_eq!(color, "#AB00FF");
+
+        editor.position_capture = Some(capture(PositionCaptureSlot::PixelColor));
+        editor.process_position_event(PositionCaptureEvent::Escape);
+        let MkAction::PixelCheck { color, .. } = &editor.draft.as_ref().unwrap().action else {
+            panic!()
+        };
+        assert_eq!(color, "#AB00FF");
     }
 
     #[test]

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -1,5 +1,5 @@
-//! UI-neutral state shared by the Image Search and Pixel Search editor widgets.
-use crate::mkmacro::{AlphaPolicy, MkWindowMatcher, PixelScanOrder, ReturnPoint, SearchRegion};
+//! UI-neutral state for the regional Image Search editor widget.
+use crate::mkmacro::{AlphaPolicy, MkWindowMatcher, ReturnPoint, SearchRegion};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotFoundPolicy {
@@ -33,33 +33,6 @@ impl Default for ImageSearchEditorState {
             y_variable: String::new(),
             found_variable: String::new(),
             not_found: NotFoundPolicy::Error,
-        }
-    }
-}
-#[derive(Debug, Clone)]
-pub struct PixelSearchEditorState {
-    pub color: [u8; 4],
-    pub picking: bool,
-    pub tolerance: u8,
-    pub alpha: AlphaPolicy,
-    pub region: SearchRegion,
-    pub order: PixelScanOrder,
-    pub x_variable: String,
-    pub y_variable: String,
-    pub found_variable: String,
-}
-impl Default for PixelSearchEditorState {
-    fn default() -> Self {
-        Self {
-            color: [0, 0, 0, 255],
-            picking: false,
-            tolerance: 0,
-            alpha: AlphaPolicy::Compare,
-            region: SearchRegion::Desktop,
-            order: PixelScanOrder::TopLeftRows,
-            x_variable: String::new(),
-            y_variable: String::new(),
-            found_variable: String::new(),
         }
     }
 }

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -606,6 +606,56 @@ mod tests {
         );
         assert!(!control.is_active());
     }
+
+    #[test]
+    fn pixel_action_updates_outputs_for_match_mismatch_and_backend_error() {
+        let fake = Arc::new(FakeBackend::default());
+        let executor = Executor::new(fake.clone().backends(), Arc::new(RunControl::default()));
+        let action = MkAction::PixelCheck {
+            target: MkCoordinateTarget::Screen {
+                point: MkPoint { x: -1, y: 2 },
+            },
+            color: "#ABCDEF".into(),
+            tolerance: 3,
+        };
+        let mut vars = RuntimeVariables::new();
+        let mut guard = InputCleanupGuard::new(fake.clone());
+        fake.conditions.lock().unwrap().insert("pixel".into(), true);
+        executor.action(7, &action, &mut vars, &mut guard).unwrap();
+        assert_eq!(vars.get("last_pixel_result"), Some(&MkValue::Boolean(true)));
+        assert_eq!(vars.get("last_pixel_found"), Some(&MkValue::Boolean(true)));
+
+        fake.conditions
+            .lock()
+            .unwrap()
+            .insert("pixel".into(), false);
+        assert_eq!(
+            executor
+                .action(7, &action, &mut vars, &mut guard)
+                .unwrap_err()
+                .kind,
+            DiagnosticKind::TargetNotFound
+        );
+        assert_eq!(
+            vars.get("last_pixel_result"),
+            Some(&MkValue::Boolean(false))
+        );
+        assert_eq!(vars.get("last_pixel_found"), Some(&MkValue::Boolean(false)));
+
+        fake.conditions
+            .lock()
+            .unwrap()
+            .insert("pixel_error".into(), true);
+        assert_eq!(
+            executor
+                .action(7, &action, &mut vars, &mut guard)
+                .unwrap_err()
+                .kind,
+            DiagnosticKind::Backend
+        );
+        assert!(!vars.contains_key("last_pixel_result"));
+        assert!(!vars.contains_key("last_pixel_found"));
+    }
 }
 impl Drop for InputCleanupGuard {
     fn drop(&mut self) {
@@ -844,6 +894,10 @@ impl Executor {
                 color,
                 tolerance,
             } => {
+                // Never expose a result left behind by an earlier check if
+                // coordinate resolution, capture, or color parsing fails.
+                v.remove("last_pixel_result");
+                v.remove("last_pixel_found");
                 let matched = self
                     .backends
                     .screen
@@ -1060,6 +1114,8 @@ impl Executor {
                 color,
                 tolerance,
             } => {
+                v.remove("last_pixel_result");
+                v.remove("last_pixel_found");
                 let x = self
                     .backends
                     .screen
@@ -1357,6 +1413,19 @@ pub mod fake {
             _: u8,
             _: &RuntimeVariables,
         ) -> ExecResult<bool> {
+            if self
+                .conditions
+                .lock()
+                .unwrap()
+                .get("pixel_error")
+                .copied()
+                .unwrap_or(false)
+            {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::Backend,
+                    "injected pixel capture failure",
+                ));
+            }
             Ok(*self
                 .conditions
                 .lock()

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -23,7 +23,42 @@ trait WindowsGeometry: Send + Sync {
 
 trait VisualSearch: Send + Sync {
     fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>>;
-    fn pixel_matches(&self, point: MkPoint, color: &str, tolerance: u8) -> ExecResult<bool>;
+    fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]>;
+}
+
+/// Parse the persisted pixel-check color. The only accepted representation is
+/// canonical CSS-style RGB (`#RRGGBB`); callers may use [`format_rgb`] to
+/// normalize letter case after a successful parse.
+pub fn parse_rgb(value: &str) -> ExecResult<[u8; 3]> {
+    if value.len() != 7 || !value.starts_with('#') {
+        return Err(ExecutionDiagnostic::new(
+            DiagnosticKind::InvalidTarget,
+            format!("invalid pixel color '{value}': expected #RRGGBB"),
+        )
+        .context("color", value));
+    }
+    let digits = &value[1..];
+    if !digits.is_ascii() || !digits.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(ExecutionDiagnostic::new(
+            DiagnosticKind::InvalidTarget,
+            format!("invalid pixel color '{value}': expected hexadecimal #RRGGBB"),
+        )
+        .context("color", value));
+    }
+    let channel = |at: usize| {
+        u8::from_str_radix(&digits[at..at + 2], 16).map_err(|_| {
+            ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                format!("invalid pixel color '{value}': expected hexadecimal #RRGGBB"),
+            )
+            .context("color", value)
+        })
+    };
+    Ok([channel(0)?, channel(2)?, channel(4)?])
+}
+
+pub fn format_rgb(rgb: [u8; 3]) -> String {
+    format!("#{:02X}{:02X}{:02X}", rgb[0], rgb[1], rgb[2])
 }
 
 /// Windows coordinate resolver. OS geometry and visual lookup are injected so
@@ -150,8 +185,16 @@ impl ScreenBackend for WindowsScreenBackend {
         tolerance: u8,
         variables: &RuntimeVariables,
     ) -> ExecResult<bool> {
-        self.visual
-            .pixel_matches(self.resolve(target, variables)?, color, tolerance)
+        let point = self
+            .resolve(target, variables)
+            .map_err(|e| e.context("coordinate_target", format!("{target:?}")))?;
+        let wanted = parse_rgb(color)?;
+        let actual = self.visual.read_pixel(point).map_err(|e| {
+            e.context("backend", "WindowsScreenBackend")
+                .context("coordinate", format!("{},{}", point.x, point.y))
+                .context("color", color)
+        })?;
+        Ok((0..3).all(|channel| actual[channel].abs_diff(wanted[channel]) <= tolerance))
     }
 }
 
@@ -226,12 +269,8 @@ impl VisualSearch for SystemVisualSearch {
         )
         .context("backend", "WindowsScreenBackend"))
     }
-    fn pixel_matches(&self, _: MkPoint, _: &str, _: u8) -> ExecResult<bool> {
-        Err(ExecutionDiagnostic::new(
-            DiagnosticKind::UnsupportedOperation,
-            "production pixel lookup is not configured",
-        )
-        .context("backend", "WindowsScreenBackend"))
+    fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]> {
+        WindowsScreenCaptureBackend::system().read_pixel(point)
     }
 }
 
@@ -432,6 +471,16 @@ impl WindowsScreenCaptureBackend {
             )
         });
         Ok(monitors)
+    }
+
+    /// Capture exactly one live desktop pixel at a signed desktop coordinate.
+    pub fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]> {
+        let rect = ScreenRect::new(point.x, point.y, 1, 1);
+        let image = self
+            .capture(&SearchRegion::Rectangle { rect }, &|| false)
+            .map_err(|e| e.context("coordinate", format!("{},{}", point.x, point.y)))?
+            .image;
+        Ok(image.get_pixel(0, 0).0)
     }
 }
 
@@ -787,8 +836,8 @@ mod windows_backend_tests {
             self.requested.lock().unwrap().push(id);
             Ok(None)
         }
-        fn pixel_matches(&self, _: MkPoint, _: &str, _: u8) -> ExecResult<bool> {
-            Ok(true)
+        fn read_pixel(&self, _: MkPoint) -> ExecResult<[u8; 4]> {
+            Ok([0, 0, 0, 255])
         }
     }
     fn backend(
@@ -804,6 +853,83 @@ mod windows_backend_tests {
             }),
             Arc::new(Visual::default()),
         )
+    }
+
+    #[test]
+    fn strict_rgb_parser_accepts_case_and_formats_canonically() {
+        assert_eq!(parse_rgb("#00A1FF").unwrap(), [0, 161, 255]);
+        assert_eq!(parse_rgb("#00a1fF").unwrap(), [0, 161, 255]);
+        assert_eq!(format_rgb([0, 161, 255]), "#00A1FF");
+        for malformed in [
+            "000000", "#FFF", "#0000000", "#00GG00", "", "# 0000", "#aébcd",
+        ] {
+            let error = parse_rgb(malformed).unwrap_err();
+            assert_eq!(error.kind, DiagnosticKind::InvalidTarget);
+            assert!(error.to_string().contains("#RRGGBB"));
+        }
+    }
+
+    struct PixelVisual([u8; 4]);
+    impl VisualSearch for PixelVisual {
+        fn find_image(&self, _: u64, _: &MkImagePayload) -> ExecResult<Option<MkPoint>> {
+            Ok(None)
+        }
+        fn read_pixel(&self, _: MkPoint) -> ExecResult<[u8; 4]> {
+            Ok(self.0)
+        }
+    }
+    fn pixel_backend(pixel: [u8; 4]) -> WindowsScreenBackend {
+        WindowsScreenBackend::new(
+            Arc::new(Geometry {
+                desktop: (-100, -100, 200, 200),
+                foreground: Some(1),
+                origin: MkPoint { x: -20, y: -30 },
+            }),
+            Arc::new(PixelVisual(pixel)),
+        )
+    }
+
+    #[test]
+    fn pixel_comparison_is_per_channel_overflow_safe_and_ignores_alpha() {
+        let vars = RuntimeVariables::new();
+        let target = screen(MkPoint { x: -50, y: -40 });
+        assert!(
+            pixel_backend([0, 255, 10, 0])
+                .pixel_matches(&target, "#00FF0A", 0, &vars)
+                .unwrap()
+        );
+        assert!(
+            pixel_backend([0, 255, 10, 255])
+                .pixel_matches(&target, "#05FA0F", 5, &vars)
+                .unwrap()
+        );
+        assert!(
+            !pixel_backend([0, 255, 10, 255])
+                .pixel_matches(&target, "#06FA0F", 5, &vars)
+                .unwrap()
+        );
+        assert!(
+            pixel_backend([0, 255, 0, 1])
+                .pixel_matches(&target, "#FF00FF", 255, &vars)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn pixel_target_is_resolved_before_reading() {
+        let backend = pixel_backend([1, 2, 3, 4]);
+        assert!(
+            backend
+                .pixel_matches(
+                    &MkCoordinateTarget::ActiveWindow {
+                        point: MkPoint { x: 2, y: 3 }
+                    },
+                    "#010203",
+                    0,
+                    &RuntimeVariables::new()
+                )
+                .unwrap()
+        );
     }
     fn screen(point: MkPoint) -> MkCoordinateTarget {
         MkCoordinateTarget::Screen { point }

--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -33,6 +33,28 @@ fn wait_for(runtime: &MacroRuntime, wanted: RuntimeState) -> RuntimeSnapshot {
     }
 }
 
+fn wait_for_successful_step(runtime: &MacroRuntime) -> RuntimeSnapshot {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let snapshot = runtime.snapshot();
+        if snapshot
+            .steps
+            .values()
+            .any(|state| *state == StepState::Success)
+        {
+            return (*snapshot).clone();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "runtime reached {:?} at step {:?} without completing a step; states: {:?}",
+            snapshot.state,
+            snapshot.step_id,
+            snapshot.steps
+        );
+        thread::sleep(Duration::from_millis(2));
+    }
+}
+
 #[derive(Default)]
 struct FakeRecorderView;
 impl RecorderControllerView for FakeRecorderView {
@@ -158,6 +180,10 @@ fn complete_authoring_recording_and_playback_workflow_uses_typed_intents() {
         CommandResult::Accepted
     );
     wait_for(&runtime, RuntimeState::Running);
+    // `Running` is published before the worker can finish its first step. Wait
+    // for observable progress so Stop cannot win that scheduling race and
+    // leave every step Pending/Running.
+    wait_for_successful_step(&runtime);
     assert_eq!(
         runtime.command(RuntimeCommand::Stop),
         CommandResult::Accepted


### PR DESCRIPTION
### Motivation

- Provide a focused, production-grade single-pixel color check that reads the live desktop pixel and compares RGB channels with a strict, well-documented color format. 
- Give the user a dedicated editor for the pixel check action that clearly expresses coordinate target, X/Y fields, live position picking, a color field with validation, and a visible swatch. 
- Preserve existing serialized variant compatibility while removing UI/ABI ambiguity that could imply unsupported regional pixel search. 

### Description

- Rename the user-visible action label and help to `"Check Pixel Color"` while keeping the persisted enum `MkAction::PixelCheck` unchanged and add broader search keywords for discoverability. 
- Add a specialized pixel editor in `src/gui/mkmacro_dialog/action_editor.rs` that includes a Coordinate section with target selection (Screen / ActiveWindow / Variable / Image), explicit X/Y fields, `Pick Position` (frame-driven `PositionCaptureState` lifecycle), a `Color` field normalized to uppercase `#RRGGBB` with validation, a visible color swatch, `Pick Color` which invokes a live-desktop read, and a `Tolerance` control clamped to `0..=255`. 
- Implement strict runtime color parsing and formatting in `src/mkmacro/screen.rs` via `parse_rgb` and `format_rgb`, which accept only canonical `#RRGGBB`, return clear `DiagnosticKind::InvalidTarget` errors for malformed inputs, and provide canonical uppercase formatting. 
- Add a live desktop pixel-read operation: `WindowsScreenCaptureBackend::read_pixel` captures a `1x1` rectangle at the resolved signed desktop coordinate and returns the pixel RGBA; `VisualSearch` now exposes `read_pixel`. 
- Implement production `pixel_matches` resolving `MkCoordinateTarget` through `WindowsScreenBackend::resolve`, parsing the configured color, reading the live pixel, comparing R/G/B channels using overflow-safe `abs_diff` and `<= tolerance`, ignoring alpha, and preserving backend/coordinate/color context in diagnostics. 
- Update the editor and executor behavior to validate/normalize colors before apply/run, and ensure `Executor` clears stale `last_pixel_result`/`last_pixel_found` before attempting a check and consistently sets them on both matches and mismatches. 
- Remove/replace the unused `PixelSearchEditorState` from the image-search module to avoid implying regional pixel-search capabilities. 
- Add focused unit tests for `parse_rgb`, canonical formatting, per-channel comparison behavior (including extremes and alpha independence), coordinate resolution, live color-pick update/cancellation, and executor variable semantics using injected fake capture backends. 

### Testing

- Ran formatting and repository checks: `cargo fmt --check` and `git diff --check` (both succeeded). 
- Built and executed unit tests for the pixel/capture logic with `cargo test --lib mkmacro::screen --no-fail-fast`; the added `mkmacro::screen` unit tests for parsing, per-channel comparison, coordinate resolution, and pixel read behavior executed using injected fake backends. 
- Attempted PR creation via `gh` but the environment has no authenticated GitHub credentials (requires `gh auth login` or `GH_TOKEN`) so the CLI step was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80e50c74a88332925a909913ae1065)