### PR TITLE
Windows native overlay renderer + editor integrations and monitor/window validation

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1465,6 +1465,16 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
     }
     let mut open = true;
     d.action_editor.tick_visual_capture(d.selected_macro_id);
+    let overlay_was_active = d.action_editor.visual_overlay.operation_id().is_some();
+    for event in d.action_editor.visual_overlay.poll() {
+        use super::visual_overlay::VisualOverlayEvent;
+        if let VisualOverlayEvent::Error { error, .. } = event {
+            d.action_editor.capture_message = Some(error.to_string());
+        }
+    }
+    if overlay_was_active || d.action_editor.visual_overlay.operation_id().is_some() {
+        ctx.request_repaint();
+    }
     let workflow_active = d
         .action_editor
         .visual_capture
@@ -1515,7 +1525,42 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     Some(CaptureRectangle) => image_request = Some(ImageAuthoringRequest::CaptureRectangle),
                     Some(PickRectangle) => image_request = Some(ImageAuthoringRequest::PickRectangle),
                     Some(PickWindow { .. }) => window = Some(super::window_picker::MatcherPath::ImageRegion),
-                    Some(other) => state.capture_message = Some(format!("{other:?} requested; desktop overlay is not available on this platform")),
+                    Some(PreviewRectangle) => {
+                        let image = state.image_search.as_ref().unwrap();
+                        if image.rectangle.is_empty() {
+                            state.capture_message = Some("Rectangle width and height must be positive".into());
+                        } else {
+                            state.visual_overlay.preview_rectangle(image.rectangle);
+                        }
+                    }
+                    Some(HighlightMonitor) => {
+                        let image = state.image_search.as_mut().unwrap();
+                        image.refresh_monitors();
+                        match &image.monitors {
+                            Ok(monitors) => match monitors.iter().find(|m| m.index == image.monitor_index) {
+                                Some(m) => { state.visual_overlay.highlight_monitor(m.clone()); }
+                                None => state.capture_message = Some(format!("Monitor {} is currently unavailable", image.monitor_index)),
+                            },
+                            Err(error) => state.capture_message = Some(format!("Monitor information unavailable: {error}")),
+                        }
+                    }
+                    Some(IdentifyMonitors) => {
+                        let image = state.image_search.as_mut().unwrap();
+                        image.refresh_monitors();
+                        match &image.monitors {
+                            Ok(monitors) if !monitors.is_empty() => { state.visual_overlay.identify_monitors(monitors.clone()); }
+                            Ok(_) => state.capture_message = Some("No monitors are currently available".into()),
+                            Err(error) => state.capture_message = Some(format!("Monitor information unavailable: {error}")),
+                        }
+                    }
+                    Some(HighlightWindow { client_area }) => {
+                        let image = state.image_search.as_ref().unwrap();
+                        let matcher = if client_area { &image.client_matcher } else { &image.window_matcher };
+                        match crate::mkmacro::resolve_window_screen_rect(matcher, client_area) {
+                            Ok(rect) => { state.visual_overlay.highlight_window(rect, if client_area { super::visual_overlay::WindowAreaKind::ClientArea } else { super::visual_overlay::WindowAreaKind::WholeWindow }); }
+                            Err(error) => state.capture_message = Some(error.to_string()),
+                        }
+                    }
                     None => {}
                 }
             }
@@ -1598,7 +1643,8 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     && !matches!(
                         super::action_catalog::draft_validation_contract(&step.action),
                         super::action_catalog::DraftValidationContract::AwaitingRequiredAsset
-                    );
+                    )
+                    && state.image_search.as_ref().and_then(|image| image.validation_error()).is_none();
                 apply = ui.add_enabled(valid && !workflow_active, egui::Button::new("Apply")).clicked();
                 cancel = ui.button(if workflow_active { "Cancel visual capture" } else { "Cancel" }).on_hover_text("Cancel editing; during playback Cancel stops the macro").clicked();
             });

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -75,6 +75,28 @@ impl ImageSearchEditorState {
     pub fn select(&mut self, kind: SearchRegionKind) {
         self.kind = kind;
     }
+    /// Refreshes display metadata without changing the persisted playback
+    /// index.  In particular, disconnecting a display must not silently point
+    /// an existing action at a different monitor.
+    pub fn refresh_monitors(&mut self) {
+        self.monitors = crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string());
+    }
+
+    pub fn validation_error(&self) -> Option<String> {
+        match self.kind {
+            SearchRegionKind::Rectangle if self.rectangle.is_empty() => {
+                Some("Rectangle width and height must be positive".into())
+            }
+            SearchRegionKind::Monitor => match &self.monitors {
+                Ok(monitors) if !monitors.iter().any(|m| m.index == self.monitor_index) => Some(
+                    format!("Monitor {} is currently unavailable", self.monitor_index),
+                ),
+                Err(error) => Some(format!("Monitor information unavailable: {error}")),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
     pub fn selected_region(&self) -> SearchRegion {
         match self.kind {
             SearchRegionKind::Desktop => SearchRegion::Desktop,
@@ -198,6 +220,9 @@ pub(super) fn show(
             ui.label("Searches the complete virtual desktop across all connected monitors.");
         }
         SearchRegionKind::Monitor => {
+            if ui.button("Refresh").clicked() {
+                state.refresh_monitors();
+            }
             match &state.monitors {
                 Ok(monitors) => {
                     let selected = monitors
@@ -249,10 +274,13 @@ pub(super) fn show(
             });
             ui.horizontal_wrapped(|ui| {
                 ui.label("Width");
-                ui.add(egui::DragValue::new(&mut state.rectangle.width).clamp_range(1..=u32::MAX));
+                ui.add(egui::DragValue::new(&mut state.rectangle.width));
                 ui.label("Height");
-                ui.add(egui::DragValue::new(&mut state.rectangle.height).clamp_range(1..=u32::MAX));
+                ui.add(egui::DragValue::new(&mut state.rectangle.height));
             });
+            if state.rectangle.is_empty() {
+                ui.colored_label(egui::Color32::RED, "Width and height must be positive.");
+            }
             ui.horizontal_wrapped(|ui| {
                 request(
                     ui,
@@ -379,5 +407,24 @@ mod tests {
                 && !json.contains("monitors")
                 && !json.contains("preview_error")
         );
+    }
+
+    #[test]
+    fn validation_preserves_invalid_rectangle_and_missing_monitor_index() {
+        let mut s = ImageSearchEditorState::from_payload(&payload(SearchRegion::Rectangle {
+            rect: ScreenRect::new(-10, -20, 0, 30),
+        }));
+        assert!(s.validation_error().unwrap().contains("positive"));
+        assert_eq!(s.rectangle, ScreenRect::new(-10, -20, 0, 30));
+
+        s.kind = SearchRegionKind::Monitor;
+        s.monitor_index = 19;
+        s.monitors = Ok(vec![MonitorDescriptor {
+            index: 2,
+            bounds: ScreenRect::new(-1920, 0, 1920, 1080),
+            primary: false,
+        }]);
+        assert!(s.validation_error().unwrap().contains("19"));
+        assert_eq!(s.monitor_index, 19);
     }
 }

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -506,6 +506,13 @@ pub fn normalized_rect(a: MkPoint, b: MkPoint) -> Result<ScreenRect, VisualOverl
     ))
 }
 
+#[cfg(windows)]
+#[path = "visual_overlay_windows.rs"]
+mod native;
+#[cfg(windows)]
+use native::NativeOverlayRenderer;
+
+#[cfg(not(windows))]
 #[derive(Default)]
 struct NativeOverlayRenderer;
 #[cfg(not(windows))]
@@ -609,6 +616,19 @@ mod tests {
     }
 
     #[test]
+    fn half_open_drag_geometry_is_identical_in_all_four_directions() {
+        let expected = ScreenRect::new(500, 300, 700, 600);
+        for (a, b) in [
+            (point(500, 300), point(1200, 900)),
+            (point(1200, 300), point(500, 900)),
+            (point(500, 900), point(1200, 300)),
+            (point(1200, 900), point(500, 300)),
+        ] {
+            assert_eq!(normalized_rect(a, b).unwrap(), expected);
+        }
+    }
+
+    #[test]
     fn pick_confirms_purpose_and_ignores_stale_input() {
         let (mut c, fake, _) = controller();
         let id = c.begin_rectangle_pick(
@@ -676,29 +696,4 @@ mod tests {
         c.shutdown();
         assert_eq!(fake.lock().unwrap().closes, closes);
     }
-}
-
-// The Windows native-window implementation is kept behind this boundary.  It
-// is intentionally conservative until invoked by the editor: all geometry it
-// receives has already been resolved by the shared screen backend.
-#[cfg(windows)]
-impl OverlayRenderer for NativeOverlayRenderer {
-    fn show(
-        &mut self,
-        _: OperationId,
-        _: &OverlayVisual,
-        _: bool,
-    ) -> Result<(), VisualOverlayError> {
-        Err(VisualOverlayError {
-            kind: OverlayErrorKind::Platform,
-            message: "native visual overlay window could not be created".into(),
-        })
-    }
-    fn repaint(&mut self, _: OperationId, _: &OverlayVisual) -> Result<(), VisualOverlayError> {
-        Ok(())
-    }
-    fn poll_input(&mut self) -> Result<Vec<OverlayInput>, VisualOverlayError> {
-        Ok(vec![])
-    }
-    fn close(&mut self) {}
 }

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -8,8 +8,8 @@ use windows::{
     Win32::{
         Foundation::{COLORREF, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
         Graphics::Gdi::{
-            CreatePen, DeleteObject, EnumDisplayMonitors, GetDC, HDC, HGDIOBJ, HMONITOR,
-            MONITORINFO, MonitorFromRect, PS_SOLID, Rectangle, ReleaseDC, SelectObject, SetBkMode,
+            CreatePen, DeleteObject, EnumDisplayMonitors, GetDC, GetMonitorInfoW, HDC, HGDIOBJ,
+            HMONITOR, MONITORINFO, PS_SOLID, Rectangle, ReleaseDC, SelectObject, SetBkMode,
             SetTextColor, TRANSPARENT, TextOutW,
         },
         System::LibraryLoader::GetModuleHandleW,
@@ -17,10 +17,10 @@ use windows::{
             Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON},
             WindowsAndMessaging::{
                 CS_HREDRAW, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
-                DispatchMessageW, GetCursorPos, GetMonitorInfoW, HWND_TOPMOST, MSG, PM_REMOVE,
-                PeekMessageW, RegisterClassW, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW,
-                SetWindowPos, ShowWindow, TranslateMessage, WINDOW_EX_STYLE, WNDCLASSW,
-                WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
+                DispatchMessageW, GetCursorPos, HWND_TOPMOST, MSG, PM_REMOVE, PeekMessageW,
+                RegisterClassW, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW, SetWindowPos,
+                ShowWindow, TranslateMessage, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE,
+                WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
             },
         },
     },
@@ -91,7 +91,7 @@ fn displays() -> Vec<ScreenRect> {
     }
     let mut result = vec![];
     unsafe {
-        EnumDisplayMonitors(
+        let _ = EnumDisplayMonitors(
             None,
             None,
             Some(collect),
@@ -119,7 +119,7 @@ impl NativeOverlayRenderer {
                 }
                 let pen = CreatePen(PS_SOLID, 5, COLORREF(0x0000ffff));
                 let old = SelectObject(dc, HGDIOBJ(pen.0));
-                let mut outline = |r: ScreenRect| {
+                let outline = |r: ScreenRect| {
                     let x = i64::from(r.x) - i64::from(window.bounds.x);
                     let y = i64::from(r.y) - i64::from(window.bounds.y);
                     let _ = Rectangle(
@@ -151,7 +151,7 @@ impl NativeOverlayRenderer {
                     }
                 }
                 SelectObject(dc, old);
-                DeleteObject(HGDIOBJ(pen.0));
+                let _ = DeleteObject(HGDIOBJ(pen.0));
                 ReleaseDC(window.hwnd, dc);
             }
         }
@@ -160,11 +160,13 @@ impl NativeOverlayRenderer {
 
 unsafe fn draw_label(dc: HDC, origin: ScreenRect, descriptor: &MonitorDescriptor) {
     let text: Vec<u16> = descriptor.index.to_string().encode_utf16().collect();
-    SetBkMode(dc, TRANSPARENT);
-    SetTextColor(dc, COLORREF(0x0000ffff));
+    unsafe {
+        SetBkMode(dc, TRANSPARENT);
+        SetTextColor(dc, COLORREF(0x0000ffff));
+    }
     let x = i64::from(descriptor.bounds.x) - i64::from(origin.x) + 30;
     let y = i64::from(descriptor.bounds.y) - i64::from(origin.y) + 30;
-    let _ = TextOutW(dc, x as i32, y as i32, &text);
+    let _ = unsafe { TextOutW(dc, x as i32, y as i32, &text) };
 }
 
 impl OverlayRenderer for NativeOverlayRenderer {
@@ -238,8 +240,9 @@ impl OverlayRenderer for NativeOverlayRenderer {
                     bounds.width as i32,
                     bounds.height as i32,
                     SWP_NOACTIVATE | SWP_SHOWWINDOW,
-                )?;
-                ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+                )
+                .map_err(|e| platform(format!("overlay positioning failed: {e}")))?;
+                let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
             }
             self.windows.push(OverlayWindow { hwnd, bounds });
         }
@@ -266,7 +269,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
         let mut msg = MSG::default();
         while unsafe { PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE) }.as_bool() {
             unsafe {
-                TranslateMessage(&msg);
+                let _ = TranslateMessage(&msg);
                 DispatchMessageW(&msg);
             }
         }

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -1,0 +1,325 @@
+//! Win32 implementation of the overlay renderer.
+//!
+//! A separate popup is used for every physical display.  This avoids holes in
+//! non-rectangular monitor arrangements and, because every conversion starts
+//! with the popup's signed origin, also handles displays above/left of primary.
+use super::*;
+use windows::{
+    Win32::{
+        Foundation::{COLORREF, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+        Graphics::Gdi::{
+            CreatePen, DeleteObject, EnumDisplayMonitors, GetDC, HDC, HGDIOBJ, HMONITOR,
+            MONITORINFO, MonitorFromRect, PS_SOLID, Rectangle, ReleaseDC, SelectObject, SetBkMode,
+            SetTextColor, TRANSPARENT, TextOutW,
+        },
+        System::LibraryLoader::GetModuleHandleW,
+        UI::{
+            Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON},
+            WindowsAndMessaging::{
+                CS_HREDRAW, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
+                DispatchMessageW, GetCursorPos, GetMonitorInfoW, HWND_TOPMOST, MSG, PM_REMOVE,
+                PeekMessageW, RegisterClassW, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW,
+                SetWindowPos, ShowWindow, TranslateMessage, WINDOW_EX_STYLE, WNDCLASSW,
+                WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
+            },
+        },
+    },
+    core::PCWSTR,
+};
+
+#[derive(Clone, Copy)]
+struct OverlayWindow {
+    hwnd: HWND,
+    bounds: ScreenRect,
+}
+
+pub(super) struct NativeOverlayRenderer {
+    windows: Vec<OverlayWindow>,
+    operation_id: Option<OperationId>,
+    visual: Option<OverlayVisual>,
+    left_down: bool,
+    escape_down: bool,
+}
+unsafe impl Send for NativeOverlayRenderer {}
+impl Default for NativeOverlayRenderer {
+    fn default() -> Self {
+        Self {
+            windows: vec![],
+            operation_id: None,
+            visual: None,
+            left_down: false,
+            escape_down: false,
+        }
+    }
+}
+
+fn platform(message: impl Into<String>) -> VisualOverlayError {
+    VisualOverlayError {
+        kind: OverlayErrorKind::Platform,
+        message: message.into(),
+    }
+}
+
+unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, w: WPARAM, l: LPARAM) -> LRESULT {
+    unsafe { DefWindowProcW(hwnd, msg, w, l) }
+}
+
+fn displays() -> Vec<ScreenRect> {
+    unsafe extern "system" fn collect(
+        monitor: HMONITOR,
+        _: HDC,
+        _: *mut RECT,
+        data: LPARAM,
+    ) -> windows::Win32::Foundation::BOOL {
+        let out = unsafe { &mut *(data.0 as *mut Vec<ScreenRect>) };
+        let mut info = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if unsafe { GetMonitorInfoW(monitor, &mut info) }.as_bool() {
+            let r = info.rcMonitor;
+            if r.right > r.left && r.bottom > r.top {
+                out.push(ScreenRect::new(
+                    r.left,
+                    r.top,
+                    (r.right - r.left) as u32,
+                    (r.bottom - r.top) as u32,
+                ));
+            }
+        }
+        true.into()
+    }
+    let mut result = vec![];
+    unsafe {
+        EnumDisplayMonitors(
+            None,
+            None,
+            Some(collect),
+            LPARAM(&mut result as *mut _ as isize),
+        );
+    }
+    result
+}
+
+fn intersects(a: ScreenRect, b: ScreenRect) -> bool {
+    i64::from(a.x) < b.right()
+        && i64::from(b.x) < a.right()
+        && i64::from(a.y) < b.bottom()
+        && i64::from(b.y) < a.bottom()
+}
+
+impl NativeOverlayRenderer {
+    fn paint(&self) {
+        for window in &self.windows {
+            let Some(visual) = &self.visual else { continue };
+            unsafe {
+                let dc = GetDC(window.hwnd);
+                if dc.0.is_null() {
+                    continue;
+                }
+                let pen = CreatePen(PS_SOLID, 5, COLORREF(0x0000ffff));
+                let old = SelectObject(dc, HGDIOBJ(pen.0));
+                let mut outline = |r: ScreenRect| {
+                    let x = i64::from(r.x) - i64::from(window.bounds.x);
+                    let y = i64::from(r.y) - i64::from(window.bounds.y);
+                    let _ = Rectangle(
+                        dc,
+                        x as i32,
+                        y as i32,
+                        (x + i64::from(r.width)) as i32,
+                        (y + i64::from(r.height)) as i32,
+                    );
+                };
+                match visual {
+                    OverlayVisual::RectanglePicker { selection, .. } => {
+                        if let Some(r) = selection {
+                            outline(*r);
+                        }
+                    }
+                    OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => {
+                        outline(*r)
+                    }
+                    OverlayVisual::Monitor(d) => {
+                        outline(d.bounds);
+                        draw_label(dc, window.bounds, d);
+                    }
+                    OverlayVisual::Monitors(ds) => {
+                        for d in ds {
+                            outline(d.bounds);
+                            draw_label(dc, window.bounds, d);
+                        }
+                    }
+                }
+                SelectObject(dc, old);
+                DeleteObject(HGDIOBJ(pen.0));
+                ReleaseDC(window.hwnd, dc);
+            }
+        }
+    }
+}
+
+unsafe fn draw_label(dc: HDC, origin: ScreenRect, descriptor: &MonitorDescriptor) {
+    let text: Vec<u16> = descriptor.index.to_string().encode_utf16().collect();
+    SetBkMode(dc, TRANSPARENT);
+    SetTextColor(dc, COLORREF(0x0000ffff));
+    let x = i64::from(descriptor.bounds.x) - i64::from(origin.x) + 30;
+    let y = i64::from(descriptor.bounds.y) - i64::from(origin.y) + 30;
+    let _ = TextOutW(dc, x as i32, y as i32, &text);
+}
+
+impl OverlayRenderer for NativeOverlayRenderer {
+    fn show(
+        &mut self,
+        operation_id: OperationId,
+        visual: &OverlayVisual,
+        mouse_transparent: bool,
+    ) -> Result<(), VisualOverlayError> {
+        self.close();
+        let module = unsafe { GetModuleHandleW(None) }
+            .map_err(|e| platform(format!("overlay module lookup failed: {e}")))?;
+        let class = windows::core::w!("MultiLauncherVisualOverlay");
+        let wc = WNDCLASSW {
+            hInstance: module.into(),
+            lpszClassName: class,
+            lpfnWndProc: Some(wndproc),
+            style: CS_HREDRAW | CS_VREDRAW,
+            ..Default::default()
+        };
+        unsafe {
+            RegisterClassW(&wc);
+        }
+        let target = match visual {
+            OverlayVisual::RectanglePicker {
+                virtual_desktop, ..
+            } => *virtual_desktop,
+            OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => *r,
+            OverlayVisual::Monitor(d) => d.bounds,
+            OverlayVisual::Monitors(ds) => ds
+                .iter()
+                .map(|d| d.bounds)
+                .reduce(|a, b| {
+                    ScreenRect::new(
+                        a.x.min(b.x),
+                        a.y.min(b.y),
+                        (a.right().max(b.right()) - i64::from(a.x.min(b.x))) as u32,
+                        (a.bottom().max(b.bottom()) - i64::from(a.y.min(b.y))) as u32,
+                    )
+                })
+                .unwrap_or(ScreenRect::new(0, 0, 0, 0)),
+        };
+        for bounds in displays().into_iter().filter(|b| intersects(*b, target)) {
+            let mut ex = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
+            if mouse_transparent {
+                ex |= WS_EX_TRANSPARENT;
+            }
+            let hwnd = unsafe {
+                CreateWindowExW(
+                    ex,
+                    class,
+                    PCWSTR::null(),
+                    WS_POPUP,
+                    bounds.x,
+                    bounds.y,
+                    bounds.width as i32,
+                    bounds.height as i32,
+                    None,
+                    None,
+                    module,
+                    None,
+                )
+            }
+            .map_err(|e| platform(format!("overlay window creation failed: {e}")))?;
+            unsafe {
+                SetWindowPos(
+                    hwnd,
+                    HWND_TOPMOST,
+                    bounds.x,
+                    bounds.y,
+                    bounds.width as i32,
+                    bounds.height as i32,
+                    SWP_NOACTIVATE | SWP_SHOWWINDOW,
+                )?;
+                ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            }
+            self.windows.push(OverlayWindow { hwnd, bounds });
+        }
+        if self.windows.is_empty() {
+            return Err(platform("no physical display intersects the overlay"));
+        }
+        self.operation_id = Some(operation_id);
+        self.visual = Some(visual.clone());
+        self.paint();
+        Ok(())
+    }
+    fn repaint(
+        &mut self,
+        operation_id: OperationId,
+        visual: &OverlayVisual,
+    ) -> Result<(), VisualOverlayError> {
+        if self.operation_id == Some(operation_id) {
+            self.visual = Some(visual.clone());
+            self.paint();
+        }
+        Ok(())
+    }
+    fn poll_input(&mut self) -> Result<Vec<OverlayInput>, VisualOverlayError> {
+        let mut msg = MSG::default();
+        while unsafe { PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE) }.as_bool() {
+            unsafe {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
+        let Some(id) = self.operation_id else {
+            return Ok(vec![]);
+        };
+        let mut out = vec![];
+        let left = unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) } < 0;
+        let esc = unsafe { GetAsyncKeyState(VK_ESCAPE.0 as i32) } < 0;
+        let mut p = POINT::default();
+        unsafe { GetCursorPos(&mut p) }
+            .map_err(|e| platform(format!("cursor query failed: {e}")))?;
+        if left && !self.left_down {
+            out.push(OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::LeftPressed(MkPoint { x: p.x, y: p.y }),
+            });
+        }
+        if left {
+            out.push(OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::PointerMoved(MkPoint { x: p.x, y: p.y }),
+            });
+        }
+        if !left && self.left_down {
+            out.push(OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::LeftReleased(MkPoint { x: p.x, y: p.y }),
+            });
+        }
+        if esc && !self.escape_down {
+            out.push(OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::Escape,
+            });
+        }
+        self.left_down = left;
+        self.escape_down = esc;
+        Ok(out)
+    }
+    fn close(&mut self) {
+        for w in self.windows.drain(..) {
+            unsafe {
+                let _ = DestroyWindow(w.hwnd);
+            }
+        }
+        self.operation_id = None;
+        self.visual = None;
+        self.left_down = false;
+    }
+}
+impl Drop for NativeOverlayRenderer {
+    fn drop(&mut self) {
+        self.close();
+    }
+}

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -615,6 +615,27 @@ pub fn monitor_descriptors() -> ExecResult<Vec<MonitorDescriptor>> {
     }
 }
 
+/// Resolves a matcher against a fresh top-level-window enumeration and returns
+/// the same geometry used by image-search playback.  No native handle escapes
+/// this call, so authoring previews cannot retain a stale HWND.
+pub fn resolve_window_screen_rect(
+    matcher: &MkWindowMatcher,
+    client_area: bool,
+) -> ExecResult<ScreenRect> {
+    #[cfg(windows)]
+    {
+        SystemCapturePlatform.window_rect(matcher, client_area)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (matcher, client_area);
+        Err(ExecutionDiagnostic::new(
+            DiagnosticKind::UnsupportedOperation,
+            "Window target resolution is available only on Windows",
+        ))
+    }
+}
+
 fn rect_from_signed_metrics(x: i32, y: i32, width: i32, height: i32) -> ExecResult<ScreenRect> {
     if width <= 0 || height <= 0 {
         return Err(invalid(format!(

--- a/src/mkmacro/windows.rs
+++ b/src/mkmacro/windows.rs
@@ -140,7 +140,7 @@ pub fn resolve_window(
     match found.len() {
         0 => Err(ExecutionDiagnostic::new(
             DiagnosticKind::TargetNotFound,
-            "matching window is missing",
+            "Window target not found",
         )),
         1 => Ok(found.remove(0)),
         _ if policy == AmbiguityPolicy::First => Ok(found.remove(0)),


### PR DESCRIPTION
### Motivation
- Provide a Windows-native overlay renderer that correctly handles per-physical-display overlays, signed virtual-desktop coordinates, and safe native resource ownership while keeping the controller as the sole state owner.
- Wire the image-action editor to the overlay controller so preview/highlight requests behave predictably and authoring cannot silently mutate persisted monitor or window targets.
- Add small authoring helpers and validations so monitor refreshes, missing indices, and invalid rectangle input are surfaced to the user rather than silently clamped or changed.

### Description
- Introduced a Windows-only native renderer in `src/gui/mkmacro_dialog/visual_overlay_windows.rs` and restructured `visual_overlay.rs` to `cfg`-gate and re-export the native implementation for Windows while keeping a stub on other platforms; the renderer creates a borderless topmost HWND per physical display, paints rectangle/monitor/window outlines and large monitor labels, supports passive mouse transparency, polls native input and translates it into `OverlayInput` with operation IDs, and closes/releases all HWND/GDI resources on close/drop.
- Kept `VisualOverlayController` behavior unchanged as the single state owner (nonblocking `poll()`, 2.5s `PASSIVE_OVERLAY_DURATION`, stale-operation filtering, replacement cancellation, renderer-error cleanup and shutdown behavior) and used the renderer boundary for native operations only.
- Connected previously-unhandled image editor requests in `src/gui/mkmacro_dialog/action_editor.rs` to the controller: `PreviewRectangle` now requests `preview_rectangle()`, `HighlightMonitor` refreshes descriptors and calls `highlight_monitor()` (with error when index unavailable), `IdentifyMonitors` calls `identify_monitors()` with fresh descriptors, and `HighlightWindow { client_area }` resolves the matcher via a fresh resolution and calls `highlight_window()` with the resolved rectangle using the same playback geometry.
- Added monitor refresh and validation logic to `src/gui/mkmacro_dialog/image_search_editor.rs` (`refresh_monitors()` and `validation_error()`), allowed rectangle width/height to be edited as signed or zero for inline validation (showing an inline error and disabling Apply), and added a UI `Refresh` button in the Monitor section while preserving `monitor_index` when the saved index is missing.
- Added an authoring-safe window resolution function `resolve_window_screen_rect()` in `src/mkmacro/screen.rs` that uses the playback capture path to return full-window or client-area geometry without exposing HWNDs to the editor.
- Standardized no-match diagnostic text to `Window target not found` in `src/mkmacro/windows.rs` while preserving ambiguity diagnostics.
- Added unit tests: geometry half-open/normalized drag tests and invalid rectangle/monitor-preservation tests; augmented overlay tests to cover normalization and behavior already present in `visual_overlay.rs` test module.

### Testing
- Ran `cargo fmt` successfully to ensure formatting compliance.
- Ran `cargo test -q` and module-level tests: `gui::mkmacro_dialog::visual_overlay::tests` and `gui::mkmacro_dialog::image_search_editor::tests`; these tests passed in the Linux CI environment because Windows-only code is `#[cfg(windows)]` gated and not compiled on this host.
- Performed `git diff --check` to verify there are no whitespace or diff issues.
- Note: the Windows-native renderer implementation is platform-gated and therefore was not exercised by the Linux-hosted test run; Windows-specific integration and native-GDI/HWND behavior should be validated on a Windows build/runner to exercise the new `visual_overlay_windows.rs` code paths and native resource cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ae83f9d8c8332b4ace3aa56238a33)