### PR TITLE
Implement macro hotkey polling service

### DIFF
--- a/src/mkmacro/hotkeys.rs
+++ b/src/mkmacro/hotkeys.rs
@@ -1,19 +1,110 @@
-//! Macro-hotkey validation and stable ID mapping.
-use super::{MkHotkey, MkKey, MkMacroDocument};
-use std::collections::{BTreeMap, HashMap};
+//! Polling macro-hotkey service and authoring diagnostics.
+use super::{MkHotkey, MkKey, MkMacroDocument, MkMacroStore};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+/// The deliberately small boundary between hotkey polling and the operating system.
+pub trait KeyStateBackend: Send + Sync {
+    fn is_down(&self, key: &MkKey) -> bool;
+}
+
+#[derive(Default)]
+struct SystemKeyStateBackend;
+
+#[cfg(windows)]
+impl KeyStateBackend for SystemKeyStateBackend {
+    fn is_down(&self, key: &MkKey) -> bool {
+        use windows::Win32::UI::Input::KeyboardAndMouse::GetAsyncKeyState;
+        fn down(vk: i32) -> bool {
+            unsafe { (GetAsyncKeyState(vk) as u16 & 0x8000) != 0 }
+        }
+        let one = |a, b| down(a) || down(b);
+        match key {
+            MkKey::Control => one(0xA2, 0xA3),
+            MkKey::Shift => one(0xA0, 0xA1),
+            MkKey::Alt => one(0xA4, 0xA5),
+            MkKey::Meta => one(0x5B, 0x5C),
+            MkKey::LeftControl => down(0xA2),
+            MkKey::RightControl => down(0xA3),
+            MkKey::LeftShift => down(0xA0),
+            MkKey::RightShift => down(0xA1),
+            MkKey::LeftAlt => down(0xA4),
+            MkKey::RightAlt => down(0xA5),
+            MkKey::LeftMeta => down(0x5B),
+            MkKey::RightMeta => down(0x5C),
+            _ => vk_from_primary(key).is_some_and(down),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl KeyStateBackend for SystemKeyStateBackend {
+    fn is_down(&self, _key: &MkKey) -> bool {
+        false
+    }
+}
+
+#[cfg(windows)]
+fn vk_from_primary(key: &MkKey) -> Option<i32> {
+    Some(match key {
+        MkKey::Character(s) if s.len() == 1 && s.is_ascii() => {
+            let c = s.as_bytes()[0].to_ascii_uppercase();
+            if !c.is_ascii_alphanumeric() {
+                return None;
+            }
+            c as i32
+        }
+        MkKey::Enter => 0x0D,
+        MkKey::Tab => 0x09,
+        MkKey::Escape => 0x1B,
+        MkKey::Space => 0x20,
+        MkKey::Backspace => 0x08,
+        MkKey::Delete => 0x2E,
+        MkKey::Up => 0x26,
+        MkKey::Down => 0x28,
+        MkKey::Left => 0x25,
+        MkKey::Right => 0x27,
+        MkKey::Home => 0x24,
+        MkKey::End => 0x23,
+        MkKey::PageUp => 0x21,
+        MkKey::PageDown => 0x22,
+        MkKey::Function(n @ 1..=12) => 0x6F + *n as i32,
+        _ => return None,
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HotkeyDiagnostic {
     pub macro_id: u64,
     pub message: String,
 }
+
+fn modifier(key: &MkKey) -> Option<MkKey> {
+    match key {
+        MkKey::Control | MkKey::LeftControl | MkKey::RightControl => Some(MkKey::Control),
+        MkKey::Alt | MkKey::LeftAlt | MkKey::RightAlt => Some(MkKey::Alt),
+        MkKey::Shift | MkKey::LeftShift | MkKey::RightShift => Some(MkKey::Shift),
+        MkKey::Meta | MkKey::LeftMeta | MkKey::RightMeta => Some(MkKey::Meta),
+        _ => None,
+    }
+}
 fn key_name(k: &MkKey) -> String {
-    match k {
-        MkKey::Character(s) => s.to_ascii_uppercase(),
-        MkKey::Control | MkKey::LeftControl | MkKey::RightControl => "CONTROL".into(),
-        MkKey::Alt | MkKey::LeftAlt | MkKey::RightAlt => "ALT".into(),
-        MkKey::Shift | MkKey::LeftShift | MkKey::RightShift => "SHIFT".into(),
-        MkKey::Meta | MkKey::LeftMeta | MkKey::RightMeta => "META".into(),
-        x => format!("{x:?}").to_ascii_uppercase(),
+    match modifier(k) {
+        Some(MkKey::Control) => "CONTROL".into(),
+        Some(MkKey::Alt) => "ALT".into(),
+        Some(MkKey::Shift) => "SHIFT".into(),
+        Some(MkKey::Meta) => "META".into(),
+        _ => match k {
+            MkKey::Character(s) => s.to_ascii_uppercase(),
+            x => format!("{x:?}").to_ascii_uppercase(),
+        },
     }
 }
 pub fn canonical_hotkey(h: &MkHotkey) -> String {
@@ -23,8 +114,51 @@ pub fn canonical_hotkey(h: &MkHotkey) -> String {
     mods.push(key_name(&h.key));
     mods.join("+")
 }
+
+fn compile_hotkey(h: &MkHotkey) -> Option<(BTreeSet<String>, MkKey)> {
+    // A modifier in the primary slot, or any non-modifier in the modifier list, is malformed.
+    if modifier(&h.key).is_some() || !usable_primary(&h.key) {
+        return None;
+    }
+    let mut mods = BTreeSet::new();
+    for key in &h.modifiers {
+        mods.insert(key_name(&modifier(key)?));
+    }
+    Some((mods, normalize_primary(&h.key)?))
+}
+fn normalize_primary(key: &MkKey) -> Option<MkKey> {
+    match key {
+        MkKey::Character(s)
+            if s.chars().count() == 1
+                && s.is_ascii()
+                && s.as_bytes()[0].is_ascii_alphanumeric() =>
+        {
+            Some(MkKey::Character(s.to_ascii_uppercase()))
+        }
+        _ if usable_primary(key) => Some(key.clone()),
+        _ => None,
+    }
+}
+fn usable_primary(key: &MkKey) -> bool {
+    match key {
+        MkKey::Character(s) => {
+            s.chars().count() == 1 && s.is_ascii() && s.as_bytes()[0].is_ascii_alphanumeric()
+        }
+        MkKey::Function(n) => (1..=12).contains(n),
+        _ => modifier(key).is_none(),
+    }
+}
+
 pub fn validate_hotkeys(doc: &MkMacroDocument, reserved: &[(&str, &str)]) -> Vec<HotkeyDiagnostic> {
-    let mut seen = HashMap::new();
+    let mut frequencies = HashMap::new();
+    for h in doc
+        .macros
+        .iter()
+        .filter(|m| m.enabled)
+        .filter_map(|m| m.hotkey.as_ref())
+    {
+        *frequencies.entry(canonical_hotkey(h)).or_insert(0usize) += 1;
+    }
     let reserved = reserved
         .iter()
         .map(|(n, h)| (h.to_ascii_uppercase().replace(' ', ""), *n))
@@ -33,39 +167,198 @@ pub fn validate_hotkeys(doc: &MkMacroDocument, reserved: &[(&str, &str)]) -> Vec
     for m in doc.macros.iter().filter(|m| m.enabled) {
         let Some(h) = &m.hotkey else { continue };
         let c = canonical_hotkey(h);
-        if let Some(other) = seen.insert(c.clone(), m.id) {
+        if frequencies[&c] > 1 {
             out.push(HotkeyDiagnostic {
                 macro_id: m.id,
-                message: format!("hotkey duplicates macro {other}"),
-            })
+                message: "hotkey is duplicated by another enabled macro".into(),
+            });
         }
         if let Some(name) = reserved.get(&c) {
             out.push(HotkeyDiagnostic {
                 macro_id: m.id,
                 message: format!("hotkey conflicts with {name}"),
-            })
+            });
         }
     }
     out
 }
-/// Rebuilt after every store update; IDs are deterministic and disabled macros are absent.
+
+/// Legacy stable ID mapping retained for callers; duplicate bindings are omitted.
 pub fn rebuild_hotkey_map(doc: &MkMacroDocument, first_registration_id: i32) -> BTreeMap<i32, u64> {
-    let mut ids = doc
-        .macros
-        .iter()
-        .filter(|m| m.enabled && m.hotkey.is_some())
-        .map(|m| m.id)
-        .collect::<Vec<_>>();
-    ids.sort_unstable();
-    ids.into_iter()
+    let bindings = compile_bindings(doc);
+    bindings
+        .into_iter()
         .enumerate()
-        .map(|(i, id)| (first_registration_id + i as i32, id))
+        .map(|(i, b)| (first_registration_id + i as i32, b.macro_id))
         .collect()
 }
+
+struct Binding {
+    macro_id: u64,
+    modifiers: BTreeSet<String>,
+    primary: MkKey,
+    triggered: bool,
+}
+fn compile_bindings(doc: &MkMacroDocument) -> Vec<Binding> {
+    let mut frequency = HashMap::new();
+    for m in doc.macros.iter().filter(|m| m.enabled) {
+        if let Some(h) = &m.hotkey {
+            *frequency.entry(canonical_hotkey(h)).or_insert(0usize) += 1;
+        }
+    }
+    let mut out = doc
+        .macros
+        .iter()
+        .filter(|m| m.enabled)
+        .filter_map(|m| {
+            let h = m.hotkey.as_ref()?;
+            if frequency[&canonical_hotkey(h)] != 1 {
+                return None;
+            }
+            let (modifiers, primary) = compile_hotkey(h)?;
+            Some(Binding {
+                macro_id: m.id,
+                modifiers,
+                primary,
+                triggered: false,
+            })
+        })
+        .collect::<Vec<_>>();
+    out.sort_by_key(|b| b.macro_id);
+    out
+}
+
+struct PollState {
+    snapshot: Arc<MkMacroDocument>,
+    bindings: Vec<Binding>,
+}
+type Trigger = dyn Fn(u64) + Send + Sync;
+
+pub struct MkMacroHotkeyService {
+    store: Arc<MkMacroStore>,
+    stop: Arc<AtomicBool>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    state: Arc<Mutex<PollState>>,
+    backend: Arc<dyn KeyStateBackend>,
+    trigger: Arc<Trigger>,
+}
+impl MkMacroHotkeyService {
+    pub fn new(store: Arc<MkMacroStore>) -> Self {
+        Self::with_backend(store, Arc::new(SystemKeyStateBackend))
+    }
+    pub fn with_backend(store: Arc<MkMacroStore>, backend: Arc<dyn KeyStateBackend>) -> Self {
+        Self::start(
+            store,
+            backend,
+            Arc::new(|id| {
+                let _ = crate::mkmacro::runtime::run(id);
+            }),
+        )
+    }
+    fn start(
+        store: Arc<MkMacroStore>,
+        backend: Arc<dyn KeyStateBackend>,
+        trigger: Arc<Trigger>,
+    ) -> Self {
+        let snapshot = store.snapshot();
+        let state = Arc::new(Mutex::new(PollState {
+            bindings: compile_bindings(&snapshot),
+            snapshot,
+        }));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (worker_store, worker_stop, worker_state, worker_backend, worker_trigger) = (
+            store.clone(),
+            stop.clone(),
+            state.clone(),
+            backend.clone(),
+            trigger.clone(),
+        );
+        let worker = thread::Builder::new()
+            .name("mkmacro-hotkeys".into())
+            .spawn(move || {
+                while !worker_stop.load(Ordering::SeqCst) {
+                    tick(
+                        &worker_store,
+                        &worker_state,
+                        worker_backend.as_ref(),
+                        worker_trigger.as_ref(),
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+            })
+            .expect("spawn macro hotkey service");
+        Self {
+            store,
+            stop,
+            worker: Mutex::new(Some(worker)),
+            state,
+            backend,
+            trigger,
+        }
+    }
+    pub fn shutdown(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.worker.lock().unwrap().take() {
+            let _ = h.join();
+        }
+    }
+}
+impl Drop for MkMacroHotkeyService {
+    fn drop(&mut self) {
+        self.shutdown()
+    }
+}
+
+fn tick(
+    store: &MkMacroStore,
+    state: &Mutex<PollState>,
+    backend: &dyn KeyStateBackend,
+    trigger: &Trigger,
+) {
+    let snapshot = store.snapshot();
+    let mut fire = Vec::new();
+    {
+        let mut state = state.lock().unwrap();
+        if !Arc::ptr_eq(&snapshot, &state.snapshot) {
+            state.bindings = compile_bindings(&snapshot);
+            state.snapshot = snapshot;
+        }
+        let ctrl = backend.is_down(&MkKey::Control);
+        let shift = backend.is_down(&MkKey::Shift);
+        let alt = backend.is_down(&MkKey::Alt);
+        let meta = backend.is_down(&MkKey::Meta);
+        let mut keys: Vec<(MkKey, bool)> = Vec::new();
+        for b in &state.bindings {
+            if !keys.iter().any(|(k, _)| k == &b.primary) {
+                keys.push((b.primary.clone(), backend.is_down(&b.primary)));
+            }
+        }
+        for b in &mut state.bindings {
+            // Like the Launcher listener, required modifiers are inclusive: extra modifiers are allowed.
+            let down = keys.iter().find(|(k, _)| k == &b.primary).unwrap().1
+                && (!b.modifiers.contains("CONTROL") || ctrl)
+                && (!b.modifiers.contains("SHIFT") || shift)
+                && (!b.modifiers.contains("ALT") || alt)
+                && (!b.modifiers.contains("META") || meta);
+            if down && !b.triggered {
+                b.triggered = true;
+                fire.push(b.macro_id);
+            } else if !down {
+                b.triggered = false;
+            }
+        }
+    }
+    // Never hold the service/store state lock across runtime admission.
+    for id in fire {
+        trigger(id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::mkmacro::{MkMacro, MkPlayback};
+    use std::sync::RwLock;
     fn mac(id: u64, on: bool) -> MkMacro {
         MkMacro {
             id,
@@ -81,12 +374,57 @@ mod tests {
         }
     }
     #[test]
-    fn duplicates_disabled_and_stable_reload() {
+    fn every_duplicate_is_diagnosed_and_unarmed() {
         let d = MkMacroDocument {
             schema_version: 1,
-            macros: vec![mac(9, true), mac(2, true), mac(1, false)],
+            macros: vec![mac(9, true), mac(2, true), mac(1, true)],
         };
-        assert_eq!(validate_hotkeys(&d, &[]).len(), 1);
+        assert_eq!(validate_hotkeys(&d, &[]).len(), 3);
+        assert!(compile_bindings(&d).is_empty());
+    }
+    #[test]
+    fn disabled_duplicate_does_not_conflict() {
+        let d = MkMacroDocument {
+            schema_version: 1,
+            macros: vec![mac(2, true), mac(1, false)],
+        };
+        assert_eq!(compile_bindings(&d).len(), 1);
+    }
+    #[test]
+    fn aliases_and_malformed_are_handled() {
+        let mut a = mac(1, true);
+        a.hotkey.as_mut().unwrap().modifiers = vec![MkKey::RightControl];
+        let mut b = mac(2, true);
+        b.hotkey.as_mut().unwrap().modifiers = vec![MkKey::LeftControl];
+        let d = MkMacroDocument {
+            schema_version: 1,
+            macros: vec![a, b],
+        };
+        assert!(compile_bindings(&d).is_empty());
+        let mut bad = mac(3, true);
+        bad.hotkey
+            .as_mut()
+            .unwrap()
+            .modifiers
+            .push(MkKey::Character("X".into()));
+        assert!(
+            compile_bindings(&MkMacroDocument {
+                schema_version: 1,
+                macros: vec![bad]
+            })
+            .is_empty()
+        );
+    }
+    #[test]
+    fn deterministic_rebuild() {
+        let d = MkMacroDocument {
+            schema_version: 1,
+            macros: vec![mac(9, true), {
+                let mut m = mac(2, true);
+                m.hotkey.as_mut().unwrap().key = MkKey::Character("J".into());
+                m
+            }],
+        };
         assert_eq!(
             rebuild_hotkey_map(&d, 100)
                 .into_values()
@@ -96,26 +434,64 @@ mod tests {
     }
     #[test]
     fn reserved_conflict() {
-        let d = MkMacroDocument {
-            schema_version: 1,
-            macros: vec![mac(1, true)],
-        };
         assert_eq!(
-            validate_hotkeys(&d, &[("emergency stop", "CONTROL+K")]).len(),
+            validate_hotkeys(
+                &MkMacroDocument {
+                    schema_version: 1,
+                    macros: vec![mac(1, true)]
+                },
+                &[("emergency stop", "CONTROL+K")]
+            )
+            .len(),
             1
-        )
+        );
+    }
+    struct Fake(RwLock<Vec<MkKey>>);
+    impl KeyStateBackend for Fake {
+        fn is_down(&self, k: &MkKey) -> bool {
+            self.0.read().unwrap().contains(k)
+        }
     }
     #[test]
-    fn canonical_modifier_order_sides_and_duplicates_are_equivalent() {
-        let key = MkKey::Character("m".into());
-        let a = MkHotkey {
-            key: key.clone(),
-            modifiers: vec![MkKey::Alt, MkKey::Control],
-        };
-        let b = MkHotkey {
-            key,
-            modifiers: vec![MkKey::RightControl, MkKey::LeftAlt, MkKey::Control],
-        };
-        assert_eq!(canonical_hotkey(&a), canonical_hotkey(&b));
+    fn tick_has_edges_and_rebuilds() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        store
+            .save(MkMacroDocument {
+                schema_version: 1,
+                macros: vec![mac(1, true)],
+            })
+            .unwrap();
+        let store = Arc::new(store);
+        let snap = store.snapshot();
+        let state = Mutex::new(PollState {
+            bindings: compile_bindings(&snap),
+            snapshot: snap,
+        });
+        let fake = Fake(RwLock::new(vec![
+            MkKey::Control,
+            MkKey::Character("K".into()),
+        ]));
+        let fired = Mutex::new(vec![]);
+        let cb = |id| fired.lock().unwrap().push(id);
+        tick(&store, &state, &fake, &cb);
+        tick(&store, &state, &fake, &cb);
+        assert_eq!(*fired.lock().unwrap(), vec![1]);
+        fake.0.write().unwrap().clear();
+        tick(&store, &state, &fake, &cb);
+        fake.0
+            .write()
+            .unwrap()
+            .extend([MkKey::Control, MkKey::Character("K".into())]);
+        tick(&store, &state, &fake, &cb);
+        assert_eq!(*fired.lock().unwrap(), vec![1, 1]);
+        store
+            .save(MkMacroDocument {
+                schema_version: 1,
+                macros: vec![],
+            })
+            .unwrap();
+        tick(&store, &state, &fake, &cb);
+        assert_eq!(*fired.lock().unwrap(), vec![1, 1]);
     }
 }

--- a/src/mkmacro/hotkeys.rs
+++ b/src/mkmacro/hotkeys.rs
@@ -309,12 +309,14 @@ impl Drop for MkMacroHotkeyService {
     }
 }
 
-fn tick(
+fn tick<F>(
     store: &MkMacroStore,
     state: &Mutex<PollState>,
     backend: &dyn KeyStateBackend,
-    trigger: &Trigger,
-) {
+    trigger: &F,
+) where
+    F: Fn(u64) + ?Sized,
+{
     let snapshot = store.snapshot();
     let mut fire = Vec::new();
     {

--- a/src/mkmacro/runtime.rs
+++ b/src/mkmacro/runtime.rs
@@ -451,11 +451,17 @@ fn run_one(
 
 static RUNTIME: Lazy<RwLock<Option<Arc<MacroRuntime>>>> = Lazy::new(|| RwLock::new(None));
 static RECORDER: Lazy<RwLock<Option<Arc<RecorderRuntime>>>> = Lazy::new(|| RwLock::new(None));
+static HOTKEYS: Lazy<RwLock<Option<Arc<super::hotkeys::MkMacroHotkeyService>>>> =
+    Lazy::new(|| RwLock::new(None));
 pub fn set_shared_store(store: Arc<MkMacroStore>) {
     set_shared_store_with_backends(store, production_backends())
 }
 /// Installs a shared runtime with injected effects (intended for tests).
 pub fn set_shared_store_with_backends(store: Arc<MkMacroStore>, backends: Backends) {
+    // Stop the old poller before replacing the runtime it dispatches into.
+    if let Some(old) = HOTKEYS.write().unwrap().take() {
+        old.shutdown()
+    }
     if let Some(old) = RUNTIME.write().unwrap().take() {
         old.shutdown()
     }
@@ -469,11 +475,12 @@ pub fn set_shared_store_with_backends(store: Arc<MkMacroStore>, backends: Backen
         guard.clone(),
     )));
     *RECORDER.write().unwrap() = Some(Arc::new(RecorderRuntime::with_guard(
-        store,
+        store.clone(),
         production_hook_service(8192),
         Arc::new(SystemRecorderClock::default()),
         guard,
-    )))
+    )));
+    *HOTKEYS.write().unwrap() = Some(Arc::new(super::hotkeys::MkMacroHotkeyService::new(store)));
 }
 fn global() -> Result<Arc<MacroRuntime>> {
     RUNTIME


### PR DESCRIPTION
### Motivation

- Add a dedicated polling-based hotkey service for macros that observes store snapshots and invokes the macro runtime on rising edges without changing the existing Launcher hotkey listener.  
- Provide a small injectable OS keyboard-state boundary so tests can run deterministically without calling live platform APIs.  

### Description

- Introduced a small `KeyStateBackend` trait and a `SystemKeyStateBackend` with a Windows `GetAsyncKeyState` implementation and a build-safe no-op fallback for other platforms.  
- Added compiled binding representation and validation logic that normalizes sided modifiers, rejects malformed hotkeys, and builds per-binding latch state.  
- Replaced the prior implicit-first-wins duplicate handling with a canonical-hotkey frequency map that disarms all enabled members of any duplicate group and reports diagnostics for every affected macro.  
- Implemented `MkMacroHotkeyService` owning the `Arc<MkMacroStore>`, an atomic stop flag, optional worker `JoinHandle`, the current `Arc<MkMacroDocument>` snapshot, compiled active bindings with latch flags, and an injected `Arc<dyn KeyStateBackend>`; the service exposes a production constructor and injectable backend constructor and performs idempotent shutdown and join on `Drop`.  
- Implemented the ~20 ms polling loop that obtains `store.snapshot()` each tick, compares via `Arc::ptr_eq` to rebuild bindings only on snapshot changes, reads modifier states and only the distinct primaries required by active bindings, treats extra modifiers as allowed (inclusive matching), uses rising-edge latching to call `crate::mkmacro::runtime::run(macro_id)` exactly once per press, and clears latches on release.  
- Wired the service lifecycle into macro runtime initialization so the old service is shut down before the runtime/store is replaced.  
- Added deterministic unit tests for duplicates, disabled duplicates, sided modifier aliases, malformed hotkeys, reserved conflicts, deterministic rebuilds, edge latching, retriggering, and snapshot-driven binding removal using a fake backend and direct `tick` invocation.  

### Testing

- `cargo fmt --all` was run and completed successfully.  
- `git diff --check` was run and completed successfully.  
- `cargo test mkmacro::hotkeys --lib` was attempted for the new hotkey unit tests, but execution in this environment was blocked by repository-wide, pre-existing non-Windows Windows-API compilation/resolution issues that prevent running the full test build here (the tests themselves are deterministic and exercise the poll tick via a fake backend).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a810cdca5cc83329ec039519661a02f)