### PR TITLE
Add comprehensive catalog capability-contract and prompt/image tests for mkmacro

### DIFF
--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -53,6 +53,185 @@ fn virtual_desktop_catalog_entries_are_searchable_typed_and_stable() {
 }
 
 #[test]
+fn catalog_is_a_complete_bidirectional_capability_contract() {
+    use action_catalog::{
+        ActionAvailability, DraftValidationContract, EditorKind, RuntimeAvailability,
+    };
+
+    let all = action_catalog::descriptors();
+    for descriptor in &all {
+        let action =
+            std::panic::catch_unwind(|| (descriptor.make_default)()).unwrap_or_else(|_| {
+                panic!("{}: default action construction panicked", descriptor.name)
+            });
+        assert!(
+            !descriptor.name.trim().is_empty(),
+            "catalog action has an empty name"
+        );
+        assert!(
+            !action_catalog::action_name(&action).trim().is_empty(),
+            "{} has no stable action_name",
+            descriptor.name
+        );
+        assert!(
+            !action_catalog::action_details(&action).trim().is_empty(),
+            "{} has no stable action_details",
+            descriptor.name
+        );
+
+        match descriptor.availability {
+            ActionAvailability::Ready => {
+                assert_eq!(
+                    descriptor.hidden_reason, None,
+                    "{} is Ready but has a hidden reason",
+                    descriptor.name
+                );
+                assert_eq!(
+                    descriptor.runtime,
+                    RuntimeAvailability::Supported,
+                    "{} was marked Ready without runtime support; implement both runtime and editor paths and their tests, or hide the entry with a concrete reason",
+                    descriptor.name
+                );
+                assert!(
+                    executor::has_runtime_support(&action),
+                    "{} was marked Ready without has_runtime_support; implement both runtime and editor paths and their tests, or hide the entry with a concrete reason",
+                    descriptor.name
+                );
+                let contract = descriptor.editor.contract().unwrap_or_else(|| panic!(
+                    "{} was marked Ready without EditorContract; implement both runtime and editor paths and their tests, or hide the entry with a concrete reason", descriptor.name));
+                assert!(
+                    action_catalog::editor_route_recognizes(&action, descriptor.editor),
+                    "{} editor/action route drifted",
+                    descriptor.name
+                );
+                if descriptor.editor == EditorKind::DirectInsert {
+                    assert!(
+                        action_catalog::requires_no_configuration(&action),
+                        "{} is not an intentional structural DirectInsert",
+                        descriptor.name
+                    );
+                } else {
+                    assert!(
+                        matches!(contract, action_catalog::EditorContract::Configurable { field_count } if field_count > 0)
+                    );
+                }
+                if action_catalog::draft_validation_contract(&action)
+                    != DraftValidationContract::CommitReady
+                {
+                    assert_eq!(
+                        action_catalog::draft_validation_contract(&action),
+                        DraftValidationContract::AwaitingRequiredAsset,
+                        "{} must explain the missing required configuration",
+                        descriptor.name
+                    );
+                }
+            }
+            ActionAvailability::Hidden => {
+                assert!(
+                    !descriptor
+                        .hidden_reason
+                        .unwrap_or_default()
+                        .trim()
+                        .is_empty(),
+                    "{} lacks a product/capability hidden_reason",
+                    descriptor.name
+                );
+                assert!(!action_catalog::is_available_in_palette(descriptor));
+                assert!(
+                    !action_catalog::visible_descriptors()
+                        .any(|visible| visible.name == descriptor.name)
+                );
+                // Matching a descriptor is deliberately separate from palette filtering:
+                // exact names and every advertised keyword still cannot make a hidden row selectable.
+                assert!(action_catalog::matches(descriptor, descriptor.name));
+                for keyword in descriptor.keywords {
+                    assert!(
+                        !action_catalog::visible_descriptors()
+                            .any(|visible| action_catalog::matches(&visible, keyword)
+                                && visible.name == descriptor.name)
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn catalog_window_desktop_prompt_and_image_inventory_is_intentional() {
+    let visible: Vec<_> = action_catalog::visible_descriptors().collect();
+    let names = |category| {
+        visible
+            .iter()
+            .filter(|d| d.category == category)
+            .map(|d| d.name)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        names(action_catalog::ActionCategory::Windows),
+        vec![
+            "Activate Window",
+            "Close Window",
+            "Wait for Window",
+            "Move / Resize Window",
+            "Minimize Window",
+            "Create Virtual Desktop",
+            "Switch Virtual Desktop Left",
+            "Switch Virtual Desktop Right",
+            "Close Current Virtual Desktop",
+            "Maximize Window",
+            "Restore Window",
+        ]
+    );
+    for expected in ["Prompt for Input", "Find Image", "Click Image"] {
+        assert_eq!(
+            visible.iter().filter(|d| d.name == expected).count(),
+            1,
+            "catalog inventory drift for {expected}"
+        );
+    }
+}
+
+#[test]
+fn prompt_input_authoring_apply_and_cancel_are_transactional() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let mut dialog = MkMacroDialog::new(Arc::new(store));
+    dialog.create_macro();
+    let payload = MkPromptInputPayload {
+        title: "Customer label".into(),
+        prompt: "Enter a value".into(),
+        default_value: "Unicode ✓ default".into(),
+        variable: "answer_2".into(),
+        copy_to_clipboard: true,
+    };
+    dialog.action_editor.begin_new_with_editor(
+        MkAction::PromptInput(payload.clone()),
+        action_catalog::EditorKind::PromptInput,
+    );
+    assert_eq!(
+        dialog.action_editor.editor,
+        Some(action_catalog::EditorKind::PromptInput)
+    );
+    let mut editor = std::mem::take(&mut dialog.action_editor);
+    editor
+        .apply(&mut dialog)
+        .expect("valid prompt draft applies");
+    dialog.action_editor = editor;
+    assert_eq!(
+        dialog.selected_macro().unwrap().steps[0].action,
+        MkAction::PromptInput(payload.clone())
+    );
+
+    let saved = dialog.selected_macro().unwrap().steps[0].clone();
+    dialog.action_editor.begin_edit(&saved);
+    if let MkAction::PromptInput(draft) = &mut dialog.action_editor.draft.as_mut().unwrap().action {
+        draft.prompt = "discard me".into();
+    }
+    dialog.action_editor.cancel();
+    assert_eq!(dialog.selected_macro().unwrap().steps[0], saved);
+}
+
+#[test]
 fn launcher_snapshot_picker_is_transactional_convertible_and_stale_safe() {
     let dir = tempfile::tempdir().unwrap();
     let (store, _) = MkMacroStore::open(dir.path()).unwrap();

--- a/tests/mkmacro_runtime.rs
+++ b/tests/mkmacro_runtime.rs
@@ -191,14 +191,12 @@ fn cancelled_prompt_honors_stop_and_has_no_later_side_effect() {
     fake.script_prompt(PromptResponse::Cancelled);
     let runtime = MacroRuntime::new(Arc::new(store), fake.clone().backends());
     runtime.command(RuntimeCommand::Run(8));
-    let snapshot = wait(&runtime, RuntimeState::Failed);
-    assert!(
-        snapshot
-            .latest_failure
-            .unwrap()
-            .message
-            .contains("cancelled")
-    );
+    let snapshot = wait(&runtime, RuntimeState::Stopped);
+    let failure = snapshot
+        .latest_failure
+        .expect("prompt cancellation should retain its step diagnostic");
+    assert_eq!(failure.kind, DiagnosticKind::Cancelled);
+    assert!(failure.message.contains("cancelled"));
     assert!(
         !fake
             .events()

--- a/tests/mkmacro_runtime.rs
+++ b/tests/mkmacro_runtime.rs
@@ -85,6 +85,123 @@ fn matcher() -> MkWindowMatcher {
 }
 
 #[test]
+fn prompt_request_result_and_following_step_form_one_runtime_transaction() {
+    let d = tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(d.path()).unwrap();
+    store
+        .save(MkMacroDocument {
+            schema_version: SCHEMA_VERSION,
+            settings: Default::default(),
+            macros: vec![MkMacro {
+                id: 7,
+                name: "prompt plumbing".into(),
+                description: String::new(),
+                enabled: true,
+                hotkey: None,
+                playback: Default::default(),
+                steps: vec![
+                    s(
+                        1,
+                        MkAction::PromptInput(MkPromptInputPayload {
+                            title: "Title ${seed}".into(),
+                            prompt: "Value for ${seed}?".into(),
+                            default_value: "$${seed} / ${seed}".into(),
+                            variable: "answer".into(),
+                            copy_to_clipboard: false,
+                        }),
+                    ),
+                    s(
+                        2,
+                        MkAction::Text(MkTextPayload {
+                            text: "received:${answer}".into(),
+                            interval_ms: 0,
+                        }),
+                    ),
+                ],
+            }],
+        })
+        .unwrap();
+    // Seed through a preceding SetVariable so interpolation demonstrably occurs at execution time.
+    let mut doc = store.snapshot().as_ref().clone();
+    doc.macros[0].steps.insert(
+        0,
+        s(
+            3,
+            MkAction::SetVariable {
+                name: "seed".into(),
+                value: MkValue::String("東京 !".into()),
+            },
+        ),
+    );
+    store.save(doc).unwrap();
+    let fake = Arc::new(FakeBackend::default());
+    fake.script_prompt(PromptResponse::Submitted("accepted ✓".into()));
+    let runtime = MacroRuntime::new(Arc::new(store), fake.clone().backends());
+    assert_eq!(
+        runtime.command(RuntimeCommand::Run(7)),
+        CommandResult::Accepted
+    );
+    let snapshot = wait(&runtime, RuntimeState::Completed);
+    assert!(snapshot.last_error.is_none());
+    let prompts = fake.prompts.lock().unwrap();
+    assert_eq!(prompts.len(), 1);
+    assert_eq!(prompts[0].title, "Title 東京 !");
+    assert_eq!(prompts[0].prompt, "Value for 東京 !?");
+    assert_eq!(
+        prompts[0].default_value, "${seed} / 東京 !",
+        "escaped placeholders stay literal and expansion is nonrecursive"
+    );
+    drop(prompts);
+    assert!(
+        fake.events()
+            .contains(&"text:received:accepted ✓".to_string()),
+        "the prompt answer is immediately consumable"
+    );
+}
+
+#[test]
+fn cancelled_prompt_honors_stop_and_has_no_later_side_effect() {
+    let d = tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(d.path()).unwrap();
+    store
+        .save(MkMacroDocument {
+            schema_version: SCHEMA_VERSION,
+            settings: Default::default(),
+            macros: vec![MkMacro {
+                id: 8,
+                name: "cancel".into(),
+                description: String::new(),
+                enabled: true,
+                hotkey: None,
+                playback: Default::default(),
+                steps: vec![
+                    s(1, MkAction::PromptInput(MkPromptInputPayload::default())),
+                    s(
+                        2,
+                        MkAction::Text(MkTextPayload {
+                            text: "must-not-run".into(),
+                            interval_ms: 0,
+                        }),
+                    ),
+                ],
+            }],
+        })
+        .unwrap();
+    let fake = Arc::new(FakeBackend::default());
+    fake.script_prompt(PromptResponse::Cancelled);
+    let runtime = MacroRuntime::new(Arc::new(store), fake.clone().backends());
+    runtime.command(RuntimeCommand::Run(8));
+    let snapshot = wait(&runtime, RuntimeState::Failed);
+    assert!(snapshot.last_error.unwrap().message.contains("cancelled"));
+    assert!(
+        !fake
+            .events()
+            .iter()
+            .any(|event| event == "text:must-not-run")
+    );
+}
+
+#[test]
 fn window_activate_forwards_complete_payload() {
     let payload = MkWindowPayload {
         matcher: matcher(),

--- a/tests/mkmacro_runtime.rs
+++ b/tests/mkmacro_runtime.rs
@@ -114,7 +114,7 @@ fn prompt_request_result_and_following_step_form_one_runtime_transaction() {
                         2,
                         MkAction::Text(MkTextPayload {
                             text: "received:${answer}".into(),
-                            interval_ms: 0,
+                            mode: MkTextMode::Type,
                         }),
                     ),
                 ],
@@ -142,7 +142,7 @@ fn prompt_request_result_and_following_step_form_one_runtime_transaction() {
         CommandResult::Accepted
     );
     let snapshot = wait(&runtime, RuntimeState::Completed);
-    assert!(snapshot.last_error.is_none());
+    assert!(snapshot.latest_failure.is_none());
     let prompts = fake.prompts.lock().unwrap();
     assert_eq!(prompts.len(), 1);
     assert_eq!(prompts[0].title, "Title 東京 !");
@@ -180,7 +180,7 @@ fn cancelled_prompt_honors_stop_and_has_no_later_side_effect() {
                         2,
                         MkAction::Text(MkTextPayload {
                             text: "must-not-run".into(),
-                            interval_ms: 0,
+                            mode: MkTextMode::Type,
                         }),
                     ),
                 ],
@@ -192,7 +192,13 @@ fn cancelled_prompt_honors_stop_and_has_no_later_side_effect() {
     let runtime = MacroRuntime::new(Arc::new(store), fake.clone().backends());
     runtime.command(RuntimeCommand::Run(8));
     let snapshot = wait(&runtime, RuntimeState::Failed);
-    assert!(snapshot.last_error.unwrap().message.contains("cancelled"));
+    assert!(
+        snapshot
+            .latest_failure
+            .unwrap()
+            .message
+            .contains("cancelled")
+    );
     assert!(
         !fake
             .events()

--- a/tests/mkmacro_visual.rs
+++ b/tests/mkmacro_visual.rs
@@ -26,6 +26,56 @@ fn plan(action: MkAction) -> MkExecutionPlan {
     })
     .unwrap()
 }
+
+#[test]
+fn image_catalog_defaults_require_assets_and_configured_payload_round_trips() {
+    use multi_launcher::gui::mkmacro_dialog::action_catalog::{self, DraftValidationContract};
+    let image_entries: Vec<_> = action_catalog::visible_descriptors()
+        .filter(|descriptor| matches!(descriptor.name, "Find Image" | "Click Image"))
+        .collect();
+    assert_eq!(
+        image_entries.len(),
+        2,
+        "both production image paths are intentionally visible"
+    );
+    for descriptor in image_entries {
+        let action = (descriptor.make_default)();
+        assert_eq!(
+            action_catalog::draft_validation_contract(&action),
+            DraftValidationContract::AwaitingRequiredAsset,
+            "{} must not apply the asset_id == 0 draft sentinel",
+            descriptor.name
+        );
+        assert!(multi_launcher::mkmacro::executor::has_runtime_support(
+            &action
+        ));
+        assert!(descriptor.editor.contract().is_some());
+    }
+
+    let payload = MkImagePayload {
+        asset_id: 42,
+        wait: MkWaitOptions {
+            timeout_ms: 12_345,
+            poll_interval_ms: 77,
+        },
+        region: SearchRegion::Rectangle {
+            rect: ScreenRect::new(-10, 20, 640, 480),
+        },
+        tolerance: 9,
+        alpha: AlphaPolicy::Ignore,
+        return_point: ReturnPoint::TopLeft,
+    };
+    let action = MkAction::ImageClick(payload.clone());
+    assert_eq!(
+        action_catalog::draft_validation_contract(&action),
+        DraftValidationContract::CommitReady
+    );
+    let json = serde_json::to_string(&action).unwrap();
+    assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), action);
+    assert!(
+        matches!(serde_json::from_str::<MkAction>(&json).unwrap(), MkAction::ImageClick(saved) if saved == payload)
+    );
+}
 #[test]
 fn image_wait_cancels_promptly_without_real_screen_access() {
     let f = Arc::new(FakeBackend::default());


### PR DESCRIPTION
### Motivation
- Ensure the GUI action catalog (`action_catalog.rs`) maintains a strict bidirectional contract with both the authoring/editor surface and the runtime so new actions cannot leak incomplete or unsupported entries into the UI or search.
- Prevent regressions and require explicit intent for hidden rows, DirectInsert structural markers, image actions requiring assets, and Prompt for Input plumbing by codifying expectations in automated tests.
- Validate interpolation and runtime prompt plumbing end-to-end so prompt answers, escaping, cancellation, and interpolation semantics behave reliably at execution time.

### Description
- Added a table-driven capability contract test in `tests/mkmacro_authoring.rs` that iterates every `action_catalog::descriptors()` entry and asserts availability/runtime/editor invariants, stable metadata, safe default construction, and explicit hidden reasons for hidden entries.
- Added inventory assertions and explicit checks for all Window/Virtual Desktop entries and for the single Prompt/Image entries to make future addition/removal an intentional test-change.
- Added transactional Prompt for Input authoring tests (apply/cancel behavior preservation) in `tests/mkmacro_authoring.rs` and runtime Prompt tests using `FakeBackend` in `tests/mkmacro_runtime.rs` to validate prompt requests, accepted/cancelled flows, escaped/nonrecursive interpolation, and immediate consumption by downstream steps.
- Added visual/image tests in `tests/mkmacro_visual.rs` to require nonzero asset IDs for applied image actions, verify editor/runtime support, and round-trip configured `MkImagePayload` fields through serialization.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Performed repository checks (`git diff --check`, `git status`) and committed the test changes as `test mkmacro action capability contracts`.
- Attempted `cargo test --test mkmacro_authoring --test mkmacro_runtime --test mkmacro_visual`, but the full build/test run could not complete in this Linux CI environment due to platform-specific (Windows API and other system library) build failures unrelated to the added tests; as a result the new tests were added and compiled where possible but the full test suite did not finish here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8a3070a4b48332958803d894cf3cee)