### PR TITLE
Consolidate transactional macro reference-image authoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ unstable_grab = ["rdev/unstable_grab"]
 
 [dev-dependencies]
 tempfile = "3"
+image = { version = "0.24", default-features = false, features = ["jpeg"] }
 criterion = "0.5"
 serial_test = "2"
 

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1374,9 +1374,8 @@ fn apply_import(
     payload: &mut MkImagePayload,
     source: &std::path::Path,
 ) -> anyhow::Result<()> {
-    let id = store.next_asset_id(macro_id)?;
-    store.import_png_asset(macro_id, id, source)?;
-    payload.asset_id = id;
+    let staged = ImageAssetAuthoringService::new(store).import_png(macro_id, source)?;
+    payload.asset_id = staged.asset_id;
     Ok(())
 }
 
@@ -1386,9 +1385,8 @@ fn apply_capture(
     payload: &mut MkImagePayload,
     image: &image::RgbaImage,
 ) -> anyhow::Result<()> {
-    let id = store.next_asset_id(macro_id)?;
-    store.write_png_asset(macro_id, id, image)?;
-    payload.asset_id = id;
+    let staged = ImageAssetAuthoringService::new(store).stage_rgba(macro_id, image)?;
+    payload.asset_id = staged.asset_id;
     Ok(())
 }
 

--- a/src/gui/mkmacro_dialog/image_preview.rs
+++ b/src/gui/mkmacro_dialog/image_preview.rs
@@ -1,8 +1,27 @@
 //! Bounded, failure-tolerant previews for macro PNG assets.
 use crate::mkmacro::MkMacroStore;
 use eframe::egui;
+use std::{collections::HashMap, fs, time::SystemTime};
 
 pub const PREVIEW_BOUND: f32 = 220.0;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct PreviewKey {
+    macro_id: u64,
+    asset_id: u64,
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+#[derive(Clone)]
+struct CachedPreview {
+    texture: egui::TextureHandle,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Default)]
+struct PreviewCache(HashMap<PreviewKey, CachedPreview>);
 
 pub fn fitted_size(width: u32, height: u32, bound: f32) -> egui::Vec2 {
     if width == 0 || height == 0 {
@@ -17,33 +36,70 @@ pub fn show(ui: &mut egui::Ui, store: &MkMacroStore, macro_id: u64, asset_id: u6
         ui.colored_label(egui::Color32::RED, "No reference image selected");
         return;
     };
-    match image::open(&path).map(|x| x.to_rgba8()) {
-        Ok(image) => {
-            let size = [image.width() as usize, image.height() as usize];
-            let texture = ui.ctx().load_texture(
-                format!(
-                    "mkmacro-preview-{macro_id}-{asset_id}-{:?}",
-                    path.metadata().and_then(|m| m.modified()).ok()
-                ),
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            ui.colored_label(
+                egui::Color32::RED,
+                format!("Missing reference image (asset {asset_id}): {error}"),
+            );
+            return;
+        }
+    };
+    let key = PreviewKey {
+        macro_id,
+        asset_id,
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    };
+    let cache_id = egui::Id::new("mkmacro-image-preview-cache");
+    let cached: Result<CachedPreview, String> = ui.ctx().data_mut(|data| {
+        let cache = data.get_temp_mut_or_default::<PreviewCache>(cache_id);
+        // A changed file identity invalidates the former texture for this asset.
+        cache
+            .0
+            .retain(|old, _| old.macro_id != macro_id || old.asset_id != asset_id || old == &key);
+        if let Some(value) = cache.0.get(&key) {
+            return Ok(value.clone());
+        }
+        let bytes = fs::read(&path).map_err(|e| e.to_string())?;
+        let image = image::load_from_memory_with_format(&bytes, image::ImageFormat::Png)
+            .map_err(|e| e.to_string())?
+            .to_rgba8();
+        if image.width() == 0 || image.height() == 0 {
+            return Err("image has zero dimensions".into());
+        }
+        let size = [image.width() as usize, image.height() as usize];
+        let value = CachedPreview {
+            texture: ui.ctx().load_texture(
+                format!("mkmacro-preview-{macro_id}-{asset_id}-{}", metadata.len()),
                 egui::ColorImage::from_rgba_unmultiplied(size, image.as_raw()),
                 Default::default(),
-            );
+            ),
+            width: image.width(),
+            height: image.height(),
+        };
+        cache.0.insert(key.clone(), value.clone());
+        Ok(value)
+    });
+    match cached {
+        Ok(cached) => {
             ui.image((
-                texture.id(),
-                fitted_size(image.width(), image.height(), PREVIEW_BOUND),
+                cached.texture.id(),
+                fitted_size(cached.width, cached.height, PREVIEW_BOUND),
             ));
             ui.label(format!(
                 "{} — {} × {} px",
                 path.file_name().unwrap_or_default().to_string_lossy(),
-                image.width(),
-                image.height()
+                cached.width,
+                cached.height
             ));
             ui.small(format!("Asset ID {asset_id}"));
         }
         Err(error) => {
             ui.colored_label(
                 egui::Color32::RED,
-                format!("Missing or corrupt reference image: {error}"),
+                format!("Missing or corrupt reference image (asset {asset_id}): {error}"),
             );
         }
     }
@@ -54,11 +110,18 @@ mod tests {
     use super::*;
     #[test]
     fn sizes_are_bounded_and_keep_aspect() {
-        for (w, h) in [(400, 100), (100, 400), (100_000, 50_000), (20, 10)] {
+        for (w, h) in [
+            (400, 100),
+            (100, 400),
+            (400, 400),
+            (100_000, 50_000),
+            (20, 10),
+        ] {
             let s = fitted_size(w, h, 220.0);
             assert!(s.x <= 220.0 && s.y <= 220.0);
             assert!((s.x / s.y - w as f32 / h as f32).abs() < 0.01);
         }
+        assert_eq!(fitted_size(20, 10, 220.0), egui::vec2(20.0, 10.0));
         assert_eq!(fitted_size(0, 3, 220.0), egui::Vec2::ZERO);
     }
 }

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -7,7 +7,7 @@
 
 use super::visual_overlay::{OperationId, RectanglePurpose};
 use crate::mkmacro::ScreenRect;
-use crate::mkmacro::{MkMacroStore, ScreenCaptureBackend};
+use crate::mkmacro::{ImageAssetAuthoringService, MkMacroStore, ScreenCaptureBackend};
 use image::RgbaImage;
 use std::sync::Arc;
 use std::time::Duration;
@@ -71,11 +71,10 @@ impl CaptureAdapter for ScreenCaptureAdapter {
 pub struct MkMacroAssetStoreAdapter(pub Arc<MkMacroStore>);
 impl AssetStoreAdapter for MkMacroAssetStoreAdapter {
     fn write_png_asset(&mut self, macro_id: u64, image: &RgbaImage) -> Result<u64, String> {
-        let id = self.0.next_asset_id(macro_id).map_err(|e| e.to_string())?;
-        self.0
-            .write_png_asset(macro_id, id, image)
-            .map_err(|e| e.to_string())?;
-        Ok(id)
+        ImageAssetAuthoringService::new(&self.0)
+            .stage_rgba(macro_id, image)
+            .map(|staged| staged.asset_id)
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/src/mkmacro/asset_authoring.rs
+++ b/src/mkmacro/asset_authoring.rs
@@ -1,0 +1,130 @@
+//! Transactional staging of reference images used while authoring macros.
+//!
+//! Staging and document replacement are deliberately separate.  In particular,
+//! callers must not remove the old asset until the edited macro has been saved;
+//! the store's normal `cleanup_assets` pass is the appropriate place to collect
+//! files which are no longer referenced by the saved document.
+
+use super::MkMacroStore;
+use anyhow::{Context, Result};
+use image::{ImageFormat, RgbaImage};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StagedImageAsset {
+    pub asset_id: u64,
+    /// Portable managed reference (`mkmacro_assets/<macro>/<id>.png`).
+    pub managed_reference: PathBuf,
+}
+
+pub struct ImageAssetAuthoringService<'a> {
+    store: &'a MkMacroStore,
+}
+
+impl<'a> ImageAssetAuthoringService<'a> {
+    pub fn new(store: &'a MkMacroStore) -> Self {
+        Self { store }
+    }
+
+    pub fn import_png(&self, macro_id: u64, source: &Path) -> Result<StagedImageAsset> {
+        // Decode before allocation and before any draft can be changed.  Supplying
+        // the format explicitly prevents a renamed JPEG from being accepted.
+        let bytes = std::fs::read(source)
+            .with_context(|| format!("read reference image {}", source.display()))?;
+        let image = image::load_from_memory_with_format(&bytes, ImageFormat::Png)
+            .with_context(|| format!("{} is not a valid PNG image", source.display()))?
+            .to_rgba8();
+        self.stage_rgba(macro_id, &image)
+    }
+
+    pub fn stage_rgba(&self, macro_id: u64, image: &RgbaImage) -> Result<StagedImageAsset> {
+        if image.width() == 0 || image.height() == 0 {
+            anyhow::bail!("reference image is empty")
+        }
+        let asset_id = self.store.next_asset_id(macro_id)?;
+        let managed_reference = self.store.write_png_asset(macro_id, asset_id, image)?;
+        Ok(StagedImageAsset {
+            asset_id,
+            managed_reference,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, GenericImageView, Rgb, RgbImage, Rgba};
+    use std::io::Cursor;
+
+    fn fixture() -> (tempfile::TempDir, MkMacroStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        (dir, store)
+    }
+
+    #[test]
+    fn png_import_is_managed_and_independent_of_source() {
+        let (dir, store) = fixture();
+        let source = dir.path().join("chosen.png");
+        DynamicImage::ImageRgba8(RgbaImage::from_pixel(3, 2, Rgba([1, 2, 3, 255])))
+            .save_with_format(&source, ImageFormat::Png)
+            .unwrap();
+        let staged = ImageAssetAuthoringService::new(&store)
+            .import_png(7, &source)
+            .unwrap();
+        assert_eq!(staged.asset_id, 1);
+        assert_eq!(
+            staged.managed_reference,
+            Path::new("mkmacro_assets/7/1.png")
+        );
+        std::fs::remove_file(source).unwrap();
+        assert_eq!(
+            image::open(store.asset_path(7, 1).unwrap())
+                .unwrap()
+                .dimensions(),
+            (3, 2)
+        );
+    }
+
+    #[test]
+    fn strict_png_rejects_renamed_jpeg_and_corruption() {
+        let (dir, store) = fixture();
+        let service = ImageAssetAuthoringService::new(&store);
+        let mut jpeg = Cursor::new(Vec::new());
+        DynamicImage::ImageRgb8(RgbImage::from_pixel(1, 1, Rgb([1, 2, 3])))
+            .write_to(&mut jpeg, ImageFormat::Jpeg)
+            .unwrap();
+        for (name, bytes) in [
+            ("renamed.png", jpeg.into_inner()),
+            ("bad.png", b"garbage".to_vec()),
+        ] {
+            let source = dir.path().join(name);
+            std::fs::write(&source, bytes).unwrap();
+            assert!(service.import_png(3, &source).is_err());
+        }
+        assert!(store.asset_ids(3).unwrap().is_empty());
+    }
+
+    #[test]
+    fn allocation_does_not_replace_existing_and_empty_capture_is_rejected() {
+        let (_dir, store) = fixture();
+        let first = RgbaImage::from_pixel(1, 1, Rgba([9, 8, 7, 255]));
+        store.write_png_asset(4, 1, &first).unwrap();
+        let second = RgbaImage::from_pixel(1, 1, Rgba([1, 2, 3, 255]));
+        let staged = ImageAssetAuthoringService::new(&store)
+            .stage_rgba(4, &second)
+            .unwrap();
+        assert_eq!(staged.asset_id, 2);
+        assert_eq!(
+            image::open(store.asset_path(4, 1).unwrap())
+                .unwrap()
+                .to_rgba8(),
+            first
+        );
+        assert!(
+            ImageAssetAuthoringService::new(&store)
+                .stage_rgba(4, &RgbaImage::new(0, 1))
+                .is_err()
+        );
+    }
+}

--- a/src/mkmacro/image_search.rs
+++ b/src/mkmacro/image_search.rs
@@ -40,7 +40,7 @@ impl ImageDecodeCache {
             ExecutionDiagnostic::new(DiagnosticKind::InvalidTarget, message)
                 .context("asset_path", path.display().to_string())
         })?;
-        let image = image::load_from_memory(&bytes)
+        let image = image::load_from_memory_with_format(&bytes, image::ImageFormat::Png)
             .map_err(|e| {
                 ExecutionDiagnostic::new(
                     DiagnosticKind::InvalidTarget,

--- a/src/mkmacro/mod.rs
+++ b/src/mkmacro/mod.rs
@@ -1,4 +1,5 @@
 //! Versioned model, validation, compilation, and persistence for the new macro system.
+pub mod asset_authoring;
 pub mod compiler;
 pub mod coordinates;
 pub mod executor;
@@ -22,6 +23,7 @@ pub mod variables;
 pub mod virtual_desktops;
 pub mod windows;
 
+pub use asset_authoring::*;
 pub use compiler::*;
 pub use coordinates::*;
 pub use executor::*;

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -328,14 +328,33 @@ fn matcher(x: &MkWindowMatcher, m: u64, s: Option<u64>, o: &mut Vec<MkDiagnostic
 fn asset(id: u64, m: u64, s: Option<u64>, root: Option<&Path>, o: &mut Vec<MkDiagnostic>) {
     if id == 0 {
         push(o, m, s, "missing_asset", "Select a reference image")
-    } else if root.is_some_and(|r| !r.join(m.to_string()).join(format!("{id}.png")).is_file()) {
-        push(
-            o,
-            m,
-            s,
-            "missing_asset",
-            format!("Image asset {id} is missing"),
-        )
+    } else if let Some(root) = root {
+        let path = root.join(m.to_string()).join(format!("{id}.png"));
+        if !path.is_file() {
+            push(
+                o,
+                m,
+                s,
+                "missing_asset",
+                format!("Image asset {id} is missing"),
+            );
+            return;
+        }
+        let valid = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| {
+                image::load_from_memory_with_format(&bytes, image::ImageFormat::Png).ok()
+            })
+            .is_some_and(|image| image.width() > 0 && image.height() > 0);
+        if !valid {
+            push(
+                o,
+                m,
+                s,
+                "invalid_image_asset",
+                format!("Image asset {id} is not a usable PNG"),
+            );
+        }
     }
 }
 
@@ -463,5 +482,38 @@ mod coordinate_target_tests {
             })
             .is_empty()
         );
+    }
+
+    #[test]
+    fn managed_image_assets_are_validated_as_png_content() {
+        use image::{Rgba, RgbaImage};
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut out = Vec::new();
+        asset(0, 7, Some(8), Some(root), &mut out);
+        assert!(out.iter().any(|d| d.code == "missing_asset"));
+        out.clear();
+        asset(1, 7, Some(8), Some(root), &mut out);
+        assert!(out.iter().any(|d| d.code == "missing_asset"));
+
+        let macro_dir = root.join("7");
+        std::fs::create_dir_all(&macro_dir).unwrap();
+        RgbaImage::from_pixel(2, 3, Rgba([1, 2, 3, 255]))
+            .save_with_format(macro_dir.join("1.png"), image::ImageFormat::Png)
+            .unwrap();
+        out.clear();
+        asset(1, 7, Some(8), Some(root), &mut out);
+        assert!(out.is_empty());
+
+        for bytes in [
+            b"corrupt".as_slice(),
+            b"\xff\xd8\xff\xe0renamed jpeg".as_slice(),
+        ] {
+            std::fs::write(macro_dir.join("1.png"), bytes).unwrap();
+            out.clear();
+            asset(1, 7, Some(8), Some(root), &mut out);
+            assert!(out.iter().any(|d| d.code == "invalid_image_asset"));
+            assert!(!can_run(&out));
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Centralize all reference-image import/capture staging behind a single authoring service to avoid duplicated mutation logic and make replacements transactional.
- Ensure imports and captures are strictly PNG-decoded, converted to RGBA, rejected when empty, and atomically persisted before a draft is mutated so the old managed asset is never lost on failure.
- Improve editor UX and performance by caching preview textures keyed by file identity and by surfacing clear diagnostics for missing/corrupt managed assets.

### Description

- Add a new authoring service `ImageAssetAuthoringService` and result type `StagedImageAsset` in `src/mkmacro/asset_authoring.rs` that allocates an asset id with `MkMacroStore::next_asset_id`, strictly decodes PNGs, converts to RGBA, rejects zero-dimension images, writes via the store, and returns only after atomic persistence succeeds.
- Route both editor import/capture paths through the service by updating `apply_import`/`apply_capture` in `src/gui/mkmacro_dialog/action_editor.rs` and the asset adapter in `src/gui/mkmacro_dialog/visual_capture_workflow.rs` so payload `asset_id` is only updated after staging succeeds.
- Keep managed filenames in the `mkmacro_assets/{macro_id}/{asset_id}.png` hierarchy and never store external absolute paths in `MkImagePayload` (only `asset_id` is persisted).
- Add a cached preview implementation in `src/gui/mkmacro_dialog/image_preview.rs` keyed by `(macro_id, asset_id, file_len, modified)` that avoids re-decoding/uploading every frame, preserves aspect ratio, bounds size by `PREVIEW_BOUND`, never upscales, and shows clear red errors while preserving `payload.asset_id` on failure.
- Strengthen validation in `src/mkmacro/validation.rs::asset` to emit `invalid_image_asset` for corrupt/non-PNG/zero-dimension managed files, and keep this diagnostic participating in `can_run()` to block playback.
- Keep runtime decoding defensive by switching to `image::load_from_memory_with_format(..., ImageFormat::Png)` in `src/mkmacro/image_search.rs` so runtime still defends against external modifications after validation.
- Add unit tests covering managed PNG import and staging, rejection of renamed JPEG/corrupt data, non-overwriting allocation, empty-capture rejection, preview sizing assertions, and validation behavior in the new and modified modules.

### Testing

- Ran `cargo fmt --all` (success) and `git diff --check` (success) and committed the changes as `Consolidate macro reference image authoring`.
- Attempted `cargo test --lib mkmacro`; the build progressed but execution of the full test-suite was blocked by unrelated, pre-existing platform-specific `windows` crate resolution/build issues in other modules (non-Windows environment), so the new unit tests could not be exercised end-to-end in this environment.
- Added focused unit tests in `src/mkmacro/asset_authoring.rs`, `src/gui/mkmacro_dialog/image_preview.rs`, and `src/mkmacro/validation.rs`; these tests are present and intended to run in CI or on a host where platform-specific dependencies build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8af1cf33b08332b1ab22bb6c68b187)