### PR TITLE
Split live image search from previous image results (schema v5, migration, runtime, validation, editor)

### DIFF
--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -2,7 +2,10 @@
 
 use super::action_editor::{matcher_ui, target_ui, value_ui};
 use crate::mkmacro::variables::{MkPoint, MkValue};
-use crate::mkmacro::{MkCompareOp, MkCondition, MkCoordinateTarget, MkImageAsset, MkWindowMatcher};
+use crate::mkmacro::{
+    AlphaPolicy, MkCompareOp, MkCondition, MkCoordinateTarget, MkImageAsset,
+    MkImageSearchCondition, MkWindowMatcher, ReturnPoint, SearchRegion,
+};
 use eframe::egui;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -10,7 +13,8 @@ pub enum ConditionKind {
     Variable,
     WindowExists,
     WindowActive,
-    ImageResult,
+    ImageSearch,
+    PreviousImageResult,
     PixelResult,
     All,
     Any,
@@ -30,8 +34,18 @@ pub fn default_condition(kind: ConditionKind) -> MkCondition {
         ConditionKind::WindowActive => MkCondition::WindowActive {
             matcher: default_matcher(),
         },
-        ConditionKind::ImageResult => MkCondition::ImageResult {
-            asset_id: 1,
+        ConditionKind::ImageSearch => MkCondition::ImageSearch {
+            search: MkImageSearchCondition {
+                asset_id: 1,
+                region: SearchRegion::Desktop,
+                tolerance: 0,
+                alpha: AlphaPolicy::Compare,
+                return_point: ReturnPoint::Center,
+            },
+            found: true,
+        },
+        ConditionKind::PreviousImageResult => MkCondition::PreviousImageResult {
+            asset_id: None,
             found: true,
         },
         ConditionKind::PixelResult => MkCondition::PixelResult {
@@ -61,7 +75,8 @@ pub fn condition_kind(c: &MkCondition) -> ConditionKind {
         MkCondition::Variable { .. } => ConditionKind::Variable,
         MkCondition::WindowExists { .. } => ConditionKind::WindowExists,
         MkCondition::WindowActive { .. } => ConditionKind::WindowActive,
-        MkCondition::ImageResult { .. } => ConditionKind::ImageResult,
+        MkCondition::ImageSearch { .. } => ConditionKind::ImageSearch,
+        MkCondition::PreviousImageResult { .. } => ConditionKind::PreviousImageResult,
         MkCondition::PixelResult { .. } => ConditionKind::PixelResult,
         MkCondition::All { .. } => ConditionKind::All,
         MkCondition::Any { .. } => ConditionKind::Any,
@@ -138,7 +153,8 @@ pub fn condition_ui_with_assets(
                     ConditionKind::Variable,
                     ConditionKind::WindowExists,
                     ConditionKind::WindowActive,
-                    ConditionKind::ImageResult,
+                    ConditionKind::ImageSearch,
+                    ConditionKind::PreviousImageResult,
                     ConditionKind::PixelResult,
                     ConditionKind::All,
                     ConditionKind::Any,
@@ -182,7 +198,7 @@ pub fn condition_ui_with_assets(
                     requested = Some(vec![]);
                 }
             }
-            MkCondition::ImageResult { asset_id, found } => {
+            MkCondition::ImageSearch { search: MkImageSearchCondition { asset_id, .. }, found } => {
                 if assets.is_empty() {
                     ui.colored_label(egui::Color32::YELLOW, "No reference images. Create or import one through Find Image or Click Image.");
                 } else {
@@ -196,6 +212,16 @@ pub fn condition_ui_with_assets(
                         ui.selectable_value(found, true, "Found");
                         ui.selectable_value(found, false, "Not found");
                     });
+            }
+            MkCondition::PreviousImageResult { asset_id, found } => {
+                let mut specific = asset_id.is_some();
+                if ui.checkbox(&mut specific, "Use a specific image's latest result").changed() {
+                    *asset_id = specific.then_some(assets.first().map_or(1, |a| a.id));
+                }
+                if let Some(id) = asset_id {
+                    egui::ComboBox::from_label("Reference image").selected_text(super::action_editor::image_asset_label(*id, assets)).show_ui(ui, |ui| for asset in assets { ui.selectable_value(id, asset.id, super::action_editor::image_asset_label(asset.id, assets)); });
+                }
+                egui::ComboBox::from_label("Result").selected_text(if *found { "Found" } else { "Not found" }).show_ui(ui, |ui| { ui.selectable_value(found, true, "Found"); ui.selectable_value(found, false, "Not found"); });
             }
             MkCondition::PixelResult {
                 target,
@@ -256,7 +282,8 @@ fn kind_label(k: ConditionKind) -> &'static str {
         ConditionKind::Variable => "Variable comparison",
         ConditionKind::WindowExists => "Window exists",
         ConditionKind::WindowActive => "Window active",
-        ConditionKind::ImageResult => "Image found / not found",
+        ConditionKind::ImageSearch => "Search image now",
+        ConditionKind::PreviousImageResult => "Previous image result",
         ConditionKind::PixelResult => "Pixel matches",
         ConditionKind::All => "ALL",
         ConditionKind::Any => "ANY",
@@ -304,8 +331,8 @@ mod tests {
                         MkCondition::WindowExists {
                             matcher: default_matcher(),
                         },
-                        MkCondition::ImageResult {
-                            asset_id: 42,
+                        MkCondition::PreviousImageResult {
+                            asset_id: Some(42),
                             found: false,
                         },
                     ],

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1600,6 +1600,10 @@ impl Executor {
         v.insert("last_image_result".into(), MkValue::Boolean(found));
         v.insert("last_image_found".into(), MkValue::Boolean(found));
         let asset = super::screen::image_result_variable(p.asset_id);
+        v.insert(
+            super::screen::image_found_variable(p.asset_id),
+            MkValue::Boolean(found),
+        );
         if let Some(point) = point {
             v.insert(asset, MkValue::Point(point));
             v.insert("last_image".into(), MkValue::Point(point));
@@ -1721,40 +1725,20 @@ impl Executor {
                 v.insert("last_window_result".into(), MkValue::Boolean(x));
                 Ok(x)
             }
-            MkCondition::ImageResult { asset_id, found } => {
-                let point = self.backends.screen.find_image(
-                    macro_id,
-                    &MkImagePayload {
-                        asset_id: *asset_id,
-                        wait: MkWaitOptions {
-                            timeout_ms: 0,
-                            poll_interval_ms: 1,
-                        },
-                        region: super::SearchRegion::Desktop,
-                        tolerance: 0,
-                        alpha: super::AlphaPolicy::Compare,
-                        return_point: super::ReturnPoint::Center,
-                        not_found_policy: MkImageNotFoundPolicy::Fail,
-                        outputs: MkImageOutputs::default(),
-                    },
-                )?;
-                // This condition intentionally performs a fresh, immediate
-                // search, but shares the same coherent compatibility snapshot.
-                let payload = MkImagePayload {
-                    asset_id: *asset_id,
-                    wait: MkWaitOptions {
-                        timeout_ms: 0,
-                        poll_interval_ms: 1,
-                    },
-                    region: super::SearchRegion::Desktop,
-                    tolerance: 0,
-                    alpha: super::AlphaPolicy::Compare,
-                    return_point: super::ReturnPoint::Center,
-                    not_found_policy: MkImageNotFoundPolicy::Fail,
-                    outputs: Default::default(),
-                };
+            MkCondition::ImageSearch { search, found } => {
+                let payload = search.as_payload();
+                // Exactly one immediate backend call per condition evaluation.
+                let point = self.backends.screen.find_image(macro_id, &payload)?;
                 Self::write_image_result(v, &payload, point);
                 Ok(point.is_some() == *found)
+            }
+            MkCondition::PreviousImageResult { asset_id, found } => {
+                let key = asset_id
+                    .map(super::screen::image_found_variable)
+                    .unwrap_or_else(|| "last_image_found".into());
+                // No recorded result is explicitly treated as "not found".
+                let recorded = matches!(v.get(&key), Some(MkValue::Boolean(true)));
+                Ok(recorded == *found)
             }
             MkCondition::PixelResult {
                 target,

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -6,7 +6,7 @@ use crate::mkmacro::variables::{MkPoint, MkValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-pub const SCHEMA_VERSION: u32 = 4;
+pub const SCHEMA_VERSION: u32 = 5;
 fn schema() -> u32 {
     SCHEMA_VERSION
 }
@@ -293,8 +293,12 @@ pub enum MkCondition {
     WindowActive {
         matcher: MkWindowMatcher,
     },
-    ImageResult {
-        asset_id: u64,
+    ImageSearch {
+        search: MkImageSearchCondition,
+        found: bool,
+    },
+    PreviousImageResult {
+        asset_id: Option<u64>,
         found: bool,
     },
     PixelResult {
@@ -311,6 +315,38 @@ pub enum MkCondition {
     Not {
         condition: Box<MkCondition>,
     },
+}
+/// A single, immediate image search used by a condition.  Action polling and
+/// output policy deliberately live in [`MkImagePayload`], not here.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MkImageSearchCondition {
+    pub asset_id: u64,
+    #[serde(default)]
+    pub region: SearchRegion,
+    #[serde(default)]
+    pub tolerance: u8,
+    #[serde(default)]
+    pub alpha: AlphaPolicy,
+    #[serde(default)]
+    pub return_point: ReturnPoint,
+}
+
+impl MkImageSearchCondition {
+    pub fn as_payload(&self) -> MkImagePayload {
+        MkImagePayload {
+            asset_id: self.asset_id,
+            wait: MkWaitOptions {
+                timeout_ms: 0,
+                poll_interval_ms: 1,
+            },
+            region: self.region.clone(),
+            tolerance: self.tolerance,
+            alpha: self.alpha,
+            return_point: self.return_point,
+            not_found_policy: MkImageNotFoundPolicy::Continue,
+            outputs: MkImageOutputs::default(),
+        }
+    }
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkTextPayload {

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -13,6 +13,11 @@ pub(crate) fn image_result_variable(asset_id: u64) -> String {
     format!("__image.{asset_id}")
 }
 
+/// Runtime-only variable recording whether the latest search for an asset found it.
+pub(crate) fn image_found_variable(asset_id: u64) -> String {
+    format!("__image_found.{asset_id}")
+}
+
 pub(crate) trait WindowsGeometry: Send + Sync {
     /// `(x, y, width, height)`, in desktop pixels. Width/height remain signed so
     /// malformed platform data can be diagnosed rather than silently cast.

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -415,8 +415,11 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
     if version <= 3 {
         migrate_v3_to_v4(&mut value);
     }
+    if version <= 4 {
+        migrate_v4_to_v5(&mut value)?;
+    }
     let mut doc: MkMacroDocument = match version {
-        0 | 1 | 2 | 3 | 4 => serde_json::from_value(value)
+        0 | 1 | 2 | 3 | 4 | 5 => serde_json::from_value(value)
             .context("mkmacros.json does not match the macro schema")?,
         _ => unreachable!(),
     };
@@ -424,6 +427,74 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
     doc.schema_version = SCHEMA_VERSION;
     changed |= repair_ids(&mut doc);
     Ok(Some((doc, changed)))
+}
+/// Splits the schema-4 ambiguous `image_result` condition into an explicit live
+/// search. Previous-result conditions did not exist in schema 4.
+fn migrate_v4_to_v5(value: &mut serde_json::Value) -> Result<()> {
+    fn condition(value: &mut serde_json::Value) -> Result<()> {
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("condition is not an object"))?;
+        match object.get("type").and_then(serde_json::Value::as_str) {
+            Some("image_result") => {
+                let asset_id = object
+                    .remove("asset_id")
+                    .ok_or_else(|| anyhow::anyhow!("legacy image_result has no asset_id"))?;
+                object.insert("type".into(), serde_json::json!("image_search"));
+                object.insert(
+                    "search".into(),
+                    serde_json::json!({
+                        "asset_id": asset_id,
+                        "region": {"type": "desktop"},
+                        "tolerance": 0,
+                        "alpha": "compare",
+                        "return_point": "center"
+                    }),
+                );
+            }
+            Some("all" | "any") => {
+                if let Some(children) = object.get_mut("conditions").and_then(|v| v.as_array_mut())
+                {
+                    for child in children {
+                        condition(child)?;
+                    }
+                }
+            }
+            Some("not") => {
+                if let Some(child) = object.get_mut("condition") {
+                    condition(child)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    if let Some(macros) = value.get_mut("macros").and_then(|v| v.as_array_mut()) {
+        for mac in macros {
+            if let Some(steps) = mac.get_mut("steps").and_then(|v| v.as_array_mut()) {
+                for step in steps {
+                    let Some(action) = step.get_mut("action").and_then(|v| v.as_object_mut())
+                    else {
+                        continue;
+                    };
+                    let ty = action.get("type").and_then(|v| v.as_str());
+                    if matches!(ty, Some("if" | "while_start")) {
+                        if let Some(data) = action.get_mut("data") {
+                            condition(data)?;
+                        }
+                    } else if ty == Some("wait_until") {
+                        if let Some(c) = action.get_mut("data").and_then(|v| v.get_mut("condition"))
+                        {
+                            condition(c)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    value["schema_version"] = serde_json::json!(5);
+    Ok(())
 }
 /// Adds the document-wide recorder control without replacing a value supplied by
 /// a forward-compatible older writer.
@@ -554,7 +625,7 @@ pub fn repair_ids(d: &mut MkMacroDocument) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mkmacro::{MkPoint, SearchRegion};
+    use crate::mkmacro::{AlphaPolicy, MkPoint, ReturnPoint, SearchRegion};
     use std::{sync::mpsc, thread, time::Duration};
     fn document() -> MkMacroDocument {
         MkMacroDocument {
@@ -578,6 +649,74 @@ mod tests {
                 image_assets: vec![],
             }],
         }
+    }
+    #[test]
+    fn v4_image_conditions_migrate_recursively_with_live_search_defaults() {
+        let legacy = serde_json::json!({
+            "schema_version": 4,
+            "macros": [{"id":1,"name":"m","steps":[{"id":2,"action":{
+                "type":"wait_until","data":{"wait":{"timeout_ms":1,"poll_interval_ms":1},
+                "condition":{"type":"all","conditions":[
+                    {"type":"image_result","asset_id":7,"found":true},
+                    {"type":"not","condition":{"type":"any","conditions":[
+                        {"type":"image_result","asset_id":8,"found":false}
+                    ]}}
+                ]}}
+            }}]}]
+        });
+        let mut migrated = legacy;
+        migrate_v4_to_v5(&mut migrated).unwrap();
+        assert_eq!(migrated["schema_version"], 5);
+        let doc: MkMacroDocument = serde_json::from_value(migrated).unwrap();
+        let MkAction::WaitUntil { condition, .. } = &doc.macros[0].steps[0].action else {
+            panic!()
+        };
+        let json = serde_json::to_value(condition).unwrap();
+        let first = &json["conditions"][0];
+        assert_eq!(first["type"], "image_search");
+        assert_eq!(first["found"], true);
+        assert_eq!(
+            first["search"],
+            serde_json::json!({
+                "asset_id":7,"region":{"type":"desktop"},"tolerance":0,
+                "alpha":"compare","return_point":"center"
+            })
+        );
+        let nested = &json["conditions"][1]["condition"]["conditions"][0];
+        assert_eq!(nested["type"], "image_search");
+        assert_eq!(nested["found"], false);
+    }
+
+    #[test]
+    fn v5_condition_types_round_trip_with_distinct_names() {
+        let conditions = vec![
+            MkCondition::ImageSearch {
+                search: MkImageSearchCondition {
+                    asset_id: 3,
+                    region: SearchRegion::Desktop,
+                    tolerance: 4,
+                    alpha: AlphaPolicy::Ignore,
+                    return_point: ReturnPoint::TopLeft,
+                },
+                found: false,
+            },
+            MkCondition::PreviousImageResult {
+                asset_id: None,
+                found: true,
+            },
+            MkCondition::PreviousImageResult {
+                asset_id: Some(3),
+                found: false,
+            },
+        ];
+        let json = serde_json::to_string(&conditions).unwrap();
+        assert!(json.contains("image_search"));
+        assert!(json.contains("previous_image_result"));
+        assert!(!json.contains("\"type\":\"image_result\""));
+        assert_eq!(
+            serde_json::from_str::<Vec<MkCondition>>(&json).unwrap(),
+            conditions
+        );
     }
     #[test]
     fn missing_empty_and_malformed_are_recoverable() {

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -555,7 +555,27 @@ fn condition(
         MkCondition::WindowExists { matcher: x } | MkCondition::WindowActive { matcher: x } => {
             matcher(x, m, s, o)
         }
-        MkCondition::ImageResult { asset_id, .. } => asset(*asset_id, m, s, root, o),
+        MkCondition::ImageSearch { search, .. } => {
+            asset(search.asset_id, m, s, root, o);
+            match &search.region {
+                SearchRegion::Rectangle { rect } if rect.validate_capture().is_err() => push(
+                    o,
+                    m,
+                    s,
+                    "invalid_image_region",
+                    "Image search rectangle is invalid",
+                ),
+                SearchRegion::Window { matcher: x } | SearchRegion::ClientArea { matcher: x } => {
+                    matcher(x, m, s, o)
+                }
+                _ => {}
+            }
+        }
+        MkCondition::PreviousImageResult {
+            asset_id: Some(asset_id),
+            ..
+        } => asset(*asset_id, m, s, root, o),
+        MkCondition::PreviousImageResult { asset_id: None, .. } => {}
         MkCondition::All { conditions } | MkCondition::Any { conditions } => {
             for x in conditions {
                 condition(x, m, s, root, o)


### PR DESCRIPTION
### Motivation

- Clarify and separate two distinct image-condition semantics that were previously conflated: an immediate live image-search (action-like) and a previous-result query (read-only) so serialization, migration, executor state, and coordinate resolution behave predictably. 

### Description

- Bumped document schema to `5` and introduced `MkCondition::ImageSearch { search: MkImageSearchCondition, found: bool }` and `MkCondition::PreviousImageResult { asset_id: Option<u64>, found: bool }` plus the `MkImageSearchCondition` helper with only search parameters; added `as_payload()` to construct an immediate `MkImagePayload`.【F:src/mkmacro/model.rs†L9-L12】【F:src/mkmacro/model.rs†L282-L350】
- Added a `migrate_v4_to_v5` pass that recursively rewrites legacy `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ca95097f48332b1b91c2d2b2d7c74)