### PR TITLE
Add first-class Find Pixel Color action and pixel-result coordinates

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -644,7 +644,7 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
             &["pixel", "color", "search"],
             Pixel,
             MkAction::FindPixel(MkPixelSearchPayload {
-                search_id: 0,
+                search_id: 1,
                 color: "#000000".into(),
                 tolerance: 0,
                 region: SearchRegion::Desktop,

--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -639,6 +639,22 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
         ),
         d!(
             Visual,
+            "Find Pixel Color",
+            "Find the first matching pixel in a region",
+            &["pixel", "color", "search"],
+            Pixel,
+            MkAction::FindPixel(MkPixelSearchPayload {
+                search_id: 0,
+                color: "#000000".into(),
+                tolerance: 0,
+                region: SearchRegion::Desktop,
+                wait: MkWaitOptions::default(),
+                not_found_policy: MkImageNotFoundPolicy::Continue,
+                outputs: MkImageOutputs::default(),
+            })
+        ),
+        d!(
+            Visual,
             "Check Pixel Color",
             "Check the color at one pixel coordinate",
             &["pixel", "color", "screen"],
@@ -763,7 +779,7 @@ pub fn editor_for_action(action: &MkAction) -> EditorKind {
         | MkAction::Break
         | MkAction::Continue => EditorKind::DirectInsert,
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => EditorKind::Image,
-        MkAction::PixelCheck { .. } => EditorKind::Pixel,
+        MkAction::PixelCheck { .. } | MkAction::FindPixel(_) => EditorKind::Pixel,
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }
@@ -1006,6 +1022,7 @@ pub fn action_name(a: &MkAction) -> &'static str {
         MkAction::Break => "Break",
         MkAction::Continue => "Continue",
         MkAction::ImageFind(_) => "Find Image",
+        MkAction::FindPixel(_) => "Find Pixel Color",
         MkAction::ImageClick(_) => "Click Image",
         MkAction::PixelCheck { .. } => "Check Pixel Color",
         MkAction::UiInvoke(_)
@@ -1099,6 +1116,16 @@ fn action_details_core(a: &MkAction, asset_name: Option<&str>, assets: &[MkImage
         MkAction::RepeatStart { count } => format!("{count} times"),
         MkAction::ImageFind(p) => format_image_details(p, asset_name, assets, false),
         MkAction::ImageClick(p) => format_image_details(p, asset_name, assets, true),
+        MkAction::FindPixel(p) => format!(
+            "{} ±{} · {} · {}",
+            p.color,
+            p.tolerance,
+            region_summary(&p.region),
+            match p.not_found_policy {
+                MkImageNotFoundPolicy::Continue => "continue if missing",
+                MkImageNotFoundPolicy::Fail => "fail if missing",
+            }
+        ),
         MkAction::PixelCheck {
             target,
             color,
@@ -1224,7 +1251,7 @@ fn asset_display_name(id: u64, preferred: Option<&str>, assets: &[MkImageAsset])
         })
         .unwrap_or_else(|| format!("Missing image #{id}"))
 }
-fn region_summary(region: &SearchRegion) -> String {
+pub(super) fn region_summary(region: &SearchRegion) -> String {
     match region {
         SearchRegion::Desktop => "Entire Desktop".into(),
         SearchRegion::Monitor { index } => format!("Monitor {index}"),
@@ -1578,6 +1605,9 @@ pub fn format_coordinate_target_with_assets(
                 offset.x,
                 offset.y
             )
+        }
+        MkCoordinateTarget::Pixel { search_id, offset } => {
+            format!("Pixel Result: #{search_id} + ({},{})", offset.x, offset.y)
         }
     }
 }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -960,8 +960,12 @@ pub(crate) fn change_target_kind(
         3 => MkCoordinateTarget::Variable {
             name: String::new(),
         },
-        _ => MkCoordinateTarget::Image {
+        4 => MkCoordinateTarget::Image {
             asset_id: assets.first().map_or(0, |a| a.id),
+            offset: MkPoint { x: 0, y: 0 },
+        },
+        _ => MkCoordinateTarget::Pixel {
+            search_id: 0,
             offset: MkPoint { x: 0, y: 0 },
         },
     };
@@ -978,6 +982,7 @@ pub(super) fn target_ui(
         MkCoordinateTarget::WindowClient { .. } => 2,
         MkCoordinateTarget::Variable { .. } => 3,
         MkCoordinateTarget::Image { .. } => 4,
+        MkCoordinateTarget::Pixel { .. } => 5,
     };
     let mut next = kind;
     egui::ComboBox::from_label("Target")
@@ -988,6 +993,7 @@ pub(super) fn target_ui(
                 "Matched Window",
                 "Variable",
                 "Image Result",
+                "Pixel Result",
             ][kind],
         )
         .show_ui(ui, |ui| {
@@ -998,6 +1004,7 @@ pub(super) fn target_ui(
             ui.add_enabled_ui(!assets.is_empty(), |ui| {
                 ui.selectable_value(&mut next, 4, "Image Result");
             });
+            ui.selectable_value(&mut next, 5, "Pixel Result");
         });
     if next != kind {
         change_target_kind(target, next, assets);
@@ -1074,6 +1081,19 @@ pub(super) fn target_ui(
                 ui.add(egui::DragValue::new(&mut offset.x));
             });
             ui.horizontal(|ui| {
+                ui.label("Y");
+                ui.add(egui::DragValue::new(&mut offset.y));
+            });
+        }
+        MkCoordinateTarget::Pixel { search_id, offset } => {
+            ui.horizontal(|ui| {
+                ui.label("Search ID");
+                ui.add(egui::DragValue::new(search_id));
+            });
+            ui.heading("Offset");
+            ui.horizontal(|ui| {
+                ui.label("X");
+                ui.add(egui::DragValue::new(&mut offset.x));
                 ui.label("Y");
                 ui.add(egui::DragValue::new(&mut offset.y));
             });
@@ -1555,6 +1575,134 @@ fn action_ui(
             }
         }
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => {}
+        MkAction::FindPixel(p) => {
+            ui.heading("Find Pixel Color");
+            ui.horizontal(|ui| {
+                ui.label("Color");
+                ui.text_edit_singleline(&mut p.color);
+                if let Ok(rgb) = crate::mkmacro::screen::parse_rgb(&p.color) {
+                    let mut picked = egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]);
+                    if ui.color_edit_button_srgba(&mut picked).changed() {
+                        p.color = crate::mkmacro::screen::format_rgb([
+                            picked.r(),
+                            picked.g(),
+                            picked.b(),
+                        ]);
+                    }
+                }
+                ui.label("Tolerance");
+                ui.add(egui::DragValue::new(&mut p.tolerance));
+            });
+            ui.small("Tolerance is the maximum absolute difference in each RGB channel.");
+            ui.horizontal(|ui| {
+                ui.label("Search ID");
+                ui.add(egui::DragValue::new(&mut p.search_id));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Timeout (ms)");
+                ui.add(egui::DragValue::new(&mut p.wait.timeout_ms));
+                ui.label("Poll (ms)");
+                ui.add(
+                    egui::DragValue::new(&mut p.wait.poll_interval_ms).clamp_range(1..=86_400_000),
+                );
+            });
+            egui::ComboBox::from_label("If missing")
+                .selected_text(match p.not_found_policy {
+                    MkImageNotFoundPolicy::Continue => "Continue",
+                    MkImageNotFoundPolicy::Fail => "Fail action",
+                })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut p.not_found_policy,
+                        MkImageNotFoundPolicy::Continue,
+                        "Continue",
+                    );
+                    ui.selectable_value(
+                        &mut p.not_found_policy,
+                        MkImageNotFoundPolicy::Fail,
+                        "Fail action",
+                    );
+                });
+            let mut region_kind = match p.region {
+                SearchRegion::Desktop => 0,
+                SearchRegion::Monitor { .. } => 1,
+                SearchRegion::Rectangle { .. } => 2,
+                SearchRegion::Window { .. } => 3,
+                SearchRegion::ClientArea { .. } => 4,
+            };
+            egui::ComboBox::from_label("Region")
+                .selected_text(
+                    ["Desktop", "Monitor", "Rectangle", "Window", "Client Area"][region_kind],
+                )
+                .show_ui(ui, |ui| {
+                    for (i, label) in ["Desktop", "Monitor", "Rectangle", "Window", "Client Area"]
+                        .into_iter()
+                        .enumerate()
+                    {
+                        ui.selectable_value(&mut region_kind, i, label);
+                    }
+                });
+            let current_kind = match p.region {
+                SearchRegion::Desktop => 0,
+                SearchRegion::Monitor { .. } => 1,
+                SearchRegion::Rectangle { .. } => 2,
+                SearchRegion::Window { .. } => 3,
+                SearchRegion::ClientArea { .. } => 4,
+            };
+            if region_kind != current_kind {
+                p.region = match region_kind {
+                    0 => SearchRegion::Desktop,
+                    1 => SearchRegion::Monitor { index: 0 },
+                    2 => SearchRegion::Rectangle {
+                        rect: ScreenRect::new(0, 0, 800, 500),
+                    },
+                    3 => SearchRegion::Window {
+                        matcher: MkWindowMatcher::default(),
+                    },
+                    _ => SearchRegion::ClientArea {
+                        matcher: MkWindowMatcher::default(),
+                    },
+                };
+            }
+            match &mut p.region {
+                SearchRegion::Monitor { index } => {
+                    ui.horizontal(|ui| {
+                        ui.label("Monitor index");
+                        ui.add(egui::DragValue::new(index));
+                    });
+                }
+                SearchRegion::Rectangle { rect } => {
+                    ui.horizontal(|ui| {
+                        ui.label("X");
+                        ui.add(egui::DragValue::new(&mut rect.x));
+                        ui.label("Y");
+                        ui.add(egui::DragValue::new(&mut rect.y));
+                        ui.label("Width");
+                        ui.add(egui::DragValue::new(&mut rect.width));
+                        ui.label("Height");
+                        ui.add(egui::DragValue::new(&mut rect.height));
+                    });
+                }
+                SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } => {
+                    matcher_ui(ui, matcher);
+                }
+                SearchRegion::Desktop => {}
+            }
+            for (label, output) in [
+                ("Found output", &mut p.outputs.found),
+                ("Point output", &mut p.outputs.point),
+                ("X output", &mut p.outputs.x),
+                ("Y output", &mut p.outputs.y),
+            ] {
+                ui.horizontal(|ui| {
+                    ui.label(label);
+                    ui.text_edit_singleline(output.get_or_insert_with(String::new));
+                });
+                if output.as_ref().is_some_and(|x| x.is_empty()) {
+                    *output = None;
+                }
+            }
+        }
         MkAction::PixelCheck {
             target,
             color,

--- a/src/mkmacro/coordinates.rs
+++ b/src/mkmacro/coordinates.rs
@@ -48,6 +48,12 @@ pub trait CoordinateData {
     fn active_client_origin(&self) -> ExecResult<MkPoint>;
     fn mouse_position(&self) -> ExecResult<MkPoint>;
     fn image_result(&self, id: u64) -> ExecResult<MkPoint>;
+    fn pixel_result(&self, id: u64) -> ExecResult<MkPoint> {
+        Err(ExecutionDiagnostic::new(
+            DiagnosticKind::TargetNotFound,
+            format!("pixel search {id} has no coordinate result"),
+        ))
+    }
     fn uia_result(&self, id: &str) -> ExecResult<MkPoint>;
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +63,7 @@ pub enum CoordinateBase {
     Client(MkPoint),
     RelativeMouse(MkPoint),
     ImageResult { id: u64, offset: MkPoint },
+    PixelResult { id: u64, offset: MkPoint },
     UiAutomationElement { id: String, offset: MkPoint },
 }
 pub trait OffsetRng {
@@ -83,6 +90,7 @@ pub fn resolve_coordinate(
         CoordinateBase::Client(p) => add(data.active_client_origin()?, *p),
         CoordinateBase::RelativeMouse(p) => add(data.mouse_position()?, *p),
         CoordinateBase::ImageResult { id, offset } => add(data.image_result(*id)?, *offset),
+        CoordinateBase::PixelResult { id, offset } => add(data.pixel_result(*id)?, *offset),
         CoordinateBase::UiAutomationElement { id, offset } => add(data.uia_result(id)?, *offset),
     };
     let r = radius.min(i32::MAX as u32) as i32;
@@ -163,6 +171,58 @@ mod tests {
                 }
             )
             .is_err()
+        );
+    }
+    struct PixelData;
+    impl CoordinateData for PixelData {
+        fn virtual_desktop(&self) -> ExecResult<VirtualDesktop> {
+            Ok(VirtualDesktop {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            })
+        }
+        fn active_window_rect(&self) -> ExecResult<Rect> {
+            unreachable!()
+        }
+        fn active_client_origin(&self) -> ExecResult<MkPoint> {
+            unreachable!()
+        }
+        fn mouse_position(&self) -> ExecResult<MkPoint> {
+            unreachable!()
+        }
+        fn image_result(&self, _: u64) -> ExecResult<MkPoint> {
+            unreachable!()
+        }
+        fn pixel_result(&self, id: u64) -> ExecResult<MkPoint> {
+            assert_eq!(id, 42);
+            Ok(MkPoint { x: 20, y: 30 })
+        }
+        fn uia_result(&self, _: &str) -> ExecResult<MkPoint> {
+            unreachable!()
+        }
+    }
+    struct NoOffset;
+    impl OffsetRng for NoOffset {
+        fn inclusive(&mut self, _: i32, _: i32) -> i32 {
+            0
+        }
+    }
+    #[test]
+    fn pixel_result_supports_offsets() {
+        assert_eq!(
+            resolve_coordinate(
+                &PixelData,
+                &CoordinateBase::PixelResult {
+                    id: 42,
+                    offset: MkPoint { x: -3, y: 5 }
+                },
+                0,
+                &mut NoOffset
+            )
+            .unwrap(),
+            MkPoint { x: 17, y: 35 }
         );
     }
 }

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -106,6 +106,12 @@ pub trait ScreenBackend: Send + Sync {
         Ok(point)
     }
     fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>>;
+    fn find_pixel(&self, _: &super::MkPixelSearchPayload) -> ExecResult<Option<MkPoint>> {
+        Err(ExecutionDiagnostic::new(
+            DiagnosticKind::UnsupportedOperation,
+            "pixel search is unavailable",
+        ))
+    }
     fn pixel_matches(
         &self,
         target: &MkCoordinateTarget,
@@ -1437,6 +1443,7 @@ impl Executor {
                 g.down_button(MkMouseButton::Left)?;
                 g.up_button(MkMouseButton::Left)
             }
+            MkAction::FindPixel(p) => self.wait_pixel(p, v).map(|_| ()),
             MkAction::PixelCheck {
                 target,
                 color,
@@ -1605,6 +1612,86 @@ impl Executor {
                 .context("timeout_ms", p.wait.timeout_ms.to_string())
                 .context("poll_interval_ms", p.wait.poll_interval_ms.to_string())
                 .context("elapsed_ms", started.elapsed().as_millis().to_string())),
+        }
+    }
+    fn wait_pixel(
+        &self,
+        p: &super::MkPixelSearchPayload,
+        v: &mut RuntimeVariables,
+    ) -> ExecResult<Option<MkPoint>> {
+        Self::write_pixel_result(v, p, None);
+        let started = Instant::now();
+        loop {
+            self.control.checkpoint()?;
+            match self.backends.screen.find_pixel(p) {
+                Err(e) => return Err(e),
+                Ok(Some(point)) => {
+                    Self::write_pixel_result(v, p, Some(point));
+                    return Ok(Some(point));
+                }
+                Ok(None) if started.elapsed() >= Duration::from_millis(p.wait.timeout_ms) => {
+                    Self::write_pixel_result(v, p, None);
+                    return match p.not_found_policy {
+                        MkImageNotFoundPolicy::Continue => Ok(None),
+                        MkImageNotFoundPolicy::Fail => Err(ExecutionDiagnostic::new(
+                            DiagnosticKind::TargetNotFound,
+                            "Pixel color was not found",
+                        )),
+                    };
+                }
+                Ok(None) => self.wait(Duration::from_millis(p.wait.poll_interval_ms.max(1)))?,
+            }
+        }
+    }
+    fn write_pixel_result(
+        v: &mut RuntimeVariables,
+        p: &super::MkPixelSearchPayload,
+        point: Option<MkPoint>,
+    ) {
+        let found = point.is_some();
+        v.insert("last_pixel_result".into(), MkValue::Boolean(found));
+        v.insert("last_pixel_found".into(), MkValue::Boolean(found));
+        v.insert(
+            super::screen::pixel_found_variable(p.search_id),
+            MkValue::Boolean(found),
+        );
+        let key = super::screen::pixel_result_variable(p.search_id);
+        if let Some(point) = point {
+            v.insert(key, MkValue::Point(point));
+            set_point(v, "last_pixel", point);
+            v.insert("last_pixel_x".into(), MkValue::Number(point.x.into()));
+            v.insert("last_pixel_y".into(), MkValue::Number(point.y.into()));
+        } else {
+            v.remove(&key);
+            for key in [
+                "last_pixel",
+                "last_pixel.x",
+                "last_pixel.y",
+                "last_pixel_x",
+                "last_pixel_y",
+            ] {
+                v.remove(key);
+            }
+        }
+        if let Some(name) = &p.outputs.found {
+            v.insert(name.clone(), MkValue::Boolean(found));
+        }
+        for name in [&p.outputs.point, &p.outputs.x, &p.outputs.y]
+            .into_iter()
+            .flatten()
+        {
+            v.remove(name);
+        }
+        if let Some(point) = point {
+            if let Some(name) = &p.outputs.point {
+                v.insert(name.clone(), MkValue::Point(point));
+            }
+            if let Some(name) = &p.outputs.x {
+                v.insert(name.clone(), MkValue::Number(point.x.into()));
+            }
+            if let Some(name) = &p.outputs.y {
+                v.insert(name.clone(), MkValue::Number(point.y.into()));
+            }
         }
     }
     /// Commits one completed search snapshot.
@@ -1833,7 +1920,8 @@ pub fn has_runtime_support(action: &MkAction) -> bool {
         | MkAction::WhileEnd
         | MkAction::Break
         | MkAction::Continue
-        | MkAction::PixelCheck { .. } => true,
+        | MkAction::PixelCheck { .. }
+        | MkAction::FindPixel(_) => true,
         MkAction::VirtualDesktop(_) => cfg!(windows),
         // Production installs `ProductionVisualSearch`, backed by the same
         // screen capture and matcher used by all visual-search execution.
@@ -1859,7 +1947,10 @@ fn action_name(a: &MkAction) -> &'static str {
         | MkAction::WindowMoveResize(_)
         | MkAction::WindowState { .. } => "window",
         MkAction::VirtualDesktop(_) => "virtual desktop",
-        MkAction::ImageFind(_) | MkAction::ImageClick(_) | MkAction::PixelCheck { .. } => "screen",
+        MkAction::ImageFind(_)
+        | MkAction::ImageClick(_)
+        | MkAction::FindPixel(_)
+        | MkAction::PixelCheck { .. } => "screen",
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }
@@ -3105,5 +3196,34 @@ mod phase_d_tests {
             )
             .unwrap_err();
         assert_eq!(error.kind, DiagnosticKind::TargetNotFound);
+    }
+
+    #[test]
+    fn pixel_found_outputs_and_miss_clear_coordinate_state() {
+        let payload = super::super::MkPixelSearchPayload {
+            search_id: 12,
+            color: "#32FF70".into(),
+            tolerance: 10,
+            region: super::super::SearchRegion::Desktop,
+            wait: MkWaitOptions::default(),
+            not_found_policy: MkImageNotFoundPolicy::Continue,
+            outputs: MkImageOutputs {
+                found: Some("hit".into()),
+                point: Some("pixel".into()),
+                x: Some("px".into()),
+                y: Some("py".into()),
+            },
+        };
+        let mut vars = RuntimeVariables::new();
+        Executor::write_pixel_result(&mut vars, &payload, Some(MkPoint { x: 8, y: 9 }));
+        assert_eq!(vars.get("hit"), Some(&MkValue::Boolean(true)));
+        assert_eq!(
+            vars.get("pixel"),
+            Some(&MkValue::Point(MkPoint { x: 8, y: 9 }))
+        );
+        Executor::write_pixel_result(&mut vars, &payload, None);
+        assert_eq!(vars.get("hit"), Some(&MkValue::Boolean(false)));
+        assert!(!vars.contains_key("pixel"));
+        assert!(!vars.contains_key("__pixel.12"));
     }
 }

--- a/src/mkmacro/image_search.rs
+++ b/src/mkmacro/image_search.rs
@@ -148,6 +148,23 @@ impl VisualSearch for ProductionVisualSearch {
             .capture(&SearchRegion::Rectangle { rect }, &|| false)?;
         Ok(frame.image.get_pixel(0, 0).0)
     }
+
+    fn find_pixel(
+        &self,
+        payload: &crate::mkmacro::MkPixelSearchPayload,
+    ) -> ExecResult<Option<MkPoint>> {
+        let rgb = crate::mkmacro::screen::parse_rgb(&payload.color)?;
+        let frame = self.capture.capture(&payload.region, &|| false)?;
+        find_pixel(
+            &frame,
+            Rgba([rgb[0], rgb[1], rgb[2], 255]),
+            payload.tolerance,
+            AlphaPolicy::Ignore,
+            PixelScanOrder::TopLeftRows,
+            &|| false,
+        )
+        .map(|p| p.map(|(x, y)| MkPoint { x, y }))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -6,7 +6,7 @@ use crate::mkmacro::variables::{MkPoint, MkValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 fn schema() -> u32 {
     SCHEMA_VERSION
 }
@@ -187,6 +187,12 @@ pub enum MkCoordinateTarget {
         asset_id: u64,
         offset: MkPoint,
     },
+    /// Result produced by a particular Find Pixel Color action.
+    Pixel {
+        search_id: u64,
+        #[serde(default)]
+        offset: MkPoint,
+    },
 }
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MkWindowMatcher {
@@ -260,7 +266,7 @@ pub enum MkUiPattern {
     SelectionItem,
     Focus,
 }
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct MkWaitOptions {
     pub timeout_ms: u64,
     pub poll_interval_ms: u64,
@@ -463,6 +469,25 @@ pub struct MkImagePayload {
     #[serde(default)]
     pub outputs: MkImageOutputs,
 }
+/// A first-class, asset-independent pixel search. Tolerance is the maximum
+/// absolute difference allowed independently for each RGB channel.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MkPixelSearchPayload {
+    /// Stable identity used to isolate coordinate results from other searches.
+    #[serde(default)]
+    pub search_id: u64,
+    pub color: String,
+    #[serde(default)]
+    pub tolerance: u8,
+    #[serde(default)]
+    pub region: SearchRegion,
+    #[serde(default)]
+    pub wait: MkWaitOptions,
+    #[serde(default)]
+    pub not_found_policy: MkImageNotFoundPolicy,
+    #[serde(default)]
+    pub outputs: MkImageOutputs,
+}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkUiPayload {
     pub window: MkWindowMatcher,
@@ -582,6 +607,7 @@ pub enum MkAction {
     Continue,
     ImageFind(MkImagePayload),
     ImageClick(MkImagePayload),
+    FindPixel(MkPixelSearchPayload),
     PixelCheck {
         target: MkCoordinateTarget,
         color: String,

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -266,10 +266,18 @@ pub enum MkUiPattern {
     SelectionItem,
     Focus,
 }
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkWaitOptions {
     pub timeout_ms: u64,
     pub poll_interval_ms: u64,
+}
+impl Default for MkWaitOptions {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 1_000,
+            poll_interval_ms: 50,
+        }
+    }
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -2,8 +2,8 @@
 //! Coordinates in a [`CapturedRegion`] are local; `origin` converts them back to
 //! virtual-desktop coordinates (and may therefore be negative).
 use crate::mkmacro::{
-    DiagnosticKind, ExecResult, ExecutionDiagnostic, MkCoordinateTarget, MkImagePayload, MkPoint,
-    MkValue, MkWindowMatcher, RuntimeVariables, ScreenBackend,
+    DiagnosticKind, ExecResult, ExecutionDiagnostic, MkCoordinateTarget, MkImagePayload,
+    MkPixelSearchPayload, MkPoint, MkValue, MkWindowMatcher, RuntimeVariables, ScreenBackend,
 };
 use image::RgbaImage;
 use std::sync::Arc;
@@ -16,6 +16,12 @@ pub(crate) fn image_result_variable(asset_id: u64) -> String {
 /// Runtime-only variable recording whether the latest search for an asset found it.
 pub(crate) fn image_found_variable(asset_id: u64) -> String {
     format!("__image_found.{asset_id}")
+}
+pub(crate) fn pixel_result_variable(search_id: u64) -> String {
+    format!("__pixel.{search_id}")
+}
+pub(crate) fn pixel_found_variable(search_id: u64) -> String {
+    format!("__pixel_found.{search_id}")
 }
 
 pub(crate) trait WindowsGeometry: Send + Sync {
@@ -30,6 +36,12 @@ pub(crate) trait WindowsGeometry: Send + Sync {
 pub(crate) trait VisualSearch: Send + Sync {
     fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>>;
     fn read_pixel(&self, point: MkPoint) -> ExecResult<[u8; 4]>;
+    fn find_pixel(&self, _: &MkPixelSearchPayload) -> ExecResult<Option<MkPoint>> {
+        Err(ExecutionDiagnostic::new(
+            DiagnosticKind::UnsupportedOperation,
+            "pixel search is unavailable",
+        ))
+    }
 }
 
 /// Parse the persisted pixel-check color. The only accepted representation is
@@ -241,6 +253,26 @@ impl ScreenBackend for WindowsScreenBackend {
                     .context("variable", key)),
                 }
             }
+            MkCoordinateTarget::Pixel { search_id, offset } => {
+                let key = pixel_result_variable(*search_id);
+                match variables.get(&key) {
+                    Some(MkValue::Point(point)) => Ok(MkPoint {
+                        x: point
+                            .x
+                            .checked_add(offset.x)
+                            .ok_or_else(|| invalid("pixel result X offset overflow"))?,
+                        y: point
+                            .y
+                            .checked_add(offset.y)
+                            .ok_or_else(|| invalid("pixel result Y offset overflow"))?,
+                    }),
+                    Some(value) => Err(type_mismatch(&key, value)),
+                    None => Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::TargetNotFound,
+                        format!("pixel search {search_id} has no result in the current run"),
+                    )),
+                }
+            }
         }
     }
 
@@ -250,6 +282,9 @@ impl ScreenBackend for WindowsScreenBackend {
 
     fn find_image(&self, macro_id: u64, payload: &MkImagePayload) -> ExecResult<Option<MkPoint>> {
         self.visual.find_image(macro_id, payload)
+    }
+    fn find_pixel(&self, payload: &MkPixelSearchPayload) -> ExecResult<Option<MkPoint>> {
+        self.visual.find_pixel(payload)
     }
 
     fn pixel_matches(

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -419,7 +419,7 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
         migrate_v4_to_v5(&mut value)?;
     }
     let mut doc: MkMacroDocument = match version {
-        0 | 1 | 2 | 3 | 4 | 5 => serde_json::from_value(value)
+        0 | 1 | 2 | 3 | 4 | 5 | 6 => serde_json::from_value(value)
             .context("mkmacros.json does not match the macro schema")?,
         _ => unreachable!(),
     };
@@ -727,7 +727,7 @@ mod tests {
 
         let (doc, changed) = read_document(&path).unwrap().unwrap();
         assert!(changed);
-        assert_eq!(doc.schema_version, 5);
+        assert_eq!(doc.schema_version, SCHEMA_VERSION);
         let encoded = serde_json::to_value(&doc).unwrap();
         assert_eq!(
             encoded["macros"][0]["steps"][2]["action"]["data"]["condition"]["conditions"][0]["conditions"]

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -103,6 +103,15 @@ pub fn validate_document_with_context(
             )
         };
         let mut ids = HashSet::new();
+        let pixel_search_ids: HashSet<u64> = m
+            .steps
+            .iter()
+            .filter_map(|s| match &s.action {
+                MkAction::FindPixel(p) if p.search_id != 0 => Some(p.search_id),
+                _ => None,
+            })
+            .collect();
+        let mut seen_pixel_ids = HashSet::new();
         let mut stack: Vec<(&str, bool)> = vec![];
         if m.playback.speed_percent == 0 {
             push(
@@ -350,11 +359,75 @@ pub fn validate_document_with_context(
                         _ => {}
                     }
                 }
-                MkAction::MouseMove(p) => target(&p.target, m.id, sid, asset_root, &mut out),
-                MkAction::MouseClick(p) => target(&p.target, m.id, sid, asset_root, &mut out),
+                MkAction::FindPixel(p) => {
+                    if p.search_id == 0 || !seen_pixel_ids.insert(p.search_id) {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_pixel_search_id",
+                            "Pixel search IDs must be non-zero and unique",
+                        );
+                    }
+                    wait(&p.wait, m.id, sid, &mut out);
+                    if super::screen::parse_rgb(&p.color).is_err() {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_pixel_color",
+                            "Enter a color as #RRGGBB",
+                        );
+                    }
+                    for name in [
+                        &p.outputs.found,
+                        &p.outputs.point,
+                        &p.outputs.x,
+                        &p.outputs.y,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        if validate_variable_name(name).is_err() {
+                            push(
+                                &mut out,
+                                m.id,
+                                sid,
+                                "invalid_pixel_output",
+                                format!("Invalid pixel output variable '{name}'"),
+                            );
+                        }
+                    }
+                    match &p.region {
+                        SearchRegion::Rectangle { rect } if rect.validate_capture().is_err() => {
+                            push(
+                                &mut out,
+                                m.id,
+                                sid,
+                                "invalid_pixel_region",
+                                "Pixel search rectangle is invalid",
+                            )
+                        }
+                        SearchRegion::Window { matcher: x }
+                        | SearchRegion::ClientArea { matcher: x } => {
+                            matcher(x, m.id, sid, &mut out)
+                        }
+                        _ => {}
+                    }
+                }
+                MkAction::MouseMove(p) => {
+                    target(&p.target, m.id, sid, asset_root, &mut out);
+                    validate_pixel_reference(&p.target, &pixel_search_ids, m.id, sid, &mut out);
+                }
+                MkAction::MouseClick(p) => {
+                    target(&p.target, m.id, sid, asset_root, &mut out);
+                    validate_pixel_reference(&p.target, &pixel_search_ids, m.id, sid, &mut out);
+                }
                 MkAction::MouseDrag(p) => {
                     target(&p.from, m.id, sid, asset_root, &mut out);
                     target(&p.to, m.id, sid, asset_root, &mut out);
+                    validate_pixel_reference(&p.from, &pixel_search_ids, m.id, sid, &mut out);
+                    validate_pixel_reference(&p.to, &pixel_search_ids, m.id, sid, &mut out);
                 }
                 MkAction::PixelCheck {
                     target: t, color, ..
@@ -508,7 +581,35 @@ fn target(
             "Point variable name is invalid",
         ),
         MkCoordinateTarget::Image { asset_id, .. } => asset(*asset_id, m, s, root, out),
+        MkCoordinateTarget::Pixel { search_id, .. } if *search_id == 0 => push(
+            out,
+            m,
+            s,
+            "missing_pixel_search",
+            "Select a Find Pixel Color result",
+        ),
+        MkCoordinateTarget::Pixel { .. } => {}
         _ => {}
+    }
+}
+fn validate_pixel_reference(
+    target: &MkCoordinateTarget,
+    ids: &HashSet<u64>,
+    m: u64,
+    s: Option<u64>,
+    out: &mut Vec<MkDiagnostic>,
+) {
+    if let MkCoordinateTarget::Pixel { search_id, .. } = target
+        && *search_id != 0
+        && !ids.contains(search_id)
+    {
+        push(
+            out,
+            m,
+            s,
+            "unknown_pixel_search",
+            format!("Pixel result references unknown search {search_id}"),
+        );
     }
 }
 fn condition(

--- a/src/mkmacro/variables.rs
+++ b/src/mkmacro/variables.rs
@@ -10,7 +10,7 @@ pub enum MkValue {
     Point(MkPoint),
     Null,
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MkPoint {
     pub x: i32,
     pub y: i32,


### PR DESCRIPTION
### Motivation

- Provide a first-class visual search for finding a pixel color (independent of image assets) with stable result isolation and outputs so multiple searches cannot clobber each other. 
- Expose authoring/editor controls and validation for pixel searches so authors can pick colors, tolerances, regions, timeouts, and name outputs safely. 
- Integrate pixel search results as coordinate sources usable by mouse actions while ensuring misses clear stale coordinate state and backend/capture failures propagate correctly.

### Description

- Bumped the macro schema to v6 and added `MkPixelSearchPayload` and a `FindPixel` action to the model with `search_id`, `color`, `tolerance`, `region`, `wait`, `not_found_policy`, and `outputs` fields for stable serialization and forward compatibility. 
- Added `CoordinateBase::PixelResult` and a `pixel_result` resolution path so pixel search results act like image-result coordinates with offset support and deterministic isolation per `search_id`. 
- Implemented backend search plumbing: `VisualSearch::find_pixel` and `ScreenBackend::find_pixel` delegate to the capture/matcher layer and use `find_pixel` logic that checks per-channel absolute RGB differences (tolerance applied independently per channel) with a deterministic scan order. Capture/backend failures return a distinct error from a clean no-match. 
- Executor changes: polling execution for `FindPixel` with `Continue`/`Fail` miss policies, atomic write of built-in and named outputs, clearing stale point state on misses, and allowing downstream coordinate consumers (Mouse Move/Click/Drag) to use pixel-result coordinates normally. 
- Authoring and GUI: catalog and editor additions for Find Pixel Color including color entry/picker, tolerance, region controls (desktop/monitor/rectangle/window/client), timeout/poll settings, not-found policy, search ID, and configurable outputs; formatted summaries and coordinate consumer formatting updated. 
- Validation: added checks for color syntax (`#RRGGBB`), unique non-zero `search_id`s, region geometry, output variable name validation, and cross-reference validation for pixel-result coordinate consumers. 
- Tests: added platform-independent unit tests for pixel-result coordinate offsets and executor tests ensuring found outputs and miss clearing behavior, plus various compile-time checks and formatting fixes applied.

### Testing

- Ran compilation checks for library and Windows target tests with `cargo check --lib --target x86_64-pc-windows-gnu` and `cargo check --tests --target x86_64-pc-windows-gnu`, both completed successfully. 
- Verified formatting and repository checks with `rustfmt` and `git diff --check` which reported no blocking issues. 
- Confirmed the new unit tests and test compilation are included in the test build; targeted tests compiled as part of the checks above. 
- Committed changes to the branch with the message "Add first-class pixel color search".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cdd0d07c48332b398b61ddc19a941)