### PR TITLE
Add durable delete-all macro persistence regressions

### DIFF
--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1445,6 +1445,11 @@ impl MkMacroDialog {
         let Some(index) = self.draft.macros.iter().position(|m| m.id == id) else {
             return;
         };
+        // Child editor requests capture the selected macro ID. Discard them
+        // before that target disappears so they cannot later apply to a stale
+        // draft (especially when the final macro is removed).
+        self.action_editor.cancel();
+        self.launcher_action_picker.cancel();
         self.draft.macros.remove(index);
         let selected = self
             .draft

--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -140,6 +140,46 @@ fn launcher_snapshot_picker_is_transactional_convertible_and_stale_safe() {
         "an earlier draft request is stale"
     );
 }
+
+#[test]
+fn deleting_last_macro_clears_editor_requests_and_persists_empty_document() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let store = Arc::new(store);
+    let mut dialog = MkMacroDialog::new(Arc::clone(&store));
+    dialog.create_macro();
+    assert!(dialog.rename_selected("Delete this final macro"));
+    insert(&mut dialog, MkAction::Delay { milliseconds: 9 });
+    dialog.save().unwrap();
+    let deleted_id = dialog.selected_macro_id.unwrap();
+
+    dialog
+        .action_editor
+        .begin_new(MkAction::Delay { milliseconds: 10 });
+    let request = dialog
+        .action_editor
+        .launcher_picker_request(PickerPurpose::LauncherCommand, deleted_id);
+    dialog.launcher_action_picker.open(request);
+    assert!(dialog.action_editor.draft.is_some());
+    assert!(dialog.launcher_action_picker.request.is_some());
+
+    dialog.delete_selected_macro();
+    assert!(dialog.draft.macros.is_empty());
+    assert_eq!(dialog.selected_macro_id, None);
+    assert!(dialog.selection.ids.is_empty());
+    assert!(dialog.action_editor.draft.is_none());
+    assert!(dialog.action_editor.insertion.is_none());
+    assert!(dialog.launcher_action_picker.request.is_none());
+    assert!(!dialog.launcher_action_picker.open);
+
+    dialog.save().unwrap();
+    assert!(store.snapshot().macros.is_empty());
+    drop(dialog);
+    drop(store);
+
+    let (reopened, _) = MkMacroStore::open(dir.path()).unwrap();
+    assert!(reopened.snapshot().macros.is_empty());
+}
 use std::{
     sync::Arc,
     thread,

--- a/tests/mkmacro_store.rs
+++ b/tests/mkmacro_store.rs
@@ -50,3 +50,113 @@ fn legacy_file_is_neither_read_nor_written() {
     assert_eq!(fs::read(&legacy).unwrap(), before);
     assert!(dir.path().join(MKMACROS_FILE).exists());
 }
+
+#[test]
+fn delete_all_is_durable_and_never_falls_back_to_legacy_file() {
+    let dir = tempdir().unwrap();
+    let legacy_path = dir.path().join("macros.json");
+    let legacy_contents = br#"[{"label":"legacy survivor","desc":"do not touch","steps":[]}]"#;
+    fs::write(&legacy_path, legacy_contents).unwrap();
+
+    let settings = MkMacroSettings {
+        record_toggle_hotkey: MkHotkey {
+            key: MkKey::Function(7),
+            modifiers: vec![MkKey::Control],
+        },
+    };
+    let document = MkMacroDocument {
+        schema_version: SCHEMA_VERSION,
+        settings: settings.clone(),
+        macros: vec![
+            MkMacro {
+                id: 101,
+                name: "First durable macro".into(),
+                description: String::new(),
+                enabled: true,
+                hotkey: None,
+                playback: Default::default(),
+                steps: vec![MkStep {
+                    id: 201,
+                    enabled: true,
+                    repeat: 1,
+                    delay_after_ms: 0,
+                    on_error: Default::default(),
+                    action: MkAction::Text(MkTextPayload {
+                        text: "first step".into(),
+                        mode: MkTextMode::Type,
+                    }),
+                }],
+            },
+            MkMacro {
+                id: 102,
+                name: "Second durable macro".into(),
+                description: String::new(),
+                enabled: true,
+                hotkey: None,
+                playback: Default::default(),
+                steps: vec![MkStep {
+                    id: 202,
+                    enabled: true,
+                    repeat: 1,
+                    delay_after_ms: 0,
+                    on_error: Default::default(),
+                    action: MkAction::Delay { milliseconds: 42 },
+                }],
+            },
+        ],
+    };
+
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    store.save(document).unwrap();
+    drop(store);
+
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let loaded = store.snapshot();
+    assert_eq!(loaded.macros.len(), 2);
+    assert!(
+        loaded
+            .macros
+            .iter()
+            .any(|item| item.id == 101 && item.name == "First durable macro")
+    );
+    assert!(
+        loaded
+            .macros
+            .iter()
+            .any(|item| item.id == 102 && item.name == "Second durable macro")
+    );
+
+    // Mirror the dialog's draft mutation: remove macros from the loaded document,
+    // then send that complete document through the public store save API.
+    let mut empty_document = (*loaded).clone();
+    empty_document.macros.clear();
+    assert!(empty_document.macros.is_empty());
+    let saved = store.save(empty_document).unwrap();
+    assert!(saved.macros.is_empty());
+    assert!(store.snapshot().macros.is_empty());
+
+    let canonical_path = dir.path().join(MKMACROS_FILE);
+    assert!(canonical_path.exists());
+    let raw = fs::read(&canonical_path).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+    assert_eq!(json["schema_version"], SCHEMA_VERSION);
+    assert_eq!(json["settings"], serde_json::to_value(&settings).unwrap());
+    assert_eq!(json["macros"].as_array().map(Vec::len), Some(0));
+    let text = String::from_utf8(raw).unwrap();
+    for stale in ["First durable macro", "Second durable macro", "101", "102"] {
+        assert!(!text.contains(stale), "canonical file retained {stale:?}");
+    }
+    assert_eq!(fs::read(&legacy_path).unwrap(), legacy_contents);
+
+    drop(saved);
+    drop(loaded);
+    drop(store);
+    let (reopened, _) = MkMacroStore::open(dir.path()).unwrap();
+    let reopened_snapshot = reopened.snapshot();
+    assert!(reopened_snapshot.macros.is_empty());
+    assert!(reopened_snapshot.macros.iter().all(|item| {
+        ![101, 102].contains(&item.id)
+            && !["First durable macro", "Second durable macro"].contains(&item.name.as_str())
+    }));
+    assert_eq!(fs::read(&legacy_path).unwrap(), legacy_contents);
+}


### PR DESCRIPTION
### Motivation

- Ensure deleting every macro persists an empty canonical `mkmacros.json` (not a legacy `macros.json`), and that reopening the store does not resurrect deleted macros from in-memory snapshots or stale UI state.
- Prevent stale editor/picker requests from targeting a macro that just got deleted, which could reintroduce data races or resurrect deleted IDs.

### Description

- Add an integration test `delete_all_is_durable_and_never_falls_back_to_legacy_file` in `tests/mkmacro_store.rs` that uses `tempfile::tempdir()` and only public store APIs to save a document with two macros, delete them via a document save, assert the canonical file parses as JSON with the expected `schema_version` and `settings`, assert `macros` is present and empty, and confirm a legacy `macros.json` fixture is untouched and reopening remains empty. 
- Add a dialog-level regression `deleting_last_macro_clears_editor_requests_and_persists_empty_document` in `tests/mkmacro_authoring.rs` that deletes the final macro through `MkMacroDialog`, asserts selection/draft/editor/picker state are cleared, saves via the dialog path, and reopens the store to assert emptiness.
- Change production deletion behavior in `src/gui/mkmacro_dialog/mod.rs` to cancel `action_editor` and `launcher_action_picker` before removing the selected macro so no stale editor/picker requests remain associated with a deleted target.
- Commit recorded as "Add durable delete-all macro regressions" updating `tests/mkmacro_store.rs`, `tests/mkmacro_authoring.rs`, and `src/gui/mkmacro_dialog/mod.rs`.

### Testing

- Ran `cargo fmt -- --check`, which succeeded.
- Performed repository checks and committed the patch (no formatting or diff errors remained).
- Attempted `cargo test --test mkmacro_store --test mkmacro_authoring`, but the overall test run was blocked by a native dependency build failure for `alsa-sys` due to missing ALSA development files (`alsa.pc`) in this environment, so the full test suite could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a222977088332a2cfe9bb5e3bdfd2)