### PR TITLE
Prevent stale MkMacro watcher publications

### DIFF
--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -52,9 +52,57 @@ pub struct MkMacroDialog {
 mod tests {
     use super::*;
     use crate::mkmacro::{
-        AlphaPolicy, MkAction, MkCoordinateTarget, MkHotkey, MkImagePayload, MkKey, MkMouseButton,
-        MkMouseMovePayload, MkMousePayload, MkStep, MkWaitOptions, ReturnPoint, SearchRegion,
+        AlphaPolicy, LoadDisposition, MKMACROS_FILE, MkAction, MkCoordinateTarget, MkHotkey,
+        MkImagePayload, MkKey, MkMouseButton, MkMouseMovePayload, MkMousePayload, MkStep,
+        MkWaitOptions, ReturnPoint, SCHEMA_VERSION, SearchRegion,
     };
+    use std::{
+        fs, thread,
+        time::{Duration, Instant},
+    };
+
+    fn five_macros() -> MkMacroDocument {
+        MkMacroDocument {
+            schema_version: SCHEMA_VERSION,
+            macros: (1..=5)
+                .map(|id| MkMacro {
+                    id,
+                    name: format!("Macro {id}"),
+                    description: String::new(),
+                    enabled: true,
+                    hotkey: None,
+                    playback: Default::default(),
+                    steps: vec![],
+                })
+                .collect(),
+        }
+    }
+
+    fn wait_for_empty_and_stable(dialog: &mut MkMacroDialog, path: &std::path::Path) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut stable_since = None;
+        loop {
+            let snapshot_count = dialog.store.snapshot().macros.len();
+            let contents =
+                fs::read_to_string(path).unwrap_or_else(|e| format!("<read error: {e}>"));
+            let disk_count = serde_json::from_str::<MkMacroDocument>(&contents)
+                .map(|d| d.macros.len())
+                .unwrap_or(usize::MAX);
+            if snapshot_count == 0 && disk_count == 0 {
+                let since = stable_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= Duration::from_millis(250) {
+                    return;
+                }
+            } else {
+                stable_since = None;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "watcher did not stabilize on empty document: snapshot_count={snapshot_count}, disk_count={disk_count}, file={contents:?}"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
     fn dialog() -> (tempfile::TempDir, MkMacroDialog) {
         let dir = tempfile::tempdir().unwrap();
         let (store, _) = MkMacroStore::open(dir.path()).unwrap();
@@ -90,6 +138,79 @@ mod tests {
         assert_eq!(d.selected_macro_id, Some(first));
         assert!(d.dirty);
         assert!(Arc::ptr_eq(&baseline, &d.store.snapshot()));
+    }
+
+    #[test]
+    fn delete_every_macro_save_empty_and_reopen_loaded_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        let store = Arc::new(store);
+        store.save(five_macros()).unwrap();
+        let mut dialog = MkMacroDialog::new(Arc::clone(&store));
+
+        while !dialog.draft.macros.is_empty() {
+            let id = dialog.draft.macros[0].id;
+            dialog.selected_macro_id = Some(id);
+            dialog.delete_selected_macro();
+            if dialog.draft.macros.is_empty() {
+                assert!(dialog.selected_macro_id.is_none());
+            } else {
+                let selected = dialog.selected_macro_id.expect("selection advances");
+                assert_ne!(selected, id);
+                assert!(dialog.draft.macros.iter().any(|m| m.id == selected));
+            }
+        }
+        assert!(dialog.draft.macros.is_empty());
+        assert!(dialog.selected_macro_id.is_none());
+        assert!(dialog.dirty);
+        assert_eq!(
+            store.snapshot().macros.len(),
+            5,
+            "deletes remain draft-only"
+        );
+
+        dialog.save().unwrap();
+        assert!(dialog.store.snapshot().macros.is_empty());
+        assert!(dialog.draft.macros.is_empty());
+        assert!(dialog.baseline.macros.is_empty());
+        assert!(!dialog.dirty);
+        assert!(!dialog.conflict);
+
+        let path = dir.path().join(MKMACROS_FILE);
+        let bytes = fs::read(&path).unwrap();
+        assert!(!bytes.is_empty());
+        let disk: MkMacroDocument = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(disk.schema_version, SCHEMA_VERSION);
+        assert!(disk.macros.is_empty());
+
+        drop(dialog);
+        drop(store);
+        let (reopened, disposition) = MkMacroStore::open(dir.path()).unwrap();
+        assert!(matches!(disposition, LoadDisposition::Loaded));
+        assert!(reopened.snapshot().macros.is_empty());
+    }
+
+    #[test]
+    fn watcher_and_external_sync_cannot_restore_macros_after_empty_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        let store = Arc::new(store);
+        store.save(five_macros()).unwrap();
+        let mut dialog = MkMacroDialog::new(store);
+        dialog.draft.macros.clear();
+        dialog.dirty = true;
+        dialog.save().unwrap();
+        dialog.sync_external();
+        assert!(dialog.draft.macros.is_empty());
+        assert!(dialog.baseline.macros.is_empty());
+        assert!(!dialog.conflict);
+
+        wait_for_empty_and_stable(&mut dialog, &dir.path().join(MKMACROS_FILE));
+        dialog.sync_external();
+        assert!(dialog.store.snapshot().macros.is_empty());
+        assert!(dialog.draft.macros.is_empty());
+        assert!(dialog.baseline.macros.is_empty());
+        assert!(!dialog.conflict);
     }
     #[test]
     fn catalog_search_and_structures() {
@@ -981,7 +1102,7 @@ impl MkMacroDialog {
     }
     pub fn sync_external(&mut self) {
         let current = self.store.snapshot();
-        if !Arc::ptr_eq(&current, &self.baseline) {
+        if *current != *self.baseline {
             if self.dirty {
                 self.conflict = true;
             } else {

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -10,7 +10,7 @@ use std::{
     collections::HashSet,
     fs,
     path::{Component, Path, PathBuf},
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 pub const MKMACROS_FILE: &str = "mkmacros.json";
 pub const ASSET_DIRECTORY: &str = "mkmacro_assets";
@@ -23,6 +23,9 @@ pub enum LoadDisposition {
 }
 struct Inner {
     path: PathBuf,
+    /// Orders the entire disk-read/write and publication transaction. In particular,
+    /// a watcher may not publish bytes it read before a completed local save.
+    transaction: Mutex<()>,
     snapshot: RwLock<Arc<MkMacroDocument>>,
     diagnostics: RwLock<Arc<[MkDiagnostic]>>,
     last_external_error: RwLock<Option<String>>,
@@ -84,6 +87,7 @@ impl MkMacroStore {
         let path = directory.as_ref().join(MKMACROS_FILE);
         let inner = Arc::new(Inner {
             path: path.clone(),
+            transaction: Mutex::new(()),
             snapshot: RwLock::new(Arc::new(MkMacroDocument::default())),
             diagnostics: RwLock::new(Arc::from([])),
             last_external_error: RwLock::new(None),
@@ -110,16 +114,7 @@ impl MkMacroStore {
         let weak = Arc::downgrade(&inner);
         let watcher = watch_json(&path, move || {
             if let Some(i) = weak.upgrade() {
-                match read_document(&i.path) {
-                    Ok(Some((d, changed))) => {
-                        if !changed || persist(&i.path, &d).is_ok() {
-                            publish(&i, d);
-                            *i.last_external_error.write().unwrap() = None
-                        }
-                    }
-                    Ok(None) => {}
-                    Err(e) => *i.last_external_error.write().unwrap() = Some(e.to_string()),
-                }
+                reload_from_disk(&i);
             }
         })
         .ok();
@@ -144,11 +139,29 @@ impl MkMacroStore {
         self.inner.last_external_error.read().unwrap().clone()
     }
     pub fn save(&self, mut doc: MkMacroDocument) -> Result<Arc<MkMacroDocument>> {
+        self.save_transaction(&mut doc, || {})
+    }
+    fn save_transaction(
+        &self,
+        doc: &mut MkMacroDocument,
+        before_publication: impl FnOnce(),
+    ) -> Result<Arc<MkMacroDocument>> {
+        let _transaction = self.inner.transaction.lock().unwrap();
+        let before = self.snapshot().macros.len();
         doc.schema_version = SCHEMA_VERSION;
-        repair_ids(&mut doc);
-        persist(&self.inner.path, &doc)?;
-        publish(&self.inner, doc);
-        Ok(self.snapshot())
+        repair_ids(doc);
+        persist(&self.inner.path, doc)?;
+        before_publication();
+        publish(&self.inner, doc.clone());
+        let saved = self.snapshot();
+        tracing::info!(
+            path = %resolved_path(&self.inner.path).display(),
+            macro_count = saved.macros.len(),
+            snapshot_macro_count_before = before,
+            snapshot_macro_count_after = saved.macros.len(),
+            "mkmacro save"
+        );
+        Ok(saved)
     }
     pub fn asset_path(&self, macro_id: u64, asset_id: u64) -> Result<PathBuf> {
         if macro_id == 0 || asset_id == 0 {
@@ -258,6 +271,27 @@ impl MkMacroStore {
         }
         Ok(())
     }
+}
+fn reload_from_disk(i: &Inner) {
+    let _transaction = i.transaction.lock().unwrap();
+    match read_document(&i.path) {
+        Ok(Some((d, changed))) => {
+            if !changed || persist(&i.path, &d).is_ok() {
+                publish(i, d);
+                *i.last_external_error.write().unwrap() = None
+            }
+        }
+        Ok(None) => {}
+        Err(e) => *i.last_external_error.write().unwrap() = Some(e.to_string()),
+    }
+}
+
+fn resolved_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    })
 }
 fn publish(i: &Inner, d: MkMacroDocument) {
     let ds = validate_document(
@@ -427,6 +461,7 @@ pub fn repair_ids(d: &mut MkMacroDocument) -> bool {
 mod tests {
     use super::*;
     use crate::mkmacro::{MkPoint, SearchRegion};
+    use std::{sync::mpsc, thread, time::Duration};
     fn document() -> MkMacroDocument {
         MkMacroDocument {
             schema_version: SCHEMA_VERSION,
@@ -470,6 +505,52 @@ mod tests {
         let (s, _) = MkMacroStore::open(d.path()).unwrap();
         assert_eq!(s.snapshot().macros[0].id, 7);
         assert_eq!(s.snapshot().macros[0].steps[0].id, 9)
+    }
+    #[test]
+    fn saving_empty_document_preserves_canonical_file_and_snapshot() {
+        let d = tempfile::tempdir().unwrap();
+        let (s, _) = MkMacroStore::open(d.path()).unwrap();
+        s.save(document()).unwrap();
+        let saved = s.save(MkMacroDocument::default()).unwrap();
+        assert_eq!(saved.schema_version, SCHEMA_VERSION);
+        assert!(saved.macros.is_empty());
+        assert!(s.snapshot().macros.is_empty());
+
+        let path = d.path().join(MKMACROS_FILE);
+        let bytes = fs::read(&path).unwrap();
+        assert!(!bytes.is_empty());
+        let disk: MkMacroDocument = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(disk.schema_version, SCHEMA_VERSION);
+        assert!(disk.macros.is_empty());
+    }
+
+    #[test]
+    fn watcher_reload_cannot_publish_across_newer_save_transaction() {
+        let d = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(d.path()).unwrap();
+        store.save(document()).unwrap();
+        let store = Arc::new(store);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let reload_inner = Arc::clone(&store.inner);
+
+        store
+            .save_transaction(&mut MkMacroDocument::default(), || {
+                thread::spawn(move || {
+                    started_tx.send(()).unwrap();
+                    reload_from_disk(&reload_inner);
+                    done_tx.send(()).unwrap();
+                });
+                started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+                assert!(done_rx.recv_timeout(Duration::from_millis(50)).is_err());
+            })
+            .unwrap();
+
+        done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(store.snapshot().macros.is_empty());
+        let disk: MkMacroDocument =
+            serde_json::from_slice(&fs::read(d.path().join(MKMACROS_FILE)).unwrap()).unwrap();
+        assert!(disk.macros.is_empty());
     }
     #[test]
     fn old_migrates_and_future_is_rejected() {


### PR DESCRIPTION
### Motivation

- Prevent a race where the filesystem watcher can publish a stale snapshot it read before a local save completed, which caused spurious dialog conflicts and possible restoration of deleted macros.
- Preserve the canonical empty document on-disk and ensure dialog/store synchronization is based on document content rather than Arc pointer identity.
- Add structured, non-sensitive diagnostics around saves to aid future debugging of ordering issues.

### Description

- Serialize the full save/reload/publication transaction by adding a `transaction: Mutex<()>` to `Inner` and routing both local `save()` and watcher reloads through a guarded path (`save_transaction` and `reload_from_disk`) in `src/mkmacro/store.rs`.
- Emit structured `tracing::info!` on save with event name `mkmacro save`, resolved `path`, `macro_count`, and snapshot counts before/after publication without logging macro contents via `resolved_path` helper.
- Make dialog synchronization compare document content (`*current != *baseline`) instead of `Arc::ptr_eq` to avoid false change detection in `MkMacroDialog::sync_external` in `src/gui/mkmacro_dialog/mod.rs`.
- Add tests: store-level unit tests `saving_empty_document_preserves_canonical_file_and_snapshot` and `watcher_reload_cannot_publish_across_newer_save_transaction`, and dialog regressions `delete_every_macro_save_empty_and_reopen_loaded_document` and `watcher_and_external_sync_cannot_restore_macros_after_empty_save`, plus helpers `five_macros()` and `wait_for_empty_and_stable()` to implement bounded polling and stabilization checks.

### Testing

- Ran `cargo fmt -- --check`, which succeeded.
- Ran `git diff --check`, which succeeded.
- Attempted targeted `cargo test` for the new store and dialog regressions, but running the crate tests on this Linux CI runner is blocked by pre-existing unconditional Windows API imports (`windows::Win32` / `windows::core`) that prevent the library from compiling here; as a result the automated `cargo test` invocations could not complete in this environment.
- The new tests are present and exercise the canonical-empty-file behavior, watcher/save ordering, dialog lifecycle (delete→save→reopen), and watcher stabilization; they should be runnable on a platform/CI configuration where the crate compiles (or after gating Windows-only code with appropriate `cfg` attributes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8774d7d81c83329f4c0bac60b6fab4)