### PR TITLE
Compose Launcher visual capture workflow with visibility bridge and shared rectangle overlay

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -25,7 +25,7 @@ pub struct ActionEditorState {
     pub(crate) draft_generation: u64,
     pub image_search: Option<super::image_search_editor::ImageSearchEditorState>,
     /// Sole owner of native visual-overlay resources for this editor draft.
-    pub visual_overlay: super::visual_overlay::VisualOverlayController,
+    pub visual_overlay: super::visual_capture_workflow::SharedVisualOverlayController,
     /// Installed by the owning launcher integration because it alone owns the
     /// launcher and dialog native-window visibility boundary.
     pub visual_capture: Option<super::visual_capture_workflow::VisualCaptureWorkflow>,
@@ -230,6 +230,12 @@ impl ActionEditorState {
         }
     }
     pub fn apply(&mut self, dialog: &mut MkMacroDialog) -> Option<u64> {
+        if let Some(workflow) = &mut self.visual_capture {
+            workflow.cancel();
+            while workflow.active() {
+                workflow.tick();
+            }
+        }
         self.visual_overlay.cancel();
         self.stop_position_capture();
         if let (Some(step), Some(image)) = (&mut self.draft, &self.image_search)

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -11,6 +11,7 @@ pub mod recorder_controller;
 mod step_table;
 mod toolbar;
 pub mod uia_editor;
+pub mod visual_capture_visibility;
 pub mod visual_capture_workflow;
 pub mod visual_overlay;
 pub mod window_picker;

--- a/src/gui/mkmacro_dialog/visual_capture_visibility.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_visibility.rs
@@ -1,0 +1,74 @@
+//! UI-thread bridge between the capture workflow and Launcher viewport state.
+use super::visual_capture_workflow::{SavedVisibility, VisibilityAdapter};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct State {
+    launcher_visible: bool,
+    mkmacro_open: bool,
+    hide_pending: bool,
+    hide_applied: bool,
+    hidden_observed: bool,
+    restore: Option<SavedVisibility>,
+}
+
+#[derive(Clone, Default)]
+pub struct LauncherVisibilityBridge(Arc<Mutex<State>>);
+
+/// Adapter owned by the workflow; it contains no egui or Launcher borrow.
+pub struct LauncherVisualCaptureVisibility(pub LauncherVisibilityBridge);
+
+pub enum VisibilityRequest {
+    None,
+    Hide,
+    Restore(SavedVisibility),
+}
+
+impl LauncherVisibilityBridge {
+    /// Called once, early, by the UI thread. A hide is only acknowledged on
+    /// the frame after the frame which emitted `ViewportCommand::Visible(false)`.
+    pub fn process_frame(&self, launcher_visible: bool, mkmacro_open: bool) -> VisibilityRequest {
+        let mut s = self.0.lock().unwrap();
+        s.launcher_visible = launcher_visible;
+        s.mkmacro_open = mkmacro_open;
+        if let Some(saved) = s.restore.take() {
+            s.hide_pending = false;
+            s.hide_applied = false;
+            s.hidden_observed = false;
+            return VisibilityRequest::Restore(saved);
+        }
+        if s.hide_applied {
+            s.hidden_observed = true;
+        }
+        if s.hide_pending && !s.hide_applied {
+            s.hide_applied = true;
+            return VisibilityRequest::Hide;
+        }
+        VisibilityRequest::None
+    }
+    pub fn pending(&self) -> bool {
+        let s = self.0.lock().unwrap();
+        s.hide_pending || s.restore.is_some()
+    }
+}
+impl VisibilityAdapter for LauncherVisualCaptureVisibility {
+    fn snapshot(&self) -> SavedVisibility {
+        let s = self.0.0.lock().unwrap();
+        SavedVisibility {
+            launcher: s.launcher_visible,
+            mkmacro_dialog: s.mkmacro_open,
+        }
+    }
+    fn request_hidden(&mut self) {
+        let mut s = self.0.0.lock().unwrap();
+        s.hide_pending = true;
+        s.hide_applied = false;
+        s.hidden_observed = false;
+    }
+    fn hidden_observed(&self) -> bool {
+        self.0.0.lock().unwrap().hidden_observed
+    }
+    fn restore(&mut self, saved: SavedVisibility) {
+        self.0.0.lock().unwrap().restore = Some(saved);
+    }
+}

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -5,12 +5,14 @@
 //! once per frame.  Consequently hiding a window never leads to a sleep on the
 //! UI thread and every terminal path passes through the same restoration step.
 
-use super::visual_overlay::{OperationId, RectanglePurpose};
+use super::visual_overlay::{
+    OperationId, RectanglePurpose, VisualOverlayController, VisualOverlayEvent,
+};
 use crate::mkmacro::ScreenRect;
 use crate::mkmacro::{ImageAssetAuthoringService, MkMacroStore, ScreenCaptureBackend};
 use image::RgbaImage;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 /// Exact visibility to put back after an authoring operation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -27,6 +29,140 @@ pub trait VisibilityAdapter: Send {
 }
 pub trait WorkflowClock: Send {
     fn now(&self) -> Duration;
+}
+
+/// Monotonic production clock.  The private epoch also makes its values small
+/// and immune to wall-clock adjustments.
+pub struct SystemWorkflowClock(Instant);
+impl Default for SystemWorkflowClock {
+    fn default() -> Self {
+        Self(Instant::now())
+    }
+}
+impl WorkflowClock for SystemWorkflowClock {
+    fn now(&self) -> Duration {
+        self.0.elapsed()
+    }
+}
+
+/// Cloneable, single-queue facade for the overlay controller.  Workflow events
+/// are routed to its adapter while passive/editor events remain available to
+/// the Action Editor, so two consumers never race the native queue.
+#[derive(Clone)]
+pub struct SharedVisualOverlayController(Arc<Mutex<SharedOverlay>>);
+struct SharedOverlay {
+    controller: VisualOverlayController,
+    editor_events: Vec<VisualOverlayEvent>,
+}
+impl Default for SharedVisualOverlayController {
+    fn default() -> Self {
+        Self::new(VisualOverlayController::default())
+    }
+}
+impl SharedVisualOverlayController {
+    pub fn new(controller: VisualOverlayController) -> Self {
+        Self(Arc::new(Mutex::new(SharedOverlay {
+            controller,
+            editor_events: vec![],
+        })))
+    }
+    pub fn operation_id(&self) -> Option<OperationId> {
+        self.0.lock().unwrap().controller.operation_id()
+    }
+    pub fn cancel(&self) {
+        self.0.lock().unwrap().controller.cancel();
+    }
+    pub fn poll(&self) -> Vec<VisualOverlayEvent> {
+        let mut shared = self.0.lock().unwrap();
+        let mut events = std::mem::take(&mut shared.editor_events);
+        events.extend(shared.controller.poll());
+        events
+    }
+    pub fn preview_rectangle(&self, rect: ScreenRect) {
+        self.0.lock().unwrap().controller.preview_rectangle(rect);
+    }
+    pub fn highlight_monitor(&self, monitor: crate::mkmacro::MonitorDescriptor) {
+        self.0.lock().unwrap().controller.highlight_monitor(monitor);
+    }
+    pub fn identify_monitors(&self, monitors: Vec<crate::mkmacro::MonitorDescriptor>) {
+        self.0
+            .lock()
+            .unwrap()
+            .controller
+            .identify_monitors(monitors);
+    }
+    pub fn highlight_window(&self, rect: ScreenRect, kind: super::visual_overlay::WindowAreaKind) {
+        self.0
+            .lock()
+            .unwrap()
+            .controller
+            .highlight_window(rect, kind);
+    }
+}
+
+pub struct VisualOverlayRectangleAdapter {
+    overlay: SharedVisualOverlayController,
+    backend: Arc<dyn ScreenCaptureBackend>,
+    operation_id: Option<OperationId>,
+}
+impl VisualOverlayRectangleAdapter {
+    pub fn new(
+        overlay: SharedVisualOverlayController,
+        backend: Arc<dyn ScreenCaptureBackend>,
+    ) -> Self {
+        Self {
+            overlay,
+            backend,
+            operation_id: None,
+        }
+    }
+}
+impl RectangleOverlay for VisualOverlayRectangleAdapter {
+    fn begin(&mut self, purpose: RectanglePurpose) -> Result<OperationId, String> {
+        let desktop = self.backend.virtual_desktop().map_err(|e| e.to_string())?;
+        let id = self
+            .overlay
+            .0
+            .lock()
+            .unwrap()
+            .controller
+            .begin_rectangle_pick(purpose, desktop);
+        self.operation_id = Some(id);
+        Ok(id)
+    }
+    fn poll(&mut self) -> SelectionEvent {
+        let Some(expected) = self.operation_id else {
+            return SelectionEvent::Pending;
+        };
+        let mut shared = self.overlay.0.lock().unwrap();
+        for event in shared.controller.poll() {
+            match event {
+                VisualOverlayEvent::RectangleConfirmed {
+                    operation_id, rect, ..
+                } if operation_id == expected => {
+                    return SelectionEvent::Confirmed { operation_id, rect };
+                }
+                VisualOverlayEvent::Cancelled { operation_id } if operation_id == expected => {
+                    return SelectionEvent::Cancelled { operation_id };
+                }
+                VisualOverlayEvent::Error {
+                    operation_id,
+                    error,
+                } if operation_id == expected => {
+                    return SelectionEvent::Failed {
+                        operation_id,
+                        message: error.to_string(),
+                    };
+                }
+                other => shared.editor_events.push(other),
+            }
+        }
+        SelectionEvent::Pending
+    }
+    fn cancel(&mut self) {
+        self.overlay.cancel();
+        self.operation_id = None;
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -443,6 +443,7 @@ pub struct LauncherApp {
     snippet_dialog: SnippetDialog,
     macro_dialog: MacroDialog,
     pub mkmacro_dialog: MkMacroDialog,
+    visual_capture_visibility: mkmacro_dialog::visual_capture_visibility::LauncherVisibilityBridge,
     pub(crate) macro_prompt: MacroPromptUi,
     mouse_gestures_dialog: MgGesturesDialog,
     mouse_gesture_settings_dialog: MouseGestureSettingsDialog,
@@ -1322,11 +1323,42 @@ impl LauncherApp {
             .collect::<HashMap<_, _>>();
         let dashboard_data_cache = DashboardDataCache::new();
         dashboard_data_cache.refresh_all(&plugins);
-        let mkmacro_dialog = MkMacroDialog::new_with_authoring_context(
+        let mut mkmacro_dialog = MkMacroDialog::new_with_authoring_context(
             Arc::clone(&plugins.internal_services().mkmacro_store),
             mkmacro_dialog::MkMacroAuthoringContext {
                 launcher_actions: Arc::clone(&actions),
             },
+        );
+        // These dependencies deliberately share the Launcher's visibility and
+        // the Action Editor's one native overlay controller.
+        let screen_backend: Arc<dyn crate::mkmacro::ScreenCaptureBackend> =
+            Arc::new(crate::mkmacro::WindowsScreenCaptureBackend::system());
+        let shared_overlay = mkmacro_dialog.action_editor.visual_overlay.clone();
+        let visual_capture_visibility =
+            mkmacro_dialog::visual_capture_visibility::LauncherVisibilityBridge::default();
+        mkmacro_dialog.action_editor.visual_capture = Some(
+            mkmacro_dialog::visual_capture_workflow::VisualCaptureWorkflow::new(
+                Box::new(
+                    mkmacro_dialog::visual_capture_visibility::LauncherVisualCaptureVisibility(
+                        visual_capture_visibility.clone(),
+                    ),
+                ),
+                Box::new(mkmacro_dialog::visual_capture_workflow::SystemWorkflowClock::default()),
+                Box::new(
+                    mkmacro_dialog::visual_capture_workflow::VisualOverlayRectangleAdapter::new(
+                        shared_overlay,
+                        Arc::clone(&screen_backend),
+                    ),
+                ),
+                Box::new(
+                    mkmacro_dialog::visual_capture_workflow::ScreenCaptureAdapter(screen_backend),
+                ),
+                Box::new(
+                    mkmacro_dialog::visual_capture_workflow::MkMacroAssetStoreAdapter(Arc::clone(
+                        &plugins.internal_services().mkmacro_store,
+                    )),
+                ),
+            ),
         );
         let mut app = Self {
             actions: Arc::clone(&actions),
@@ -1403,6 +1435,7 @@ impl LauncherApp {
             snippet_dialog: SnippetDialog::default(),
             macro_dialog: MacroDialog::default(),
             mkmacro_dialog,
+            visual_capture_visibility,
             macro_prompt: MacroPromptUi::default(),
             mouse_gestures_dialog: MgGesturesDialog::default(),
             mouse_gesture_settings_dialog: MouseGestureSettingsDialog::default(),

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -773,6 +773,35 @@ impl eframe::App for LauncherApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         use egui::*;
 
+        use super::mkmacro_dialog::visual_capture_visibility::VisibilityRequest;
+        match self.visual_capture_visibility.process_frame(
+            self.visible_flag.load(Ordering::SeqCst),
+            self.mkmacro_dialog.open,
+        ) {
+            VisibilityRequest::Hide => {
+                self.visible_flag.store(false, Ordering::SeqCst);
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
+                ctx.request_repaint();
+            }
+            VisibilityRequest::Restore(saved) => {
+                self.mkmacro_dialog.open = saved.mkmacro_dialog;
+                self.visible_flag.store(saved.launcher, Ordering::SeqCst);
+                ctx.send_viewport_cmd(egui::ViewportCommand::Visible(saved.launcher));
+                ctx.request_repaint();
+            }
+            VisibilityRequest::None => {}
+        }
+        if self.visual_capture_visibility.pending()
+            || self
+                .mkmacro_dialog
+                .action_editor
+                .visual_capture
+                .as_ref()
+                .is_some_and(|w| w.active())
+        {
+            ctx.request_repaint();
+        }
+
         self.poll_macro_prompt(ctx);
 
         // tracing::debug!("LauncherApp::update called");


### PR DESCRIPTION
### Motivation

- Provide a production composition for `VisualCaptureWorkflow` in the Launcher/GU I layer so the visibility boundary and rectangle-picker share Launcher-owned state and a single overlay controller.
- Ensure hide/restore semantics are safe on the UI thread and preserve the workflow’s desktop-redraw delay before the picker opens.
- Resolve the ownership conflict between the Action Editor and the workflow over the native overlay controller and harden terminal/cancellation paths.

### Description

- Added a monotonic `SystemWorkflowClock` (`std::time::Instant`-backed) and kept the dependency-injected `VisualCaptureWorkflow::new` for tests. (`src/gui/mkmacro_dialog/visual_capture_workflow.rs`).
- Implemented a cloneable `SharedVisualOverlayController` facade that serialises access to the single `VisualOverlayController` and preserves an editor event queue so only one native queue is polled at a time, and added `VisualOverlayRectangleAdapter` which resolves `virtual_desktop()` immediately before `begin`. (`src/gui/mkmacro_dialog/visual_capture_workflow.rs`).
- Introduced `LauncherVisualCaptureVisibility` / `LauncherVisibilityBridge` as a small UI-thread bridge that snapshots Launcher/MkMacro visibility, requests root-viewport hide, tracks when the hide is observed on the subsequent frame, and can restore the exact prior visibility. (`src/gui/mkmacro_dialog/visual_capture_visibility.rs`).
- Composed production dependencies in `LauncherApp` near `MkMacroDialog::new_with_authoring_context`: shared `WindowsScreenCaptureBackend::system()` backend, the Action Editor’s shared overlay controller, the visibility bridge, the system workflow clock, the rectangle adapter, `ScreenCaptureAdapter`, and `MkMacroAssetStoreAdapter`; installed the workflow into `mkmacro_dialog.action_editor.visual_capture`. (`src/gui/mod.rs`).
- Processed visibility-bridge requests early in `LauncherApp::update` so the root viewport is hidden before `hidden_observed()` becomes true and continued requesting repaint while visibility/workflow transitions are pending. (`src/gui/render.rs`).
- Updated `ActionEditorState` to use the shared overlay handle and to synchronously cancel/drive any active workflow restoration during `apply()` and `cancel()` paths, preserving the existing post-selection semantics for `SearchRegion` vs `ReferenceImageCapture` and draft-token validation. (`src/gui/mkmacro_dialog/action_editor.rs`).
- Kept production `CaptureAdapter` (`ScreenCaptureAdapter`) and asset boundary (`MkMacroAssetStoreAdapter`) with the same transactional semantics as before, and ensured `RectangleOverlay` events are translated into `SelectionEvent` with stale operation IDs ignored and `cancel()` closing the controller. (`src/gui/mkmacro_dialog/visual_capture_workflow.rs`).

### Testing

- Ran `cargo check --target x86_64-pc-windows-gnu` to validate the Windows-target composition and dependency wiring; this completed successfully. (Succeeded)
- Ran `cargo fmt --check` and `git diff --check` to ensure formatting and whitespace checks passed. (Succeeded)
- Attempted `cargo test --target x86_64-pc-windows-gnu visual_capture_workflow --no-run` to exercise the workflow tests, but compiling the full cross-target test dependency graph exceeded the interactive validation window in this environment and did not fully run to completion. (Attempted / partial)
- Verified repository changes and committed the work (commit message: "Compose launcher visual capture workflow"); updated files compiled in the local build runs shown above. (Committed)

Files changed/added: `src/gui/mkmacro_dialog/visual_capture_workflow.rs` (substantial additions), `src/gui/mkmacro_dialog/visual_capture_visibility.rs` (new), `src/gui/mkmacro_dialog/mod.rs`, `src/gui/mkmacro_dialog/action_editor.rs`, `src/gui/mod.rs`, and `src/gui/render.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b12ba2c0483329f08f2f89421fccb)