### PR TITLE
Preserve mouse scroll axis across macros (vertical/horizontal)

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -313,7 +313,10 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             "Scroll the mouse wheel",
             &["mouse"],
             MouseScroll,
-            MkAction::MouseScroll { i32_delta: -120 }
+            MkAction::MouseScroll {
+                axis: MkMouseScrollAxis::Vertical,
+                i32_delta: -120,
+            }
         ),
         d!(
             Timing,
@@ -908,7 +911,25 @@ pub fn action_details(a: &MkAction) -> String {
             format_coordinate_target(&p.target)
         ),
         MkAction::MouseDown(b) | MkAction::MouseUp(b) => mouse(b).into(),
-        MkAction::MouseScroll { i32_delta } => format!("{i32_delta} wheel units"),
+        MkAction::MouseScroll { axis, i32_delta } => {
+            let direction = match (axis, i32_delta.is_negative()) {
+                (MkMouseScrollAxis::Vertical, false) => "Vertical Up",
+                (MkMouseScrollAxis::Vertical, true) => "Vertical Down",
+                (MkMouseScrollAxis::Horizontal, false) => "Horizontal Right",
+                (MkMouseScrollAxis::Horizontal, true) => "Horizontal Left",
+            };
+            if *i32_delta % 120 == 0 {
+                format!(
+                    "{direction} · {} notch(es) · {i32_delta} wheel units",
+                    (i32_delta / 120).unsigned_abs()
+                )
+            } else {
+                format!(
+                    "{direction} · raw delta {} wheel units",
+                    i32_delta.unsigned_abs()
+                )
+            }
+        }
         MkAction::Delay { milliseconds } => format!("{milliseconds} ms"),
         MkAction::Process(p) => format!("{} {}", p.program, p.arguments.join(" ")),
         MkAction::LauncherCommand { command, args } => {
@@ -1033,6 +1054,17 @@ mod paste_tests {
             "Paste 3 characters"
         );
         assert!(!action_details(&action(MkTextMode::Paste)).contains("Coming"));
+    }
+
+    #[test]
+    fn horizontal_scroll_details_include_axis_direction_and_magnitude() {
+        let details = action_details(&MkAction::MouseScroll {
+            axis: MkMouseScrollAxis::Horizontal,
+            i32_delta: -240,
+        });
+        assert!(details.contains("Horizontal Left"));
+        assert!(details.contains("2 notch(es)"));
+        assert!(details.contains("-240 wheel units"));
     }
 }
 pub fn format_coordinate_target(target: &MkCoordinateTarget) -> String {

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -907,38 +907,48 @@ fn action_ui(
                     }
                 });
         }
-        MkAction::MouseScroll { i32_delta } => {
+        MkAction::MouseScroll { axis, i32_delta } => {
             const WHEEL: i32 = 120;
+            let mut direction = match (*axis, i32_delta.is_negative()) {
+                (MkMouseScrollAxis::Vertical, false) => 0,
+                (MkMouseScrollAxis::Vertical, true) => 1,
+                (MkMouseScrollAxis::Horizontal, true) => 2,
+                (MkMouseScrollAxis::Horizontal, false) => 3,
+            };
+            let before_direction = direction;
+            ui.label("Direction");
+            ui.horizontal_wrapped(|ui| {
+                ui.radio_value(&mut direction, 0, "Vertical Up");
+                ui.radio_value(&mut direction, 1, "Vertical Down");
+                ui.radio_value(&mut direction, 2, "Horizontal Left");
+                ui.radio_value(&mut direction, 3, "Horizontal Right");
+            });
+            let (selected_axis, positive) = match direction {
+                0 => (MkMouseScrollAxis::Vertical, true),
+                1 => (MkMouseScrollAxis::Vertical, false),
+                // WM_MOUSEHWHEEL and MOUSEEVENTF_HWHEEL define positive as right.
+                2 => (MkMouseScrollAxis::Horizontal, false),
+                _ => (MkMouseScrollAxis::Horizontal, true),
+            };
+            if direction != before_direction {
+                apply_scroll_direction(axis, i32_delta, selected_axis, positive);
+            }
             if *i32_delta % WHEEL != 0 {
                 ui.label(format!("Legacy raw wheel delta: {i32_delta}"));
-                ui.small("Choose a direction to normalize this legacy value to whole notches.");
-                ui.horizontal(|ui| {
-                    if ui.button("Normalize Up").clicked() {
-                        *i32_delta = WHEEL;
-                    }
-                    if ui.button("Normalize Down").clicked() {
-                        *i32_delta = -WHEEL;
-                    }
-                });
+                ui.small("The raw delta is preserved. Select a direction above to normalize it to one whole notch.");
             } else {
-                let mut up = *i32_delta >= 0;
                 let mut notches = (*i32_delta / WHEEL).unsigned_abs().max(1);
-                let before = (up, notches);
-                ui.horizontal(|ui| {
-                    ui.label("Direction");
-                    ui.radio_value(&mut up, true, "Vertical Up");
-                    ui.radio_value(&mut up, false, "Vertical Down");
-                });
+                let before = notches;
                 ui.add(
                     egui::DragValue::new(&mut notches)
                         .clamp_range(1..=(i32::MAX as u32 / WHEEL as u32))
                         .prefix("Notches "),
                 );
-                if before != (up, notches) || *i32_delta == 0 {
+                if before != notches || *i32_delta == 0 {
                     let magnitude = (notches as i32)
                         .checked_mul(WHEEL)
                         .unwrap_or(i32::MAX / WHEEL * WHEEL);
-                    *i32_delta = if up { magnitude } else { -magnitude };
+                    *i32_delta = if positive { magnitude } else { -magnitude };
                 }
             }
         }
@@ -1298,6 +1308,50 @@ fn action_ui(
         }
     }
     (pick, window_pick, launcher_pick, image_request)
+}
+
+fn apply_scroll_direction(
+    axis: &mut MkMouseScrollAxis,
+    delta: &mut i32,
+    selected_axis: MkMouseScrollAxis,
+    positive: bool,
+) {
+    const WHEEL: i32 = 120;
+    *axis = selected_axis;
+    let magnitude = if *delta % WHEEL == 0 {
+        delta.unsigned_abs().max(WHEEL as u32) as i32
+    } else {
+        WHEEL
+    };
+    *delta = if positive { magnitude } else { -magnitude };
+}
+
+#[cfg(test)]
+mod scroll_editor_tests {
+    use super::*;
+
+    #[test]
+    fn all_directions_normalize_legacy_raw_deltas() {
+        for (selected_axis, positive, expected) in [
+            (MkMouseScrollAxis::Vertical, true, 120),
+            (MkMouseScrollAxis::Vertical, false, -120),
+            (MkMouseScrollAxis::Horizontal, false, -120),
+            (MkMouseScrollAxis::Horizontal, true, 120),
+        ] {
+            let mut axis = MkMouseScrollAxis::Vertical;
+            let mut delta = 37;
+            apply_scroll_direction(&mut axis, &mut delta, selected_axis, positive);
+            assert_eq!((axis, delta), (selected_axis, expected));
+        }
+    }
+
+    #[test]
+    fn whole_notch_magnitude_is_retained_when_direction_changes() {
+        let mut axis = MkMouseScrollAxis::Vertical;
+        let mut delta = -360;
+        apply_scroll_direction(&mut axis, &mut delta, MkMouseScrollAxis::Horizontal, true);
+        assert_eq!((axis, delta), (MkMouseScrollAxis::Horizontal, 360));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -67,8 +67,8 @@ mod tests {
     use super::*;
     use crate::mkmacro::{
         AlphaPolicy, LoadDisposition, MKMACROS_FILE, MkAction, MkCoordinateTarget, MkHotkey,
-        MkImagePayload, MkKey, MkMouseButton, MkMouseMovePayload, MkMousePayload, MkStep,
-        MkWaitOptions, ReturnPoint, SCHEMA_VERSION, SearchRegion,
+        MkImagePayload, MkKey, MkMouseButton, MkMouseMovePayload, MkMousePayload,
+        MkMouseScrollAxis, MkStep, MkWaitOptions, ReturnPoint, SCHEMA_VERSION, SearchRegion,
     };
     use std::{
         fs, thread,
@@ -1119,7 +1119,10 @@ mod tests {
         );
         assert!(matches!(
             action("Mouse Scroll"),
-            MkAction::MouseScroll { i32_delta: -120 }
+            MkAction::MouseScroll {
+                axis: MkMouseScrollAxis::Vertical,
+                i32_delta: -120
+            }
         ));
         for name in [
             "Mouse Move",

--- a/src/gui/mkmacro_dialog/uia_editor.rs
+++ b/src/gui/mkmacro_dialog/uia_editor.rs
@@ -135,7 +135,7 @@ pub(super) fn show(ui: &mut eframe::egui::Ui, state: &mut UiaEditorState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mkmacro::{MkUiControlType, MkUiSelector, MkWindowMatcher};
+    use crate::mkmacro::{MkMouseScrollAxis, MkUiControlType, MkUiSelector, MkWindowMatcher};
     use std::collections::HashSet;
     fn info(invoke: bool) -> UiElementInfo {
         UiElementInfo {
@@ -183,14 +183,23 @@ mod tests {
     }
     #[test]
     fn conversion_is_explicit_and_preserves_unrelated_action() {
-        let original = MkAction::MouseScroll { i32_delta: 1 };
+        let original = MkAction::MouseScroll {
+            axis: MkMouseScrollAxis::Vertical,
+            i32_delta: 1,
+        };
         let mut s = UiaEditorState::default();
         s.begin_recorded_click_conversion(7, info(true));
         assert!(matches!(
             s.conversion_draft(7, payload()).unwrap(),
             MkAction::UiInvoke(_)
         ));
-        assert_eq!(original, MkAction::MouseScroll { i32_delta: 1 });
+        assert_eq!(
+            original,
+            MkAction::MouseScroll {
+                axis: MkMouseScrollAxis::Vertical,
+                i32_delta: 1
+            }
+        );
         assert!(s.conversion_draft(8, payload()).is_err());
     }
     #[test]

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1,7 +1,7 @@
 //! Platform-neutral plan executor and injectable effect boundaries.
 use super::{
     Jump, MkAction, MkCompareOp, MkCondition, MkCoordinateTarget, MkExecutionPlan, MkImagePayload,
-    MkKey, MkMacroStore, MkMouseButton, MkPlayback, MkPoint, MkProcessPayload,
+    MkKey, MkMacroStore, MkMouseButton, MkMouseScrollAxis, MkPlayback, MkPoint, MkProcessPayload,
     MkPromptInputPayload, MkTextPayload, MkUiPayload, MkValue, MkWaitOptions, MkWindowMatcher,
     MkWindowMoveResizePayload, MkWindowPayload, MkWindowState, PromptBackend, PromptRequest,
     PromptResponse, RuntimeVariables, interpolate,
@@ -72,7 +72,7 @@ pub trait InputBackend: Send + Sync {
     fn button_up(&self, button: MkMouseButton) -> ExecResult;
     fn move_mouse(&self, point: MkPoint) -> ExecResult;
     fn cursor_position(&self) -> ExecResult<MkPoint>;
-    fn scroll(&self, delta: i32) -> ExecResult;
+    fn scroll(&self, axis: MkMouseScrollAxis, delta: i32) -> ExecResult;
     fn text(&self, payload: &MkTextPayload) -> ExecResult;
 }
 pub trait WindowBackend: Send + Sync {
@@ -207,7 +207,7 @@ impl InputBackend for Unsupported {
     fn cursor_position(&self) -> ExecResult<MkPoint> {
         unsupported()
     }
-    fn scroll(&self, _: i32) -> ExecResult {
+    fn scroll(&self, _: MkMouseScrollAxis, _: i32) -> ExecResult {
         unsupported()
     }
     fn text(&self, _: &MkTextPayload) -> ExecResult {
@@ -1305,7 +1305,9 @@ impl Executor {
             }
             MkAction::MouseDown(b) => g.down_button(b.clone()),
             MkAction::MouseUp(b) => g.up_button(b.clone()),
-            MkAction::MouseScroll { i32_delta } => self.backends.input.scroll(*i32_delta),
+            MkAction::MouseScroll { axis, i32_delta } => {
+                self.backends.input.scroll(*axis, *i32_delta)
+            }
             MkAction::Delay { milliseconds } => self.wait(Duration::from_millis(
                 scale_playback_duration(*milliseconds, playback.speed_percent),
             )),
@@ -1927,8 +1929,8 @@ pub mod fake {
             self.event("cursor_position".into())?;
             Ok(*self.cursor.lock().unwrap())
         }
-        fn scroll(&self, d: i32) -> ExecResult {
-            self.event(format!("scroll:{d}"))
+        fn scroll(&self, axis: MkMouseScrollAxis, d: i32) -> ExecResult {
+            self.event(format!("scroll:{axis:?}:{d}"))
         }
         fn text(&self, p: &MkTextPayload) -> ExecResult {
             self.event(format!("text:{}", p.text))
@@ -2315,6 +2317,35 @@ mod phase_d_tests {
         let c = Arc::new(RunControl::default());
         c.reset();
         Executor::new(fake.backends(), c).execute(&plan(steps), &|_| {})
+    }
+
+    #[test]
+    fn playback_passes_exact_scroll_axis_and_delta_to_backend() {
+        let fake = Arc::new(FakeBackend::default());
+        run(
+            vec![
+                s(
+                    1,
+                    MkAction::MouseScroll {
+                        axis: MkMouseScrollAxis::Vertical,
+                        i32_delta: -37,
+                    },
+                ),
+                s(
+                    2,
+                    MkAction::MouseScroll {
+                        axis: MkMouseScrollAxis::Horizontal,
+                        i32_delta: 241,
+                    },
+                ),
+            ],
+            fake.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            fake.events(),
+            ["scroll:Vertical:-37", "scroll:Horizontal:241"]
+        );
     }
 
     #[test]

--- a/src/mkmacro/input.rs
+++ b/src/mkmacro/input.rs
@@ -1,7 +1,7 @@
 //! Production input synthesis. This is intentionally independent of legacy `actions::keys`.
 use super::{
-    DiagnosticKind, ExecResult, ExecutionDiagnostic, InputBackend, MkKey, MkMouseButton, MkPoint,
-    MkTextMode, MkTextPayload,
+    DiagnosticKind, ExecResult, ExecutionDiagnostic, InputBackend, MkKey, MkMouseButton,
+    MkMouseScrollAxis, MkPoint, MkTextMode, MkTextPayload,
 };
 use std::time::{Duration, Instant};
 
@@ -261,8 +261,12 @@ impl<S: InputSink> InputBackend for Win32InputBackend<S> {
     fn cursor_position(&self) -> ExecResult<MkPoint> {
         cursor_position()
     }
-    fn scroll(&self, d: i32) -> ExecResult {
-        self.mouse(0, 0, d as u32, MOUSEEVENTF_WHEEL_)
+    fn scroll(&self, axis: MkMouseScrollAxis, d: i32) -> ExecResult {
+        // Casting retains the signed two's-complement bit pattern required in mouseData.
+        match axis {
+            MkMouseScrollAxis::Vertical => self.mouse(0, 0, d as u32, MOUSEEVENTF_WHEEL_),
+            MkMouseScrollAxis::Horizontal => self.horizontal_scroll(d),
+        }
     }
     fn text(&self, p: &MkTextPayload) -> ExecResult {
         match p.mode {
@@ -475,6 +479,25 @@ mod tests {
             RawInputEvent::Mouse {
                 data: 2,
                 flags: MOUSEEVENTF_XDOWN_,
+                ..
+            }
+        ));
+    }
+    #[test]
+    fn scroll_axis_selects_flag_and_preserves_signed_data_bits() {
+        let s = Sink::default();
+        let b = Win32InputBackend::with_sink(&s);
+        b.scroll(MkMouseScrollAxis::Vertical, -120).unwrap();
+        b.scroll(MkMouseScrollAxis::Horizontal, 37).unwrap();
+        let events = s.0.lock().unwrap();
+        assert!(matches!(events[0], RawInputEvent::Mouse {
+            data, flags: MOUSEEVENTF_WHEEL_, ..
+        } if data == (-120_i32) as u32));
+        assert!(matches!(
+            events[1],
+            RawInputEvent::Mouse {
+                data: 37,
+                flags: MOUSEEVENTF_HWHEEL_,
                 ..
             }
         ));

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -429,6 +429,15 @@ pub enum MkVirtualDesktopAction {
     SwitchRight,
     CloseCurrent,
 }
+/// The wheel axis used by a mouse-scroll action.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MkMouseScrollAxis {
+    /// The default preserves compatibility with actions serialized before axes existed.
+    #[default]
+    Vertical,
+    Horizontal,
+}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum MkAction {
@@ -443,6 +452,8 @@ pub enum MkAction {
     MouseDown(MkMouseButton),
     MouseUp(MkMouseButton),
     MouseScroll {
+        #[serde(default)]
+        axis: MkMouseScrollAxis,
         i32_delta: i32,
     },
     Delay {
@@ -691,5 +702,34 @@ mod prompt_payload_tests {
         let json = r#"{"schema_version":4,"macros":[{"id":1,"name":"old","steps":[{"id":1,"action":{"type":"delay","data":{"milliseconds":1}}}]}]}"#;
         let doc: MkMacroDocument = serde_json::from_str(json).unwrap();
         assert_eq!(doc.macros[0].steps.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod mouse_scroll_serialization_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_scroll_without_axis_defaults_to_vertical() {
+        let action: MkAction =
+            serde_json::from_str(r#"{"type":"mouse_scroll","data":{"i32_delta":-37}}"#).unwrap();
+        assert_eq!(
+            action,
+            MkAction::MouseScroll {
+                axis: MkMouseScrollAxis::Vertical,
+                i32_delta: -37,
+            }
+        );
+    }
+
+    #[test]
+    fn horizontal_scroll_round_trips_losslessly() {
+        let action = MkAction::MouseScroll {
+            axis: MkMouseScrollAxis::Horizontal,
+            i32_delta: i32::MIN + 1,
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        assert!(json.contains(r#""axis":"horizontal""#));
+        assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), action);
     }
 }

--- a/src/mkmacro/recorder.rs
+++ b/src/mkmacro/recorder.rs
@@ -1,8 +1,8 @@
 //! Worker-side, pure recording normalization. No OS, UI automation, or persistence is used here.
 use super::{
     HookEvent, KeyTransition, MkAction, MkCoordinateTarget, MkErrorPolicy, MkKey, MkMouseButton,
-    MkMouseDragPayload, MkMouseMovePayload, MkMousePayload, MkPoint, MkStep, MkWindowMatcher,
-    MkWindowPayload, MouseButton, MouseMessage, should_record,
+    MkMouseDragPayload, MkMouseMovePayload, MkMousePayload, MkMouseScrollAxis, MkPoint, MkStep,
+    MkWindowMatcher, MkWindowPayload, MouseButton, MouseMessage, should_record,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -645,7 +645,16 @@ pub fn to_macro_steps(
                 button: button(b),
                 duration_ms: up_timestamp_us.saturating_sub(down_timestamp_us) / 1000,
             }),
-            RecordedAction::Wheel { delta, .. } => MkAction::MouseScroll { i32_delta: delta },
+            RecordedAction::Wheel {
+                delta, horizontal, ..
+            } => MkAction::MouseScroll {
+                axis: if horizontal {
+                    MkMouseScrollAxis::Horizontal
+                } else {
+                    MkMouseScrollAxis::Vertical
+                },
+                i32_delta: delta,
+            },
         });
         let count = actions.len();
         for (i, action) in actions.into_iter().enumerate() {
@@ -909,6 +918,47 @@ mod tests {
         )));
         assert!(v[0].delay_after_ms > 0);
     }
+    #[test]
+    fn wheel_axes_and_signed_deltas_survive_conversion_without_coalescing() {
+        let events = [
+            mouse(0, MouseMessage::Wheel(120), 1, 2),
+            mouse(1, MouseMessage::Wheel(-73), 1, 2),
+            mouse(2, MouseMessage::HorizontalWheel(240), 1, 2),
+            mouse(3, MouseMessage::HorizontalWheel(-41), 1, 2),
+        ];
+        let normalized = normalize(&events, &NormalizationConfig::default(), None);
+        assert_eq!(
+            normalized.len(),
+            4,
+            "adjacent wheel axes/deltas stay distinct"
+        );
+        let actions: Vec<_> = to_macro_steps(&normalized, 0, false)
+            .into_iter()
+            .map(|step| step.action)
+            .collect();
+        assert_eq!(
+            actions,
+            vec![
+                MkAction::MouseScroll {
+                    axis: MkMouseScrollAxis::Vertical,
+                    i32_delta: 120
+                },
+                MkAction::MouseScroll {
+                    axis: MkMouseScrollAxis::Vertical,
+                    i32_delta: -73
+                },
+                MkAction::MouseScroll {
+                    axis: MkMouseScrollAxis::Horizontal,
+                    i32_delta: 240
+                },
+                MkAction::MouseScroll {
+                    axis: MkMouseScrollAxis::Horizontal,
+                    i32_delta: -41
+                },
+            ]
+        );
+    }
+
     #[test]
     fn sampling_pause_and_key_fidelity() {
         let mut c = NormalizationConfig::default();


### PR DESCRIPTION
### Motivation

- Make the scroll axis an explicit part of the macro model so recorded wheel events carry `Vertical`/`Horizontal` semantics end-to-end. 
- Preserve backward compatibility for legacy serialized actions that only contained a signed delta. 
- Keep recorder deltas lossless, ensure axis is part of grouping identity so coalescing never mixes vertical and horizontal events, and route playback to the correct OS input path.

### Description

- Add `MkMouseScrollAxis` (`Vertical`/`Horizontal`) and include it in `MkAction::MouseScroll` with a serde default to preserve legacy axis-less JSON as `Vertical`.
- Map recorder `RecordedAction::Wheel { horizontal: bool, delta }` into `MkAction::MouseScroll { axis, i32_delta }` preserving the signed `i32` magnitude and using the axis as part of grouping/normalization identity.
- Extend the input/executor abstraction by changing `InputBackend::scroll` to accept `(axis: MkMouseScrollAxis, delta: i32)`, update the executor to forward the axis, and update `FakeBackend` logging to include the axis for test assertions.
- Implement platform routing in the Win32 input backend so vertical scroll uses `MOUSEEVENTF_WHEEL` and horizontal uses the existing `horizontal_scroll` / `MOUSEEVENTF_HWHEEL` path while preserving the signed two's-complement bits in `mouseData`.
- Update editor/UI: the `MouseScroll` editor exposes four explicit direction choices (`Vertical Up/Down`, `Horizontal Left/Right`), adds normalization behavior that respects axis and preserves legacy raw deltas, and makes `action_details()` display axis, direction, notch count (when whole multiples of 120) and raw-delta magnitude.
- Add unit tests covering model serialization (legacy axis-less load and horizontal round-trip), recorder conversion and coalescing behavior, executor playback with a fake backend asserting exact axis+delta, Win32 input event construction test (where platform factoring permits), and editor normalization tests.

### Testing

- `cargo fmt -- --check` was run and passed.
- `git diff --check` was run and passed.
- `cargo check` / full `cargo test` could not be completed in this Linux environment because the repository builds unguarded Windows-only APIs and the toolchain initially required missing system dev packages; those platform-specific compilation failures block a full CI-style check here.
- Unit tests were added for `model`, `recorder`, `executor`, `input`, and editor logic (listed in the diff); targeted test execution was attempted but the same Windows-only build constraints prevented a reliable complete run of the whole test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89f3b16abc8332b59ed7badadeae59)