### PR TITLE
Add 'Wait for Image' / 'Wait for Image to Disappear' catalog presets

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -102,6 +102,20 @@ fn point() -> MkCoordinateTarget {
 fn cond() -> MkCondition {
     MkCondition::All { conditions: vec![] }
 }
+fn image_cond(found: bool) -> MkCondition {
+    MkCondition::ImageSearch {
+        search: MkImageSearchCondition {
+            // Required-asset draft sentinel; Apply remains disabled until the
+            // user imports, captures, or selects a reference image.
+            asset_id: 0,
+            region: SearchRegion::Desktop,
+            tolerance: 0,
+            alpha: AlphaPolicy::Compare,
+            return_point: ReturnPoint::Center,
+        },
+        found,
+    }
+}
 fn wait() -> MkWaitOptions {
     MkWaitOptions {
         timeout_ms: 5000,
@@ -338,6 +352,44 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             Condition,
             MkAction::WaitUntil {
                 condition: cond(),
+                wait: wait()
+            }
+        ),
+        d!(
+            Visual,
+            "Wait for Image",
+            "Wait until a reference image becomes visible",
+            &[
+                "wait",
+                "image",
+                "visual",
+                "appear",
+                "visible",
+                "disappear",
+                "gone"
+            ],
+            Condition,
+            MkAction::WaitUntil {
+                condition: image_cond(true),
+                wait: wait()
+            }
+        ),
+        d!(
+            Visual,
+            "Wait for Image to Disappear",
+            "Wait until a reference image is no longer visible",
+            &[
+                "wait",
+                "image",
+                "visual",
+                "appear",
+                "visible",
+                "disappear",
+                "gone"
+            ],
+            Condition,
+            MkAction::WaitUntil {
+                condition: image_cond(false),
                 wait: wait()
             }
         ),
@@ -1092,6 +1144,23 @@ fn action_details_core(a: &MkAction, asset_name: Option<&str>, assets: &[MkImage
         MkAction::VirtualDesktop(MkVirtualDesktopAction::CloseCurrent) => {
             "Close the current virtual desktop using native Windows behavior".into()
         }
+        MkAction::WaitUntil {
+            condition: MkCondition::ImageSearch { search, found },
+            wait,
+        } => {
+            let image = assets
+                .iter()
+                .find(|asset| asset.id == search.asset_id)
+                .map(|_| super::action_editor::image_asset_label(search.asset_id, assets))
+                .or_else(|| asset_name.map(str::to_owned))
+                .unwrap_or_else(|| format!("Asset {}", search.asset_id));
+            format!(
+                "Image {} · {} · Timeout {} ms",
+                if *found { "visible" } else { "not visible" },
+                image,
+                wait.timeout_ms
+            )
+        }
         MkAction::WaitUntil { wait, .. } => format!("Timeout {} ms", wait.timeout_ms),
         MkAction::If(_) | MkAction::WhileStart { .. } => "Condition".into(),
         MkAction::Else
@@ -1220,6 +1289,72 @@ mod paste_tests {
         assert!(details.contains("Horizontal Left"));
         assert!(details.contains("2 notch(es)"));
         assert!(details.contains("-240 wheel units"));
+    }
+
+    #[test]
+    fn image_wait_presets_are_searchable_configurable_wait_until_actions() {
+        let standard_wait = wait();
+        for (name, expected_found) in [
+            ("Wait for Image", true),
+            ("Wait for Image to Disappear", false),
+        ] {
+            let descriptor = visible_descriptors()
+                .find(|descriptor| descriptor.name == name)
+                .unwrap_or_else(|| panic!("missing visible descriptor {name}"));
+            assert_eq!(descriptor.category, ActionCategory::Visual);
+            assert_eq!(descriptor.editor, EditorKind::Condition);
+            assert_eq!(descriptor.runtime, RuntimeAvailability::Supported);
+            assert!(matches!(
+                descriptor.editor.contract(),
+                Some(EditorContract::Configurable { field_count: 1.. })
+            ));
+            for keyword in [
+                "wait",
+                "image",
+                "visual",
+                "appear",
+                "visible",
+                "disappear",
+                "gone",
+            ] {
+                assert!(
+                    matches(&descriptor, keyword),
+                    "{name} did not match {keyword}"
+                );
+            }
+
+            let action = (descriptor.make_default)();
+            assert!(editor_route_recognizes(&action, EditorKind::Condition));
+            let MkAction::WaitUntil { condition, wait } = action else {
+                panic!("{name} did not create WaitUntil")
+            };
+            assert_eq!(wait, standard_wait);
+            assert_eq!(
+                condition,
+                image_cond(expected_found),
+                "{name} image-search defaults"
+            );
+        }
+    }
+
+    #[test]
+    fn image_wait_details_distinguish_expected_result_and_asset() {
+        let visible = MkAction::WaitUntil {
+            condition: image_cond(true),
+            wait: wait(),
+        };
+        let absent = MkAction::WaitUntil {
+            condition: image_cond(false),
+            wait: wait(),
+        };
+        assert!(
+            action_details_with_asset_name(&visible, Some("button.png"))
+                .contains("Image visible · button.png")
+        );
+        assert!(
+            action_details_with_asset_name(&absent, Some("button.png"))
+                .contains("Image not visible · button.png")
+        );
     }
 }
 pub fn format_coordinate_target(target: &MkCoordinateTarget) -> String {

--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -842,8 +842,28 @@ pub fn draft_validation_contract(action: &MkAction) -> DraftValidationContract {
         MkAction::ImageFind(payload) | MkAction::ImageClick(payload) if payload.asset_id == 0 => {
             DraftValidationContract::AwaitingRequiredAsset
         }
+        MkAction::WaitUntil {
+            condition: MkCondition::ImageSearch { search, .. },
+            ..
+        } if search.asset_id == 0 => DraftValidationContract::AwaitingRequiredAsset,
         _ => DraftValidationContract::CommitReady,
     }
+}
+
+/// Catalog presets may give a canonical action a more discoverable authoring
+/// name without introducing a new persisted action variant.
+pub fn descriptor_name_matches_action(descriptor: &ActionDescriptor, action: &MkAction) -> bool {
+    descriptor.name == action_name(action)
+        || matches!(
+            (descriptor.name, action),
+            (
+                "Wait for Image" | "Wait for Image to Disappear",
+                MkAction::WaitUntil {
+                    condition: MkCondition::ImageSearch { .. },
+                    ..
+                }
+            )
+        )
 }
 
 /// Structural markers are complete actions at insertion time and intentionally

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -74,8 +74,8 @@ pub struct MkMacroDialog {
 mod tests {
     use super::*;
     use crate::mkmacro::{
-        AlphaPolicy, LoadDisposition, MKMACROS_FILE, MkAction, MkCoordinateTarget, MkHotkey,
-        MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload, MkKey, MkMouseButton,
+        AlphaPolicy, LoadDisposition, MKMACROS_FILE, MkAction, MkCondition, MkCoordinateTarget,
+        MkHotkey, MkImageNotFoundPolicy, MkImageOutputs, MkImagePayload, MkKey, MkMouseButton,
         MkMouseMovePayload, MkMousePayload, MkMouseScrollAxis, MkStep, MkWaitOptions, ReturnPoint,
         SCHEMA_VERSION, SearchRegion,
     };

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -955,6 +955,10 @@ mod tests {
                     MkAction::VirtualDesktop(operation) => {
                         Some(format!("virtual_desktop:{operation:?}"))
                     }
+                    MkAction::WaitUntil {
+                        condition: MkCondition::ImageSearch { found, .. },
+                        ..
+                    } => Some(format!("wait_image:{found}")),
                     _ => None,
                 },
             );
@@ -1033,6 +1037,9 @@ mod tests {
                     let draft = &dialog.action_editor.draft.as_ref().unwrap().action;
                     assert!(
                         matches!(draft, MkAction::ImageFind(p) | MkAction::ImageClick(p) if p.asset_id == 0)
+                            || matches!(draft, MkAction::WaitUntil {
+                                condition: MkCondition::ImageSearch { search, .. }, ..
+                            } if search.asset_id == 0)
                     );
                 }
             }
@@ -1060,9 +1067,8 @@ mod tests {
                 "{context}: duplicate descriptor name"
             );
             if descriptor.category != action_catalog::ActionCategory::UiAutomation {
-                assert_eq!(
-                    descriptor.name,
-                    action_catalog::action_name(&action),
+                assert!(
+                    action_catalog::descriptor_name_matches_action(&descriptor, &action),
                     "{context}: action-name mapping"
                 );
             } else {
@@ -1176,9 +1182,8 @@ mod tests {
                         serde_json::to_vec(&action).is_ok(),
                         "{context}: serialization"
                     );
-                    assert_eq!(
-                        descriptor.name,
-                        action_catalog::action_name(&action),
+                    assert!(
+                        action_catalog::descriptor_name_matches_action(&descriptor, &action),
                         "{context}: action name"
                     );
                     let details = action_catalog::action_details(&action);


### PR DESCRIPTION
### Motivation
- Provide two preconfigured, discoverable catalog entries that author `MkAction::WaitUntil` steps backed by the shared live image-search condition so users can easily wait for an image to appear or disappear.
- Ensure the presets route through the normal Condition editor and initialize the image-search draft with the product's standard wait defaults and the editor draft sentinel for required assets.
- Surface image-specific context in step details so inserted `WaitUntil` steps are distinguishable as image-waits in the UI.

### Description
- Added `image_cond(found: bool) -> MkCondition` helper and two visible descriptors in `src/gui/mkmacro_dialog/action_catalog.rs` named `Wait for Image` and `Wait for Image to Disappear`, placed in the Visual category and carrying the requested keywords (`wait`, `image`, `visual`, `appear`, `visible`, `disappear`, `gone`).
- Each descriptor is configured with `EditorKind::Condition` and `make_default` returns a plain `MkAction::WaitUntil` whose `condition` is an `MkCondition::ImageSearch` initialized with asset sentinel `0`, `SearchRegion::Desktop`, `tolerance: 0`, `AlphaPolicy::Compare`, `ReturnPoint::Center`, and the standard wait defaults (`timeout_ms: 5000`, `poll_interval_ms: 100`). The two presets differ only by the `found` boolean (Expected = Found vs Not Found).
- Enhanced `action_details_core` for `WaitUntil` image-search variants to produce human-friendly strings like `Image visible · <asset name> · Timeout <n> ms` or `Image not visible · <asset name> · Timeout <n> ms` when an asset name is available.
- Added unit tests in the action-catalog test module verifying descriptor visibility and searchability, editor routing (`EditorKind::Condition`), runtime availability, that `make_default` produces `MkAction::WaitUntil` with opposite expected values, wait defaults, editor contract presence, and that `action_details` reflects the image expectation and friendly asset names.

### Testing
- Ran `rustfmt --edition 2024 src/gui/mkmacro_dialog/action_catalog.rs`, which succeeded.
- Ran `git diff --check`, which reported no check errors for the changed file.
- Attempted `cargo test image_wait -- --nocapture` to exercise the new catalog/runtime behaviors, but the build failed in this environment due to a missing system dependency (the ALSA development package / `alsa.pc`) during native crate build, preventing test completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cb5648c3883328b00b5f2edf7ac11)