### PR TITLE
Strengthen mkmacro production-boundary coverage

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -29,6 +29,12 @@ impl ActionCategory {
             Self::UiAutomation => "UI Automation",
         }
     }
+
+    /// Product-level palette switch. Keeping this explicit makes catalog tests
+    /// fail at the descriptor boundary if a disabled category leaks into UI.
+    pub fn is_enabled(self) -> bool {
+        !matches!(self, Self::UiAutomation)
+    }
 }
 pub struct ActionDescriptor {
     pub category: ActionCategory,
@@ -632,6 +638,20 @@ pub enum EditorContract {
     DirectInsert { context: InsertionContextRoute },
 }
 
+/// Structural markers are complete actions at insertion time and intentionally
+/// have no configurable fields. All other actions must pass through an editor.
+pub fn requires_no_configuration(action: &MkAction) -> bool {
+    matches!(
+        action,
+        MkAction::Else
+            | MkAction::EndIf
+            | MkAction::RepeatEnd
+            | MkAction::WhileEnd
+            | MkAction::Break
+            | MkAction::Continue
+    )
+}
+
 /// The concrete validation path used before a structural marker is inserted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InsertionContextRoute {
@@ -681,7 +701,7 @@ pub fn editor_contract(editor: EditorKind) -> Option<EditorContract> {
 /// Descriptors currently offered by the macro-authoring UI.
 pub fn is_available_in_palette(descriptor: &ActionDescriptor) -> bool {
     descriptor.availability == ActionAvailability::Ready
-        && descriptor.category != ActionCategory::UiAutomation
+        && descriptor.category.is_enabled()
         && descriptor.hidden_reason.is_none()
         && descriptor.runtime == RuntimeAvailability::Supported
 }

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -203,21 +203,21 @@ mod tests {
     #[test]
     fn visible_catalog_metadata_is_routable_and_supported() {
         for descriptor in action_catalog::visible_descriptors() {
+            let action = (descriptor.make_default)();
             assert_eq!(
                 descriptor.availability,
                 action_catalog::ActionAvailability::Ready
             );
             assert!(
                 descriptor.category.is_enabled(),
-                "{}",
-                context("enabled category", &action)
+                "disabled category leaked through visible descriptor {:?}",
+                descriptor.name
             );
             assert_eq!(
                 descriptor.runtime,
                 action_catalog::RuntimeAvailability::Supported
             );
             assert!(!descriptor.name.trim().is_empty());
-            let action = (descriptor.make_default)();
             let details = action_catalog::action_details(&action);
             assert!(
                 !details.trim().is_empty(),
@@ -609,6 +609,11 @@ mod tests {
                 )
             };
             let action = (descriptor.make_default)();
+            assert!(
+                descriptor.category.is_enabled(),
+                "{}",
+                context("enabled category", &action)
+            );
             assert_eq!(
                 descriptor.availability,
                 action_catalog::ActionAvailability::Ready,

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -207,6 +207,11 @@ mod tests {
                 descriptor.availability,
                 action_catalog::ActionAvailability::Ready
             );
+            assert!(
+                descriptor.category.is_enabled(),
+                "{}",
+                context("enabled category", &action)
+            );
             assert_eq!(
                 descriptor.runtime,
                 action_catalog::RuntimeAvailability::Supported
@@ -643,8 +648,16 @@ mod tests {
                 "duplicate action variant for {}",
                 descriptor.name
             );
+            let no_configuration = action_catalog::requires_no_configuration(&action);
+            assert_eq!(
+                no_configuration,
+                matches!(descriptor.editor, action_catalog::EditorKind::DirectInsert),
+                "{}",
+                context("no-configuration classification", &action)
+            );
             assert!(
-                action_catalog::editor_route_recognizes(&action, descriptor.editor),
+                no_configuration
+                    || action_catalog::editor_route_recognizes(&action, descriptor.editor),
                 "{}",
                 context("implemented editor route", &action)
             );

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -686,6 +686,123 @@ mod tests {
         assert_eq!(positions, vec![(0, 0), (30, 0), (31, 0)]);
         assert_eq!(sampled[1].delay_after_ms, 1);
     }
+
+    #[test]
+    fn detailed_and_sampled_share_a_long_timed_pointer_fixture() {
+        // Exact 10 ms spacing makes the expected timeline independent of
+        // fractional rounding while 101 points provide meaningful compression.
+        let events: Vec<_> = (0..=100)
+            .map(|i| mouse(i * 10_000, MouseMessage::Move, -500 + i as i32 * 10, -75))
+            .collect();
+        let mut cfg = NormalizationConfig::default();
+        cfg.movement_distance_px = 40;
+        cfg.movement_interval_ms = 1_000;
+        cfg.movement_mode = MovementMode::DetailedMovement;
+        let detailed = normalize(&events, &cfg, None);
+        cfg.movement_mode = MovementMode::SampledMovement;
+        let sampled = normalize(&events, &cfg, None);
+
+        let detailed_moves: Vec<_> = detailed.iter().filter_map(point).collect();
+        let sampled_moves: Vec<_> = sampled.iter().filter_map(point).collect();
+        assert!(detailed_moves.len() > sampled_moves.len());
+        assert!(
+            sampled_moves.len() * 10 <= detailed_moves.len(),
+            "straight-line sampling should remove at least 90%: detailed={}, sampled={}",
+            detailed_moves.len(),
+            sampled_moves.len()
+        );
+        assert_eq!(sampled_moves.first(), Some(&(-500, -75)));
+        assert_eq!(sampled_moves.last(), Some(&(500, -75)));
+
+        let elapsed = |steps: &[RecordedStep]| -> u64 {
+            steps
+                .iter()
+                .map(|step| match step.action {
+                    RecordedAction::Move { duration_ms, .. } => duration_ms,
+                    _ => 0,
+                })
+                .sum::<u64>()
+                + steps.iter().map(|step| step.delay_after_ms).sum::<u64>()
+        };
+        assert_eq!(elapsed(&detailed), 1_000);
+        assert_eq!(elapsed(&sampled), 1_000);
+    }
+
+    #[test]
+    fn sampling_preserves_click_drag_and_button_transition_anchors() {
+        let events = [
+            mouse(0, MouseMessage::Move, -100, -50),
+            mouse(500, MouseMessage::Move, -99, -50),
+            mouse(1_000, MouseMessage::Down(MouseButton::Left), -90, -40),
+            mouse(1_500, MouseMessage::Up(MouseButton::Left), -90, -40),
+            mouse(2_000, MouseMessage::Down(MouseButton::Left), -90, -40),
+            mouse(2_500, MouseMessage::Up(MouseButton::Left), -90, -40),
+            mouse(3_000, MouseMessage::Move, -80, -30),
+            mouse(3_100, MouseMessage::Move, -79, -29),
+            mouse(3_200, MouseMessage::Down(MouseButton::Right), -70, -20),
+            mouse(3_300, MouseMessage::Move, -10, 10),
+            mouse(3_400, MouseMessage::Up(MouseButton::Right), 40, 25),
+            mouse(3_500, MouseMessage::Move, 41, 26),
+            mouse(3_600, MouseMessage::Move, 42, 27),
+        ];
+        let mut cfg = NormalizationConfig::default();
+        cfg.movement_distance_px = 1_000;
+        cfg.movement_interval_ms = 1_000;
+        let normalized = normalize(&events, &cfg, None);
+
+        assert!(matches!(
+            normalized[0].action,
+            RecordedAction::Move {
+                x: -100,
+                y: -50,
+                ..
+            }
+        ));
+        assert!(matches!(
+            normalized[1].action,
+            RecordedAction::Move { x: -99, y: -50, .. }
+        ));
+        assert!(matches!(
+            normalized[2].action,
+            RecordedAction::Click {
+                button: MouseButton::Left,
+                x: -90,
+                y: -40,
+                count: 2
+            }
+        ));
+        assert!(matches!(
+            normalized[3].action,
+            RecordedAction::Move { x: -80, y: -30, .. }
+        ));
+        assert!(matches!(
+            normalized[4].action,
+            RecordedAction::Move { x: -79, y: -29, .. }
+        ));
+        assert!(matches!(
+            normalized[5].action,
+            RecordedAction::Drag {
+                button: MouseButton::Right,
+                from: (-70, -20),
+                to: (40, 25),
+                down_timestamp_us: 3_200,
+                up_timestamp_us: 3_400
+            }
+        ));
+        assert!(matches!(
+            normalized[6].action,
+            RecordedAction::Move { x: 41, y: 26, .. }
+        ));
+        assert!(matches!(
+            normalized[7].action,
+            RecordedAction::Move { x: 42, y: 27, .. }
+        ));
+        assert_eq!(
+            normalized.len(),
+            8,
+            "in-drag movement must not escape as a waypoint"
+        );
+    }
     #[test]
     fn clicks_repeats_drag_wheels_and_delay() {
         let c = NormalizationConfig::default();


### PR DESCRIPTION
### Motivation
- Improve confidence in recorder normalization and sampling by adding deterministic fixtures that exercise long, timestamped pointer runs and rapid/button-transition sequences. 
- Make the action catalog and runtime capability metadata authoritative and testable so UI-visible descriptors cannot drift out of sync with available editors or executor support. 
- Do this without changing historical persisted formats or refactoring unrelated subsystems, and keep tests pure unit tests that do not touch OS input backends.

### Description
- Added two recorder normalization tests in `src/mkmacro/recorder.rs`: `detailed_and_sampled_share_a_long_timed_pointer_fixture` (101-point, timestamped straight-line sampling fixture with timeline assertions) and `sampling_preserves_click_drag_and_button_transition_anchors` (verifies click, double-click, drag endpoints, negative coordinates, rapid events, and that in-drag movement does not leak). 
- Introduced `ActionCategory::is_enabled` and `requires_no_configuration(&MkAction)` in `src/gui/mkmacro_dialog/action_catalog.rs`, and made `is_available_in_palette` consult `is_enabled`, preserving `UiAutomation` as disabled at the palette boundary. 
- Added the structural/no-configuration classification to the catalog contract and used it when validating visible descriptors so that `DirectInsert` markers are explicitly recognized as requiring no editor configuration while other actions must map to a real editor route. 
- Strengthened visible-descriptor invariants and tests in `src/gui/mkmacro_dialog/mod.rs` to assert category enablement, unique names/variants, editor routing agreement, runtime capability agreement (`has_runtime_support`), non-placeholder text, and serializability; tests exercise selecting descriptors through the dialog contract but do not instantiate live OS backends. 

### Testing
- ✅ Ran `cargo fmt --check` and formatting was clean. 
- ✅ Ran repository safety checks with `git diff --check` and no issues were reported. 
- ⚠️ Ran `cargo test` but the build/test run was blocked by an environment limitation: the build of native crate `alsa-sys` failed because the container lacks the ALSA `pkg-config` metadata (`alsa.pc`), so full test execution could not complete in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a819c0c1c608332b42bfc2063225251)