### PR TITLE
Add authoritative capability audit, editor completeness and image draft contracts

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -124,7 +124,9 @@ fn wp() -> MkWindowPayload {
 }
 fn ip() -> MkImagePayload {
     MkImagePayload {
-        asset_id: 1,
+        // Zero is the documented editor-draft sentinel. The editor requires an
+        // imported/captured asset before enabling Apply.
+        asset_id: 0,
         wait: wait(),
         region: SearchRegion::Desktop,
         tolerance: 0,
@@ -729,6 +731,67 @@ pub enum EditorContract {
     DirectInsert { context: InsertionContextRoute },
 }
 
+/// Static completeness declaration for a configurable editor.  This is kept
+/// separate from transient widget state: an Apply button may be disabled while
+/// required input is missing, but the feature itself must never be presented
+/// as a permanently disabled/placeholder control.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EditorCompleteness {
+    pub has_primary_control: bool,
+    pub intentionally_disabled: bool,
+    pub placeholder_copy: Option<&'static str>,
+}
+
+pub fn editor_completeness(editor: EditorKind) -> Option<EditorCompleteness> {
+    match editor {
+        EditorKind::General => None,
+        EditorKind::DirectInsert => Some(EditorCompleteness {
+            has_primary_control: false,
+            intentionally_disabled: false,
+            placeholder_copy: None,
+        }),
+        EditorKind::Keyboard
+        | EditorKind::Text
+        | EditorKind::MouseMove
+        | EditorKind::MouseClick
+        | EditorKind::MouseDrag
+        | EditorKind::MouseButton
+        | EditorKind::MouseScroll
+        | EditorKind::Timing
+        | EditorKind::Window
+        | EditorKind::Process
+        | EditorKind::Launcher
+        | EditorKind::Image
+        | EditorKind::Pixel
+        | EditorKind::Condition
+        | EditorKind::Repeat
+        | EditorKind::Variable
+        | EditorKind::PromptInput => Some(EditorCompleteness {
+            has_primary_control: true,
+            intentionally_disabled: false,
+            placeholder_copy: None,
+        }),
+    }
+}
+
+/// Contract for validating a freshly-created editor value. Image actions are
+/// valid drafts before an asset is chosen, but cannot be committed until the
+/// editor has attached an asset. All other defaults are commit-ready.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DraftValidationContract {
+    CommitReady,
+    AwaitingRequiredAsset,
+}
+
+pub fn draft_validation_contract(action: &MkAction) -> DraftValidationContract {
+    match action {
+        MkAction::ImageFind(payload) | MkAction::ImageClick(payload) if payload.asset_id == 0 => {
+            DraftValidationContract::AwaitingRequiredAsset
+        }
+        _ => DraftValidationContract::CommitReady,
+    }
+}
+
 /// Structural markers are complete actions at insertion time and intentionally
 /// have no configurable fields. All other actions must pass through an editor.
 pub fn requires_no_configuration(action: &MkAction) -> bool {
@@ -753,12 +816,15 @@ pub enum InsertionContextRoute {
 /// Shared product-copy guard used by catalog invariants.  This deliberately
 /// complements (rather than replaces) the exact historical-string regression.
 pub fn contains_placeholder_wording(value: &str) -> bool {
-    const PLACEHOLDERS: [&str; 5] = [
+    const PLACEHOLDERS: [&str; 8] = [
         "existing specialized editor",
         "legacy action",
         "not implemented",
         "unavailable",
         "placeholder",
+        "coming later",
+        "coming soon",
+        "todo",
     ];
     let value = value.to_ascii_lowercase();
     PLACEHOLDERS.iter().any(|wording| value.contains(wording))

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1570,7 +1570,11 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 });
             ui.separator();
             ui.horizontal(|ui| {
-                let valid = !matches!(&step.action, MkAction::PromptInput(p) if crate::mkmacro::variables::validate_variable_name(&p.variable).is_err());
+                let valid = !matches!(&step.action, MkAction::PromptInput(p) if crate::mkmacro::variables::validate_variable_name(&p.variable).is_err())
+                    && !matches!(
+                        super::action_catalog::draft_validation_contract(&step.action),
+                        super::action_catalog::DraftValidationContract::AwaitingRequiredAsset
+                    );
                 apply = ui.add_enabled(valid, egui::Button::new("Apply")).clicked();
                 cancel = ui.button("Cancel").on_hover_text("Cancel editing; during playback Cancel stops the macro").clicked();
             });
@@ -1765,6 +1769,102 @@ mod tests {
                 !editor.apply_window_matcher(&request, MkWindowMatcher::default(), Some(6)),
                 "another macro must not be modified"
             );
+        }
+    }
+
+    #[test]
+    fn condition_window_picker_routes_every_host_kind_and_preserves_siblings_on_apply_or_cancel() {
+        fn matcher(title: &str) -> MkWindowMatcher {
+            MkWindowMatcher {
+                title: Some(title.into()),
+                ..Default::default()
+            }
+        }
+        for active in [false, true] {
+            for host in ["if", "while", "wait"] {
+                let target = if active {
+                    MkCondition::WindowActive {
+                        matcher: matcher("original"),
+                    }
+                } else {
+                    MkCondition::WindowExists {
+                        matcher: matcher("original"),
+                    }
+                };
+                // Exercise all recursive containers and retain two sentinels to
+                // prove MatcherPath::Condition mutates only the requested leaf.
+                let condition = MkCondition::All {
+                    conditions: vec![
+                        MkCondition::WindowExists {
+                            matcher: matcher("all-sibling"),
+                        },
+                        MkCondition::Any {
+                            conditions: vec![
+                                MkCondition::WindowActive {
+                                    matcher: matcher("any-sibling"),
+                                },
+                                MkCondition::Not {
+                                    condition: Box::new(target),
+                                },
+                            ],
+                        },
+                    ],
+                };
+                let picker_path =
+                    super::super::condition_editor::first_window_picker_path(match &condition {
+                        MkCondition::All { conditions } => &conditions[1],
+                        _ => unreachable!(),
+                    })
+                    .unwrap();
+                let mut full_path = vec![1];
+                full_path.extend(picker_path);
+                assert_eq!(full_path, vec![1, 0], "condition_ui recursive picker path");
+                // Select the second Any child (the Not branch), exactly as a
+                // picker request emitted from that rendered control does.
+                let path = super::super::window_picker::MatcherPath::Condition(vec![1, 1, 0]);
+                let action = match host {
+                    "if" => MkAction::If(condition),
+                    "while" => MkAction::WhileStart { condition },
+                    _ => MkAction::WaitUntil {
+                        condition,
+                        wait: MkWaitOptions {
+                            timeout_ms: 1000,
+                            poll_interval_ms: 50,
+                        },
+                    },
+                };
+                let mut editor = ActionEditorState::default();
+                editor.begin_edit(&step(action));
+                let before_cancel = editor.draft.as_ref().unwrap().action.clone();
+                // Cancellation never calls apply_window_matcher.
+                assert_eq!(
+                    editor.draft.as_ref().unwrap().action,
+                    before_cancel,
+                    "{host}: picker cancellation"
+                );
+                let request = super::super::window_picker::MatcherEditRequest {
+                    destination: super::super::window_picker::MatcherDestination::Action {
+                        macro_id: 9,
+                        draft_generation: editor.draft_generation,
+                        path: path.clone(),
+                    },
+                    original: matcher("original"),
+                };
+                assert!(editor.apply_window_matcher(&request, matcher("chosen"), Some(9)));
+                assert_eq!(
+                    matcher_at_path(&mut editor.draft.as_mut().unwrap().action, &path)
+                        .unwrap()
+                        .title
+                        .as_deref(),
+                    Some("chosen")
+                );
+                let serialized =
+                    serde_json::to_string(&editor.draft.as_ref().unwrap().action).unwrap();
+                assert!(
+                    serialized.contains("all-sibling") && serialized.contains("any-sibling"),
+                    "{host}: sibling changed"
+                );
+            }
         }
     }
 

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -96,6 +96,29 @@ pub fn condition_ui(ui: &mut egui::Ui, condition: &mut MkCondition) -> Option<Ve
     condition_ui_with_assets(ui, condition, &[])
 }
 
+/// Resolves the same recursive path shape returned by `condition_ui` when the
+/// picker button for the first window condition is requested. Kept private to
+/// the dialog module so routing tests do not expose editor internals publicly.
+#[cfg(test)]
+pub(super) fn first_window_picker_path(condition: &MkCondition) -> Option<Vec<usize>> {
+    match condition {
+        MkCondition::WindowExists { .. } | MkCondition::WindowActive { .. } => Some(vec![]),
+        MkCondition::All { conditions } | MkCondition::Any { conditions } => {
+            conditions.iter().enumerate().find_map(|(index, child)| {
+                first_window_picker_path(child).map(|mut path| {
+                    path.insert(0, index);
+                    path
+                })
+            })
+        }
+        MkCondition::Not { condition } => first_window_picker_path(condition).map(|mut path| {
+            path.insert(0, 0);
+            path
+        }),
+        _ => None,
+    }
+}
+
 /// Edits a condition tree using only assets from the active macro.  The same
 /// catalog is threaded through every recursive child, so nested conditions do
 /// not lose their authoring context.

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -900,18 +900,31 @@ mod tests {
             let (_dir, mut dialog) = dialog();
             dialog.create_macro();
             assert!(action_catalog::select_descriptor(&mut dialog, &descriptor));
-            if configurable {
+            let draft_contract = action_catalog::draft_validation_contract(&action);
+            if configurable
+                && draft_contract == action_catalog::DraftValidationContract::CommitReady
+            {
                 assert!(dialog.action_editor.draft.is_some());
                 let mut editor = std::mem::take(&mut dialog.action_editor);
                 assert!(editor.apply(&mut dialog).is_some());
                 dialog.action_editor = editor;
             }
             let diagnostics = validate_document(&dialog.draft, None);
-            assert!(
-                crate::mkmacro::can_run(&diagnostics),
-                "invalid default {}: {diagnostics:?}",
-                descriptor.name
-            );
+            match draft_contract {
+                action_catalog::DraftValidationContract::CommitReady => assert!(
+                    crate::mkmacro::can_run(&diagnostics),
+                    "invalid default {}: {diagnostics:?}",
+                    descriptor.name
+                ),
+                action_catalog::DraftValidationContract::AwaitingRequiredAsset => {
+                    assert!(dialog.action_editor.draft.is_some());
+                    assert!(dialog.selected_macro().unwrap().steps.is_empty());
+                    let draft = &dialog.action_editor.draft.as_ref().unwrap().action;
+                    assert!(
+                        matches!(draft, MkAction::ImageFind(p) | MkAction::ImageClick(p) if p.asset_id == 0)
+                    );
+                }
+            }
         }
     }
 
@@ -953,6 +966,11 @@ mod tests {
                 "{context}: runtime contract"
             );
             if descriptor.availability == action_catalog::ActionAvailability::Hidden {
+                assert_eq!(
+                    descriptor.category,
+                    action_catalog::ActionCategory::UiAutomation,
+                    "{context}: only explicitly deferred UI Automation actions may be hidden"
+                );
                 assert!(
                     descriptor
                         .hidden_reason
@@ -986,6 +1004,105 @@ mod tests {
                 let encoded = serde_json::to_vec(&action).unwrap();
                 let decoded: MkAction = serde_json::from_slice(&encoded).unwrap();
                 assert_eq!(decoded, action, "{context}: saved payload changed");
+            }
+        }
+    }
+
+    #[test]
+    fn authoritative_capability_audit_covers_every_descriptor() {
+        for descriptor in action_catalog::descriptors() {
+            let action = (descriptor.make_default)();
+            let context = format!(
+                "descriptor={:?}, action={}",
+                descriptor.name,
+                action_catalog::action_name(&action)
+            );
+            match descriptor.availability {
+                action_catalog::ActionAvailability::Ready => {
+                    assert_eq!(
+                        descriptor.runtime,
+                        action_catalog::RuntimeAvailability::Supported,
+                        "{context}: runtime metadata"
+                    );
+                    assert!(
+                        crate::mkmacro::executor::has_runtime_support(&action),
+                        "{context}: executor support"
+                    );
+                    let contract = descriptor
+                        .editor
+                        .contract()
+                        .unwrap_or_else(|| panic!("{context}: missing editor contract"));
+                    match contract {
+                        action_catalog::EditorContract::DirectInsert { .. } => assert_eq!(
+                            descriptor.editor,
+                            action_catalog::EditorKind::DirectInsert,
+                            "{context}"
+                        ),
+                        action_catalog::EditorContract::Configurable { field_count } => {
+                            assert!(field_count > 0, "{context}: editor has no fields");
+                            assert!(
+                                action_catalog::editor_route_recognizes(&action, descriptor.editor),
+                                "{context}: editor route"
+                            );
+                            let completeness =
+                                action_catalog::editor_completeness(descriptor.editor)
+                                    .expect("complete editor metadata");
+                            assert!(
+                                completeness.has_primary_control,
+                                "{context}: no primary control"
+                            );
+                            assert!(
+                                !completeness.intentionally_disabled,
+                                "{context}: permanently disabled editor"
+                            );
+                            assert!(
+                                completeness.placeholder_copy.is_none(),
+                                "{context}: placeholder editor copy"
+                            );
+                        }
+                    }
+                    assert!(
+                        serde_json::to_vec(&action).is_ok(),
+                        "{context}: serialization"
+                    );
+                    assert_eq!(
+                        descriptor.name,
+                        action_catalog::action_name(&action),
+                        "{context}: action name"
+                    );
+                    let details = action_catalog::action_details(&action);
+                    assert!(
+                        !details.trim().is_empty() && details.trim() != descriptor.name,
+                        "{context}: meaningful details"
+                    );
+                    for text in [
+                        descriptor.name,
+                        descriptor.description,
+                        action_catalog::action_name(&action),
+                        details.as_str(),
+                    ] {
+                        assert!(
+                            !action_catalog::contains_placeholder_wording(text),
+                            "{context}: deferred wording: {text:?}"
+                        );
+                    }
+                }
+                action_catalog::ActionAvailability::Hidden => {
+                    assert_eq!(
+                        descriptor.category,
+                        action_catalog::ActionCategory::UiAutomation,
+                        "{context}: hidden non-UIA action"
+                    );
+                    assert_eq!(
+                        descriptor.runtime,
+                        action_catalog::RuntimeAvailability::Unavailable,
+                        "{context}: hidden UIA must remain unavailable until independently complete"
+                    );
+                    assert!(
+                        !action_catalog::is_available_in_palette(&descriptor),
+                        "{context}: hidden palette leak"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Consolidate and harden catalog invariants by auditing every `ActionDescriptor` (not only visible rows) and making capability failures data-driven.
- Make editor completeness and draft validation explicit so editors declare primary controls and image actions are treated as draft-awaiting-assets rather than silently commit-invalid.
- Strengthen picker routing guarantees for nested window conditions and enforce that hidden descriptors follow a narrow UI Automation deferral policy.

### Description

- Added `EditorCompleteness`, `editor_completeness()`, `DraftValidationContract`, and `draft_validation_contract()` to `src/gui/mkmacro_dialog/action_catalog.rs` to declare editor completeness and draft semantics, and changed image default payload to use asset id `0` as the draft sentinel.
- Updated the action editor `Apply` enablement to consult `draft_validation_contract()` so image actions that require an attached asset block commit until an asset is provided (`src/gui/mkmacro_dialog/action_editor.rs`).
- Expanded placeholder-detection strings (added "coming later", "coming soon", "todo") in `contains_placeholder_wording()` to catch deferred copy cases (`src/gui/mkmacro_dialog/action_catalog.rs`).
- Added a private recursive path helper `first_window_picker_path()` in `src/gui/mkmacro_dialog/condition_editor.rs` and focused tests exercising `MatcherPath::Condition` routing across `If`, `WhileStart`, and `WaitUntil` including nested `All`/`Any`/`Not` containers, ensuring exact-leaf replacement and sibling preservation (`src/gui/mkmacro_dialog/action_editor.rs`).
- Introduced a comprehensive, data-driven audit test that iterates `action_catalog::descriptors()` and asserts runtime metadata, editor contracts/routing, serialization, naming/details, absence of placeholder wording, and hidden-policy constraints (`src/gui/mkmacro_dialog/mod.rs`).

### Testing

- Ran `cargo fmt --check` and `git diff --check` successfully in the development environment.
- Executing `cargo test` initially failed due to missing native dependencies required by some crates (e.g. `alsa-sys`); installing `libasound2-dev` and X11 dev packages addressed some native library errors but the full test run is still blocked by platform-specific Windows APIs/crates when building on the Linux CI host.
- A targeted test exercise of the new audit surfaced via local test attempts, but the repository’s cross-platform build requirements prevented a complete green test run in this Linux-based environment; the new unit tests and assertions are in place and should pass in an environment that can compile platform-specific crates or when run on the intended platform/CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89fa98bd748332adcf22d2ce73a522)