### PR TITLE
Add launcher-action picker, Run Program browse, and immutable authoring context

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -22,7 +22,7 @@ pub struct ActionEditorState {
     pub capture_message: Option<String>,
     pub editor: Option<super::action_catalog::EditorKind>,
     position_capture: Option<PositionCaptureState>,
-    draft_generation: u64,
+    pub(crate) draft_generation: u64,
     picker: NativePositionPicker,
 }
 
@@ -758,9 +758,11 @@ fn action_ui(
 ) -> (
     Option<PositionCaptureSlot>,
     Option<super::window_picker::MatcherPath>,
+    Option<super::launcher_action_picker::PickerPurpose>,
 ) {
     let mut pick = None;
     let mut window_pick = None;
+    let mut launcher_pick = None;
     match &mut step.action {
         MkAction::KeyPress(k) | MkAction::KeyDown(k) | MkAction::KeyUp(k) => {
             ui.label(format!("Captured: {}", key_name(k)));
@@ -950,6 +952,16 @@ fn action_ui(
             ui.horizontal(|ui| {
                 ui.label("Program");
                 ui.text_edit_singleline(&mut p.program);
+                if ui.button("Browse…").clicked()
+                    && let Some(path) = rfd::FileDialog::new()
+                        .add_filter("Executable", &["exe", "bat", "cmd", "com"])
+                        .pick_file()
+                {
+                    super::launcher_action_picker::apply_chosen_program_path(p, path);
+                }
+                if ui.button("Choose From Launcher…").clicked() {
+                    launcher_pick = Some(super::launcher_action_picker::PickerPurpose::Process);
+                }
             });
             let mut args = p.arguments.join(" ");
             ui.horizontal(|ui| {
@@ -961,8 +973,13 @@ fn action_ui(
             ui.horizontal(|ui| {
                 ui.label("Working directory");
                 ui.text_edit_singleline(wd);
+                if ui.button("Browse…").clicked()
+                    && let Some(path) = rfd::FileDialog::new().pick_folder()
+                {
+                    *wd = path.to_string_lossy().into_owned();
+                }
             });
-            if wd.is_empty() {
+            if wd.trim().is_empty() {
                 p.working_directory = None;
             }
             ui.checkbox(&mut p.wait, "Wait for completion");
@@ -1040,6 +1057,9 @@ fn action_ui(
             ui.small(
                 "Search uses canonical launcher action values; display labels are not persisted.",
             );
+            if ui.button("Choose Launcher Action…").clicked() {
+                launcher_pick = Some(super::launcher_action_picker::PickerPurpose::LauncherCommand);
+            }
         }
         MkAction::ImageFind(p) | MkAction::ImageClick(p) => {
             ui.heading("Reference Image");
@@ -1174,7 +1194,7 @@ fn action_ui(
             );
         }
     }
-    (pick, window_pick)
+    (pick, window_pick, launcher_pick)
 }
 
 fn condition_at_path<'a>(
@@ -1271,12 +1291,21 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             let step = state.draft.as_mut().unwrap();
             let editor = state.editor.expect("action editor draft has no editor strategy");
             assert!(super::action_catalog::editor_route_recognizes(&step.action, editor), "action editor strategy does not match draft action");
-            let (position, window)=action_ui(ui, step, &mut state.capture_keys);
+            let (position, window, launcher)=action_ui(ui, step, &mut state.capture_keys);
             pick_request = position;
             if let Some(path)=window {
                 let original=matcher_at_path(&mut step.action, &path).expect("picker path must resolve").clone();
                 let macro_id=d.selected_macro_id.unwrap_or(0);
                 d.window_picker.open(super::window_picker::MatcherEditRequest { destination: super::window_picker::MatcherDestination::Action { macro_id, draft_generation: state.draft_generation, path }, original });
+            }
+            if let Some(purpose) = launcher {
+                let request = super::launcher_action_picker::LauncherActionRequest {
+                    purpose,
+                    macro_id: d.selected_macro_id.unwrap_or(0),
+                    step_id: state.editing_id,
+                    draft_generation: state.draft_generation,
+                };
+                d.launcher_action_picker.open(request);
             }
             if state.position_capture.is_some() {
                 ui.colored_label(egui::Color32::YELLOW, "Move the mouse to the desired location. Left-click or press Enter to capture. Escape cancels.");
@@ -1367,10 +1396,12 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         d.action_editor = state;
         d.window_picker
             .cancel("Window picker closed because the action editor was applied");
+        d.launcher_action_picker.cancel();
     } else if cancel || !open {
         d.action_editor.cancel();
         d.window_picker
             .cancel("Window picker closed because the action editor was cancelled");
+        d.launcher_action_picker.cancel();
     }
 }
 

--- a/src/gui/mkmacro_dialog/launcher_action_picker.rs
+++ b/src/gui/mkmacro_dialog/launcher_action_picker.rs
@@ -1,0 +1,442 @@
+//! Searchable launcher-action picker and its transactional conversion helpers.
+use crate::{
+    actions::Action,
+    mkmacro::{MkAction, MkProcessPayload},
+};
+use eframe::egui;
+use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PickerPurpose {
+    Process,
+    LauncherCommand,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LauncherActionRequest {
+    pub purpose: PickerPurpose,
+    pub macro_id: u64,
+    pub step_id: Option<u64>,
+    pub draft_generation: u64,
+}
+
+#[derive(Default)]
+pub struct LauncherActionPickerState {
+    pub open: bool,
+    pub search: String,
+    pub selected: Option<usize>,
+    pub request: Option<LauncherActionRequest>,
+    pub conversion_confirmation: Option<Action>,
+}
+
+impl LauncherActionPickerState {
+    pub fn open(&mut self, request: LauncherActionRequest) {
+        self.open = true;
+        self.search.clear();
+        self.selected = None;
+        self.conversion_confirmation = None;
+        self.request = Some(request);
+    }
+    pub fn cancel(&mut self) {
+        self.open = false;
+        self.search.clear();
+        self.selected = None;
+        self.request = None;
+        self.conversion_confirmation = None;
+    }
+}
+
+/// Results ranked with the launcher's fuzzy matcher; source position is the
+/// stable tie breaker.
+pub fn matching_action_indices(actions: &[Action], query: &str) -> Vec<usize> {
+    let needle = query.trim();
+    if needle.is_empty() {
+        return (0..actions.len()).collect();
+    }
+    let matcher = SkimMatcherV2::default().ignore_case();
+    let mut found: Vec<(usize, i64)> = actions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, a)| {
+            [
+                &a.label,
+                &a.desc,
+                &a.action,
+                a.args.as_deref().unwrap_or(""),
+            ]
+            .into_iter()
+            .filter_map(|v| matcher.fuzzy_match(v, needle))
+            .max()
+            .map(|score| (i, score))
+        })
+        .collect();
+    found.sort_by(|(ai, ascore), (bi, bscore)| bscore.cmp(ascore).then(ai.cmp(bi)));
+    found.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Conservative recognition of launcher values that can be run directly.
+pub fn is_direct_program(action: &str) -> bool {
+    let value = action.trim();
+    if value.is_empty()
+        || value.starts_with("mm ")
+        || value.starts_with("system:")
+        || value.starts_with("notes:")
+    {
+        return false;
+    }
+    // Other canonical namespaces are launcher commands, except a Windows drive.
+    if value.contains(':')
+        && !(value.len() >= 3
+            && value.as_bytes()[1] == b':'
+            && matches!(value.as_bytes()[2], b'\\' | b'/'))
+    {
+        return false;
+    }
+    let lower = value.to_ascii_lowercase();
+    let known = [".exe", ".bat", ".cmd", ".com"]
+        .iter()
+        .any(|e| lower.ends_with(e));
+    known || value.contains('/') || value.contains('\\')
+}
+
+fn inferred_parent(program: &str) -> Option<String> {
+    Path::new(program)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+pub fn apply_chosen_program_path(payload: &mut MkProcessPayload, path: PathBuf) {
+    let program = path.to_string_lossy().into_owned();
+    if payload
+        .working_directory
+        .as_deref()
+        .is_none_or(|v| v.trim().is_empty())
+    {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            payload.working_directory = Some(parent.to_string_lossy().into_owned());
+        }
+    }
+    payload.program = program;
+}
+
+pub fn apply_chosen_folder(payload: &mut MkProcessPayload, path: PathBuf) {
+    payload.working_directory = Some(path.to_string_lossy().into_owned());
+}
+
+pub fn apply_program_action(payload: &mut MkProcessPayload, action: &Action) {
+    payload.program = action.action.clone();
+    payload.arguments = action
+        .args
+        .as_deref()
+        .map(|v| shlex::split(v).unwrap_or_else(|| vec![v.to_owned()]))
+        .unwrap_or_default();
+    if payload
+        .working_directory
+        .as_deref()
+        .is_none_or(|v| v.trim().is_empty())
+    {
+        if let Some(parent) = inferred_parent(&action.action) {
+            payload.working_directory = Some(parent);
+        }
+    }
+}
+
+fn normalized_args(args: &Option<String>) -> Option<String> {
+    args.as_ref().filter(|v| !v.trim().is_empty()).cloned()
+}
+
+pub fn apply_launcher_action(target: &mut MkAction, action: &Action) {
+    *target = MkAction::LauncherCommand {
+        command: action.action.clone(),
+        args: normalized_args(&action.args),
+    };
+}
+
+impl super::action_editor::ActionEditorState {
+    pub fn launcher_picker_request(
+        &self,
+        purpose: PickerPurpose,
+        macro_id: u64,
+    ) -> LauncherActionRequest {
+        LauncherActionRequest {
+            purpose,
+            macro_id,
+            step_id: self.editing_id,
+            draft_generation: self.draft_generation,
+        }
+    }
+    pub fn apply_launcher_picker_action(
+        &mut self,
+        request: &LauncherActionRequest,
+        action: &Action,
+        current_macro_id: Option<u64>,
+        convert: bool,
+    ) -> bool {
+        if Some(request.macro_id) != current_macro_id
+            || request.step_id != self.editing_id
+            || request.draft_generation != self.draft_generation
+        {
+            return false;
+        }
+        let Some(step) = self.draft.as_mut() else {
+            return false;
+        };
+        match request.purpose {
+            PickerPurpose::Process if is_direct_program(&action.action) => {
+                let MkAction::Process(payload) = &mut step.action else {
+                    return false;
+                };
+                apply_program_action(payload, action);
+            }
+            PickerPurpose::Process if convert => {
+                apply_launcher_action(&mut step.action, action);
+                self.editor = Some(super::action_catalog::EditorKind::Launcher);
+            }
+            PickerPurpose::Process => return false,
+            PickerPurpose::LauncherCommand => {
+                if !matches!(step.action, MkAction::LauncherCommand { .. }) {
+                    return false;
+                }
+                apply_launcher_action(&mut step.action, action);
+            }
+        }
+        true
+    }
+}
+
+pub fn show(ctx: &egui::Context, dialog: &mut super::MkMacroDialog) {
+    if !dialog.launcher_action_picker.open {
+        return;
+    }
+    let actions = dialog.authoring_context.launcher_actions.clone();
+    let mut open = true;
+    let mut choose = false;
+    let mut cancel = false;
+    egui::Window::new("Choose Launcher Action")
+        .collapsible(false)
+        .open(&mut open)
+        .default_width(680.0)
+        .show(ctx, |ui| {
+            let state = &mut dialog.launcher_action_picker;
+            let response = ui.add(
+                egui::TextEdit::singleline(&mut state.search)
+                    .hint_text("Search label, description, action, or arguments"),
+            );
+            response.request_focus();
+            let visible = matching_action_indices(&actions, &state.search);
+            if actions.is_empty() {
+                ui.label("No launcher actions are available in this authoring snapshot.");
+            } else if visible.is_empty() {
+                ui.label("No launcher actions match this search.");
+            }
+            egui::ScrollArea::vertical()
+                .max_height(320.0)
+                .show(ui, |ui| {
+                    for &index in &visible {
+                        let a = &actions[index];
+                        let text = format!(
+                            "{}\n{}\n{}{}",
+                            a.label,
+                            a.desc,
+                            a.action,
+                            a.args
+                                .as_ref()
+                                .map(|v| format!("  {v}"))
+                                .unwrap_or_default()
+                        );
+                        let row = ui.selectable_label(state.selected == Some(index), text);
+                        if row.clicked() {
+                            state.selected = Some(index);
+                        }
+                        if row.double_clicked() {
+                            state.selected = Some(index);
+                            choose = true;
+                        }
+                    }
+                });
+            let down = ui.input(|i| i.key_pressed(egui::Key::ArrowDown));
+            let up = ui.input(|i| i.key_pressed(egui::Key::ArrowUp));
+            if (down || up) && !visible.is_empty() {
+                let pos = state
+                    .selected
+                    .and_then(|s| visible.iter().position(|i| *i == s));
+                let next = if down {
+                    pos.map_or(0, |p| (p + 1).min(visible.len() - 1))
+                } else {
+                    pos.map_or(visible.len() - 1, |p| p.saturating_sub(1))
+                };
+                state.selected = Some(visible[next]);
+            }
+            if ui.input(|i| i.key_pressed(egui::Key::Enter)) && state.selected.is_some() {
+                choose = true;
+            }
+            if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+                cancel = true;
+            }
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(
+                        state.selected.is_some(),
+                        egui::Button::new("Use Selected Action"),
+                    )
+                    .clicked()
+                {
+                    choose = true;
+                }
+                if ui.button("Cancel").clicked() {
+                    cancel = true;
+                }
+            });
+            if let Some(action) = state.conversion_confirmation.clone() {
+                ui.separator();
+                ui.label("This is a launcher command rather than a directly runnable program.");
+                if ui.button("Use as Launcher Command instead").clicked() {
+                    if let Some(request) = state.request.clone() {
+                        dialog.action_editor.apply_launcher_picker_action(
+                            &request,
+                            &action,
+                            dialog.selected_macro_id,
+                            true,
+                        );
+                    }
+                    cancel = true;
+                }
+                if ui.button("Keep Run Program").clicked() {
+                    state.conversion_confirmation = None;
+                }
+            }
+        });
+    if !open || cancel {
+        dialog.launcher_action_picker.cancel();
+        return;
+    }
+    if choose {
+        let state = &mut dialog.launcher_action_picker;
+        if let (Some(index), Some(request)) = (state.selected, state.request.clone()) {
+            if let Some(action) = actions.get(index) {
+                if request.purpose == PickerPurpose::Process && !is_direct_program(&action.action) {
+                    state.conversion_confirmation = Some(action.clone());
+                } else {
+                    dialog.action_editor.apply_launcher_picker_action(
+                        &request,
+                        action,
+                        dialog.selected_macro_id,
+                        false,
+                    );
+                    state.cancel();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn action(label: &str, desc: &str, command: &str, args: Option<&str>) -> Action {
+        Action {
+            label: label.into(),
+            desc: desc.into(),
+            action: command.into(),
+            args: args.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn matching_covers_every_field_case_insensitively_and_is_stable() {
+        let items = vec![
+            action("Alpha", "Editor", "one.exe", Some("--FIRST")),
+            action("Beta", "ALPHA helper", "two.exe", None),
+        ];
+        assert_eq!(matching_action_indices(&items, " alpha "), vec![0, 1]);
+        assert_eq!(matching_action_indices(&items, "editor"), vec![0]);
+        assert_eq!(matching_action_indices(&items, "ONE.EXE"), vec![0]);
+        assert_eq!(matching_action_indices(&items, "first"), vec![0]);
+        assert_eq!(matching_action_indices(&items, ""), vec![0, 1]);
+    }
+
+    #[test]
+    fn program_classifier_is_conservative() {
+        for value in [
+            r"C:\Tools\app.exe",
+            "wt.exe",
+            "build.bat",
+            "go.cmd",
+            "old.com",
+            "/usr/local/bin/tool",
+            "scripts/run",
+        ] {
+            assert!(is_direct_program(value), "{value}");
+        }
+        for value in [
+            "notes:dialog",
+            "system:shutdown",
+            "mm open settings",
+            "ambiguous",
+        ] {
+            assert!(!is_direct_program(value), "{value}");
+        }
+    }
+
+    #[test]
+    fn process_transfer_parses_quotes_and_respects_working_directory() {
+        let selected = action(
+            "Display",
+            "metadata",
+            "/opt/tools/run",
+            Some("--name \"two words\""),
+        );
+        let mut payload = MkProcessPayload {
+            program: String::new(),
+            arguments: vec![],
+            working_directory: None,
+            wait: false,
+        };
+        apply_program_action(&mut payload, &selected);
+        assert_eq!(payload.program, "/opt/tools/run");
+        assert_eq!(payload.arguments, ["--name", "two words"]);
+        assert_eq!(payload.working_directory.as_deref(), Some("/opt/tools"));
+        payload.working_directory = Some("explicit".into());
+        apply_program_action(&mut payload, &action("", "", "/elsewhere/run", None));
+        assert_eq!(payload.working_directory.as_deref(), Some("explicit"));
+    }
+
+    #[test]
+    fn chosen_paths_infer_only_meaningful_parents() {
+        let mut payload = MkProcessPayload {
+            program: String::new(),
+            arguments: vec![],
+            working_directory: Some("  ".into()),
+            wait: false,
+        };
+        apply_chosen_program_path(&mut payload, PathBuf::from("/tmp/bin/tool"));
+        assert_eq!(payload.working_directory.as_deref(), Some("/tmp/bin"));
+        payload.working_directory = None;
+        apply_chosen_program_path(&mut payload, PathBuf::from("tool"));
+        assert_eq!(payload.working_directory, None);
+    }
+
+    #[test]
+    fn launcher_transfer_persists_no_display_metadata() {
+        let selected = action(
+            "Secret label",
+            "Secret description",
+            "notes:dialog",
+            Some("  "),
+        );
+        let mut target = MkAction::Delay { milliseconds: 1 };
+        apply_launcher_action(&mut target, &selected);
+        assert_eq!(
+            target,
+            MkAction::LauncherCommand {
+                command: "notes:dialog".into(),
+                args: None
+            }
+        );
+        let json = serde_json::to_string(&target).unwrap();
+        assert!(!json.contains("Secret"));
+        assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), target);
+    }
+}

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -3,6 +3,7 @@ pub mod action_editor;
 pub mod condition_editor;
 pub mod image_search_editor;
 mod key_capture;
+pub mod launcher_action_picker;
 mod macro_list;
 mod macro_properties;
 pub mod recorder_controller;
@@ -25,9 +26,17 @@ pub enum DirtyDecision {
     Discard,
 }
 
+/// Immutable launcher data made available to macro authoring.  This is a
+/// snapshot: authoring a macro can never edit the launcher's action list.
+#[derive(Clone, Default)]
+pub struct MkMacroAuthoringContext {
+    pub launcher_actions: Arc<Vec<crate::actions::Action>>,
+}
+
 pub struct MkMacroDialog {
     pub open: bool,
     pub store: Arc<MkMacroStore>,
+    pub authoring_context: MkMacroAuthoringContext,
     pub draft: MkMacroDocument,
     baseline: Arc<MkMacroDocument>,
     pub dirty: bool,
@@ -44,6 +53,7 @@ pub struct MkMacroDialog {
     pub uia_editor: uia_editor::UiaEditorState,
     pub action_editor: action_editor::ActionEditorState,
     pub window_picker: window_picker::WindowPickerState,
+    pub launcher_action_picker: launcher_action_picker::LauncherActionPickerState,
     pub command_error: Option<String>,
     /// Editable options are copied into the runtime at Start and never mutate an active session.
     pub recorder_options: NormalizationConfig,
@@ -1088,12 +1098,19 @@ mod tests {
 }
 impl MkMacroDialog {
     pub fn new(store: Arc<MkMacroStore>) -> Self {
+        Self::new_with_authoring_context(store, MkMacroAuthoringContext::default())
+    }
+    pub fn new_with_authoring_context(
+        store: Arc<MkMacroStore>,
+        authoring_context: MkMacroAuthoringContext,
+    ) -> Self {
         let baseline = store.snapshot();
         Self {
             open: false,
             draft: (*baseline).clone(),
             baseline,
             store,
+            authoring_context,
             dirty: false,
             conflict: false,
             selected_macro_id: None,
@@ -1108,6 +1125,7 @@ impl MkMacroDialog {
             uia_editor: Default::default(),
             action_editor: Default::default(),
             window_picker: Default::default(),
+            launcher_action_picker: Default::default(),
             command_error: None,
             recorder_options: Default::default(),
             pending_recording: None,
@@ -1390,6 +1408,7 @@ impl MkMacroDialog {
         self.structural_insertion = None;
         self.window_picker
             .cancel("Window picker closed because the macro dialog closed");
+        self.launcher_action_picker.cancel();
     }
     pub fn show_contents(&mut self, ui: &mut eframe::egui::Ui) {
         for result in crate::mkmacro::runtime::take_pending_recordings() {
@@ -1427,6 +1446,7 @@ impl MkMacroDialog {
         }
         action_catalog::show_modal(ui.ctx(), self);
         action_editor::show(ui.ctx(), self);
+        launcher_action_picker::show(ui.ctx(), self);
         window_picker::show(ui.ctx(), &mut self.window_picker);
         if self.window_picker.confirm_ready {
             self.window_picker.confirm_ready = false;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1314,8 +1314,12 @@ impl LauncherApp {
             .collect::<HashMap<_, _>>();
         let dashboard_data_cache = DashboardDataCache::new();
         dashboard_data_cache.refresh_all(&plugins);
-        let mkmacro_dialog =
-            MkMacroDialog::new(Arc::clone(&plugins.internal_services().mkmacro_store));
+        let mkmacro_dialog = MkMacroDialog::new_with_authoring_context(
+            Arc::clone(&plugins.internal_services().mkmacro_store),
+            mkmacro_dialog::MkMacroAuthoringContext {
+                launcher_actions: Arc::clone(&actions),
+            },
+        );
         let mut app = Self {
             actions: Arc::clone(&actions),
             query: String::new(),

--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -1,13 +1,104 @@
 use multi_launcher::{
+    actions::Action,
     gui::mkmacro_dialog::{
-        MkMacroDialog, action_catalog,
+        MkMacroAuthoringContext, MkMacroDialog, action_catalog,
         action_editor::ActionEditorState,
+        launcher_action_picker::PickerPurpose,
         recorder_controller::{
             RecorderController, RecorderControllerView, RecorderState, RecorderStatusSnapshot,
         },
     },
     mkmacro::{executor::fake::FakeBackend, *},
 };
+
+#[test]
+fn launcher_snapshot_picker_is_transactional_convertible_and_stale_safe() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let actions = Arc::new(vec![
+        Action {
+            label: "Terminal".into(),
+            desc: "display only".into(),
+            action: "wt.exe".into(),
+            args: Some("--title \"Two Words\"".into()),
+        },
+        Action {
+            label: "Notes".into(),
+            desc: "internal".into(),
+            action: "notes:dialog".into(),
+            args: None,
+        },
+    ]);
+    let mut dialog = MkMacroDialog::new_with_authoring_context(
+        Arc::new(store),
+        MkMacroAuthoringContext {
+            launcher_actions: actions.clone(),
+        },
+    );
+    assert!(Arc::ptr_eq(
+        &dialog.authoring_context.launcher_actions,
+        &actions
+    ));
+    dialog.create_macro();
+    let macro_id = dialog.selected_macro_id.unwrap();
+    dialog
+        .action_editor
+        .begin_new(MkAction::Process(MkProcessPayload {
+            program: String::new(),
+            arguments: vec![],
+            working_directory: None,
+            wait: false,
+        }));
+    let request = dialog
+        .action_editor
+        .launcher_picker_request(PickerPurpose::Process, macro_id);
+    assert!(dialog.action_editor.apply_launcher_picker_action(
+        &request,
+        &actions[0],
+        Some(macro_id),
+        false
+    ));
+    assert!(
+        dialog.selected_macro().unwrap().steps.is_empty(),
+        "picker edits only the modal draft"
+    );
+    dialog.action_editor.cancel();
+    assert!(dialog.selected_macro().unwrap().steps.is_empty());
+
+    dialog
+        .action_editor
+        .begin_new(MkAction::Process(MkProcessPayload {
+            program: String::new(),
+            arguments: vec![],
+            working_directory: None,
+            wait: false,
+        }));
+    let conversion = dialog
+        .action_editor
+        .launcher_picker_request(PickerPurpose::Process, macro_id);
+    assert!(dialog.action_editor.apply_launcher_picker_action(
+        &conversion,
+        &actions[1],
+        Some(macro_id),
+        true
+    ));
+    assert!(
+        matches!(dialog.action_editor.draft.as_ref().unwrap().action, MkAction::LauncherCommand { ref command, .. } if command == "notes:dialog")
+    );
+    dialog.action_editor.cancel();
+    dialog
+        .action_editor
+        .begin_new(MkAction::Delay { milliseconds: 1 });
+    assert!(
+        !dialog.action_editor.apply_launcher_picker_action(
+            &conversion,
+            &actions[0],
+            Some(macro_id),
+            false
+        ),
+        "an earlier draft request is stale"
+    );
+}
 use std::{
     sync::Arc,
     thread,


### PR DESCRIPTION
### Motivation

- Provide a single cohesive authoring experience for Run Program and Launcher Command by exposing a snapshot of launcher actions to the macro editor and offering a searchable chooser and safe conversion flow.
- Allow authors to pick launcher actions or filesystem programs from the launcher without mutating the live launcher actions and preserve transactional editor semantics and stale-request safety.

### Description

- Introduce an immutable `MkMacroAuthoringContext` (holds `Arc<Vec<Action>>`) on `MkMacroDialog` with a `new_with_authoring_context` constructor and preserved default constructor for tests. (file: `src/gui/mkmacro_dialog/mod.rs`)
- Add a new `launcher_action_picker` module implementing a fuzzy, case-insensitive searchable chooser, deterministic ranking, keyboard navigation, visible empty states, selection/confirmation UI, conservative program classification, and conversion helpers to convert selections into either `MkProcessPayload` or `MkAction::LauncherCommand`. (file: `src/gui/mkmacro_dialog/launcher_action_picker.rs`)
- Wire the picker into the action editor UI by adding `Browse…` buttons for Program and Working directory (using `rfd::FileDialog`) and `Choose From Launcher…` / `Choose Launcher Action…` buttons in the `MkAction::Process` and `MkAction::LauncherCommand` branches, applying inferred working-directory rules and safe UTF-8 conversion. (file: `src/gui/mkmacro_dialog/action_editor.rs`)
- Keep picker usage transactional and stale-safe by integrating chooser requests with `ActionEditorState::draft_generation` and validating macro/step identity before applying results; cancelling or closing the macro dialog resets the picker state. (files: `src/gui/mkmacro_dialog/launcher_action_picker.rs`, `src/gui/mkmacro_dialog/action_editor.rs`, `src/gui/mkmacro_dialog/mod.rs`)
- Pass the launcher action snapshot from the application into the dialog authoring context at construction time. (file: `src/gui/mod.rs`)
- Add unit tests for matcher, classifier, path inference, argument parsing preservation, and launcher-to-process/launcher-command conversion, and extend `tests/mkmacro_authoring.rs` with transactional and stale-request tests. (files: `src/gui/mkmacro_dialog/launcher_action_picker.rs`, `tests/mkmacro_authoring.rs`)

### Testing

- Ran `cargo fmt --all` and `git diff --check` with no issues reported. (succeeded)
- Performed cross-target compile sanity checks with `cargo check --target x86_64-pc-windows-gnu --tests` to validate Windows-target-only code paths and type-level integration; this passed. (succeeded)
- Added unit tests for the new picker and integration tests in `tests/mkmacro_authoring.rs`; these are compile-time covered by the cross-target checks and designed to avoid native file dialogs; running full `cargo test` involving native platform APIs may fail in non-native CI environments and was not executed end-to-end here. (unit tests added; runtime/native GUI/file-dialog tests intentionally omitted)
- Manual code inspection and egui UI wiring validated that the picker is opened and cancelled consistently, that chosen program paths infer working directories only when appropriate, and that non-program choices require explicit conversion to `LauncherCommand` rather than silently overwriting `Program`. (verification performed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88e93d63dc8332ac8191b25f6ce08e)