### PR TITLE
Add Clipboard Modify launcher visibility preference

### DIFF
--- a/src/clipboard_modify/coordinator.rs
+++ b/src/clipboard_modify/coordinator.rs
@@ -331,6 +331,7 @@ pub struct ImmediateRequestMetadata {
     pub action: Action,
     pub query: String,
     pub source: ActivationSource,
+    pub hide_launcher_on_success: bool,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuredClipboardModifyError {
@@ -618,6 +619,7 @@ mod tests {
                     action: action(),
                     query: "cm upper".into(),
                     source: ActivationSource::Enter,
+                    hide_launcher_on_success: true,
                 },
             )
             .unwrap();
@@ -641,6 +643,7 @@ mod tests {
                     action: action(),
                     query: "q".into(),
                     source: ActivationSource::Enter,
+                    hide_launcher_on_success: true,
                 },
             )
             .unwrap();
@@ -686,6 +689,7 @@ mod tests {
             action: action(),
             query: query.into(),
             source: ActivationSource::Enter,
+            hide_launcher_on_success: true,
         }
     }
 
@@ -858,6 +862,7 @@ mod tests {
                 action: action(),
                 query: "q".into(),
                 source: ActivationSource::Click,
+                hide_launcher_on_success: true,
             },
         )
         .unwrap();

--- a/src/gui/actions.rs
+++ b/src/gui/actions.rs
@@ -962,17 +962,22 @@ impl LauncherApp {
                     return true;
                 }
             };
-            let (intent, canonical_command) = match payload {
+            let (intent, canonical_command, hide_launcher_on_success) = match payload {
                 ClipboardModifyActionPayload::ExecuteAdHocStages {
                     canonical_command,
                     stages,
-                } => (ClipboardModifyIntent::Stages(stages), canonical_command),
+                } => (
+                    ClipboardModifyIntent::Stages(stages),
+                    canonical_command,
+                    true,
+                ),
                 ClipboardModifyActionPayload::ExecuteTemplate {
                     canonical_command,
                     name,
                 } => (
                     ClipboardModifyIntent::ApplyTemplate { name },
                     canonical_command,
+                    self.clipboard_modify_hide_launcher_after_apply,
                 ),
                 ClipboardModifyActionPayload::ExecuteSavedPipeline {
                     canonical_command,
@@ -980,6 +985,7 @@ impl LauncherApp {
                 } => (
                     ClipboardModifyIntent::ApplySavedPipeline { name },
                     canonical_command,
+                    self.clipboard_modify_hide_launcher_after_apply,
                 ),
                 _ => {
                     self.report_clipboard_modify_action_error("unexpected execute payload".into());
@@ -990,6 +996,7 @@ impl LauncherApp {
                 action: action.clone(),
                 query: canonical_command,
                 source,
+                hide_launcher_on_success,
             };
             match self.clipboard_modify_immediate.start(
                 intent,
@@ -1031,7 +1038,18 @@ impl LauncherApp {
                     if let Some(meta) = meta.as_ref() {
                         self.record_history_usage(&meta.action, &meta.query, meta.source);
                     }
-                    self.visible_flag.store(false, Ordering::SeqCst);
+                    // Missing metadata uses the conservative historical policy: hide.
+                    if meta
+                        .as_ref()
+                        .map(|meta| meta.hide_launcher_on_success)
+                        .unwrap_or(true)
+                    {
+                        self.visible_flag.store(false, Ordering::SeqCst);
+                    } else {
+                        self.visible_flag.store(true, Ordering::SeqCst);
+                        self.move_cursor_end = true;
+                        self.focus_input();
+                    }
                     if self.enable_toasts {
                         push_toast(
                             &mut self.toasts,
@@ -1615,7 +1633,8 @@ mod tests {
 mod clipboard_modify_gui_action_tests {
     use super::*;
     use crate::clipboard_modify::actions::{
-        encode_action_payload, execute_stages_payload, open_dialog_payload, undo_payload,
+        encode_action_payload, execute_saved_pipeline_payload, execute_stages_payload,
+        execute_template_payload, open_dialog_payload, undo_payload,
     };
     use crate::clipboard_modify::model::{OperationId, StageArguments, StageSpec};
     use crate::clipboard_modify::parser::ModifySection;
@@ -1695,6 +1714,32 @@ mod clipboard_modify_gui_action_tests {
             .expect("pending immediate metadata");
         assert_eq!(meta.query, "cm camel-case");
         assert_eq!(meta.action.action, "clipboard_modify:execute");
+        assert!(meta.hide_launcher_on_success, "ad-hoc stages always hide");
+    }
+
+    #[test]
+    fn template_and_pipeline_snapshot_the_runtime_visibility_preference() {
+        let ctx = egui::Context::default();
+        for payload in [
+            execute_template_payload("example".into()),
+            execute_saved_pipeline_payload("example".into()),
+        ] {
+            for expected in [true, false] {
+                let mut app = super::tests::new_app(&ctx);
+                app.clipboard_modify_hide_launcher_after_apply = expected;
+                let args = encode_action_payload(&payload).unwrap();
+                assert!(app.handle_clipboard_modify_action(
+                    &action("clipboard_modify:execute", Some(args)),
+                    ActivationSource::Enter,
+                ));
+                let meta = app
+                    .pending_clipboard_modify_immediate
+                    .values()
+                    .next()
+                    .unwrap();
+                assert_eq!(meta.hide_launcher_on_success, expected);
+            }
+        }
     }
 
     #[test]
@@ -1816,6 +1861,7 @@ mod clipboard_modify_gui_action_tests {
             action: action("clipboard_modify:execute", None),
             query: "cm uppercase".into(),
             source: ActivationSource::Enter,
+            hide_launcher_on_success: false,
         };
         app.pending_clipboard_modify_immediate
             .insert(7, meta.clone());
@@ -1855,6 +1901,7 @@ mod clipboard_modify_gui_action_tests {
             action: action("clipboard_modify:execute", None),
             query: "cm uppercase".into(),
             source: ActivationSource::Gesture,
+            hide_launcher_on_success: true,
         };
         app.pending_clipboard_modify_immediate
             .insert(8, meta.clone());
@@ -1879,6 +1926,38 @@ mod clipboard_modify_gui_action_tests {
             "cm uppercase"
         );
         std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn immediate_success_keep_open_restores_visibility_cursor_and_focus() {
+        let ctx = egui::Context::default();
+        let mut app = super::tests::new_app(&ctx);
+        app.visible_flag.store(false, Ordering::SeqCst);
+        app.move_cursor_end = false;
+        app.focus_query = false;
+        let meta = ImmediateRequestMetadata {
+            action: action("clipboard_modify:execute", None),
+            query: "cm template example".into(),
+            source: ActivationSource::Enter,
+            hide_launcher_on_success: false,
+        };
+        app.pending_clipboard_modify_immediate
+            .insert(9, meta.clone());
+        app.clipboard_modify_immediate.inject_completion_for_test(
+            meta,
+            crate::clipboard_modify::coordinator::ImmediateCompletionEvent {
+                request_id: crate::clipboard_modify::coordinator::OperationId(9),
+                display_label: "Test".into(),
+                character_count: 1,
+                line_count: 1,
+                undo_available: true,
+                result: Ok(()),
+            },
+        );
+        app.drain_clipboard_modify_immediate();
+        assert!(app.visible_flag.load(Ordering::SeqCst));
+        assert!(app.move_cursor_end);
+        assert!(app.focus_query);
     }
 
     #[test]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -468,6 +468,7 @@ pub struct LauncherApp {
     pub clipboard_modify_config_diagnostic: Option<String>,
     clipboard_modify_watcher: Option<crate::clipboard_modify::watch::ClipboardModifyWatcher>,
     pending_clipboard_modify_immediate: HashMap<u64, ImmediateRequestMetadata>,
+    pub(crate) clipboard_modify_hide_launcher_after_apply: bool,
     clipboard_modify_immediate: ImmediateExecutionCoordinator<
         crate::clipboard_modify::clipboard::ProductionClipboardService,
     >,
@@ -1431,6 +1432,8 @@ impl LauncherApp {
             clipboard_modify_config_diagnostic,
             clipboard_modify_watcher,
             pending_clipboard_modify_immediate: HashMap::new(),
+            clipboard_modify_hide_launcher_after_apply: clipboard_modify_settings
+                .hide_launcher_after_apply,
             clipboard_modify_immediate: ImmediateExecutionCoordinator::new(clipboard_service()),
             clipboard_modify_events: Vec::new(),
             convert_panel: ConvertPanel::default(),

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1464,10 +1464,15 @@ impl eframe::App for LauncherApp {
                 .cloned()
                 .and_then(|value| serde_json::from_value(value).ok())
                 .unwrap_or_default();
+            let hide_launcher_after_apply = clipboard_modify_preferences.hide_launcher_after_apply;
             clipboard_modify_preferences.dialog_width =
                 self.clipboard_modify_dialog.persisted_window_size.x;
             clipboard_modify_preferences.dialog_height =
                 self.clipboard_modify_dialog.persisted_window_size.y;
+            debug_assert_eq!(
+                clipboard_modify_preferences.hide_launcher_after_apply, hide_launcher_after_apply,
+                "persisting dialog geometry must not reset the live visibility preference"
+            );
             if let Ok(value) = serde_json::to_value(clipboard_modify_preferences) {
                 settings
                     .plugin_settings

--- a/src/plugins/clipboard_modify.rs
+++ b/src/plugins/clipboard_modify.rs
@@ -98,6 +98,10 @@ impl Plugin for ClipboardModifyPlugin {
         let mut cfg = serde_json::from_value::<ClipboardModifyPluginSettings>(value.clone())
             .unwrap_or_default();
         ui.small("Clipboard Modify stores only UI preferences here; templates, pipelines, source text, previews, and undo text are not stored in settings.");
+        ui.checkbox(
+            &mut cfg.hide_launcher_after_apply,
+            "Hide Launcher after applying template or pipeline",
+        );
         ui.horizontal(|ui| {
             ui.label("Dialog size");
             ui.add(eframe::egui::DragValue::new(&mut cfg.dialog_width).clamp_range(320.0..=2400.0));

--- a/src/settings/model.rs
+++ b/src/settings/model.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ClipboardModifyPluginSettings {
+    pub hide_launcher_after_apply: bool,
     pub dialog_width: f32,
     pub dialog_height: f32,
     pub navigation_width: f32,
@@ -26,6 +27,7 @@ pub struct ClipboardModifyPluginSettings {
 impl Default for ClipboardModifyPluginSettings {
     fn default() -> Self {
         Self {
+            hide_launcher_after_apply: true,
             dialog_width: 900.0,
             dialog_height: 640.0,
             navigation_width: 150.0,
@@ -35,6 +37,33 @@ impl Default for ClipboardModifyPluginSettings {
             management_sort_field: "name".into(),
             management_sort_ascending: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod clipboard_modify_plugin_settings_tests {
+    use super::ClipboardModifyPluginSettings;
+
+    #[test]
+    fn hide_launcher_default_and_legacy_json_preserve_historical_behavior() {
+        assert!(ClipboardModifyPluginSettings::default().hide_launcher_after_apply);
+        let legacy = serde_json::json!({ "dialog_width": 777.0 });
+        let decoded: ClipboardModifyPluginSettings = serde_json::from_value(legacy).unwrap();
+        assert!(decoded.hide_launcher_after_apply);
+    }
+
+    #[test]
+    fn explicit_keep_open_value_round_trips() {
+        let settings = ClipboardModifyPluginSettings {
+            hide_launcher_after_apply: false,
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&settings).unwrap();
+        assert_eq!(value["hide_launcher_after_apply"], false);
+        assert_eq!(
+            serde_json::from_value::<ClipboardModifyPluginSettings>(value).unwrap(),
+            settings
+        );
     }
 }
 

--- a/src/settings_editor/mapping.rs
+++ b/src/settings_editor/mapping.rs
@@ -368,6 +368,7 @@ mod tests {
     fn clipboard_modify_settings_round_trip_editor_conversion() {
         let mut initial = Settings::default();
         let cfg = ClipboardModifyPluginSettings {
+            hide_launcher_after_apply: false,
             dialog_width: 777.0,
             dialog_height: 555.0,
             navigation_width: 123.0,

--- a/src/settings_editor/save.rs
+++ b/src/settings_editor/save.rs
@@ -1,6 +1,7 @@
 use super::state::SettingsEditor;
 use crate::dashboard::config::DashboardConfig;
 use crate::gui::{LauncherApp, UiErrorEvent};
+use crate::plugins::clipboard_modify::ClipboardModifyPluginSettings;
 use crate::plugins::note::NotePluginSettings;
 use crate::settings::Settings;
 use eframe::egui;
@@ -160,6 +161,11 @@ impl SettingsEditor {
             && let Ok(cfg) = serde_json::from_value::<NotePluginSettings>(val.clone())
         {
             app.note_external_open = cfg.external_open;
+        }
+        if let Some(val) = new_settings.plugin_settings.get("clipboard_modify")
+            && let Ok(cfg) = serde_json::from_value::<ClipboardModifyPluginSettings>(val.clone())
+        {
+            app.clipboard_modify_hide_launcher_after_apply = cfg.hide_launcher_after_apply;
         }
         crate::request_hotkey_restart(new_settings);
         if app.enable_toasts {


### PR DESCRIPTION
### Motivation

- Allow users to choose whether the launcher is hidden after applying a Clipboard Modify template or saved pipeline while preserving the historical default behavior of hiding the launcher.
- Keep this a non-sensitive, plugin-level preference inside the existing `clipboard_modify` plugin settings shape so legacy JSON continues to work unchanged.
- Snapshot the visibility preference into immediate-execution metadata so executions behave the same regardless of later mutable changes to settings.

### Description

- Added `pub hide_launcher_after_apply: bool` to `ClipboardModifyPluginSettings` and set it to `true` in `Default`, retaining `#[serde(default)]` so legacy JSON decodes to `true` unchanged.
- Exposed the preference in the plugin UI by adding a checkbox labeled `"Hide Launcher after applying template or pipeline"` in `ClipboardModifyPlugin::settings_ui`, and the UI continues to read/write the same `serde_json::Value` used for other settings.
- Added `pub(crate) clipboard_modify_hide_launcher_after_apply: bool` to `LauncherApp`, initialized from the parsed `ClipboardModifyPluginSettings`, and updated `SettingsEditor::apply_saved_settings` to refresh that runtime field after saving plugin settings.
- Extended `ImmediateRequestMetadata` with `pub hide_launcher_on_success: bool`, set that field when dispatching clipboard-modify immediate executions (ad-hoc stages always set `true`; templates and saved pipelines snapshot `self.clipboard_modify_hide_launcher_after_apply`), store it in `pending_clipboard_modify_immediate`, and propagate it into the coordinator.
- Modified `drain_clipboard_modify_immediate` to consult metadata on successful completions: if `hide_launcher_on_success` is `true` keep historic hide behavior, otherwise keep the launcher visible, set `move_cursor_end = true`, and call `focus_input()` so another command can be entered immediately; failure handling and the `cm undo` path are unchanged.
- Added a `debug_assert!` in `render.rs` to ensure the geometry persist flow does not reset the live visibility preference, and added unit tests that validate the default/legacy behavior, explicit `false` round-trips, settings-editor/plugin-settings round trips, metadata snapshot behavior, and keep-open completion focus/flags.

### Testing

- `cargo fmt -- --check` completed successfully.
- `git diff --check` completed successfully.
- Attempted `cargo test --no-run`, but the workspace test/build is blocked by unrelated platform-specific compilation errors for `windows::Win32` imports on this Linux runner, so the full test execution could not complete here; unit tests were added (and included in the changes) to cover defaults, settings round trips, metadata snapshotting, keep-open completion behavior, and failure handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81afcf4a688332b38a99c6579d812e)