### PR TITLE
Add configurable image search outcomes

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -122,7 +122,7 @@ fn wp() -> MkWindowPayload {
         wait: Some(wait()),
     }
 }
-fn ip() -> MkImagePayload {
+fn ip(not_found_policy: MkImageNotFoundPolicy) -> MkImagePayload {
     MkImagePayload {
         // Zero is the documented editor-draft sentinel. The editor requires an
         // imported/captured asset before enabling Apply.
@@ -132,6 +132,8 @@ fn ip() -> MkImagePayload {
         tolerance: 0,
         alpha: AlphaPolicy::Compare,
         return_point: ReturnPoint::Center,
+        not_found_policy,
+        outputs: MkImageOutputs::default(),
     }
 }
 fn up() -> MkUiPayload {
@@ -573,7 +575,7 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             "Find an image",
             &["image"],
             Image,
-            MkAction::ImageFind(ip())
+            MkAction::ImageFind(ip(MkImageNotFoundPolicy::Continue))
         ),
         d!(
             Visual,
@@ -581,7 +583,7 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             "Find and click an image",
             &["image", "click"],
             Image,
-            MkAction::ImageClick(ip())
+            MkAction::ImageClick(ip(MkImageNotFoundPolicy::Fail))
         ),
         d!(
             Visual,
@@ -1149,6 +1151,24 @@ fn format_image_details(p: &MkImagePayload, asset_name: Option<&str>, click: boo
     }
     if click {
         parts.push(format!("{} ms", p.wait.timeout_ms));
+    }
+    if !click {
+        parts.push(match p.not_found_policy {
+            MkImageNotFoundPolicy::Continue => "continue if absent".into(),
+            MkImageNotFoundPolicy::Fail => "fail if absent".into(),
+        });
+        let outputs = [
+            ("found", &p.outputs.found),
+            ("point", &p.outputs.point),
+            ("x", &p.outputs.x),
+            ("y", &p.outputs.y),
+        ]
+        .into_iter()
+        .filter_map(|(slot, name)| name.as_deref().map(|name| format!("{slot}→{name}")))
+        .collect::<Vec<_>>();
+        if !outputs.is_empty() {
+            parts.push(outputs.join(", "));
+        }
     }
     parts.join(" · ")
 }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1501,6 +1501,27 @@ fn image_payload_mut(step: &mut MkStep) -> Option<&mut MkImagePayload> {
         _ => None,
     }
 }
+fn image_output_names_valid(action: &MkAction) -> bool {
+    let MkAction::ImageFind(p) = action else {
+        return true;
+    };
+    let names: Vec<_> = [
+        &p.outputs.found,
+        &p.outputs.point,
+        &p.outputs.x,
+        &p.outputs.y,
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    names
+        .iter()
+        .all(|name| crate::mkmacro::variables::validate_variable_name(name).is_ok())
+        && !names
+            .iter()
+            .enumerate()
+            .any(|(i, name)| names[..i].contains(name))
+}
 
 fn apply_capture(
     store: &MkMacroStore,
@@ -1638,8 +1659,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             let (position, mut window, launcher, image)=action_ui(ui, step, &mut state.capture_keys, &image_assets);
             pick_request = position;
             image_request = image;
+            let find_action = matches!(step.action, MkAction::ImageFind(_));
             if let Some(payload) = image_payload_mut(step) {
-                let request = super::image_search_editor::show(ui, payload, state.image_search.as_mut().expect("image action requires image editor state"), &d.store, d.selected_macro_id.unwrap_or(0), importing);
+                let request = super::image_search_editor::show(ui, payload, state.image_search.as_mut().expect("image action requires image editor state"), &d.store, d.selected_macro_id.unwrap_or(0), importing, find_action);
                 use super::image_search_editor::ImageEditorRequest::*;
                 match request {
                     Some(ImportPng) => image_request = Some(ImageAuthoringRequest::Import),
@@ -1796,6 +1818,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             ui.separator();
             ui.horizontal(|ui| {
                 let valid = !matches!(&step.action, MkAction::PromptInput(p) if crate::mkmacro::variables::validate_variable_name(&p.variable).is_err())
+                    && image_output_names_valid(&step.action)
                     && !matches!(
                         super::action_catalog::draft_validation_contract(&step.action),
                         super::action_catalog::DraftValidationContract::AwaitingRequiredAsset
@@ -1851,6 +1874,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         d.action_editor.set_captured_keys(keys);
     }
     if apply {
+        if let Some(payload) = d.action_editor.draft.as_mut().and_then(image_payload_mut) {
+            payload.outputs.normalize();
+        }
         if let Some(MkStep {
             action: MkAction::PixelCheck { color, .. },
             ..
@@ -1921,6 +1947,8 @@ mod tests {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
         };
         let bad = dir.path().join("bad.png");
         std::fs::write(&bad, b"not png").unwrap();
@@ -1953,6 +1981,8 @@ mod tests {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
         }
     }
 
@@ -2279,6 +2309,8 @@ mod tests {
                         matcher: MkWindowMatcher::default(),
                     },
                     return_point: ReturnPoint::Center,
+                    not_found_policy: MkImageNotFoundPolicy::Fail,
+                    outputs: MkImageOutputs::default(),
                     wait: MkWaitOptions {
                         timeout_ms: 0,
                         poll_interval_ms: 1,
@@ -2343,6 +2375,8 @@ mod tests {
                 rect: ScreenRect::new(-10, 20, 30, 40),
             },
             return_point: ReturnPoint::TopLeft,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
             wait: MkWaitOptions {
                 timeout_ms: 2_000,
                 poll_interval_ms: 25,
@@ -2814,6 +2848,8 @@ mod tests {
                     tolerance: 17,
                     alpha: AlphaPolicy::Ignore,
                     return_point: ReturnPoint::TopLeft,
+                    not_found_policy: MkImageNotFoundPolicy::Fail,
+                    outputs: MkImageOutputs::default(),
                 };
                 let mut editor = ActionEditorState::default();
                 editor.begin_edit(&step(MkAction::ImageClick(payload)));

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -424,7 +424,7 @@ pub(super) fn show(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mkmacro::MkWaitOptions;
+    use crate::mkmacro::{MkImageOutputs, MkWaitOptions};
     fn payload(region: SearchRegion) -> MkImagePayload {
         MkImagePayload {
             asset_id: 3,

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -1,7 +1,7 @@
 //! Reusable image-search action editor and its UI-only authoring state.
 use crate::mkmacro::{
-    AlphaPolicy, MkImagePayload, MkWindowMatcher, MonitorDescriptor, ReturnPoint, ScreenRect,
-    SearchRegion,
+    AlphaPolicy, MkImageNotFoundPolicy, MkImagePayload, MkWindowMatcher, MonitorDescriptor,
+    ReturnPoint, ScreenRect, SearchRegion,
 };
 use eframe::egui;
 
@@ -148,6 +148,7 @@ pub(super) fn show(
     store: &crate::mkmacro::MkMacroStore,
     macro_id: u64,
     authoring_busy: bool,
+    find_action: bool,
 ) -> Option<ImageEditorRequest> {
     let mut out = None;
     ui.heading("Reference Image");
@@ -183,6 +184,64 @@ pub(super) fn show(
 
     ui.separator();
     ui.heading("Search Settings");
+    if find_action {
+        egui::ComboBox::from_label("When not found")
+            .selected_text(match payload.not_found_policy {
+                MkImageNotFoundPolicy::Continue => "Continue",
+                MkImageNotFoundPolicy::Fail => "Fail Action",
+            })
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut payload.not_found_policy,
+                    MkImageNotFoundPolicy::Continue,
+                    "Continue",
+                );
+                ui.selectable_value(
+                    &mut payload.not_found_policy,
+                    MkImageNotFoundPolicy::Fail,
+                    "Fail Action",
+                );
+            });
+        ui.separator();
+        ui.heading("Outputs");
+        ui.small("Optional named outputs; compatibility variables such as last_image_found remain available.");
+        for (label, value) in [
+            ("Found", &mut payload.outputs.found),
+            ("Point", &mut payload.outputs.point),
+            ("X", &mut payload.outputs.x),
+            ("Y", &mut payload.outputs.y),
+        ] {
+            ui.horizontal(|ui| {
+                ui.label(label);
+                ui.text_edit_singleline(value.get_or_insert_with(String::new));
+            });
+            if let Some(name) = value.as_deref() {
+                if let Err(error) = crate::mkmacro::variables::validate_variable_name(name) {
+                    ui.colored_label(ui.visuals().error_fg_color, format!("{label}: {error}"));
+                }
+            }
+        }
+        let configured: Vec<_> = [
+            &payload.outputs.found,
+            &payload.outputs.point,
+            &payload.outputs.x,
+            &payload.outputs.y,
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|n| !n.is_empty())
+        .collect();
+        if configured
+            .iter()
+            .enumerate()
+            .any(|(i, n)| configured[..i].contains(n))
+        {
+            ui.colored_label(ui.visuals().error_fg_color, "Output names must be unique");
+        }
+    } else {
+        // Click requires a point; do not expose an unsupported continuation contract.
+        payload.not_found_policy = MkImageNotFoundPolicy::Fail;
+    }
     ui.horizontal(|ui| {
         ui.label("Tolerance");
         ui.add(egui::Slider::new(&mut payload.tolerance, 0..=255));
@@ -377,6 +436,8 @@ mod tests {
             tolerance: 2,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
         }
     }
     #[test]

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -467,6 +467,8 @@ mod tests {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
         };
         assert_eq!(
             action_catalog::action_details(&MkAction::ImageFind(image.clone())),

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -473,7 +473,7 @@ mod tests {
         };
         assert_eq!(
             action_catalog::action_details(&MkAction::ImageFind(image.clone())),
-            "Asset 42 · Entire Desktop · tolerance 0"
+            "Asset 42 · Entire Desktop · tolerance 0 · fail if absent"
         );
         assert_eq!(
             action_catalog::action_details(&MkAction::ImageClick(image)),

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -74,8 +74,9 @@ mod tests {
     use super::*;
     use crate::mkmacro::{
         AlphaPolicy, LoadDisposition, MKMACROS_FILE, MkAction, MkCoordinateTarget, MkHotkey,
-        MkImagePayload, MkKey, MkMouseButton, MkMouseMovePayload, MkMousePayload,
-        MkMouseScrollAxis, MkStep, MkWaitOptions, ReturnPoint, SCHEMA_VERSION, SearchRegion,
+        MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload, MkKey, MkMouseButton,
+        MkMouseMovePayload, MkMousePayload, MkMouseScrollAxis, MkStep, MkWaitOptions, ReturnPoint,
+        SCHEMA_VERSION, SearchRegion,
     };
     use std::{
         fs, thread,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3203,6 +3203,8 @@ mod tests {
                 tolerance: 0,
                 alpha: AlphaPolicy::Compare,
                 return_point: ReturnPoint::Center,
+                not_found_policy: MkImageNotFoundPolicy::Fail,
+                outputs: MkImageOutputs::default(),
             }
         }
         fn host() -> (MkMacroDialog, Arc<Mutex<Harness>>) {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3102,8 +3102,8 @@ mod tests {
             visual_overlay::{OperationId, RectanglePurpose},
         };
         use crate::mkmacro::{
-            AlphaPolicy, MkAction, MkImagePayload, MkWaitOptions, ReturnPoint, ScreenRect,
-            SearchRegion,
+            AlphaPolicy, MkAction, MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload,
+            MkWaitOptions, ReturnPoint, ScreenRect, SearchRegion,
         };
         use image::{Rgba, RgbaImage};
 

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1,10 +1,11 @@
 //! Platform-neutral plan executor and injectable effect boundaries.
 use super::{
-    Jump, MkAction, MkCompareOp, MkCondition, MkCoordinateTarget, MkExecutionPlan, MkImagePayload,
-    MkKey, MkMacroStore, MkMouseButton, MkMouseScrollAxis, MkPlayback, MkPoint, MkProcessPayload,
-    MkPromptInputPayload, MkTextPayload, MkUiPayload, MkValue, MkWaitOptions, MkWindowMatcher,
-    MkWindowMoveResizePayload, MkWindowPayload, MkWindowState, PromptBackend, PromptRequest,
-    PromptResponse, RuntimeVariables, interpolate,
+    Jump, MkAction, MkCompareOp, MkCondition, MkCoordinateTarget, MkExecutionPlan,
+    MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload, MkKey, MkMacroStore, MkMouseButton,
+    MkMouseScrollAxis, MkPlayback, MkPoint, MkProcessPayload, MkPromptInputPayload, MkTextPayload,
+    MkUiPayload, MkValue, MkWaitOptions, MkWindowMatcher, MkWindowMoveResizePayload,
+    MkWindowPayload, MkWindowState, PromptBackend, PromptRequest, PromptResponse, RuntimeVariables,
+    interpolate,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -865,15 +866,17 @@ mod tests {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Continue,
+            outputs: MkImageOutputs::default(),
         };
         let mut vars = RuntimeVariables::new();
         assert_eq!(
             executor.wait_image(1, &payload(7), &mut vars).unwrap(),
-            MkPoint { x: 1, y: 1 }
+            Some(MkPoint { x: 1, y: 1 })
         );
         assert_eq!(
             executor.wait_image(1, &payload(8), &mut vars).unwrap(),
-            MkPoint { x: 1, y: 1 }
+            Some(MkPoint { x: 1, y: 1 })
         );
         for key in [
             "last_image",
@@ -898,16 +901,14 @@ mod tests {
             .lock()
             .unwrap()
             .insert("image".into(), false);
-        let error = executor.wait_image(1, &payload(7), &mut vars).unwrap_err();
-        assert_eq!(error.kind, DiagnosticKind::Timeout);
-        assert_eq!(error.message, "Image was not found within 0 ms");
         assert_eq!(
-            error.context.get("timeout_ms").map(String::as_str),
-            Some("0")
+            executor.wait_image(1, &payload(7), &mut vars).unwrap(),
+            None
         );
-        assert!(error.context.contains_key("elapsed_ms"));
         assert!(!vars.contains_key("__image.7"));
         assert!(vars.contains_key("__image.8"));
+        assert_eq!(vars.get("last_image_found"), Some(&MkValue::Boolean(false)));
+        assert!(!vars.contains_key("last_image_x"));
     }
     #[test]
     fn stop_wakes_a_long_wait() {
@@ -1410,7 +1411,14 @@ impl Executor {
             MkAction::PromptInput(p) => self.prompt_input(p, v),
             MkAction::ImageFind(p) => self.wait_image(macro_id, p, v).map(|_| ()),
             MkAction::ImageClick(p) => {
-                let pt = self.wait_image(macro_id, p, v)?;
+                let pt = self.wait_image(macro_id, p, v)?.ok_or_else(|| {
+                    ExecutionDiagnostic::new(
+                        DiagnosticKind::TargetNotFound,
+                        "Click Image requires a matching point",
+                    )
+                    .context("macro_id", macro_id.to_string())
+                    .context("asset_id", p.asset_id.to_string())
+                })?;
                 self.backends.input.move_mouse(pt)?;
                 set_point(v, "mouse", pt);
                 set_point(v, "last_point", pt);
@@ -1533,24 +1541,15 @@ impl Executor {
         macro_id: u64,
         p: &MkImagePayload,
         v: &mut RuntimeVariables,
-    ) -> ExecResult<MkPoint> {
-        let image_variable = super::screen::image_result_variable(p.asset_id);
-        v.remove(&image_variable);
-        for key in ["last_image", "last_image_x", "last_image_y"] {
-            v.remove(key);
-        }
-        let mut found = None;
+    ) -> ExecResult<Option<MkPoint>> {
         let started = Instant::now();
-        let result = loop {
+        let result: ExecResult<Option<MkPoint>> = loop {
             if let Err(error) = self.control.checkpoint() {
                 break Err(error);
             }
             match self.backends.screen.find_image(macro_id, p) {
                 Err(error) => break Err(error),
-                Ok(Some(point)) => {
-                    found = Some(point);
-                    break Ok(());
-                }
+                Ok(Some(point)) => break Ok(Some(point)),
                 Ok(None) => {}
             }
             let elapsed = started.elapsed();
@@ -1560,12 +1559,15 @@ impl Executor {
                 if let Err(error) = self.control.checkpoint() {
                     break Err(error);
                 }
-                break Err(ExecutionDiagnostic::new(
-                    DiagnosticKind::Timeout,
-                    format!("Image was not found within {} ms", p.wait.timeout_ms),
-                )
-                .context("timeout_ms", p.wait.timeout_ms.to_string())
-                .context("elapsed_ms", elapsed.as_millis().to_string()));
+                break match p.not_found_policy {
+                    MkImageNotFoundPolicy::Continue => Ok(None),
+                    MkImageNotFoundPolicy::Fail => Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::Timeout,
+                        format!("Image was not found within {} ms", p.wait.timeout_ms),
+                    )
+                    .context("timeout_ms", p.wait.timeout_ms.to_string())
+                    .context("elapsed_ms", elapsed.as_millis().to_string())),
+                };
             }
             if let Err(error) = self.wait(
                 Duration::from_millis(p.wait.poll_interval_ms.max(1))
@@ -1574,34 +1576,69 @@ impl Executor {
                 break Err(error);
             }
         };
-        v.insert(
-            "last_image_result".into(),
-            MkValue::Boolean(found.is_some()),
-        );
-        v.insert("last_image_found".into(), MkValue::Boolean(found.is_some()));
-        if let Some(point) = found {
-            v.insert(image_variable, MkValue::Point(point));
-            v.insert("last_image".into(), MkValue::Point(point));
-            set_point(v, "last_image", point);
-            v.insert("last_image_x".into(), MkValue::Number(point.x.into()));
-            v.insert("last_image_y".into(), MkValue::Number(point.y.into()));
-        }
-        match (result, found) {
-            (_, Some(point)) => Ok(point),
-            (Err(error), None) => Err(error
+        match result {
+            Ok(point) => {
+                Self::write_image_result(v, p, point);
+                Ok(point)
+            }
+            Err(error) => Err(error
                 .context("macro_id", macro_id.to_string())
                 .context("asset_id", p.asset_id.to_string())
                 .context("region", format!("{:?}", p.region))
                 .context("tolerance", p.tolerance.to_string())
                 .context("alpha", format!("{:?}", p.alpha))
-                .context("poll_interval_ms", p.wait.poll_interval_ms.to_string())),
-            (Ok(()), None) => Err(ExecutionDiagnostic::new(
-                DiagnosticKind::TargetNotFound,
-                "Target image was not found",
-            )
-            .context("macro_id", macro_id.to_string())
-            .context("asset_id", p.asset_id.to_string())
-            .context("region", format!("{:?}", p.region))),
+                .context("timeout_ms", p.wait.timeout_ms.to_string())
+                .context("poll_interval_ms", p.wait.poll_interval_ms.to_string())
+                .context("elapsed_ms", started.elapsed().as_millis().to_string())),
+        }
+    }
+    /// Commits one completed search snapshot. Technical errors intentionally
+    /// leave the previous snapshot untouched: they are not a negative search.
+    fn write_image_result(v: &mut RuntimeVariables, p: &MkImagePayload, point: Option<MkPoint>) {
+        let found = point.is_some();
+        v.insert("last_image_result".into(), MkValue::Boolean(found));
+        v.insert("last_image_found".into(), MkValue::Boolean(found));
+        let asset = super::screen::image_result_variable(p.asset_id);
+        if let Some(point) = point {
+            v.insert(asset, MkValue::Point(point));
+            v.insert("last_image".into(), MkValue::Point(point));
+            set_point(v, "last_image", point);
+            v.insert("last_image_x".into(), MkValue::Number(point.x.into()));
+            v.insert("last_image_y".into(), MkValue::Number(point.y.into()));
+        } else {
+            v.remove(&asset);
+            for key in [
+                "last_image",
+                "last_image.x",
+                "last_image.y",
+                "last_image_x",
+                "last_image_y",
+            ] {
+                v.remove(key);
+            }
+        }
+        for (name, value) in [
+            (&p.outputs.found, MkValue::Boolean(found)),
+            (
+                &p.outputs.point,
+                point.map(MkValue::Point).unwrap_or(MkValue::Null),
+            ),
+            (
+                &p.outputs.x,
+                point
+                    .map(|p| MkValue::Number(p.x.into()))
+                    .unwrap_or(MkValue::Null),
+            ),
+            (
+                &p.outputs.y,
+                point
+                    .map(|p| MkValue::Number(p.y.into()))
+                    .unwrap_or(MkValue::Null),
+            ),
+        ] {
+            if let Some(name) = name {
+                v.insert(name.clone(), value);
+            }
         }
     }
     fn wait_condition(
@@ -1696,19 +1733,26 @@ impl Executor {
                         tolerance: 0,
                         alpha: super::AlphaPolicy::Compare,
                         return_point: super::ReturnPoint::Center,
+                        not_found_policy: MkImageNotFoundPolicy::Fail,
+                        outputs: MkImageOutputs::default(),
                     },
                 )?;
-                v.insert(
-                    "last_image_result".into(),
-                    MkValue::Boolean(point.is_some()),
-                );
-                v.insert("last_image_found".into(), MkValue::Boolean(point.is_some()));
-                if let Some(p) = point {
-                    v.insert("last_image".into(), MkValue::Point(p));
-                    set_point(v, "last_image", p);
-                    v.insert("last_image_x".into(), MkValue::Number(p.x.into()));
-                    v.insert("last_image_y".into(), MkValue::Number(p.y.into()));
+                // This condition intentionally performs a fresh, immediate
+                // search, but shares the same coherent compatibility snapshot.
+                let payload = MkImagePayload {
+                    asset_id: *asset_id,
+                    wait: MkWaitOptions {
+                        timeout_ms: 0,
+                        poll_interval_ms: 1,
+                    },
+                    region: super::SearchRegion::Desktop,
+                    tolerance: 0,
+                    alpha: super::AlphaPolicy::Compare,
+                    return_point: super::ReturnPoint::Center,
+                    not_found_policy: MkImageNotFoundPolicy::Fail,
+                    outputs: Default::default(),
                 };
+                Self::write_image_result(v, &payload, point);
                 Ok(point.is_some() == *found)
             }
             MkCondition::PixelResult {

--- a/src/mkmacro/image_search.rs
+++ b/src/mkmacro/image_search.rs
@@ -134,8 +134,6 @@ impl VisualSearch for ProductionVisualSearch {
                 tolerance: payload.tolerance,
                 alpha: payload.alpha,
                 return_point: payload.return_point,
-                not_found_policy: MkImageNotFoundPolicy::Fail,
-                outputs: MkImageOutputs::default(),
                 first_result: true,
             },
             &|| false,
@@ -183,8 +181,6 @@ impl Default for MatchOptions {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
-            not_found_policy: MkImageNotFoundPolicy::Fail,
-            outputs: MkImageOutputs::default(),
             first_result: true,
         }
     }
@@ -511,8 +507,6 @@ mod tests {
                 &n,
                 MatchOptions {
                     return_point: ReturnPoint::TopLeft,
-                    not_found_policy: MkImageNotFoundPolicy::Fail,
-                    outputs: MkImageOutputs::default(),
                     ..Default::default()
                 },
                 &|| false

--- a/src/mkmacro/image_search.rs
+++ b/src/mkmacro/image_search.rs
@@ -10,7 +10,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use super::{MkImagePayload, MkPoint, ScreenCaptureBackend, SearchRegion, VisualSearch};
+use super::{
+    MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload, MkPoint, ScreenCaptureBackend,
+    SearchRegion, VisualSearch,
+};
 
 /// Run-scoped decode cache. Construct one for each playback; repeated visual waits
 /// and searches using the same stable reference share the decoded pixels.
@@ -131,6 +134,8 @@ impl VisualSearch for ProductionVisualSearch {
                 tolerance: payload.tolerance,
                 alpha: payload.alpha,
                 return_point: payload.return_point,
+                not_found_policy: MkImageNotFoundPolicy::Fail,
+                outputs: MkImageOutputs::default(),
                 first_result: true,
             },
             &|| false,
@@ -178,6 +183,8 @@ impl Default for MatchOptions {
             tolerance: 0,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
             first_result: true,
         }
     }
@@ -401,6 +408,8 @@ mod tests {
             tolerance,
             alpha: AlphaPolicy::Compare,
             return_point: ReturnPoint::Center,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
         }
     }
     fn adapter_fixture(
@@ -502,6 +511,8 @@ mod tests {
                 &n,
                 MatchOptions {
                     return_point: ReturnPoint::TopLeft,
+                    not_found_policy: MkImageNotFoundPolicy::Fail,
+                    outputs: MkImageOutputs::default(),
                     ..Default::default()
                 },
                 &|| false

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -371,6 +371,42 @@ pub struct MkWindowMoveResizePayload {
     pub height: Option<u32>,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MkImageNotFoundPolicy {
+    Continue,
+    Fail,
+}
+impl Default for MkImageNotFoundPolicy {
+    /// Authoring default. Persisted legacy data deliberately uses
+    /// `legacy_image_not_found_policy` instead.
+    fn default() -> Self {
+        Self::Continue
+    }
+}
+fn legacy_image_not_found_policy() -> MkImageNotFoundPolicy {
+    MkImageNotFoundPolicy::Fail
+}
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MkImageOutputs {
+    #[serde(default)]
+    pub found: Option<String>,
+    #[serde(default)]
+    pub point: Option<String>,
+    #[serde(default)]
+    pub x: Option<String>,
+    #[serde(default)]
+    pub y: Option<String>,
+}
+impl MkImageOutputs {
+    pub fn normalize(&mut self) {
+        for value in [&mut self.found, &mut self.point, &mut self.x, &mut self.y] {
+            if value.as_ref().is_some_and(|name| name.trim().is_empty()) {
+                *value = None;
+            }
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkImagePayload {
     pub asset_id: u64,
     pub wait: MkWaitOptions,
@@ -382,6 +418,11 @@ pub struct MkImagePayload {
     pub alpha: AlphaPolicy,
     #[serde(default)]
     pub return_point: ReturnPoint,
+    /// Missing in historical documents meant that absence failed the action.
+    #[serde(default = "legacy_image_not_found_policy")]
+    pub not_found_policy: MkImageNotFoundPolicy,
+    #[serde(default)]
+    pub outputs: MkImageOutputs,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkUiPayload {
@@ -583,8 +624,32 @@ mod image_payload_tests {
         assert_eq!(p.tolerance, 0);
         assert_eq!(p.alpha, AlphaPolicy::Compare);
         assert_eq!(p.return_point, ReturnPoint::Center);
+        assert_eq!(p.not_found_policy, MkImageNotFoundPolicy::Fail);
+        assert_eq!(p.outputs, MkImageOutputs::default());
         let json = serde_json::to_string(&p).unwrap();
         assert_eq!(serde_json::from_str::<MkImagePayload>(&json).unwrap(), p);
+    }
+    #[test]
+    fn image_policy_and_outputs_have_stable_json_and_round_trip() {
+        let mut p: MkImagePayload =
+            serde_json::from_str(r#"{"asset_id":4,"wait":{"timeout_ms":10,"poll_interval_ms":2}}"#)
+                .unwrap();
+        p.not_found_policy = MkImageNotFoundPolicy::Continue;
+        p.outputs = MkImageOutputs {
+            found: Some("found_out".into()),
+            point: Some("point_out".into()),
+            x: Some("x_out".into()),
+            y: Some("y_out".into()),
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains(r#""not_found_policy":"continue""#));
+        assert_eq!(serde_json::from_str::<MkImagePayload>(&json).unwrap(), p);
+        p.not_found_policy = MkImageNotFoundPolicy::Fail;
+        assert!(
+            serde_json::to_string(&p)
+                .unwrap()
+                .contains(r#""not_found_policy":"fail""#)
+        );
     }
     #[test]
     fn matched_window_coordinate_has_stable_tag_and_round_trips() {

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -44,6 +44,35 @@ fn push(
         message: msg.into(),
     })
 }
+fn image_outputs(p: &MkImagePayload, m: u64, s: Option<u64>, out: &mut Vec<MkDiagnostic>) {
+    let slots = [
+        ("found", "invalid_image_output_found", &p.outputs.found),
+        ("point", "invalid_image_output_point", &p.outputs.point),
+        ("x", "invalid_image_output_x", &p.outputs.x),
+        ("y", "invalid_image_output_y", &p.outputs.y),
+    ];
+    let mut names = HashSet::new();
+    for (slot, code, name) in slots {
+        let Some(name) = name else { continue };
+        if let Err(reason) = validate_variable_name(name) {
+            push(
+                out,
+                m,
+                s,
+                code,
+                format!("Image output {slot} name '{name}' is invalid: {reason}"),
+            );
+        } else if !names.insert(name.as_str()) {
+            push(
+                out,
+                m,
+                s,
+                code,
+                format!("Image output {slot} duplicates configured name '{name}'"),
+            );
+        }
+    }
+}
 pub fn can_run(ds: &[MkDiagnostic]) -> bool {
     !ds.iter().any(|d| d.severity == DiagnosticSeverity::Fatal)
 }
@@ -269,6 +298,7 @@ pub fn validate_document_with_context(
                 MkAction::ImageFind(p) | MkAction::ImageClick(p) => {
                     wait(&p.wait, m.id, sid, &mut out);
                     asset(p.asset_id, m.id, sid, asset_root, &mut out);
+                    image_outputs(p, m.id, sid, &mut out);
                     match &p.region {
                         SearchRegion::Rectangle { rect } => {
                             if let Err(error) = rect.validate_capture() {

--- a/tests/mkmacro_visual.rs
+++ b/tests/mkmacro_visual.rs
@@ -64,6 +64,8 @@ fn image_catalog_defaults_require_assets_and_configured_payload_round_trips() {
         tolerance: 9,
         alpha: AlphaPolicy::Ignore,
         return_point: ReturnPoint::TopLeft,
+        not_found_policy: MkImageNotFoundPolicy::Fail,
+        outputs: MkImageOutputs::default(),
     };
     let action = MkAction::ImageClick(payload.clone());
     assert_eq!(
@@ -95,6 +97,8 @@ fn image_wait_cancels_promptly_without_real_screen_access() {
                     tolerance: 0,
                     alpha: AlphaPolicy::Compare,
                     return_point: ReturnPoint::Center,
+                    not_found_policy: MkImageNotFoundPolicy::Fail,
+                    outputs: MkImageOutputs::default(),
                 })),
                 &|_| {},
             )


### PR DESCRIPTION
### Motivation
- Provide a backward-compatible persisted policy for image searches so authors can choose to `Continue` when a reference image is not found or `Fail` the action, while preserving historical behavior for legacy JSON. 
- Add optional named outputs (Found/Point/X/Y) so image searches can populate user-visible variables in a predictable, validated way. 
- Make runtime semantics explicit: keep ordinary not-found distinct from backend/technical errors and centralize coherent result writing so stale values cannot leak between searches.

### Description
- Added `MkImageNotFoundPolicy` (serialized as stable snake_case `continue`/`fail`), a Serde legacy default function that yields `Fail` for historical documents, and `MkImageOutputs` with `Option<String>` slots and a `normalize()` helper. (model changes in `MkImagePayload` include `not_found_policy` and `outputs` with Serde defaults.)
- Updated all image payload constructors and editor/ catalog entry points so new `ImageFind` drafts explicitly use `Continue` and new `ImageClick` drafts explicitly use `Fail`, and added outputs defaults where needed. 
- Extended the reusable image editor to: render a “When not found” selector for Find Image, hide/lock it for Click Image (forcing `Fail`), render the Outputs section with editable Found/Point/X/Y slots, normalize empty editor text to `None`, show inline validation messages, and prevent Apply when names are invalid. 
- Added `image_outputs` validation that reuses `variables::validate_variable_name` to reject empty names, built-in collisions, and duplicate names across the four slots, and attached field-specific diagnostic codes. 
- Refactored `Executor::wait_image` to return `ExecResult<Option<MkPoint>>`, implemented `write_image_result` to atomically commit compatibility and configured outputs (using `MkValue::Null` for missing numeric/point outputs and removing legacy asset-scoped entries on absence), and preserved technical errors as errors (they do not become `found=false`). 
- Updated `ImageClick` dispatch to require a point (returns a `TargetNotFound` diagnostic when absent) while `ImageFind` accepts `Ok(None)` as success when policy is `Continue`. 
- Ensured `MkCondition::ImageResult` performs a fresh immediate search but reuses the same result-writing helper to keep compatibility variables coherent. 
- Added unit tests for model serialization round-trips and legacy defaults, and wired up many editor/executor/validation test fixtures (new tests added alongside model/validation/executor/editor sources).

### Testing
- ✅ `git diff --check` — repository diff/format checks completed successfully. 
- ✅ `cargo fmt -- --check` (after formatting) — formatting check passed. 
- ⚠️ `cargo check` — attempted; installing Linux dev packages progressed dependency compilation, but the full `cargo check` cannot complete in this Linux environment because several repository modules expose unguarded Win32-only APIs, producing platform-specific unresolved Win32 imports that block a complete cross-platform check. The substantive Rust-level unit tests added were not executed to completion for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b6553f3e88332b8c4170e8be84df2)