### PR TITLE
Add shared Window Picker UI/state with screen-pick and matcher preview

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1262,7 +1262,10 @@ mod tests {
                         matcher: MkWindowMatcher::default(),
                     },
                     return_point: ReturnPoint::Center,
-                    wait: MkWaitOptions::default(),
+                    wait: MkWaitOptions {
+                        timeout_ms: 0,
+                        poll_interval_ms: 1,
+                    },
                 }),
                 super::super::window_picker::MatcherPath::ImageRegion,
             ),

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -81,6 +81,31 @@ struct NativePositionPicker {
 }
 
 impl ActionEditorState {
+    pub fn apply_window_matcher(
+        &mut self,
+        request: &super::window_picker::MatcherEditRequest,
+        matcher: MkWindowMatcher,
+        current_macro_id: Option<u64>,
+    ) -> bool {
+        let super::window_picker::MatcherDestination::Action {
+            macro_id,
+            draft_generation,
+            path,
+        } = &request.destination;
+        if Some(*macro_id) != current_macro_id || *draft_generation != self.draft_generation {
+            return false;
+        }
+        let Some(step) = self.draft.as_mut() else {
+            return false;
+        };
+        let Some(target) = matcher_at_path(&mut step.action, path) else {
+            return false;
+        };
+        if *target != matcher {
+            *target = matcher;
+        }
+        true
+    }
     pub fn begin_new(&mut self, action: MkAction) {
         let editor = super::action_catalog::editor_for_action(&action);
         self.begin_new_with_editor(action, editor);
@@ -466,15 +491,12 @@ fn optional_field(ui: &mut egui::Ui, label: &str, value: &mut Option<String>) {
         *value = None;
     }
 }
-pub(super) fn matcher_ui(ui: &mut egui::Ui, m: &mut MkWindowMatcher) {
+pub(super) fn matcher_ui(ui: &mut egui::Ui, m: &mut MkWindowMatcher) -> bool {
     optional_field(ui, "Executable", &mut m.process);
     optional_field(ui, "Title contains", &mut m.title);
     optional_field(ui, "Title regex", &mut m.title_regex);
     optional_field(ui, "Class", &mut m.class);
-    ui.add_enabled(
-        false,
-        egui::Button::new("Pick window (unavailable on this platform/session)"),
-    );
+    ui.button("Choose Window…").clicked()
 }
 pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> bool {
     let kind = match target {
@@ -609,8 +631,12 @@ fn action_ui(
     ui: &mut egui::Ui,
     step: &mut MkStep,
     capture: &mut bool,
-) -> Option<PositionCaptureSlot> {
+) -> (
+    Option<PositionCaptureSlot>,
+    Option<super::window_picker::MatcherPath>,
+) {
     let mut pick = None;
+    let mut window_pick = None;
     match &mut step.action {
         MkAction::KeyPress(k) | MkAction::KeyDown(k) | MkAction::KeyUp(k) => {
             ui.label(format!("Captured: {}", key_name(k)));
@@ -794,7 +820,9 @@ fn action_ui(
             ui.checkbox(&mut p.wait, "Wait for completion");
         }
         MkAction::WindowActivate(p) | MkAction::WindowWait(p) => {
-            matcher_ui(ui, &mut p.matcher);
+            if matcher_ui(ui, &mut p.matcher) {
+                window_pick = Some(super::window_picker::MatcherPath::Action);
+            }
             if let Some(w) = &mut p.wait {
                 ui.horizontal(|ui| {
                     ui.label("Timeout (ms)");
@@ -806,7 +834,11 @@ fn action_ui(
                 });
             }
         }
-        MkAction::WindowClose(m) => matcher_ui(ui, m),
+        MkAction::WindowClose(m) => {
+            if matcher_ui(ui, m) {
+                window_pick = Some(super::window_picker::MatcherPath::Action);
+            }
+        }
         MkAction::SetVariable { name, value } => {
             ui.horizontal(|ui| {
                 ui.label("Name");
@@ -827,10 +859,14 @@ fn action_ui(
             });
         }
         MkAction::If(condition) | MkAction::WhileStart { condition } => {
-            super::condition_editor::condition_ui(ui, condition);
+            if let Some(path) = super::condition_editor::condition_ui(ui, condition) {
+                window_pick = Some(super::window_picker::MatcherPath::Condition(path));
+            }
         }
         MkAction::WaitUntil { condition, wait } => {
-            super::condition_editor::condition_ui(ui, condition);
+            if let Some(path) = super::condition_editor::condition_ui(ui, condition) {
+                window_pick = Some(super::window_picker::MatcherPath::Condition(path));
+            }
             ui.horizontal(|ui| {
                 ui.label("Timeout (ms)");
                 ui.add(egui::DragValue::new(&mut wait.timeout_ms).clamp_range(0..=86_400_000));
@@ -892,7 +928,32 @@ fn action_ui(
                         rect: ScreenRect::new(0, 0, 1, 1),
                     };
                 }
+                if ui
+                    .selectable_label(matches!(p.region, SearchRegion::Window { .. }), "Window")
+                    .clicked()
+                {
+                    p.region = SearchRegion::Window {
+                        matcher: MkWindowMatcher::default(),
+                    };
+                }
+                if ui
+                    .selectable_label(
+                        matches!(p.region, SearchRegion::ClientArea { .. }),
+                        "Client area",
+                    )
+                    .clicked()
+                {
+                    p.region = SearchRegion::ClientArea {
+                        matcher: MkWindowMatcher::default(),
+                    };
+                }
             });
+            if let SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } =
+                &mut p.region
+                && matcher_ui(ui, matcher)
+            {
+                window_pick = Some(super::window_picker::MatcherPath::ImageRegion);
+            }
             if let SearchRegion::Rectangle { rect } = &mut p.region {
                 ui.horizontal(|ui| {
                     ui.label("X");
@@ -959,7 +1020,57 @@ fn action_ui(
             );
         }
     }
-    pick
+    (pick, window_pick)
+}
+
+fn condition_at_path<'a>(
+    mut c: &'a mut MkCondition,
+    path: &[usize],
+) -> Option<&'a mut MkWindowMatcher> {
+    for &index in path {
+        c = match c {
+            MkCondition::All { conditions } | MkCondition::Any { conditions } => {
+                conditions.get_mut(index)?
+            }
+            MkCondition::Not { condition } if index == 0 => condition,
+            _ => return None,
+        };
+    }
+    match c {
+        MkCondition::WindowExists { matcher } | MkCondition::WindowActive { matcher } => {
+            Some(matcher)
+        }
+        _ => None,
+    }
+}
+
+fn matcher_at_path<'a>(
+    action: &'a mut MkAction,
+    path: &super::window_picker::MatcherPath,
+) -> Option<&'a mut MkWindowMatcher> {
+    use super::window_picker::MatcherPath;
+    match path {
+        MatcherPath::Action => match action {
+            MkAction::WindowActivate(p) | MkAction::WindowWait(p) => Some(&mut p.matcher),
+            MkAction::WindowClose(m) => Some(m),
+            _ => None,
+        },
+        MatcherPath::Condition(path) => match action {
+            MkAction::If(c)
+            | MkAction::WhileStart { condition: c }
+            | MkAction::WaitUntil { condition: c, .. } => condition_at_path(c, path),
+            _ => None,
+        },
+        MatcherPath::ImageRegion => match action {
+            MkAction::ImageFind(p) | MkAction::ImageClick(p) => match &mut p.region {
+                SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } => {
+                    Some(matcher)
+                }
+                _ => None,
+            },
+            _ => None,
+        },
+    }
 }
 
 pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
@@ -991,7 +1102,13 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             let step = state.draft.as_mut().unwrap();
             let editor = state.editor.expect("action editor draft has no editor strategy");
             assert!(super::action_catalog::editor_route_recognizes(&step.action, editor), "action editor strategy does not match draft action");
-            pick_request = action_ui(ui, step, &mut state.capture_keys);
+            let (position, window)=action_ui(ui, step, &mut state.capture_keys);
+            pick_request = position;
+            if let Some(path)=window {
+                let original=matcher_at_path(&mut step.action, &path).expect("picker path must resolve").clone();
+                let macro_id=d.selected_macro_id.unwrap_or(0);
+                d.window_picker.open(super::window_picker::MatcherEditRequest { destination: super::window_picker::MatcherDestination::Action { macro_id, draft_generation: state.draft_generation, path }, original });
+            }
             if state.position_capture.is_some() {
                 ui.colored_label(egui::Color32::YELLOW, "Move the mouse to the desired location. Left-click or press Enter to capture. Escape cancels.");
             }
@@ -1079,8 +1196,12 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         let mut state = std::mem::take(&mut d.action_editor);
         state.apply(d);
         d.action_editor = state;
+        d.window_picker
+            .cancel("Window picker closed because the action editor was applied");
     } else if cancel || !open {
         d.action_editor.cancel();
+        d.window_picker
+            .cancel("Window picker closed because the action editor was cancelled");
     }
 }
 
@@ -1106,6 +1227,65 @@ mod tests {
             last_screen_position: None,
             #[cfg(windows)]
             foreground_window: 0,
+        }
+    }
+
+    #[test]
+    fn window_picker_routes_root_nested_and_image_matchers() {
+        let replacement = MkWindowMatcher {
+            process: Some("picked.exe".into()),
+            title: Some("Picked".into()),
+            title_regex: None,
+            class: None,
+        };
+        for (action, path) in [
+            (
+                MkAction::WindowClose(MkWindowMatcher::default()),
+                super::super::window_picker::MatcherPath::Action,
+            ),
+            (
+                MkAction::WhileStart {
+                    condition: MkCondition::All {
+                        conditions: vec![MkCondition::WindowExists {
+                            matcher: MkWindowMatcher::default(),
+                        }],
+                    },
+                },
+                super::super::window_picker::MatcherPath::Condition(vec![0]),
+            ),
+            (
+                MkAction::ImageFind(MkImagePayload {
+                    asset_id: 1,
+                    tolerance: 0,
+                    alpha: AlphaPolicy::Compare,
+                    region: SearchRegion::Window {
+                        matcher: MkWindowMatcher::default(),
+                    },
+                    return_point: ReturnPoint::Center,
+                    wait: MkWaitOptions::default(),
+                }),
+                super::super::window_picker::MatcherPath::ImageRegion,
+            ),
+        ] {
+            let mut editor = ActionEditorState::default();
+            editor.begin_edit(&step(action));
+            let request = super::super::window_picker::MatcherEditRequest {
+                destination: super::super::window_picker::MatcherDestination::Action {
+                    macro_id: 5,
+                    draft_generation: editor.draft_generation,
+                    path: path.clone(),
+                },
+                original: MkWindowMatcher::default(),
+            };
+            assert!(editor.apply_window_matcher(&request, replacement.clone(), Some(5)));
+            assert_eq!(
+                matcher_at_path(&mut editor.draft.as_mut().unwrap().action, &path),
+                Some(&mut replacement.clone())
+            );
+            assert!(
+                !editor.apply_window_matcher(&request, MkWindowMatcher::default(), Some(6)),
+                "another macro must not be modified"
+            );
         }
     }
 

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -92,7 +92,8 @@ pub fn remove_child(c: &mut MkCondition, index: usize) -> bool {
     }
 }
 
-pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) {
+pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) -> Option<Vec<usize>> {
+    let mut requested = None;
     ui.group(|ui| {
         let kind = condition_kind(condition);
         let mut next = kind;
@@ -143,7 +144,9 @@ pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) {
                 value_ui(ui, value);
             }
             MkCondition::WindowExists { matcher } | MkCondition::WindowActive { matcher } => {
-                matcher_ui(ui, matcher)
+                if matcher_ui(ui, matcher) {
+                    requested = Some(vec![]);
+                }
             }
             MkCondition::ImageResult { asset_id, found } => {
                 ui.horizontal(|ui| {
@@ -171,19 +174,29 @@ pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) {
                 });
             }
             MkCondition::All { conditions } | MkCondition::Any { conditions } => {
-                group_ui(ui, conditions)
+                requested = group_ui(ui, conditions)
             }
             MkCondition::Not { condition } => {
-                ui.indent("not-child", |ui| condition_ui(ui, condition));
+                ui.indent("not-child", |ui| {
+                    if let Some(mut p) = condition_ui(ui, condition) {
+                        p.insert(0, 0);
+                        requested = Some(p)
+                    }
+                });
             }
         }
     });
+    requested
 }
-fn group_ui(ui: &mut egui::Ui, conditions: &mut Vec<MkCondition>) {
+fn group_ui(ui: &mut egui::Ui, conditions: &mut Vec<MkCondition>) -> Option<Vec<usize>> {
     let mut remove = None;
+    let mut requested = None;
     for (index, child) in conditions.iter_mut().enumerate() {
         ui.indent(index, |ui| {
-            condition_ui(ui, child);
+            if let Some(mut p) = condition_ui(ui, child) {
+                p.insert(0, index);
+                requested = Some(p);
+            }
             if ui.button("Remove").clicked() {
                 remove = Some(index);
             }
@@ -195,6 +208,7 @@ fn group_ui(ui: &mut egui::Ui, conditions: &mut Vec<MkCondition>) {
     if ui.button("+ Add Condition").clicked() {
         conditions.push(default_condition(ConditionKind::Variable));
     }
+    requested
 }
 fn kind_label(k: ConditionKind) -> &'static str {
     match k {

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -9,6 +9,7 @@ pub mod recorder_controller;
 mod step_table;
 mod toolbar;
 pub mod uia_editor;
+pub mod window_picker;
 
 use crate::gui::confirmation_modal::{ConfirmationModal, ConfirmationResult, DestructiveAction};
 use crate::mkmacro::{
@@ -41,6 +42,7 @@ pub struct MkMacroDialog {
     pub structural_insertion: Option<action_catalog::StructuralInsertion>,
     pub uia_editor: uia_editor::UiaEditorState,
     pub action_editor: action_editor::ActionEditorState,
+    pub window_picker: window_picker::WindowPickerState,
     pub command_error: Option<String>,
     /// Editable options are copied into the runtime at Start and never mutate an active session.
     pub recorder_options: NormalizationConfig,
@@ -1091,6 +1093,7 @@ impl MkMacroDialog {
             structural_insertion: None,
             uia_editor: Default::default(),
             action_editor: Default::default(),
+            window_picker: Default::default(),
             command_error: None,
             recorder_options: Default::default(),
             pending_recording: None,
@@ -1358,6 +1361,8 @@ impl MkMacroDialog {
         self.action_catalog_visible = false;
         self.action_editor.cancel();
         self.structural_insertion = None;
+        self.window_picker
+            .cancel("Window picker closed because the macro dialog closed");
     }
     pub fn show_contents(&mut self, ui: &mut eframe::egui::Ui) {
         toolbar::show(ui, self);
@@ -1383,6 +1388,20 @@ impl MkMacroDialog {
         }
         action_catalog::show_modal(ui.ctx(), self);
         action_editor::show(ui.ctx(), self);
+        window_picker::show(ui.ctx(), &mut self.window_picker);
+        if self.window_picker.confirm_ready {
+            self.window_picker.confirm_ready = false;
+            if let Some((request, matcher)) = self.window_picker.take_confirmation() {
+                if !self.action_editor.apply_window_matcher(
+                    &request,
+                    matcher,
+                    self.selected_macro_id,
+                ) {
+                    self.command_error =
+                        Some("The matcher target no longer exists; no changes were made".into());
+                }
+            }
+        }
         if self.delete_confirmation.ui(ui.ctx()) == ConfirmationResult::Confirmed {
             self.delete_selected_macro();
         }

--- a/src/gui/mkmacro_dialog/window_picker.rs
+++ b/src/gui/mkmacro_dialog/window_picker.rs
@@ -1,0 +1,607 @@
+//! Shared, transactional window-target picker. Native handles live only in this state.
+use crate::mkmacro::{MkWindowMatcher, windows::WindowCandidate};
+use eframe::egui;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MatcherDestination {
+    Action {
+        macro_id: u64,
+        draft_generation: u64,
+        path: MatcherPath,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MatcherPath {
+    Action,
+    Condition(Vec<usize>),
+    ImageRegion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MatcherEditRequest {
+    pub destination: MatcherDestination,
+    pub original: MkWindowMatcher,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PickerMode {
+    #[default]
+    WindowList,
+    ScreenPick,
+    Preview,
+}
+
+#[derive(Clone, Debug)]
+pub struct WindowPickerState {
+    pub open: bool,
+    pub mode: PickerMode,
+    pub search: String,
+    pub candidates: Vec<WindowCandidate>,
+    pub selected: Option<usize>,
+    pub executable: String,
+    pub title: String,
+    pub class_name: String,
+    pub process_path: String,
+    pub regex: String,
+    pub executable_enabled: bool,
+    pub title_enabled: bool,
+    pub class_enabled: bool,
+    pub regex_enabled: bool,
+    pub error: Option<String>,
+    pub message: Option<String>,
+    pub request: Option<MatcherEditRequest>,
+    pub confirm_ready: bool,
+    #[cfg(windows)]
+    native: NativeScreenPicker,
+}
+
+impl Default for WindowPickerState {
+    fn default() -> Self {
+        Self {
+            open: false,
+            mode: PickerMode::WindowList,
+            search: String::new(),
+            candidates: vec![],
+            selected: None,
+            executable: String::new(),
+            title: String::new(),
+            class_name: String::new(),
+            process_path: String::new(),
+            regex: String::new(),
+            executable_enabled: true,
+            title_enabled: true,
+            class_enabled: false,
+            regex_enabled: false,
+            error: None,
+            message: None,
+            request: None,
+            confirm_ready: false,
+            #[cfg(windows)]
+            native: Default::default(),
+        }
+    }
+}
+
+pub fn filtered_candidates<'a>(
+    items: &'a [WindowCandidate],
+    search: &str,
+) -> Vec<&'a WindowCandidate> {
+    let needle = search.to_lowercase();
+    items
+        .iter()
+        .filter(|c| {
+            needle.is_empty()
+                || [&c.title, &c.executable, &c.class_name, &c.process_path]
+                    .iter()
+                    .any(|v| v.to_lowercase().contains(&needle))
+        })
+        .collect()
+}
+
+pub fn matcher_from_preview(s: &WindowPickerState) -> Result<MkWindowMatcher, String> {
+    let value = |enabled: bool, text: &str| {
+        (enabled && !text.trim().is_empty()).then(|| text.trim().to_owned())
+    };
+    let title_regex = value(s.regex_enabled, &s.regex);
+    if let Some(pattern) = &title_regex {
+        regex::Regex::new(pattern).map_err(|e| format!("Invalid title regex: {e}"))?;
+    }
+    let matcher = MkWindowMatcher {
+        process: value(s.executable_enabled, &s.executable),
+        title: if title_regex.is_some() {
+            None
+        } else {
+            value(s.title_enabled, &s.title)
+        },
+        class: value(s.class_enabled, &s.class_name),
+        title_regex,
+    };
+    if matcher.process.is_none()
+        && matcher.title.is_none()
+        && matcher.class.is_none()
+        && matcher.title_regex.is_none()
+    {
+        Err("Enable and enter at least one matching criterion".into())
+    } else {
+        Ok(matcher)
+    }
+}
+
+impl WindowPickerState {
+    pub fn open(&mut self, request: MatcherEditRequest) {
+        *self = Self::default();
+        self.open = true;
+        self.request = Some(request);
+        self.refresh();
+    }
+    pub fn cancel(&mut self, message: impl Into<String>) {
+        self.open = false;
+        self.request = None;
+        self.message = Some(message.into());
+    }
+    pub fn refresh(&mut self) {
+        self.error = None;
+        match crate::multi_manager::win::enumerate_top_level_windows() {
+            Ok(v) => {
+                self.candidates = v.into_iter().map(WindowCandidate::from).collect();
+                self.selected = None;
+            }
+            Err(e) => {
+                self.candidates.clear();
+                self.error = Some(format!("Could not enumerate windows: {e}"));
+            }
+        }
+    }
+    fn preview(&mut self, candidate: WindowCandidate) {
+        self.executable = candidate
+            .executable
+            .rsplit(['/', '\\'])
+            .next()
+            .filter(|v| !v.is_empty())
+            .or_else(|| candidate.process_path.rsplit(['/', '\\']).next())
+            .unwrap_or_default()
+            .to_owned();
+        self.title = candidate.title;
+        self.class_name = candidate.class_name;
+        self.process_path = candidate.process_path;
+        self.regex.clear();
+        self.executable_enabled = true;
+        self.title_enabled = true;
+        self.class_enabled = false;
+        self.regex_enabled = false;
+        self.mode = PickerMode::Preview;
+        self.error = None;
+    }
+    pub fn choose_index(&mut self, index: usize) {
+        if let Some(c) = self.candidates.get(index).cloned() {
+            self.preview(c);
+        }
+    }
+    pub fn take_confirmation(&mut self) -> Option<(MatcherEditRequest, MkWindowMatcher)> {
+        let matcher = matcher_from_preview(self).ok()?;
+        let request = self.request.take()?;
+        self.open = false;
+        Some((request, matcher))
+    }
+}
+
+pub trait ScreenPickBackend {
+    fn poll(&mut self) -> Result<ScreenPickPoll, String>;
+    fn identity(&self, root: usize) -> Result<WindowCandidate, String>;
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScreenPickPoll {
+    Idle,
+    Hover { child: usize, root: usize },
+    Select { child: usize, root: usize },
+    Cancel,
+}
+
+#[cfg(windows)]
+#[derive(Default, Debug, Clone)]
+struct NativeScreenPicker {
+    left_down: bool,
+    escape_down: bool,
+}
+#[cfg(windows)]
+impl ScreenPickBackend for NativeScreenPicker {
+    fn poll(&mut self) -> Result<ScreenPickPoll, String> {
+        use windows::Win32::{
+            Foundation::POINT,
+            UI::{
+                Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON},
+                WindowsAndMessaging::{
+                    GA_ROOT, GetAncestor, GetCursorPos, IsWindow, WindowFromPoint,
+                },
+            },
+        };
+        let mut p = POINT::default();
+        unsafe { GetCursorPos(&mut p) }.map_err(|e| e.to_string())?;
+        let child = unsafe { WindowFromPoint(p) };
+        let root = unsafe { GetAncestor(child, GA_ROOT) };
+        if child.0.is_null() || root.0.is_null() || !unsafe { IsWindow(root) }.as_bool() {
+            return Err("The pointed window disappeared; move the pointer and retry".into());
+        }
+        let left = unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) } < 0;
+        let escape = unsafe { GetAsyncKeyState(VK_ESCAPE.0 as i32) } < 0;
+        let event = if escape && !self.escape_down {
+            ScreenPickPoll::Cancel
+        } else if left && !self.left_down {
+            ScreenPickPoll::Select {
+                child: child.0 as usize,
+                root: root.0 as usize,
+            }
+        } else {
+            ScreenPickPoll::Hover {
+                child: child.0 as usize,
+                root: root.0 as usize,
+            }
+        };
+        self.left_down = left;
+        self.escape_down = escape;
+        Ok(event)
+    }
+    fn identity(&self, root: usize) -> Result<WindowCandidate, String> {
+        use crate::multi_manager::win::{
+            window_class_name, window_executable, window_process_path, window_title,
+        };
+        Ok(WindowCandidate {
+            handle: root,
+            title: window_title(root).ok_or("Could not read the selected window title")?,
+            executable: window_executable(root).ok_or("Could not read the selected executable")?,
+            class_name: window_class_name(root)
+                .ok_or("Could not read the selected window class")?,
+            process_path: window_process_path(root)
+                .ok_or("Could not read the selected process path")?,
+        })
+    }
+}
+
+fn poll_screen<B: ScreenPickBackend>(state: &mut WindowPickerState, backend: &mut B) {
+    match backend.poll() {
+        Ok(ScreenPickPoll::Select { root, .. }) => match backend.identity(root) {
+            Ok(c) => state.preview(c),
+            Err(e) => state.error = Some(e),
+        },
+        Ok(ScreenPickPoll::Cancel) => state.cancel("Window picking cancelled"),
+        Ok(_) => {}
+        Err(e) => state.error = Some(e),
+    }
+}
+
+pub fn show(ctx: &egui::Context, state: &mut WindowPickerState) {
+    if !state.open {
+        return;
+    }
+    if state.mode == PickerMode::ScreenPick {
+        ctx.request_repaint();
+        #[cfg(windows)]
+        {
+            let mut native = std::mem::take(&mut state.native);
+            poll_screen(state, &mut native);
+            state.native = native;
+        }
+    }
+    let mut open = state.open;
+    egui::Window::new("Window Picker")
+        .collapsible(false)
+        .open(&mut open)
+        .default_width(720.0)
+        .show(ctx, |ui| match state.mode {
+            PickerMode::WindowList => {
+                ui.horizontal(|ui| {
+                    ui.label("Search");
+                    ui.text_edit_singleline(&mut state.search);
+                    if ui.button("Refresh").clicked() {
+                        state.refresh()
+                    }
+                    if ui.button("Pick From Screen").clicked() {
+                        #[cfg(windows)]
+                        {
+                            state.mode = PickerMode::ScreenPick;
+                            state.error = None;
+                        }
+                        #[cfg(not(windows))]
+                        {
+                            state.error =
+                                Some("Direct screen picking is available only on Windows".into());
+                        }
+                    }
+                });
+                ui.columns(3, |c| {
+                    c[0].strong("Application");
+                    c[1].strong("Title");
+                    c[2].strong("Class");
+                });
+                let visible: Vec<usize> = state
+                    .candidates
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| {
+                        filtered_candidates(std::slice::from_ref(c), &state.search).len() == 1
+                    })
+                    .map(|(i, _)| i)
+                    .collect();
+                egui::ScrollArea::vertical()
+                    .max_height(300.0)
+                    .show(ui, |ui| {
+                        for i in visible {
+                            let c = &state.candidates[i];
+                            if ui
+                                .selectable_label(
+                                    state.selected == Some(i),
+                                    format!(
+                                        "{}    |    {}    |    {}",
+                                        c.executable, c.title, c.class_name
+                                    ),
+                                )
+                                .clicked()
+                            {
+                                state.selected = Some(i);
+                            }
+                        }
+                    });
+                if state.error.is_none() {
+                    if state.candidates.is_empty() {
+                        ui.label("No windows found.");
+                    } else if filtered_candidates(&state.candidates, &state.search).is_empty() {
+                        ui.label("No windows match this search.");
+                    }
+                }
+                ui.horizontal(|ui| {
+                    if ui
+                        .add_enabled(
+                            state.selected.is_some(),
+                            egui::Button::new("Choose Selected Window"),
+                        )
+                        .clicked()
+                    {
+                        state.choose_index(state.selected.unwrap())
+                    }
+                    if ui.button("Cancel").clicked() {
+                        state.cancel("Window picking cancelled")
+                    }
+                });
+            }
+            PickerMode::ScreenPick => {
+                ui.heading("Pick From Screen");
+                ui.label("Move the pointer over a window. Click to select it. Esc cancels.");
+                if ui.button("Back").clicked() {
+                    state.mode = PickerMode::WindowList;
+                }
+            }
+            PickerMode::Preview => {
+                ui.heading("Window Target");
+                ui.checkbox(&mut state.executable_enabled, "Executable");
+                ui.text_edit_singleline(&mut state.executable);
+                ui.checkbox(&mut state.title_enabled, "Title contains");
+                ui.text_edit_singleline(&mut state.title);
+                if ui
+                    .checkbox(
+                        &mut state.regex_enabled,
+                        "Regex (takes precedence over title contains)",
+                    )
+                    .clicked()
+                    && state.regex_enabled
+                {
+                    state.title_enabled = false;
+                }
+                ui.text_edit_singleline(&mut state.regex);
+                ui.checkbox(&mut state.class_enabled, "Class");
+                ui.text_edit_singleline(&mut state.class_name);
+                ui.label(format!("Process path: {}", state.process_path));
+                let validation = matcher_from_preview(state).err();
+                if let Some(e) = &validation {
+                    ui.colored_label(egui::Color32::RED, e);
+                }
+                ui.horizontal(|ui| {
+                    if ui.button("Back / Retry").clicked() {
+                        state.mode = PickerMode::WindowList
+                    }
+                    if ui.button("Cancel").clicked() {
+                        state.cancel("Window picking cancelled")
+                    }
+                    if ui
+                        .add_enabled(validation.is_none(), egui::Button::new("Use Target"))
+                        .clicked()
+                    {
+                        state.confirm_ready = true;
+                    }
+                });
+            }
+        });
+    if !open {
+        state.cancel("Window picking cancelled")
+    }
+    if let Some(e) = &state.error {
+        egui::Area::new(egui::Id::new("picker_error")).show(ctx, |ui| {
+            ui.colored_label(egui::Color32::RED, e);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn c(h: usize, t: &str, e: &str, k: &str, p: &str) -> WindowCandidate {
+        WindowCandidate {
+            handle: h,
+            title: t.into(),
+            executable: e.into(),
+            class_name: k.into(),
+            process_path: p.into(),
+        }
+    }
+    fn preview() -> WindowPickerState {
+        let mut s = WindowPickerState::default();
+        s.preview(c(
+            99,
+            "Editor - file",
+            "edit.exe",
+            "Main",
+            "C:/Apps/edit.exe",
+        ));
+        s
+    }
+    #[test]
+    fn filtering_all_fields() {
+        let v = vec![c(
+            1,
+            "Hello World",
+            "APP.EXE",
+            "MainClass",
+            "C:/Tools/app.exe",
+        )];
+        for q in ["hello", "app.exe", "mainclass", "tools", "HELLO"] {
+            assert_eq!(filtered_candidates(&v, q).len(), 1)
+        }
+        assert_eq!(filtered_candidates(&v, "").len(), 1);
+        assert!(filtered_candidates(&v, "other").is_empty())
+    }
+    #[test]
+    fn enumerated_conversion_preserves_identity() {
+        let w = crate::multi_manager::win::EnumeratedWindow {
+            hwnd: 42,
+            title: "Title".into(),
+            executable: "app.exe".into(),
+            class_name: "Class".into(),
+            process_path: "C:/app.exe".into(),
+            rect: crate::multi_manager::model::MmRect {
+                x: 1,
+                y: 2,
+                w: 3,
+                h: 4,
+            },
+        };
+        let c = WindowCandidate::from(w);
+        assert_eq!(
+            (
+                c.handle,
+                c.title.as_str(),
+                c.executable.as_str(),
+                c.class_name.as_str(),
+                c.process_path.as_str()
+            ),
+            (42, "Title", "app.exe", "Class", "C:/app.exe")
+        );
+    }
+    #[test]
+    fn defaults_and_options() {
+        let mut s = preview();
+        let m = matcher_from_preview(&s).unwrap();
+        assert_eq!(m.process.as_deref(), Some("edit.exe"));
+        assert_eq!(m.title.as_deref(), Some("Editor - file"));
+        assert!(m.class.is_none());
+        s.class_enabled = true;
+        assert_eq!(
+            matcher_from_preview(&s).unwrap().class.as_deref(),
+            Some("Main")
+        );
+        s.regex_enabled = true;
+        s.regex = "^Editor".into();
+        let m = matcher_from_preview(&s).unwrap();
+        assert!(m.title.is_none());
+        assert_eq!(m.title_regex.as_deref(), Some("^Editor"));
+    }
+    #[test]
+    fn validation_and_handle_never_persist() {
+        let mut s = preview();
+        s.regex_enabled = true;
+        s.regex = "[".into();
+        assert!(matcher_from_preview(&s).is_err());
+        s.regex_enabled = false;
+        s.executable_enabled = false;
+        s.title_enabled = false;
+        assert!(matcher_from_preview(&s).is_err());
+        let json = serde_json::to_string(&preview().request).unwrap();
+        assert!(!json.contains("99"));
+    }
+    #[test]
+    fn cancellation_preserves_original_matcher() {
+        let original = MkWindowMatcher {
+            title: Some("Original".into()),
+            ..Default::default()
+        };
+        let mut s = WindowPickerState::default();
+        s.open(MatcherEditRequest {
+            destination: MatcherDestination::Action {
+                macro_id: 1,
+                draft_generation: 2,
+                path: MatcherPath::Action,
+            },
+            original: original.clone(),
+        });
+        s.cancel("cancelled");
+        assert!(s.request.is_none());
+        assert_eq!(original.title.as_deref(), Some("Original"));
+    }
+    #[test]
+    fn generated_matcher_is_runtime_compatible() {
+        let s = preview();
+        let m = matcher_from_preview(&s).unwrap();
+        let source = c(99, "Editor - file", "edit.exe", "Main", "C:/Apps/edit.exe");
+        assert!(crate::mkmacro::windows::candidate_matches(&m, &source).unwrap());
+        assert!(
+            !crate::mkmacro::windows::candidate_matches(
+                &m,
+                &c(2, "Other", "edit.exe", "Main", "C:/Apps/edit.exe")
+            )
+            .unwrap()
+        );
+        assert!(
+            !crate::mkmacro::windows::candidate_matches(
+                &m,
+                &c(3, "Editor - file", "other.exe", "Main", "C:/Apps/other.exe")
+            )
+            .unwrap()
+        );
+    }
+    struct Fake {
+        polls: Vec<Result<ScreenPickPoll, String>>,
+        identity: Result<WindowCandidate, String>,
+    }
+    impl ScreenPickBackend for Fake {
+        fn poll(&mut self) -> Result<ScreenPickPoll, String> {
+            self.polls.remove(0)
+        }
+        fn identity(&self, _: usize) -> Result<WindowCandidate, String> {
+            self.identity.clone()
+        }
+    }
+    #[test]
+    fn screen_poll_transitions_are_transactional() {
+        let candidate = c(7, "Picked", "pick.exe", "Root", "C:/pick.exe");
+        let mut s = WindowPickerState::default();
+        s.open = true;
+        s.mode = PickerMode::ScreenPick;
+        let mut fake = Fake {
+            polls: vec![
+                Ok(ScreenPickPoll::Hover { child: 8, root: 7 }),
+                Ok(ScreenPickPoll::Select { child: 8, root: 7 }),
+            ],
+            identity: Ok(candidate),
+        };
+        poll_screen(&mut s, &mut fake);
+        assert_eq!(s.mode, PickerMode::ScreenPick);
+        poll_screen(&mut s, &mut fake);
+        assert_eq!(s.mode, PickerMode::Preview);
+        assert_eq!(s.executable, "pick.exe");
+    }
+    #[test]
+    fn screen_poll_cancel_and_failures_are_non_destructive() {
+        let mut s = WindowPickerState::default();
+        s.open = true;
+        s.mode = PickerMode::ScreenPick;
+        let mut fake = Fake {
+            polls: vec![Ok(ScreenPickPoll::Select { child: 2, root: 1 })],
+            identity: Err("disappeared".into()),
+        };
+        poll_screen(&mut s, &mut fake);
+        assert_eq!(s.error.as_deref(), Some("disappeared"));
+        assert_eq!(s.mode, PickerMode::ScreenPick);
+        fake.polls = vec![Ok(ScreenPickPoll::Cancel)];
+        poll_screen(&mut s, &mut fake);
+        assert!(!s.open);
+    }
+}

--- a/src/gui/mkmacro_dialog/window_picker.rs
+++ b/src/gui/mkmacro_dialog/window_picker.rs
@@ -514,7 +514,8 @@ mod tests {
         s.executable_enabled = false;
         s.title_enabled = false;
         assert!(matcher_from_preview(&s).is_err());
-        let json = serde_json::to_string(&preview().request).unwrap();
+        let matcher = matcher_from_preview(&preview()).unwrap();
+        let json = serde_json::to_string(&matcher).unwrap();
         assert!(!json.contains("99"));
     }
     #[test]

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -154,7 +154,7 @@ pub enum MkCoordinateTarget {
     Variable { name: String },
     Image { asset_id: u64, offset: MkPoint },
 }
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MkWindowMatcher {
     #[serde(default)]
     pub title: Option<String>,

--- a/src/mkmacro/windows.rs
+++ b/src/mkmacro/windows.rs
@@ -11,6 +11,17 @@ pub struct WindowCandidate {
     pub process_path: String,
     pub class_name: String,
 }
+impl From<crate::multi_manager::win::EnumeratedWindow> for WindowCandidate {
+    fn from(w: crate::multi_manager::win::EnumeratedWindow) -> Self {
+        Self {
+            handle: w.hwnd,
+            title: w.title,
+            executable: w.executable,
+            process_path: w.process_path,
+            class_name: w.class_name,
+        }
+    }
+}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AmbiguityPolicy {
     Error,
@@ -95,17 +106,7 @@ pub struct Win32WindowBackend;
 impl Win32WindowBackend {
     fn candidates(&self) -> ExecResult<Vec<WindowCandidate>> {
         crate::multi_manager::win::enumerate_top_level_windows()
-            .map(|v| {
-                v.into_iter()
-                    .map(|w| WindowCandidate {
-                        handle: w.hwnd,
-                        title: w.title,
-                        executable: w.executable,
-                        process_path: w.process_path,
-                        class_name: w.class_name,
-                    })
-                    .collect()
-            })
+            .map(|v| v.into_iter().map(WindowCandidate::from).collect())
             .map_err(|e| {
                 ExecutionDiagnostic::new(
                     DiagnosticKind::Backend,


### PR DESCRIPTION
### Motivation

- Provide a single, testable, UI-neutral window-picker state and flow so matcher editing and native screen picking can be unit tested without leaking native HWNDs into persisted matchers or other models.
- Reuse the existing window enumeration helpers as the single source of truth and avoid duplicating title/executable/class/process-path extraction.
- Make matcher destinations stable and structural so a confirmed result is applied to the correct action/condition even if editors change while the picker is open.

### Description

- Added a new transactional picker module `src/gui/mkmacro_dialog/window_picker.rs` implementing `WindowPickerState`, picker modes (list/screen/preview), a small `ScreenPickBackend` trait, a Windows `NativeScreenPicker` implementation, deterministic filtering, preview editing, regex validation, and confirmation/cancellation behavior while keeping HWNDs session-only.
- Wired the picker through UI and model code: `matcher_ui` now returns a chooser request, `action_editor.rs` gained `matcher_at_path`, `condition_at_path`, `apply_window_matcher`, and routes action, nested condition, and image-region matchers to the shared picker; `condition_editor.rs` now produces structural paths for nested matcher destinations.
- Reused `crate::multi_manager::win::enumerate_top_level_windows()` by adding a conversion `From<EnumeratedWindow> for WindowCandidate` in `src/mkmacro/windows.rs` and removed duplicated mapping in the Win32 backend; the picker converts enumerated windows into transient candidates and never persists HWNDs into matchers or serialized payloads.
- Registered the single shared picker on `MkMacroDialog` and render it once from `show_contents()`, including lifecycle handling so requests are cancelled if the dialog/editor closes or the target no longer resolves.
- Added UI-neutral unit tests and fake-backend tests in `window_picker.rs` and routing tests in `action_editor.rs` that cover filtering, candidate conversion, default matcher generation, regex precedence/validation, empty-matcher rejection, cancellation semantics, screen-pick transitions, and destination routing.

### Testing

- Ran `cargo fmt --all` and `cargo check -q` with no errors reported.
- Executed unit tests including the window picker tests via `cargo test -q` and targeted picker tests `cargo test -q window_picker -- --nocapture`, which passed locally in the CI/dev environment.
- Ran `cargo clippy -q --all-targets -- -D warnings` with no warnings, and `git diff --check` to ensure no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8780275c288332b6fec1f7fd332976)