### PR TITLE
Add production VisualSearch adapter and extend screen/image tests with injectable capture/geometry

### DIFF
--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1,8 +1,8 @@
 //! Platform-neutral plan executor and injectable effect boundaries.
 use super::{
     Jump, MkAction, MkCompareOp, MkCondition, MkCoordinateTarget, MkExecutionPlan, MkImagePayload,
-    MkKey, MkMouseButton, MkPlayback, MkPoint, MkProcessPayload, MkTextPayload, MkUiPayload,
-    MkValue, MkWaitOptions, MkWindowMatcher, MkWindowPayload, RuntimeVariables,
+    MkKey, MkMacroStore, MkMouseButton, MkPlayback, MkPoint, MkProcessPayload, MkTextPayload,
+    MkUiPayload, MkValue, MkWaitOptions, MkWindowMatcher, MkWindowPayload, RuntimeVariables,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -312,6 +312,19 @@ pub fn production_backends() -> Backends {
     {
         unsupported
     }
+}
+
+/// Store-aware production wiring used by the macro runtime. Keeping this
+/// separate preserves callers that only need non-visual production boundaries.
+pub fn production_backends_with_store(store: Arc<MkMacroStore>) -> Backends {
+    let mut backends = production_backends();
+    #[cfg(windows)]
+    {
+        backends.screen = Arc::new(super::screen::WindowsScreenBackend::production(store));
+    }
+    #[cfg(not(windows))]
+    let _ = store;
+    backends
 }
 impl LauncherBackend for Unsupported {
     fn launch_process(&self, _: &MkProcessPayload) -> ExecResult {

--- a/src/mkmacro/image_search.rs
+++ b/src/mkmacro/image_search.rs
@@ -4,7 +4,13 @@ use crate::mkmacro::{
     CapturedRegion, DiagnosticKind, ExecResult, ExecutionDiagnostic, cancelled_error,
 };
 use image::{Rgba, RgbaImage};
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use super::{MkImagePayload, MkPoint, ScreenCaptureBackend, SearchRegion, VisualSearch};
 
 /// Run-scoped decode cache. Construct one for each playback; repeated visual waits
 /// and searches using the same stable reference share the decoded pixels.
@@ -25,12 +31,22 @@ impl ImageDecodeCache {
         let path = store
             .resolve_asset_reference(macro_id, Path::new(reference))
             .map_err(|e| ExecutionDiagnostic::new(DiagnosticKind::InvalidTarget, e.to_string()))?;
-        let image = image::open(&path)
+        let bytes = std::fs::read(&path).map_err(|e| {
+            let message = if e.kind() == std::io::ErrorKind::NotFound {
+                format!("reference image is missing: {}", path.display())
+            } else {
+                format!("reference image is unreadable: {}: {e}", path.display())
+            };
+            ExecutionDiagnostic::new(DiagnosticKind::InvalidTarget, message)
+                .context("asset_path", path.display().to_string())
+        })?;
+        let image = image::load_from_memory(&bytes)
             .map_err(|e| {
                 ExecutionDiagnostic::new(
                     DiagnosticKind::InvalidTarget,
-                    format!("decode reference image {}: {e}", path.display()),
+                    format!("reference image is undecodable: {}: {e}", path.display()),
                 )
+                .context("asset_path", path.display().to_string())
             })?
             .to_rgba8();
         let image = Arc::new(image);
@@ -42,6 +58,64 @@ impl ImageDecodeCache {
     }
     pub fn is_empty(&self) -> bool {
         self.images.is_empty()
+    }
+}
+
+/// Production orchestration for one image-search attempt. Polling and deadlines
+/// deliberately remain in `Executor`, so this adapter never sleeps and is easy
+/// to exercise with deterministic capture fixtures.
+pub struct ProductionVisualSearch {
+    store: Arc<MkMacroStore>,
+    capture: Arc<dyn ScreenCaptureBackend>,
+    cache: Mutex<ImageDecodeCache>,
+}
+
+impl ProductionVisualSearch {
+    pub fn new(store: Arc<MkMacroStore>, capture: Arc<dyn ScreenCaptureBackend>) -> Self {
+        Self {
+            store,
+            capture,
+            cache: Mutex::new(ImageDecodeCache::default()),
+        }
+    }
+
+    fn asset_reference(macro_id: u64, asset_id: u64) -> String {
+        format!(
+            "{}/{macro_id}/{asset_id}.png",
+            super::store::ASSET_DIRECTORY
+        )
+    }
+}
+
+impl VisualSearch for ProductionVisualSearch {
+    fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>> {
+        let reference = Self::asset_reference(macro_id, payload.asset_id);
+        let needle = self
+            .cache
+            .lock()
+            .unwrap()
+            .get_or_decode(&self.store, macro_id, &reference)?;
+        let frame = self.capture.capture(&payload.region, &|| false)?;
+        find_template(
+            &frame,
+            &needle,
+            MatchOptions {
+                tolerance: payload.tolerance,
+                alpha: payload.alpha,
+                return_point: payload.return_point,
+                first_result: true,
+            },
+            &|| false,
+        )
+        .map(|point| point.map(|(x, y)| MkPoint { x, y }))
+    }
+
+    fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]> {
+        let rect = super::ScreenRect::new(point.x, point.y, 1, 1);
+        let frame = self
+            .capture
+            .capture(&SearchRegion::Rectangle { rect }, &|| false)?;
+        Ok(frame.image.get_pixel(0, 0).0)
     }
 }
 
@@ -207,6 +281,7 @@ pub fn find_pixel(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     fn cap(w: u32, h: u32) -> CapturedRegion {
         CapturedRegion {
             image: RgbaImage::from_pixel(w, h, Rgba([0, 0, 0, 255])),
@@ -253,6 +328,115 @@ mod tests {
         assert!(find_template(&f, &n, o, &|| false).unwrap().is_some());
         o.tolerance = 1;
         assert_eq!(find_template(&f, &n, o, &|| false).unwrap(), None)
+    }
+    #[test]
+    fn cancellation_is_reported_without_finishing_the_scan() {
+        let calls = AtomicUsize::new(0);
+        let error = find_template(
+            &cap(8, 8),
+            &RgbaImage::from_pixel(2, 2, Rgba([1, 1, 1, 255])),
+            MatchOptions::default(),
+            &|| calls.fetch_add(1, Ordering::SeqCst) >= 2,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind, DiagnosticKind::Cancelled);
+    }
+
+    struct FakeCapture {
+        frame: CapturedRegion,
+        captures: AtomicUsize,
+    }
+    impl ScreenCaptureBackend for FakeCapture {
+        fn virtual_desktop(&self) -> ExecResult<super::super::ScreenRect> {
+            Ok(self.frame.rect())
+        }
+        fn region_bounds(&self, _: &SearchRegion) -> ExecResult<super::super::ScreenRect> {
+            Ok(self.frame.rect())
+        }
+        fn capture_rect(
+            &self,
+            _: super::super::ScreenRect,
+            _: &dyn Fn() -> bool,
+        ) -> ExecResult<RgbaImage> {
+            self.captures.fetch_add(1, Ordering::SeqCst);
+            Ok(self.frame.image.clone())
+        }
+    }
+    fn payload(asset_id: u64, tolerance: u8) -> MkImagePayload {
+        MkImagePayload {
+            asset_id,
+            wait: super::super::MkWaitOptions {
+                timeout_ms: 0,
+                poll_interval_ms: 0,
+            },
+            region: SearchRegion::Desktop,
+            tolerance,
+            alpha: AlphaPolicy::Compare,
+            return_point: ReturnPoint::Center,
+        }
+    }
+    fn adapter_fixture(
+        frame: CapturedRegion,
+        needle: &RgbaImage,
+    ) -> (tempfile::TempDir, Arc<MkMacroStore>, ProductionVisualSearch) {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        store.write_png_asset(7, 3, needle).unwrap();
+        let store = Arc::new(store);
+        let capture = Arc::new(FakeCapture {
+            frame,
+            captures: AtomicUsize::new(0),
+        });
+        let adapter = ProductionVisualSearch::new(store.clone(), capture);
+        (dir, store, adapter)
+    }
+    #[test]
+    fn production_adapter_loads_store_asset_forwards_tolerance_and_translates_center() {
+        let mut frame = CapturedRegion {
+            image: RgbaImage::from_pixel(5, 4, Rgba([0, 0, 0, 255])),
+            origin: (-120, 35),
+        };
+        let needle = RgbaImage::from_pixel(2, 2, Rgba([10, 20, 30, 255]));
+        for y in 1..3 {
+            for x in 2..4 {
+                frame.image.put_pixel(x, y, Rgba([12, 20, 30, 255]));
+            }
+        }
+        let (_dir, _store, adapter) = adapter_fixture(frame, &needle);
+        assert_eq!(adapter.find_image(7, &payload(3, 1)).unwrap(), None);
+        assert_eq!(
+            adapter.find_image(7, &payload(3, 2)).unwrap(),
+            Some(MkPoint { x: -117, y: 37 })
+        );
+    }
+    #[test]
+    fn production_adapter_distinguishes_asset_failures() {
+        let frame = cap(2, 2);
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        let store = Arc::new(store);
+        let make = || {
+            ProductionVisualSearch::new(
+                store.clone(),
+                Arc::new(FakeCapture {
+                    frame: frame.clone(),
+                    captures: AtomicUsize::new(0),
+                }),
+            )
+        };
+        let missing = make().find_image(7, &payload(3, 0)).unwrap_err();
+        assert!(missing.message.contains("missing"));
+
+        let path = store.asset_path(7, 3).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"not a png").unwrap();
+        let undecodable = make().find_image(7, &payload(3, 0)).unwrap_err();
+        assert!(undecodable.message.contains("undecodable"));
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        let unreadable = make().find_image(7, &payload(3, 0)).unwrap_err();
+        assert!(unreadable.message.contains("unreadable"));
     }
     #[test]
     fn too_large_and_deterministic() {

--- a/src/mkmacro/runtime.rs
+++ b/src/mkmacro/runtime.rs
@@ -454,7 +454,7 @@ static RECORDER: Lazy<RwLock<Option<Arc<RecorderRuntime>>>> = Lazy::new(|| RwLoc
 static HOTKEYS: Lazy<RwLock<Option<Arc<super::hotkeys::MkMacroHotkeyService>>>> =
     Lazy::new(|| RwLock::new(None));
 pub fn set_shared_store(store: Arc<MkMacroStore>) {
-    set_shared_store_with_backends(store, production_backends())
+    set_shared_store_with_backends(store.clone(), production_backends_with_store(store))
 }
 /// Installs a shared runtime with injected effects (intended for tests).
 pub fn set_shared_store_with_backends(store: Arc<MkMacroStore>, backends: Backends) {

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -13,7 +13,7 @@ pub(crate) fn image_result_variable(asset_id: u64) -> String {
     format!("__image.{asset_id}")
 }
 
-trait WindowsGeometry: Send + Sync {
+pub(crate) trait WindowsGeometry: Send + Sync {
     /// `(x, y, width, height)`, in desktop pixels. Width/height remain signed so
     /// malformed platform data can be diagnosed rather than silently cast.
     fn virtual_desktop(&self) -> ExecResult<(i32, i32, i32, i32)>;
@@ -21,7 +21,7 @@ trait WindowsGeometry: Send + Sync {
     fn client_origin(&self, hwnd: isize) -> ExecResult<MkPoint>;
 }
 
-trait VisualSearch: Send + Sync {
+pub(crate) trait VisualSearch: Send + Sync {
     fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>>;
     fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]>;
 }
@@ -74,6 +74,21 @@ impl WindowsScreenBackend {
         Self {
             geometry: Arc::new(SystemWindowsGeometry),
             visual: Arc::new(SystemVisualSearch),
+        }
+    }
+
+    /// Constructs the live geometry/capture adapter while keeping asset access
+    /// explicit.  This is the constructor used by the runtime; tests use the
+    /// same adapter shape with fake capture and geometry boundaries.
+    #[cfg(windows)]
+    pub fn production(store: Arc<crate::mkmacro::MkMacroStore>) -> Self {
+        let capture: Arc<dyn ScreenCaptureBackend> =
+            Arc::new(WindowsScreenCaptureBackend::system());
+        Self {
+            geometry: Arc::new(SystemWindowsGeometry),
+            visual: Arc::new(crate::mkmacro::image_search::ProductionVisualSearch::new(
+                store, capture,
+            )),
         }
     }
 


### PR DESCRIPTION
### Motivation

- Make image-search and coordinate resolution testable without instantiating live Windows input/cursor APIs by keeping geometry/capture boundaries injectable and creating a store-aware production adapter.
- Surface distinct diagnostics for asset-loading failures and ensure image-adapter tests exercise the real asset layout/API (`MkMacroStore`) rather than bypassing the adapter load path.
- Provide a production wiring path that composes the system capture with the `MkMacroStore`-backed visual search while preserving the existing injectable test seams.

### Description

- Exposed geometry/visual boundaries as `pub(crate)` with `WindowsGeometry` and `VisualSearch` to keep dependencies injectable and testable. (`src/mkmacro/screen.rs`).
- Added `ProductionVisualSearch` which: loads assets via `MkMacroStore`, caches decoded RGBA images with `ImageDecodeCache`, performs captures through an injected `ScreenCaptureBackend`, forwards `MatchOptions` (tolerance/alpha/return-point) into `find_template`, and converts matches to desktop `MkPoint`s. (`src/mkmacro/image_search.rs`).
- Improved asset error handling to distinguish missing, unreadable, and undecodable reference images and attach `asset_path` context to diagnostics. (`src/mkmacro/image_search.rs`).
- Added a `WindowsScreenBackend::production(store)` constructor and `production_backends_with_store(store)` wiring so the runtime can be constructed with a store-aware screen adapter while preserving test-only constructors. (`src/mkmacro/screen.rs`, `src/mkmacro/executor.rs`, `src/mkmacro/runtime.rs`).
- Extended matcher test coverage and added adapter-level tests: pure `find_template` tests now include deterministic cancellation; production-adapter tests create temporary macro asset fixtures via `MkMacroStore::write_png_asset`, verify tolerance forwarding, center-point translation (desktop origin handling), and distinct diagnostics for missing/unreadable/undecodable assets, all using fake capture backends and no wall-clock sleeps. (`src/mkmacro/image_search.rs`).

### Testing

- Ran `cargo fmt --check` which passed. 
- Ran repository checks (`git diff --check`) which passed locally before committing the changes. 
- Attempted `cargo test mkmacro::image_search --no-fail-fast` but the full build/test run could not complete in this Linux CI environment due to unrelated platform-specific system dependencies and Windows-only APIs in other parts of the workspace, so the automated test run did not finish here; the newly added unit tests are pure and exercise matching and adapter wiring without invoking live Windows input or `SendInput`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8197ba2f7c8332bf3b26999a2001f2)