### PR TITLE
Add WindowClient matched-window coordinate targets and editor/picker support

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -855,6 +855,16 @@ pub fn format_coordinate_target(target: &MkCoordinateTarget) -> String {
         MkCoordinateTarget::ActiveWindow { point } => {
             format!("Active Window ({}, {})", point.x, point.y)
         }
+        MkCoordinateTarget::WindowClient { matcher, point } => {
+            let identity = matcher
+                .process
+                .as_deref()
+                .or(matcher.title.as_deref())
+                .or(matcher.title_regex.as_deref())
+                .or(matcher.class.as_deref())
+                .unwrap_or("unconfigured window");
+            format!("Matched Window {identity} ({}, {})", point.x, point.y)
+        }
         MkCoordinateTarget::Variable { name } => format!("Variable <{name}>"),
         MkCoordinateTarget::Image { asset_id, offset } => {
             format!("Image asset {asset_id} offset ({}, {})", offset.x, offset.y)

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -302,11 +302,20 @@ impl ActionEditorState {
             self.capture_message = result.err();
             return;
         }
-        let window = picked_foreground_window(&capture);
+        let needs_matched = matches!(
+            self.target_mut(capture.slot),
+            Some(MkCoordinateTarget::WindowClient { .. })
+        );
+        let window = if needs_matched {
+            picked_window_at(screen)
+        } else {
+            picked_foreground_window(&capture)
+        };
         let result = match self.target_mut(capture.slot) {
-            Some(target @ MkCoordinateTarget::ActiveWindow { .. }) => {
-                window.and_then(|w| apply_picked_position(target, screen, Some(&w)))
-            }
+            Some(
+                target @ (MkCoordinateTarget::ActiveWindow { .. }
+                | MkCoordinateTarget::WindowClient { .. }),
+            ) => window.and_then(|w| apply_picked_position(target, screen, Some(&w))),
             Some(target) => apply_picked_position(target, screen, None),
             None => Err("The captured field no longer exists".into()),
         };
@@ -455,6 +464,50 @@ fn picked_foreground_window(c: &PositionCaptureState) -> Result<PickedWindow, St
 fn picked_foreground_window(_: &PositionCaptureState) -> Result<PickedWindow, String> {
     Err("Active-window capture is available only on Windows".into())
 }
+#[cfg(windows)]
+fn picked_window_at(screen: MkPoint) -> Result<PickedWindow, String> {
+    use ::windows::Win32::{
+        Foundation::{HWND, POINT},
+        Graphics::Gdi::ClientToScreen,
+        UI::WindowsAndMessaging::{GA_ROOT, GetAncestor, IsWindow, WindowFromPoint},
+    };
+    let child = unsafe {
+        WindowFromPoint(POINT {
+            x: screen.x,
+            y: screen.y,
+        })
+    };
+    let root = unsafe { GetAncestor(child, GA_ROOT) };
+    if child.0.is_null() || root.0.is_null() || !unsafe { IsWindow(root) }.as_bool() {
+        return Err("The pointed window disappeared; move the pointer and retry".into());
+    }
+    let handle = root.0 as usize;
+    let candidate = crate::multi_manager::win::enumerate_top_level_windows()
+        .map_err(|e| format!("Could not read the pointed window identity: {e}"))?
+        .into_iter()
+        .find(|w| w.hwnd == handle)
+        .ok_or("The pointed window disappeared before its identity could be read")?;
+    let mut origin = POINT::default();
+    if !unsafe { ClientToScreen(HWND(root.0), &mut origin) }.as_bool() {
+        return Err("Could not determine the pointed window client origin".into());
+    }
+    Ok(PickedWindow {
+        matcher: MkWindowMatcher {
+            title: Some(candidate.title),
+            title_regex: None,
+            process: Some(candidate.executable),
+            class: None,
+        },
+        client_origin: MkPoint {
+            x: origin.x,
+            y: origin.y,
+        },
+    })
+}
+#[cfg(not(windows))]
+fn picked_window_at(_: MkPoint) -> Result<PickedWindow, String> {
+    Err("Matched-window capture is available only on Windows".into())
+}
 pub trait WindowPicker {
     fn pick_window(&mut self) -> Result<Option<PickedWindow>, String>;
 }
@@ -468,14 +521,39 @@ pub fn apply_picked_position(
         MkCoordinateTarget::Screen { point } => *point = screen,
         MkCoordinateTarget::ActiveWindow { point } => {
             let w = window.ok_or("No matching active window is available")?;
-            *point = MkPoint {
-                x: screen.x - w.client_origin.x,
-                y: screen.y - w.client_origin.y,
+            *point = translated_client_point(screen, w.client_origin)?;
+        }
+        MkCoordinateTarget::WindowClient { matcher, point } => {
+            let w = window.ok_or("No pointed window is available")?;
+            let candidate = crate::mkmacro::windows::WindowCandidate {
+                handle: 0,
+                title: w.matcher.title.clone().unwrap_or_default(),
+                executable: w.matcher.process.clone().unwrap_or_default(),
+                process_path: String::new(),
+                class_name: w.matcher.class.clone().unwrap_or_default(),
             };
+            if !crate::mkmacro::windows::candidate_matches(matcher, &candidate)
+                .map_err(|e| e.to_string())?
+            {
+                return Err("The pointed window does not match this target. Use Choose Window… to deliberately replace the matcher, then pick the position again".into());
+            }
+            *point = translated_client_point(screen, w.client_origin)?;
         }
         _ => return Err("This target does not store a fixed position".into()),
     }
     Ok(())
+}
+fn translated_client_point(screen: MkPoint, origin: MkPoint) -> Result<MkPoint, String> {
+    Ok(MkPoint {
+        x: screen
+            .x
+            .checked_sub(origin.x)
+            .ok_or("Client-relative X coordinate overflow")?,
+        y: screen
+            .y
+            .checked_sub(origin.y)
+            .ok_or("Client-relative Y coordinate overflow")?,
+    })
 }
 pub fn apply_picked_window(payload: &mut MkWindowPayload, picked: &PickedWindow) {
     payload.matcher = picked.matcher.clone();
@@ -498,21 +576,36 @@ pub(super) fn matcher_ui(ui: &mut egui::Ui, m: &mut MkWindowMatcher) -> bool {
     optional_field(ui, "Class", &mut m.class);
     ui.button("Choose Window…").clicked()
 }
-pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> bool {
+#[derive(Default)]
+pub(super) struct TargetUiOutcome {
+    pick_position: bool,
+    pick_matcher: bool,
+}
+pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> TargetUiOutcome {
     let kind = match target {
         MkCoordinateTarget::Screen { .. } => 0,
         MkCoordinateTarget::ActiveWindow { .. } => 1,
-        MkCoordinateTarget::Variable { .. } => 2,
-        MkCoordinateTarget::Image { .. } => 3,
+        MkCoordinateTarget::WindowClient { .. } => 2,
+        MkCoordinateTarget::Variable { .. } => 3,
+        MkCoordinateTarget::Image { .. } => 4,
     };
     let mut next = kind;
     egui::ComboBox::from_label("Target")
-        .selected_text(["Screen", "Active Window", "Variable", "Image Result"][kind])
+        .selected_text(
+            [
+                "Screen",
+                "Active Window",
+                "Matched Window",
+                "Variable",
+                "Image Result",
+            ][kind],
+        )
         .show_ui(ui, |ui| {
             ui.selectable_value(&mut next, 0, "Screen");
             ui.selectable_value(&mut next, 1, "Active Window");
-            ui.selectable_value(&mut next, 2, "Variable");
-            ui.selectable_value(&mut next, 3, "Image Result");
+            ui.selectable_value(&mut next, 2, "Matched Window");
+            ui.selectable_value(&mut next, 3, "Variable");
+            ui.selectable_value(&mut next, 4, "Image Result");
         });
     if next != kind {
         *target = match next {
@@ -522,7 +615,11 @@ pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> b
             1 => MkCoordinateTarget::ActiveWindow {
                 point: MkPoint { x: 0, y: 0 },
             },
-            2 => MkCoordinateTarget::Variable {
+            2 => MkCoordinateTarget::WindowClient {
+                matcher: MkWindowMatcher::default(),
+                point: MkPoint { x: 0, y: 0 },
+            },
+            3 => MkCoordinateTarget::Variable {
                 name: String::new(),
             },
             _ => MkCoordinateTarget::Image {
@@ -546,7 +643,34 @@ pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> b
                 ui.add_enabled(false, egui::Button::new("Pick Position (Windows only)"));
                 false
             };
-            return picked;
+            return TargetUiOutcome {
+                pick_position: picked,
+                pick_matcher: false,
+            };
+        }
+        MkCoordinateTarget::WindowClient { matcher, point } => {
+            ui.heading("Window");
+            let choose = matcher_ui(ui, matcher);
+            ui.heading("Position");
+            ui.horizontal(|ui| {
+                ui.label("X");
+                ui.add(egui::DragValue::new(&mut point.x));
+                ui.label("Y");
+                ui.add(egui::DragValue::new(&mut point.y));
+            });
+            #[cfg(windows)]
+            let position = ui.button("Pick Position").clicked();
+            #[cfg(not(windows))]
+            let position = {
+                ui.add_enabled(false, egui::Button::new("Pick Position (Windows only)"));
+                false
+            };
+            // The matcher picker is routed by the action-level caller; position capture remains
+            // the boolean return for backward-compatible shared condition editing.
+            return TargetUiOutcome {
+                pick_position: position,
+                pick_matcher: choose,
+            };
         }
         MkCoordinateTarget::Variable { name } => {
             ui.horizontal(|ui| {
@@ -564,7 +688,7 @@ pub(super) fn target_ui(ui: &mut egui::Ui, target: &mut MkCoordinateTarget) -> b
             });
         }
     }
-    false
+    TargetUiOutcome::default()
 }
 
 /// A shared typed editor. Switching type constructs a fresh value rather than
@@ -671,8 +795,14 @@ fn action_ui(
             }
         }
         MkAction::MouseMove(p) => {
-            if target_ui(ui, &mut p.target) {
+            let response = target_ui(ui, &mut p.target);
+            if response.pick_position {
                 pick = Some(PositionCaptureSlot::MoveTarget);
+            }
+            if response.pick_matcher {
+                window_pick = Some(super::window_picker::MatcherPath::Coordinate(
+                    super::window_picker::CoordinateMatcherPath::MoveTarget,
+                ));
             }
             let mut smooth = p.duration_ms != 0;
             ui.horizontal(|ui| {
@@ -695,12 +825,24 @@ fn action_ui(
         }
         MkAction::MouseDrag(p) => {
             ui.label("Start");
-            if target_ui(ui, &mut p.from) {
+            let response = target_ui(ui, &mut p.from);
+            if response.pick_position {
                 pick = Some(PositionCaptureSlot::DragFrom);
             }
+            if response.pick_matcher {
+                window_pick = Some(super::window_picker::MatcherPath::Coordinate(
+                    super::window_picker::CoordinateMatcherPath::DragFrom,
+                ));
+            }
             ui.label("Destination");
-            if target_ui(ui, &mut p.to) {
+            let response = target_ui(ui, &mut p.to);
+            if response.pick_position {
                 pick = Some(PositionCaptureSlot::DragTo);
+            }
+            if response.pick_matcher {
+                window_pick = Some(super::window_picker::MatcherPath::Coordinate(
+                    super::window_picker::CoordinateMatcherPath::DragTo,
+                ));
             }
             egui::ComboBox::from_label("Button")
                 .selected_text(format!("{:?}", p.button))
@@ -721,8 +863,14 @@ fn action_ui(
             });
         }
         MkAction::MouseClick(p) => {
-            if target_ui(ui, &mut p.target) {
+            let response = target_ui(ui, &mut p.target);
+            if response.pick_position {
                 pick = Some(PositionCaptureSlot::ClickTarget);
+            }
+            if response.pick_matcher {
+                window_pick = Some(super::window_picker::MatcherPath::Coordinate(
+                    super::window_picker::CoordinateMatcherPath::ClickTarget,
+                ));
             }
             egui::ComboBox::from_label("Button")
                 .selected_text(format!("{:?}", p.button))
@@ -981,8 +1129,14 @@ fn action_ui(
             tolerance,
         } => {
             ui.heading("Coordinate");
-            if target_ui(ui, target) {
+            let response = target_ui(ui, target);
+            if response.pick_position {
                 pick = Some(PositionCaptureSlot::PixelPosition);
+            }
+            if response.pick_matcher {
+                window_pick = Some(super::window_picker::MatcherPath::Coordinate(
+                    super::window_picker::CoordinateMatcherPath::PixelPosition,
+                ));
             }
             ui.separator();
             ui.heading("Color");
@@ -1070,6 +1224,21 @@ fn matcher_at_path<'a>(
             },
             _ => None,
         },
+        MatcherPath::Coordinate(path) => {
+            use super::window_picker::CoordinateMatcherPath::*;
+            let target = match (path, action) {
+                (MoveTarget, MkAction::MouseMove(p)) => &mut p.target,
+                (ClickTarget, MkAction::MouseClick(p)) => &mut p.target,
+                (DragFrom, MkAction::MouseDrag(p)) => &mut p.from,
+                (DragTo, MkAction::MouseDrag(p)) => &mut p.to,
+                (PixelPosition, MkAction::PixelCheck { target, .. }) => target,
+                _ => return None,
+            };
+            match target {
+                MkCoordinateTarget::WindowClient { matcher, .. } => Some(matcher),
+                _ => None,
+            }
+        }
     }
 }
 

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -383,6 +383,17 @@ mod tests {
             "Active Window (-8, -12)"
         );
         assert_eq!(
+            action_catalog::format_coordinate_target(&MkCoordinateTarget::WindowClient {
+                matcher: crate::mkmacro::MkWindowMatcher {
+                    process: Some("editor.exe".into()),
+                    title: Some("Document".into()),
+                    ..Default::default()
+                },
+                point: MkPoint { x: 8, y: -2 },
+            }),
+            "Matched Window editor.exe (8, -2)"
+        );
+        assert_eq!(
             action_catalog::format_coordinate_target(&MkCoordinateTarget::Variable {
                 name: "cursor".into()
             }),

--- a/src/gui/mkmacro_dialog/window_picker.rs
+++ b/src/gui/mkmacro_dialog/window_picker.rs
@@ -16,6 +16,16 @@ pub enum MatcherPath {
     Action,
     Condition(Vec<usize>),
     ImageRegion,
+    Coordinate(CoordinateMatcherPath),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CoordinateMatcherPath {
+    MoveTarget,
+    ClickTarget,
+    DragFrom,
+    DragTo,
+    PixelPosition,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -149,10 +149,23 @@ pub enum MkMouseButton {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MkCoordinateTarget {
-    Screen { point: MkPoint },
-    ActiveWindow { point: MkPoint },
-    Variable { name: String },
-    Image { asset_id: u64, offset: MkPoint },
+    Screen {
+        point: MkPoint,
+    },
+    ActiveWindow {
+        point: MkPoint,
+    },
+    WindowClient {
+        matcher: MkWindowMatcher,
+        point: MkPoint,
+    },
+    Variable {
+        name: String,
+    },
+    Image {
+        asset_id: u64,
+        offset: MkPoint,
+    },
 }
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MkWindowMatcher {
@@ -449,5 +462,30 @@ mod image_payload_tests {
         assert_eq!(p.return_point, ReturnPoint::Center);
         let json = serde_json::to_string(&p).unwrap();
         assert_eq!(serde_json::from_str::<MkImagePayload>(&json).unwrap(), p);
+    }
+    #[test]
+    fn matched_window_coordinate_has_stable_tag_and_round_trips() {
+        let target = MkCoordinateTarget::WindowClient {
+            matcher: MkWindowMatcher {
+                process: Some("app.exe".into()),
+                title: Some("Editor".into()),
+                ..Default::default()
+            },
+            point: MkPoint { x: -4, y: 12 },
+        };
+        let json = serde_json::to_string(&target).unwrap();
+        assert!(json.contains(r#""kind":"window_client""#));
+        assert_eq!(
+            serde_json::from_str::<MkCoordinateTarget>(&json).unwrap(),
+            target
+        );
+        let old: MkCoordinateTarget =
+            serde_json::from_str(r#"{"kind":"active_window","point":{"x":1,"y":2}}"#).unwrap();
+        assert_eq!(
+            old,
+            MkCoordinateTarget::ActiveWindow {
+                point: MkPoint { x: 1, y: 2 }
+            }
+        );
     }
 }

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -19,6 +19,7 @@ pub(crate) trait WindowsGeometry: Send + Sync {
     fn virtual_desktop(&self) -> ExecResult<(i32, i32, i32, i32)>;
     fn foreground_window(&self) -> ExecResult<Option<isize>>;
     fn client_origin(&self, hwnd: isize) -> ExecResult<MkPoint>;
+    fn top_level_windows(&self) -> ExecResult<Vec<crate::mkmacro::windows::WindowCandidate>>;
 }
 
 pub(crate) trait VisualSearch: Send + Sync {
@@ -172,6 +173,39 @@ impl ScreenBackend for WindowsScreenBackend {
                 };
                 self.require_on_desktop(desktop)
             }
+            MkCoordinateTarget::WindowClient { matcher, point } => {
+                let candidates = self.geometry.top_level_windows().map_err(|e| {
+                    e.context("backend", "WindowsScreenBackend")
+                        .context("action", "enumerate matched-window coordinate candidates")
+                })?;
+                let candidate = crate::mkmacro::windows::resolve_window(
+                    matcher,
+                    &candidates,
+                    crate::mkmacro::windows::AmbiguityPolicy::Error,
+                )
+                .map_err(|e| e.context("window_matcher", format!("{matcher:?}")))?;
+                let origin = self
+                    .geometry
+                    .client_origin(candidate.handle as isize)
+                    .map_err(|e| {
+                        e.context(
+                            "window",
+                            format!("{} ({})", candidate.title, candidate.executable),
+                        )
+                        .context("action", "read matched-window client origin")
+                    })?;
+                let desktop =
+                    MkPoint {
+                        x: origin.x.checked_add(point.x).ok_or_else(|| {
+                            invalid("matched-window client X coordinate overflow")
+                        })?,
+                        y: origin.y.checked_add(point.y).ok_or_else(|| {
+                            invalid("matched-window client Y coordinate overflow")
+                        })?,
+                    };
+                self.require_on_desktop(desktop)
+                    .map_err(|e| e.context("action", "resolve matched-window client point"))
+            }
             MkCoordinateTarget::Variable { name } => match variables.get(name) {
                 Some(MkValue::Point(point)) => Ok(*point),
                 Some(value) => Err(type_mismatch(name, value)),
@@ -290,6 +324,16 @@ impl WindowsGeometry for SystemWindowsGeometry {
             x: point.x,
             y: point.y,
         })
+    }
+    fn top_level_windows(&self) -> ExecResult<Vec<crate::mkmacro::windows::WindowCandidate>> {
+        crate::multi_manager::win::enumerate_top_level_windows()
+            .map(|items| items.into_iter().map(Into::into).collect())
+            .map_err(|e| {
+                ExecutionDiagnostic::new(
+                    DiagnosticKind::Backend,
+                    format!("window enumeration failed: {e}"),
+                )
+            })
     }
 }
 
@@ -849,6 +893,7 @@ mod windows_backend_tests {
         desktop: (i32, i32, i32, i32),
         foreground: Option<isize>,
         origin: MkPoint,
+        candidates: Vec<crate::mkmacro::windows::WindowCandidate>,
     }
     impl WindowsGeometry for Geometry {
         fn virtual_desktop(&self) -> ExecResult<(i32, i32, i32, i32)> {
@@ -859,6 +904,9 @@ mod windows_backend_tests {
         }
         fn client_origin(&self, _: isize) -> ExecResult<MkPoint> {
             Ok(self.origin)
+        }
+        fn top_level_windows(&self) -> ExecResult<Vec<crate::mkmacro::windows::WindowCandidate>> {
+            Ok(self.candidates.clone())
         }
     }
     #[derive(Default)]
@@ -885,6 +933,7 @@ mod windows_backend_tests {
                 desktop,
                 foreground,
                 origin,
+                candidates: vec![],
             }),
             Arc::new(Visual::default()),
         )
@@ -919,6 +968,7 @@ mod windows_backend_tests {
                 desktop: (-100, -100, 200, 200),
                 foreground: Some(1),
                 origin: MkPoint { x: -20, y: -30 },
+                candidates: vec![],
             }),
             Arc::new(PixelVisual(pixel)),
         )
@@ -1076,6 +1126,76 @@ mod windows_backend_tests {
             .unwrap_err();
         assert_eq!(err.kind, DiagnosticKind::InvalidTarget);
         assert!(err.message.contains("overflow"));
+    }
+    fn candidate(handle: usize, title: &str) -> crate::mkmacro::windows::WindowCandidate {
+        crate::mkmacro::windows::WindowCandidate {
+            handle,
+            title: title.into(),
+            executable: "app.exe".into(),
+            process_path: "C:\\app.exe".into(),
+            class_name: "App".into(),
+        }
+    }
+    fn matched_backend(
+        candidates: Vec<crate::mkmacro::windows::WindowCandidate>,
+        origin: MkPoint,
+    ) -> WindowsScreenBackend {
+        WindowsScreenBackend::new(
+            Arc::new(Geometry {
+                desktop: (-1000, -1000, 2000, 2000),
+                foreground: Some(999),
+                origin,
+                candidates,
+            }),
+            Arc::new(Visual::default()),
+        )
+    }
+    #[test]
+    fn matched_window_resolves_without_foreground_and_translates_negative_origin() {
+        let backend = matched_backend(vec![candidate(7, "Editor")], MkPoint { x: -200, y: -100 });
+        let target = MkCoordinateTarget::WindowClient {
+            matcher: MkWindowMatcher {
+                process: Some("app.exe".into()),
+                title: Some("Edit".into()),
+                ..Default::default()
+            },
+            point: MkPoint { x: 25, y: 30 },
+        };
+        assert_eq!(
+            backend.resolve(&target, &RuntimeVariables::new()).unwrap(),
+            MkPoint { x: -175, y: -70 }
+        );
+    }
+    #[test]
+    fn matched_window_reports_missing_ambiguity_and_overflow() {
+        let target = |point| MkCoordinateTarget::WindowClient {
+            matcher: MkWindowMatcher {
+                process: Some("app.exe".into()),
+                ..Default::default()
+            },
+            point,
+        };
+        assert_eq!(
+            matched_backend(vec![], MkPoint { x: 0, y: 0 })
+                .resolve(&target(MkPoint { x: 0, y: 0 }), &RuntimeVariables::new())
+                .unwrap_err()
+                .kind,
+            DiagnosticKind::TargetNotFound
+        );
+        assert_eq!(
+            matched_backend(
+                vec![candidate(1, "One"), candidate(2, "Two")],
+                MkPoint { x: 0, y: 0 }
+            )
+            .resolve(&target(MkPoint { x: 0, y: 0 }), &RuntimeVariables::new())
+            .unwrap_err()
+            .kind,
+            DiagnosticKind::AmbiguousTarget
+        );
+        let error = matched_backend(vec![candidate(1, "One")], MkPoint { x: i32::MAX, y: 0 })
+            .resolve(&target(MkPoint { x: 1, y: 0 }), &RuntimeVariables::new())
+            .unwrap_err();
+        assert!(error.message.contains("overflow"));
     }
     #[test]
     fn variables_are_strictly_typed() {

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -285,6 +285,7 @@ fn target(
     out: &mut Vec<MkDiagnostic>,
 ) {
     match target {
+        MkCoordinateTarget::WindowClient { matcher: value, .. } => matcher(value, m, s, out),
         MkCoordinateTarget::Variable { name } if name.trim().is_empty() => push(
             out,
             m,
@@ -355,5 +356,50 @@ fn condition(
         }
         MkCondition::Not { condition: x } => condition(x, m, s, root, o),
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod coordinate_target_tests {
+    use super::*;
+
+    fn diagnostics(matcher: MkWindowMatcher) -> Vec<MkDiagnostic> {
+        let mut out = Vec::new();
+        target(
+            &MkCoordinateTarget::WindowClient {
+                matcher,
+                point: MkPoint { x: 0, y: 0 },
+            },
+            1,
+            Some(2),
+            None,
+            &mut out,
+        );
+        out
+    }
+
+    #[test]
+    fn matched_coordinate_validates_matcher() {
+        assert!(
+            diagnostics(MkWindowMatcher::default())
+                .iter()
+                .any(|d| d.code == "empty_window_matcher")
+        );
+        assert!(
+            diagnostics(MkWindowMatcher {
+                title_regex: Some("[".into()),
+                ..Default::default()
+            })
+            .iter()
+            .any(|d| d.code == "invalid_regex")
+        );
+        assert!(
+            diagnostics(MkWindowMatcher {
+                process: Some("app.exe".into()),
+                title: Some("Editor".into()),
+                ..Default::default()
+            })
+            .is_empty()
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Allow persisted coordinate targets to reference a matched top-level window's client area (client-relative coordinates) without breaking existing documents or ActiveWindow behavior.
- Resolve and validate those matched-window coordinates at runtime using the existing matcher/resolver behavior and provide editor/picker UI to author them safely.

### Description

- Added a new `MkCoordinateTarget::WindowClient { matcher: MkWindowMatcher, point: MkPoint }` variant with the same tagged serde representation (`kind: "window_client"`) so existing documents and `ActiveWindow` remain compatible; updated model and serde round-trip test. (src/mkmacro/model.rs)
- Implemented matched-window coordinate resolution in `WindowsScreenBackend::resolve()` by enumerating top-level window candidates via a new `WindowsGeometry::top_level_windows()` call, calling the existing `crate::mkmacro::windows::resolve_window()` to pick a WindowCandidate, reading the selected window’s client origin from the geometry backend, adding the stored client-relative `point` with checked arithmetic, and validating the desktop point with `require_on_desktop`. Errors for not-found, ambiguous, overflow, and off-desktop are returned as diagnostics consistent with existing targets. (src/mkmacro/screen.rs)
- Extended Windows geometry test helper and production geometry to expose top-level enumeration in a testable way and added unit tests for successful resolution, missing/ambiguous matches, translation, and overflow cases. (src/mkmacro/screen.rs)
- Extended target validation to run window-matcher checks for `WindowClient.matcher`, reject empty matchers, and validate `title_regex` syntax; added tests for matcher validation. (src/mkmacro/validation.rs)
- Updated GUI editors and picker routing to expose Matched Window in the coordinate-target chooser (Screen, Active Window, Matched Window, Variable, Image Result), construct a default `WindowClient` when chosen, present a Window matcher editor plus X/Y client-relative fields, reuse the shared matcher UI and routed matcher-picking paths for coordinate targets, and added a readable formatting string for Matched Window entries in action details. (src/gui/mkmacro_dialog/action_editor.rs, src/gui/mkmacro_dialog/window_picker.rs, src/gui/mkmacro_dialog/action_catalog.rs, src/gui/mkmacro_dialog/mod.rs)
- Reworked position capture logic to reuse native window-picking: added `picked_window_at()` to read the pointed root identity and client origin, translated desktop picks into client coordinates, and ensured matcher adoption is explicit (matcher not silently replaced); updated `apply_picked_position` to support `WindowClient`. (src/gui/mkmacro_dialog/action_editor.rs)
- Added exhaustive match-site updates and tests so existing behavior for the four original coordinate-target variants is preserved while extending coverage for the new variant. (multiple files)

### Testing

- `cargo fmt -- --check` succeeded for the modified files.
- `git diff --check` passed (no trailing-whitespace / diff issues introduced).
- `cargo test --lib` / full test run could not complete in this Linux environment due to the repository’s existing platform-specific Windows API bindings and crate configuration (the build fails on Linux with unresolved `windows::Win32` imports), so the full test suite and GUI-integration checks could not be executed here; the new unit tests were added under the existing test harness and will run on the intended Windows CI/hosts.
- Local `cargo check`/formatting and iterative compilation were used during development to validate compilation of the modified mkmacro and dialog modules where platform constraints allowed; runtime GUI and Windows-only behaviors should be verified on Windows during CI or manual testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8796da28108332a56b4a7900dd5bf6)