### PR TITLE
Fix layered overlay window painting

### DIFF
--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -790,10 +790,7 @@ mod tests {
             assert_eq!(frame.first(), Some(&OverlayFramePrimitive::Clear));
             assert_eq!(
                 frame.get(1),
-                selection
-                    .as_ref()
-                    .map(OverlayFramePrimitive::Outline)
-                    .as_ref()
+                selection.map(OverlayFramePrimitive::Outline).as_ref()
             );
         }
     }

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -141,6 +141,91 @@ impl OverlayVisual {
     }
 }
 
+/// Platform-neutral description of the pixels a native overlay must produce.
+/// The clear is deliberately first so repainting cannot leave an old drag
+/// rectangle behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OverlayFramePrimitive {
+    Clear,
+    Outline(ScreenRect),
+    MonitorLabel { bounds: ScreenRect, index: usize },
+}
+
+pub(crate) fn overlay_frame(visual: &OverlayVisual) -> Vec<OverlayFramePrimitive> {
+    let mut frame = vec![OverlayFramePrimitive::Clear];
+    match visual {
+        OverlayVisual::RectanglePicker { selection, .. } => {
+            if let Some(rect) = selection {
+                frame.push(OverlayFramePrimitive::Outline(*rect));
+            }
+        }
+        OverlayVisual::RectanglePreview(rect) | OverlayVisual::Window { rect, .. } => {
+            frame.push(OverlayFramePrimitive::Outline(*rect))
+        }
+        OverlayVisual::Monitor(monitor) => {
+            frame.push(OverlayFramePrimitive::Outline(monitor.bounds));
+            frame.push(OverlayFramePrimitive::MonitorLabel {
+                bounds: monitor.bounds,
+                index: monitor.index,
+            });
+        }
+        OverlayVisual::Monitors(monitors) => {
+            for monitor in monitors {
+                frame.push(OverlayFramePrimitive::Outline(monitor.bounds));
+                frame.push(OverlayFramePrimitive::MonitorLabel {
+                    bounds: monitor.bounds,
+                    index: monitor.index,
+                });
+            }
+        }
+    }
+    frame
+}
+
+pub(crate) fn intersecting_monitor_bounds(
+    monitors: &[ScreenRect],
+    target: ScreenRect,
+) -> Vec<ScreenRect> {
+    monitors
+        .iter()
+        .copied()
+        .filter(|m| {
+            i64::from(m.x) < target.right()
+                && i64::from(target.x) < m.right()
+                && i64::from(m.y) < target.bottom()
+                && i64::from(target.y) < m.bottom()
+        })
+        .collect()
+}
+
+pub(crate) fn desktop_to_overlay(rect: ScreenRect, origin: ScreenRect) -> (i64, i64, i64, i64) {
+    let left = i64::from(rect.x) - i64::from(origin.x);
+    let top = i64::from(rect.y) - i64::from(origin.y);
+    (
+        left,
+        top,
+        left + i64::from(rect.width),
+        top + i64::from(rect.height),
+    )
+}
+
+pub(crate) fn monitor_union(monitors: &[MonitorDescriptor]) -> Option<ScreenRect> {
+    monitors.iter().map(|m| m.bounds).reduce(|a, b| {
+        let left = a.x.min(b.x);
+        let top = a.y.min(b.y);
+        ScreenRect::new(
+            left,
+            top,
+            (a.right().max(b.right()) - i64::from(left)) as u32,
+            (a.bottom().max(b.bottom()) - i64::from(top)) as u32,
+        )
+    })
+}
+
+pub(crate) fn overlay_is_mouse_transparent(visual: &OverlayVisual) -> bool {
+    visual.passive()
+}
+
 /// Isolates native windows, input, painting and resource ownership from the
 /// deterministic state machine.
 pub trait OverlayRenderer: Send {
@@ -418,6 +503,9 @@ impl VisualOverlayController {
                     return;
                 };
                 *current = Some(point);
+                // Publish the final pointer position through the same repaint
+                // path as press/move before confirmation tears the windows down.
+                self.repaint_picker();
                 self.confirm_picker();
             }
             OverlayInputKind::Enter => self.confirm_picker(),
@@ -544,6 +632,7 @@ mod tests {
         inputs: Vec<OverlayInput>,
         closes: usize,
         transparent: Vec<bool>,
+        repaints: Vec<OverlayVisual>,
     }
     struct FakeRenderer(Arc<Mutex<FakeData>>);
     impl OverlayRenderer for FakeRenderer {
@@ -556,7 +645,12 @@ mod tests {
             self.0.lock().unwrap().transparent.push(transparent);
             Ok(())
         }
-        fn repaint(&mut self, _: OperationId, _: &OverlayVisual) -> Result<(), VisualOverlayError> {
+        fn repaint(
+            &mut self,
+            _: OperationId,
+            visual: &OverlayVisual,
+        ) -> Result<(), VisualOverlayError> {
+            self.0.lock().unwrap().repaints.push(visual.clone());
             Ok(())
         }
         fn poll_input(&mut self) -> Result<Vec<OverlayInput>, VisualOverlayError> {
@@ -625,6 +719,82 @@ mod tests {
             (point(1200, 900), point(500, 300)),
         ] {
             assert_eq!(normalized_rect(a, b).unwrap(), expected);
+        }
+    }
+
+    fn monitor(index: usize, bounds: ScreenRect) -> MonitorDescriptor {
+        MonitorDescriptor {
+            index,
+            bounds,
+            primary: index == 1,
+        }
+    }
+
+    #[test]
+    fn monitor_selection_handles_negative_origins_spans_and_irregular_gaps() {
+        let monitors = [
+            ScreenRect::new(-1920, -200, 1920, 1080),
+            ScreenRect::new(0, 0, 1920, 1080),
+            ScreenRect::new(2500, -1200, 1200, 900),
+        ];
+        assert_eq!(
+            intersecting_monitor_bounds(&monitors, ScreenRect::new(-100, -100, 300, 300)),
+            vec![monitors[0], monitors[1]]
+        );
+        assert!(
+            intersecting_monitor_bounds(&monitors, ScreenRect::new(2100, 100, 200, 200)).is_empty()
+        );
+        assert_eq!(
+            desktop_to_overlay(ScreenRect::new(-1800, -100, 20, 30), monitors[0]),
+            (120, 100, 140, 130)
+        );
+    }
+
+    #[test]
+    fn monitor_identification_union_preserves_signed_extents_and_gaps() {
+        let monitors = vec![
+            monitor(1, ScreenRect::new(-1600, 100, 1600, 900)),
+            monitor(2, ScreenRect::new(400, -800, 1000, 700)),
+        ];
+        assert_eq!(
+            monitor_union(&monitors),
+            Some(ScreenRect::new(-1600, -800, 3000, 1800))
+        );
+        assert_eq!(monitor_union(&[]), None);
+    }
+
+    #[test]
+    fn picker_style_is_interactive_and_passive_styles_are_mouse_transparent() {
+        let picker = OverlayVisual::RectanglePicker {
+            virtual_desktop: ScreenRect::new(0, 0, 1, 1),
+            selection: None,
+        };
+        assert!(!overlay_is_mouse_transparent(&picker));
+        assert!(overlay_is_mouse_transparent(
+            &OverlayVisual::RectanglePreview(ScreenRect::new(0, 0, 1, 1))
+        ));
+        assert!(overlay_is_mouse_transparent(&OverlayVisual::Monitor(
+            monitor(1, ScreenRect::new(0, 0, 1, 1))
+        )));
+    }
+
+    #[test]
+    fn every_repaint_frame_clears_before_drawing_the_new_selection() {
+        let old = ScreenRect::new(-20, -20, 10, 10);
+        let new = ScreenRect::new(20, 20, 30, 30);
+        for selection in [Some(old), Some(new), None] {
+            let frame = overlay_frame(&OverlayVisual::RectanglePicker {
+                virtual_desktop: ScreenRect::new(-100, -100, 200, 200),
+                selection,
+            });
+            assert_eq!(frame.first(), Some(&OverlayFramePrimitive::Clear));
+            assert_eq!(
+                frame.get(1),
+                selection
+                    .as_ref()
+                    .map(OverlayFramePrimitive::Outline)
+                    .as_ref()
+            );
         }
     }
 

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -1,36 +1,49 @@
-//! Win32 implementation of the overlay renderer.
-//!
-//! A separate popup is used for every physical display.  This avoids holes in
-//! non-rectangular monitor arrangements and, because every conversion starts
-//! with the popup's signed origin, also handles displays above/left of primary.
+//! Win32 color-key overlay renderer.  There is deliberately one popup per
+//! physical monitor: a single virtual-desktop popup would cover monitor gaps.
 use super::*;
 use windows::{
+    core::PCWSTR,
     Win32::{
-        Foundation::{COLORREF, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+        Foundation::{
+            GetLastError, COLORREF, ERROR_CLASS_ALREADY_EXISTS, HWND, LPARAM, LRESULT, POINT, RECT,
+            WPARAM,
+        },
         Graphics::Gdi::{
-            CreatePen, DeleteObject, EnumDisplayMonitors, GetDC, GetMonitorInfoW, HDC, HGDIOBJ,
-            HMONITOR, MONITORINFO, PS_SOLID, Rectangle, ReleaseDC, SelectObject, SetBkMode,
-            SetTextColor, TRANSPARENT, TextOutW,
+            BeginPaint, CreatePen, CreateSolidBrush, DeleteObject, EndPaint, EnumDisplayMonitors,
+            FillRect, GetMonitorInfoW, GetStockObject, InvalidateRect, Rectangle, SelectObject,
+            SetBkMode, SetTextColor, TextOutW, UpdateWindow, HDC, HGDIOBJ, HMONITOR, MONITORINFO,
+            NULL_BRUSH, PAINTSTRUCT, PS_SOLID, TRANSPARENT,
         },
         System::LibraryLoader::GetModuleHandleW,
         UI::{
             Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON},
             WindowsAndMessaging::{
-                CS_HREDRAW, CS_VREDRAW, CreateWindowExW, DefWindowProcW, DestroyWindow,
-                DispatchMessageW, GetCursorPos, HWND_TOPMOST, MSG, PM_REMOVE, PeekMessageW,
-                RegisterClassW, SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_SHOWWINDOW, SetWindowPos,
-                ShowWindow, TranslateMessage, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE,
-                WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
+                CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetCursorPos,
+                GetWindowLongPtrW, PeekMessageW, RegisterClassW, SetLayeredWindowAttributes,
+                SetWindowLongPtrW, SetWindowPos, ShowWindow, TranslateMessage, CREATESTRUCTW,
+                CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HWND_TOPMOST, LWA_COLORKEY, MSG, PM_REMOVE,
+                SWP_NOACTIVATE, SWP_SHOWWINDOW, SW_SHOWNOACTIVATE, WM_ERASEBKGND, WM_NCCREATE,
+                WM_PAINT, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+                WS_EX_TRANSPARENT, WS_POPUP,
             },
         },
     },
-    core::PCWSTR,
 };
 
-#[derive(Clone, Copy)]
+// COLORREF is 0x00bbggrr. Magenta is reserved exclusively for transparency.
+const TRANSPARENT_KEY: COLORREF = COLORREF(0x00ff00ff);
+const OUTLINE_COLOR: COLORREF = COLORREF(0x0000ffff); // bright yellow
+const BADGE_COLOR: COLORREF = COLORREF(0x00400000); // dark blue
+const LABEL_COLOR: COLORREF = COLORREF(0x00ffffff);
+
+struct WindowPaintState {
+    bounds: ScreenRect,
+    frame: Vec<OverlayFramePrimitive>,
+}
 struct OverlayWindow {
     hwnd: HWND,
-    bounds: ScreenRect,
+    // The pointee address stays stable while wndproc reads it through GWLP_USERDATA.
+    state: Box<WindowPaintState>,
 }
 
 pub(super) struct NativeOverlayRenderer {
@@ -61,7 +74,82 @@ fn platform(message: impl Into<String>) -> VisualOverlayError {
 }
 
 unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, w: WPARAM, l: LPARAM) -> LRESULT {
-    unsafe { DefWindowProcW(hwnd, msg, w, l) }
+    if msg == WM_NCCREATE {
+        let create = unsafe { &*(l.0 as *const CREATESTRUCTW) };
+        unsafe { SetWindowLongPtrW(hwnd, GWLP_USERDATA, create.lpCreateParams as isize) };
+    }
+    let state = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const WindowPaintState };
+    match msg {
+        WM_ERASEBKGND => LRESULT(1), // WM_PAINT owns clearing the complete surface.
+        WM_PAINT if !state.is_null() => {
+            let mut ps = PAINTSTRUCT::default();
+            let dc = unsafe { BeginPaint(hwnd, &mut ps) };
+            unsafe { paint_frame(dc, &*state) };
+            unsafe {
+                let _ = EndPaint(hwnd, &ps);
+            };
+            LRESULT(0)
+        }
+        _ => unsafe { DefWindowProcW(hwnd, msg, w, l) },
+    }
+}
+
+unsafe fn paint_frame(dc: HDC, state: &WindowPaintState) {
+    let client = RECT {
+        left: 0,
+        top: 0,
+        right: state.bounds.width as i32,
+        bottom: state.bounds.height as i32,
+    };
+    let clear = unsafe { CreateSolidBrush(TRANSPARENT_KEY) };
+    unsafe { FillRect(dc, &client, clear) };
+    unsafe {
+        let _ = DeleteObject(HGDIOBJ(clear.0));
+    };
+
+    let pen = unsafe { CreatePen(PS_SOLID, 5, OUTLINE_COLOR) };
+    let old_pen = unsafe { SelectObject(dc, HGDIOBJ(pen.0)) };
+    let old_brush = unsafe { SelectObject(dc, GetStockObject(NULL_BRUSH)) };
+    for primitive in &state.frame {
+        match primitive {
+            OverlayFramePrimitive::Clear => {}
+            OverlayFramePrimitive::Outline(rect) => {
+                let (left, top, right, bottom) = desktop_to_overlay(*rect, state.bounds);
+                unsafe {
+                    let _ = Rectangle(dc, left as i32, top as i32, right as i32, bottom as i32);
+                };
+            }
+            OverlayFramePrimitive::MonitorLabel { bounds, index } => unsafe {
+                draw_label(dc, state.bounds, *bounds, *index)
+            },
+        }
+    }
+    unsafe { SelectObject(dc, old_brush) };
+    unsafe { SelectObject(dc, old_pen) };
+    unsafe {
+        let _ = DeleteObject(HGDIOBJ(pen.0));
+    };
+}
+
+unsafe fn draw_label(dc: HDC, origin: ScreenRect, bounds: ScreenRect, index: usize) {
+    let (left, top, _, _) = desktop_to_overlay(bounds, origin);
+    let badge = RECT {
+        left: left as i32 + 24,
+        top: top as i32 + 24,
+        right: left as i32 + 86,
+        bottom: top as i32 + 66,
+    };
+    let brush = unsafe { CreateSolidBrush(BADGE_COLOR) };
+    unsafe { FillRect(dc, &badge, brush) };
+    unsafe {
+        let _ = DeleteObject(HGDIOBJ(brush.0));
+    };
+    let text: Vec<u16> = index.to_string().encode_utf16().collect();
+    unsafe { SetBkMode(dc, TRANSPARENT) };
+    unsafe { SetTextColor(dc, LABEL_COLOR) };
+    unsafe {
+        let _ = TextOutW(dc, badge.left + 18, badge.top + 12, &text);
+    };
 }
 
 fn displays() -> Vec<ScreenRect> {
@@ -101,72 +189,22 @@ fn displays() -> Vec<ScreenRect> {
     result
 }
 
-fn intersects(a: ScreenRect, b: ScreenRect) -> bool {
-    i64::from(a.x) < b.right()
-        && i64::from(b.x) < a.right()
-        && i64::from(a.y) < b.bottom()
-        && i64::from(b.y) < a.bottom()
-}
-
 impl NativeOverlayRenderer {
-    fn paint(&self) {
-        for window in &self.windows {
-            let Some(visual) = &self.visual else { continue };
-            unsafe {
-                let dc = GetDC(window.hwnd);
-                if dc.0.is_null() {
-                    continue;
-                }
-                let pen = CreatePen(PS_SOLID, 5, COLORREF(0x0000ffff));
-                let old = SelectObject(dc, HGDIOBJ(pen.0));
-                let outline = |r: ScreenRect| {
-                    let x = i64::from(r.x) - i64::from(window.bounds.x);
-                    let y = i64::from(r.y) - i64::from(window.bounds.y);
-                    let _ = Rectangle(
-                        dc,
-                        x as i32,
-                        y as i32,
-                        (x + i64::from(r.width)) as i32,
-                        (y + i64::from(r.height)) as i32,
-                    );
-                };
-                match visual {
-                    OverlayVisual::RectanglePicker { selection, .. } => {
-                        if let Some(r) = selection {
-                            outline(*r);
-                        }
-                    }
-                    OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => {
-                        outline(*r)
-                    }
-                    OverlayVisual::Monitor(d) => {
-                        outline(d.bounds);
-                        draw_label(dc, window.bounds, d);
-                    }
-                    OverlayVisual::Monitors(ds) => {
-                        for d in ds {
-                            outline(d.bounds);
-                            draw_label(dc, window.bounds, d);
-                        }
-                    }
-                }
-                SelectObject(dc, old);
-                let _ = DeleteObject(HGDIOBJ(pen.0));
-                ReleaseDC(window.hwnd, dc);
-            }
+    fn target(visual: &OverlayVisual) -> Option<ScreenRect> {
+        match visual {
+            OverlayVisual::RectanglePicker {
+                virtual_desktop, ..
+            } => Some(*virtual_desktop),
+            OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => Some(*r),
+            OverlayVisual::Monitor(d) => Some(d.bounds),
+            OverlayVisual::Monitors(ds) => monitor_union(ds),
         }
     }
-}
-
-unsafe fn draw_label(dc: HDC, origin: ScreenRect, descriptor: &MonitorDescriptor) {
-    let text: Vec<u16> = descriptor.index.to_string().encode_utf16().collect();
-    unsafe {
-        SetBkMode(dc, TRANSPARENT);
-        SetTextColor(dc, COLORREF(0x0000ffff));
+    fn fail<T>(&mut self, message: impl Into<String>) -> Result<T, VisualOverlayError> {
+        let error = platform(message);
+        self.close();
+        Err(error)
     }
-    let x = i64::from(descriptor.bounds.x) - i64::from(origin.x) + 30;
-    let y = i64::from(descriptor.bounds.y) - i64::from(origin.y) + 30;
-    let _ = unsafe { TextOutW(dc, x as i32, y as i32, &text) };
 }
 
 impl OverlayRenderer for NativeOverlayRenderer {
@@ -174,7 +212,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
         &mut self,
         operation_id: OperationId,
         visual: &OverlayVisual,
-        mouse_transparent: bool,
+        _mouse_transparent: bool,
     ) -> Result<(), VisualOverlayError> {
         self.close();
         let module = unsafe { GetModuleHandleW(None) }
@@ -187,34 +225,31 @@ impl OverlayRenderer for NativeOverlayRenderer {
             style: CS_HREDRAW | CS_VREDRAW,
             ..Default::default()
         };
-        unsafe {
-            RegisterClassW(&wc);
+        if unsafe { RegisterClassW(&wc) } == 0
+            && unsafe { GetLastError() } != ERROR_CLASS_ALREADY_EXISTS
+        {
+            return self.fail(format!("overlay class registration failed: {}", unsafe {
+                GetLastError().0
+            }));
         }
-        let target = match visual {
-            OverlayVisual::RectanglePicker {
-                virtual_desktop, ..
-            } => *virtual_desktop,
-            OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => *r,
-            OverlayVisual::Monitor(d) => d.bounds,
-            OverlayVisual::Monitors(ds) => ds
-                .iter()
-                .map(|d| d.bounds)
-                .reduce(|a, b| {
-                    ScreenRect::new(
-                        a.x.min(b.x),
-                        a.y.min(b.y),
-                        (a.right().max(b.right()) - i64::from(a.x.min(b.x))) as u32,
-                        (a.bottom().max(b.bottom()) - i64::from(a.y.min(b.y))) as u32,
-                    )
-                })
-                .unwrap_or(ScreenRect::new(0, 0, 0, 0)),
+        let Some(target) = Self::target(visual) else {
+            return self.fail("No physical display intersects the requested preview region");
         };
-        for bounds in displays().into_iter().filter(|b| intersects(*b, target)) {
+        let monitor_bounds = intersecting_monitor_bounds(&displays(), target);
+        if monitor_bounds.is_empty() {
+            return self.fail("No physical display intersects the requested preview region");
+        }
+        let frame = overlay_frame(visual);
+        for bounds in monitor_bounds {
+            let mut state = Box::new(WindowPaintState {
+                bounds,
+                frame: frame.clone(),
+            });
             let mut ex = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
-            if mouse_transparent {
+            if overlay_is_mouse_transparent(visual) {
                 ex |= WS_EX_TRANSPARENT;
             }
-            let hwnd = unsafe {
+            let created = unsafe {
                 CreateWindowExW(
                     ex,
                     class,
@@ -227,11 +262,20 @@ impl OverlayRenderer for NativeOverlayRenderer {
                     None,
                     None,
                     module,
-                    None,
+                    Some(state.as_mut() as *mut _ as *const _),
                 )
+            };
+            let hwnd = match created {
+                Ok(hwnd) => hwnd,
+                Err(e) => return self.fail(format!("overlay window creation failed: {e}")),
+            };
+            self.windows.push(OverlayWindow { hwnd, state });
+            if let Err(e) =
+                unsafe { SetLayeredWindowAttributes(hwnd, TRANSPARENT_KEY, 0, LWA_COLORKEY) }
+            {
+                return self.fail(format!("overlay layered configuration failed: {e}"));
             }
-            .map_err(|e| platform(format!("overlay window creation failed: {e}")))?;
-            unsafe {
+            if let Err(e) = unsafe {
                 SetWindowPos(
                     hwnd,
                     HWND_TOPMOST,
@@ -241,30 +285,48 @@ impl OverlayRenderer for NativeOverlayRenderer {
                     bounds.height as i32,
                     SWP_NOACTIVATE | SWP_SHOWWINDOW,
                 )
-                .map_err(|e| platform(format!("overlay positioning failed: {e}")))?;
+            } {
+                return self.fail(format!("overlay positioning failed: {e}"));
+            }
+            unsafe {
                 let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
             }
-            self.windows.push(OverlayWindow { hwnd, bounds });
-        }
-        if self.windows.is_empty() {
-            return Err(platform("no physical display intersects the overlay"));
+            if !unsafe { InvalidateRect(hwnd, None, false) }.as_bool()
+                || !unsafe { UpdateWindow(hwnd) }.as_bool()
+            {
+                return self.fail(format!("overlay initial paint failed: {}", unsafe {
+                    GetLastError().0
+                }));
+            }
         }
         self.operation_id = Some(operation_id);
         self.visual = Some(visual.clone());
-        self.paint();
         Ok(())
     }
+
     fn repaint(
         &mut self,
         operation_id: OperationId,
         visual: &OverlayVisual,
     ) -> Result<(), VisualOverlayError> {
-        if self.operation_id == Some(operation_id) {
-            self.visual = Some(visual.clone());
-            self.paint();
+        if self.operation_id != Some(operation_id) {
+            return Ok(());
+        }
+        let frame = overlay_frame(visual);
+        self.visual = Some(visual.clone());
+        for window in &mut self.windows {
+            window.state.frame.clone_from(&frame);
+            if !unsafe { InvalidateRect(window.hwnd, None, false) }.as_bool()
+                || !unsafe { UpdateWindow(window.hwnd) }.as_bool()
+            {
+                return Err(platform(format!("overlay repaint failed: {}", unsafe {
+                    GetLastError().0
+                })));
+            }
         }
         Ok(())
     }
+
     fn poll_input(&mut self) -> Result<Vec<OverlayInput>, VisualOverlayError> {
         let mut msg = MSG::default();
         while unsafe { PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE) }.as_bool() {
@@ -310,15 +372,18 @@ impl OverlayRenderer for NativeOverlayRenderer {
         self.escape_down = esc;
         Ok(out)
     }
+
     fn close(&mut self) {
-        for w in self.windows.drain(..) {
+        for window in self.windows.drain(..) {
             unsafe {
-                let _ = DestroyWindow(w.hwnd);
+                SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);
+                let _ = DestroyWindow(window.hwnd);
             }
         }
         self.operation_id = None;
         self.visual = None;
         self.left_down = false;
+        self.escape_down = false;
     }
 }
 impl Drop for NativeOverlayRenderer {


### PR DESCRIPTION
### Motivation

- Make the Win32 overlay implementation robust and repaint-safe by using a single, complete layered-window color-key strategy and avoid mixed/competing approaches. 
- Preserve the existing one-window-per-physical-monitor architecture and signed virtual-desktop coordinate behavior while making the rectangle picker interactive and passive overlays mouse-transparent.

### Description

- Implemented a color-key layered-window renderer on Windows that uses `WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE`, reserves a magenta `TRANSPARENT_KEY`, and configures each HWND with `SetLayeredWindowAttributes` immediately after creation.
- Replaced one-shot `GetDC`/`ReleaseDC` painting with a paint-safe `WM_PAINT` path using `BeginPaint`/`EndPaint`, suppressed default erasure via `WM_ERASEBKGND`, and store per-window `WindowPaintState` (frame primitives) accessible from `wndproc` via `GWLP_USERDATA`.
- Made construction transactional: class registration, per-monitor window creation, layered configuration, positioning, and initial paint failures clean up all created HWNDs and return a contextual `VisualOverlayError` when no physical displays intersect the requested visual.
- Added a small platform-neutral rendering model and helpers (`OverlayFramePrimitive`, `overlay_frame`, `intersecting_monitor_bounds`, `desktop_to_overlay`, `monitor_union`, `overlay_is_mouse_transparent`) and adjusted the controller so press/move/release all repaint through the same `OverlayRenderer::repaint` path; monitor labels now use filled badges and high-contrast colors.

### Testing

- Ran `rustfmt` on the modified files (`visual_overlay.rs`, `visual_overlay_windows.rs`).
- Ran `cargo check --target x86_64-pc-windows-gnu --lib`; the Windows-target check completed after installing the required cross-toolchain packages (mingw) and development headers.
- Added and exercised pure-Rust unit tests (monitor intersection/union, desktop-to-overlay conversion, passive vs interactive style, and frame primitives including clear-first repaint behavior); those pure helpers were covered by `cargo test` where the host environment could run them and they passed.
- Attempted to run the full Windows-gated integration tests in this environment but they could not be completed due to missing platform/system dependencies (native X11/ALSA development packages and other platform-specific libraries), so Win32 API behavior is covered by the code changes and designed to be testable via a Win32 seam in Windows CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b181b77748332a3161e2e174c44a7)