### PR TITLE
Add WaitForVisualChange action with baseline-based frame comparison and UI

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -647,6 +647,14 @@ pub fn descriptors() -> Vec<ActionDescriptor> {
         ),
         d!(
             Visual,
+            "Wait for Visual Change",
+            "Wait until a percentage of pixels changes from the initial frame",
+            &["wait", "change", "screen", "visual"],
+            Screenshot,
+            MkAction::WaitForVisualChange(WaitForVisualChange::default())
+        ),
+        d!(
+            Visual,
             "Click Image",
             "Find and click an image",
             &["image", "click"],
@@ -795,7 +803,7 @@ pub fn editor_for_action(action: &MkAction) -> EditorKind {
         | MkAction::Break
         | MkAction::Continue => EditorKind::DirectInsert,
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => EditorKind::Image,
-        MkAction::CaptureScreenshot(_) => EditorKind::Screenshot,
+        MkAction::CaptureScreenshot(_) | MkAction::WaitForVisualChange(_) => EditorKind::Screenshot,
         MkAction::PixelCheck { .. } | MkAction::FindPixel(_) => EditorKind::Pixel,
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
@@ -1045,6 +1053,7 @@ pub fn action_name(a: &MkAction) -> &'static str {
         MkAction::ImageClick(_) => "Click Image",
         MkAction::PixelCheck { .. } => "Check Pixel Color",
         MkAction::CaptureScreenshot(_) => "Capture Screenshot",
+        MkAction::WaitForVisualChange(_) => "Wait for Visual Change",
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }
@@ -1166,6 +1175,12 @@ fn action_details_core(a: &MkAction, asset_name: Option<&str>, assets: &[MkImage
             }
             format!("{summary} · {destination}")
         }
+        MkAction::WaitForVisualChange(p) => format!(
+            "{} changes ≥ {}% · timeout {} ms",
+            region_summary(&p.region),
+            p.change_threshold_percent,
+            p.timeout_ms
+        ),
         MkAction::UiSetValue { value, .. } => {
             format!("Unavailable UI Automation action (set value to {value})")
         }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1575,6 +1575,81 @@ fn action_ui(
             }
         }
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => {}
+        MkAction::WaitForVisualChange(p) => {
+            ui.heading("Wait for Visual Change");
+            let mut region =
+                super::image_search_controls::ImageSearchControlState::from_region(&p.region);
+            egui::ComboBox::from_label("Region")
+                .selected_text(format!("{:?}", region.kind))
+                .show_ui(ui, |ui| {
+                    use super::image_search_controls::SearchRegionKind as K;
+                    for (kind, label) in [
+                        (K::Desktop, "Desktop"),
+                        (K::Monitor, "Monitor"),
+                        (K::Rectangle, "Rectangle"),
+                        (K::Window, "Window"),
+                        (K::ClientArea, "Client Area"),
+                    ] {
+                        ui.selectable_value(&mut region.kind, kind, label);
+                    }
+                });
+            match region.kind {
+                super::image_search_controls::SearchRegionKind::Monitor => {
+                    ui.add(egui::DragValue::new(&mut region.monitor_index).prefix("Monitor "));
+                }
+                super::image_search_controls::SearchRegionKind::Rectangle => {
+                    ui.horizontal(|ui| {
+                        ui.add(egui::DragValue::new(&mut region.rectangle.x).prefix("X "));
+                        ui.add(egui::DragValue::new(&mut region.rectangle.y).prefix("Y "));
+                        ui.add(egui::DragValue::new(&mut region.rectangle.width).prefix("W "));
+                        ui.add(egui::DragValue::new(&mut region.rectangle.height).prefix("H "));
+                    });
+                }
+                super::image_search_controls::SearchRegionKind::Window
+                | super::image_search_controls::SearchRegionKind::ClientArea => {
+                    let matcher = if matches!(
+                        region.kind,
+                        super::image_search_controls::SearchRegionKind::Window
+                    ) {
+                        &mut region.window_matcher
+                    } else {
+                        &mut region.client_matcher
+                    };
+                    ui.label("Window matcher");
+                    ui.text_edit_singleline(matcher.title.get_or_insert_default());
+                }
+                _ => {}
+            }
+            p.region = region.selected_region();
+            ui.horizontal(|ui| {
+                ui.label("Change threshold (%)");
+                ui.add(
+                    egui::DragValue::new(&mut p.change_threshold_percent).clamp_range(0.01..=100.0),
+                );
+            });
+            ui.small("Changed-pixel percentage: a pixel counts when any RGBA channel exceeds the tolerance.");
+            ui.horizontal(|ui| {
+                ui.label("Per-channel tolerance");
+                let tolerance = p.per_pixel_tolerance.get_or_insert(8);
+                ui.add(egui::DragValue::new(tolerance));
+                if ui.button("Disable tolerance").clicked() {
+                    p.per_pixel_tolerance = None;
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Timeout (ms)");
+                ui.add(egui::DragValue::new(&mut p.timeout_ms).clamp_range(1..=86_400_000));
+                ui.label("Poll (ms)");
+                ui.add(egui::DragValue::new(&mut p.poll_interval_ms).clamp_range(1..=86_400_000));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Consecutive changed frames");
+                ui.add(
+                    egui::DragValue::new(p.consecutive_changed_frames.get_or_insert(2))
+                        .clamp_range(1..=1000),
+                );
+            });
+        }
         MkAction::CaptureScreenshot(p) => {
             ui.heading("Capture Screenshot");
             let mut region =

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1581,6 +1581,61 @@ impl Executor {
         }
         Ok(())
     }
+
+    fn wait_for_visual_change(&self, p: &super::WaitForVisualChange) -> ExecResult {
+        let capture = || {
+            self.backends
+                .screenshot_capture
+                .capture(&p.region, &|| self.control.is_stopped())
+                .map_err(|e| {
+                    e.context("action", "wait for visual change")
+                        .context("region", format!("{:?}", p.region))
+                })
+        };
+        // This frame is never replaced: every poll is measured against the
+        // visual state at action entry rather than against the previous poll.
+        let baseline = capture()?;
+        let started = Instant::now();
+        let timeout = Duration::from_millis(p.timeout_ms);
+        let required = p.consecutive_changed_frames.unwrap_or(1).max(1);
+        let mut consecutive = 0u32;
+        loop {
+            self.control.checkpoint()?;
+            let fresh = capture()?;
+            let changed = match super::visual_frame_difference(
+                &baseline,
+                &fresh,
+                p.per_pixel_tolerance.unwrap_or(0),
+            )? {
+                super::VisualFrameDifference::RegionSizeChanged => true,
+                super::VisualFrameDifference::ChangedPixelPercent(percent) => {
+                    percent >= p.change_threshold_percent
+                }
+            };
+            // Drop the fresh frame before sleeping; only the baseline survives.
+            drop(fresh);
+            consecutive = if changed {
+                consecutive.saturating_add(1)
+            } else {
+                0
+            };
+            if consecutive >= required {
+                return Ok(());
+            }
+            let elapsed = started.elapsed();
+            if elapsed >= timeout {
+                return Err(ExecutionDiagnostic::new(
+                    DiagnosticKind::Timeout,
+                    "timed out waiting for visual change",
+                )
+                .context("timeout_ms", p.timeout_ms.to_string())
+                .context("threshold_percent", p.change_threshold_percent.to_string()));
+            }
+            self.wait(
+                Duration::from_millis(p.poll_interval_ms).min(timeout.saturating_sub(elapsed)),
+            )?;
+        }
+    }
     pub fn execute(&self, plan: &MkExecutionPlan, observe: &dyn Fn(ExecutionEvent)) -> ExecResult {
         let _activity = RunActivityGuard(&self.control);
         let mut guard = InputCleanupGuard::new(self.backends.input.clone());
@@ -1934,6 +1989,7 @@ impl Executor {
                 }
                 Ok(())
             }
+            MkAction::WaitForVisualChange(p) => self.wait_for_visual_change(p),
             MkAction::PixelCheck {
                 target,
                 color,
@@ -2412,7 +2468,7 @@ pub fn has_runtime_support(action: &MkAction) -> bool {
         | MkAction::Continue
         | MkAction::PixelCheck { .. }
         | MkAction::FindPixel(_) => true,
-        MkAction::CaptureScreenshot(_) => true,
+        MkAction::CaptureScreenshot(_) | MkAction::WaitForVisualChange(_) => true,
         MkAction::VirtualDesktop(_) => cfg!(windows),
         // Production installs `ProductionVisualSearch`, backed by the same
         // screen capture and matcher used by all visual-search execution.
@@ -2442,7 +2498,7 @@ fn action_name(a: &MkAction) -> &'static str {
         | MkAction::ImageClick(_)
         | MkAction::FindPixel(_)
         | MkAction::PixelCheck { .. } => "screen",
-        MkAction::CaptureScreenshot(_) => "screen capture",
+        MkAction::CaptureScreenshot(_) | MkAction::WaitForVisualChange(_) => "screen capture",
         MkAction::UiInvoke(_)
         | MkAction::UiSetValue { .. }
         | MkAction::UiReadValue { .. }

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -604,6 +604,33 @@ pub enum MkMouseScrollAxis {
     Vertical,
     Horizontal,
 }
+/// Waits until a stable percentage of pixels differs from the frame captured
+/// when the action starts. `change_threshold_percent` is in user-facing percent
+/// units (5.0 means five percent); a pixel is changed when any RGBA channel
+/// differs by more than `per_pixel_tolerance`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WaitForVisualChange {
+    pub region: SearchRegion,
+    pub timeout_ms: u64,
+    pub poll_interval_ms: u64,
+    pub change_threshold_percent: f64,
+    #[serde(default)]
+    pub per_pixel_tolerance: Option<u8>,
+    #[serde(default)]
+    pub consecutive_changed_frames: Option<u32>,
+}
+impl Default for WaitForVisualChange {
+    fn default() -> Self {
+        Self {
+            region: SearchRegion::Desktop,
+            timeout_ms: 10_000,
+            poll_interval_ms: 100,
+            change_threshold_percent: 5.0,
+            per_pixel_tolerance: Some(8),
+            consecutive_changed_frames: Some(2),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum MkAction {
@@ -670,6 +697,7 @@ pub enum MkAction {
     ImageClick(MkImagePayload),
     FindPixel(MkPixelSearchPayload),
     CaptureScreenshot(MkScreenshotPayload),
+    WaitForVisualChange(WaitForVisualChange),
     PixelCheck {
         target: MkCoordinateTarget,
         color: String,

--- a/src/mkmacro/screen.rs
+++ b/src/mkmacro/screen.rs
@@ -550,6 +550,41 @@ mod capture_geometry_tests {
                 .contains("allocation size overflow")
         );
     }
+
+    fn frame(width: u32, height: u32, pixels: &[[u8; 4]]) -> CapturedRegion {
+        CapturedRegion {
+            image: RgbaImage::from_raw(width, height, pixels.iter().flatten().copied().collect())
+                .unwrap(),
+            origin: (0, 0),
+        }
+    }
+
+    #[test]
+    fn visual_difference_is_deterministic_at_boundary_and_ignores_noise() {
+        let baseline = frame(2, 2, &[[0, 0, 0, 255]; 4]);
+        let one_changed = frame(
+            2,
+            2,
+            &[
+                [9, 0, 0, 255],
+                [0, 0, 0, 255],
+                [0, 0, 0, 255],
+                [0, 0, 0, 255],
+            ],
+        );
+        assert_eq!(
+            visual_frame_difference(&baseline, &one_changed, 8).unwrap(),
+            VisualFrameDifference::ChangedPixelPercent(25.0)
+        );
+        assert_eq!(
+            visual_frame_difference(&baseline, &one_changed, 9).unwrap(),
+            VisualFrameDifference::ChangedPixelPercent(0.0)
+        );
+        assert_eq!(
+            visual_frame_difference(&baseline, &frame(1, 1, &[[0, 0, 0, 255]]), 0).unwrap(),
+            VisualFrameDifference::RegionSizeChanged
+        );
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -581,6 +616,52 @@ impl CapturedRegion {
         let p = (u32::try_from(x).ok()?, u32::try_from(y).ok()?);
         (p.0 < self.image.width() && p.1 < self.image.height()).then_some(p)
     }
+}
+
+/// Result of comparing a fresh capture with the immutable initial capture.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VisualFrameDifference {
+    /// A changed capture geometry is itself a meaningful visual change.
+    RegionSizeChanged,
+    /// Percentage of pixels for which at least one channel exceeds tolerance.
+    ChangedPixelPercent(f64),
+}
+
+/// Compares logical pixels row-by-row. Iterating image rows deliberately avoids
+/// treating storage outside a row's pixel width (backend row padding/stride) as
+/// image content. Integer counts use `u64`; the dimension product is checked.
+pub fn visual_frame_difference(
+    baseline: &CapturedRegion,
+    fresh: &CapturedRegion,
+    tolerance: u8,
+) -> ExecResult<VisualFrameDifference> {
+    if baseline.image.dimensions() != fresh.image.dimensions() {
+        return Ok(VisualFrameDifference::RegionSizeChanged);
+    }
+    let total = u64::from(baseline.image.width())
+        .checked_mul(u64::from(baseline.image.height()))
+        .ok_or_else(|| invalid("visual comparison pixel count overflow"))?;
+    if total == 0 {
+        return Err(invalid("visual comparison region is empty"));
+    }
+    let mut changed = 0u64;
+    for (base_row, fresh_row) in baseline.image.rows().zip(fresh.image.rows()) {
+        for (base, current) in base_row.zip(fresh_row) {
+            if base
+                .0
+                .iter()
+                .zip(current.0.iter())
+                .any(|(a, b)| a.abs_diff(*b) > tolerance)
+            {
+                changed = changed
+                    .checked_add(1)
+                    .ok_or_else(|| invalid("visual comparison changed-pixel count overflow"))?;
+            }
+        }
+    }
+    Ok(VisualFrameDifference::ChangedPixelPercent(
+        (changed as f64) * 100.0 / (total as f64),
+    ))
 }
 
 /// Capture boundary. Implementations resolve windows/client areas without changing

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -483,6 +483,75 @@ pub fn validate_document_with_context(
                         _ => {}
                     }
                 }
+                MkAction::WaitForVisualChange(p) => {
+                    if !p.change_threshold_percent.is_finite()
+                        || !(0.0..=100.0).contains(&p.change_threshold_percent)
+                        || p.change_threshold_percent == 0.0
+                    {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_visual_change_threshold",
+                            "Visual change threshold must be greater than 0 and at most 100 percent",
+                        );
+                    }
+                    if p.timeout_ms == 0 {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_visual_change_timeout",
+                            "Visual change timeout must be greater than zero",
+                        );
+                    }
+                    if p.poll_interval_ms == 0 || p.poll_interval_ms > p.timeout_ms {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_visual_change_poll",
+                            "Visual change poll interval must be greater than zero and no longer than the timeout",
+                        );
+                    }
+                    if p.consecutive_changed_frames.unwrap_or(1) == 0
+                        || u64::from(p.consecutive_changed_frames.unwrap_or(1))
+                            > p.timeout_ms / p.poll_interval_ms.max(1) + 1
+                    {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "impossible_visual_change_settling",
+                            "Visual change settling frames cannot be observed within the timeout",
+                        );
+                    }
+                    match &p.region {
+                        SearchRegion::Rectangle { rect } if rect.validate_capture().is_err() => {
+                            push(
+                                &mut out,
+                                m.id,
+                                sid,
+                                "invalid_visual_change_region",
+                                "Visual change rectangle is invalid",
+                            )
+                        }
+                        SearchRegion::Window { matcher: x }
+                        | SearchRegion::ClientArea { matcher: x } => {
+                            matcher(x, m.id, sid, &mut out)
+                        }
+                        SearchRegion::Monitor { index } if matches!(context.monitors, MonitorValidation::Available(monitors) if !monitors.iter().any(|d| d.index == *index)) => {
+                            push(
+                                &mut out,
+                                m.id,
+                                sid,
+                                "unavailable_visual_change_monitor",
+                                format!("Selected monitor {index} is no longer available"),
+                            )
+                        }
+                        _ => {}
+                    }
+                }
                 MkAction::MouseMove(p) => {
                     target(&p.target, m.id, sid, asset_root, &mut out);
                     validate_pixel_reference(&p.target, &pixel_search_ids, m.id, sid, &mut out);


### PR DESCRIPTION
### Motivation

- Provide an action that waits for meaningful visual change in a region after image/pixel regression is stable, with user-configurable threshold, tolerance, polling and settling semantics.

### Description

- Add a serializable `WaitForVisualChange` payload to the macro model with `SearchRegion`, `timeout_ms`, `poll_interval_ms`, `change_threshold_percent`, optional `per_pixel_tolerance`, and optional `consecutive_changed_frames` with sensible defaults. 
- Implement deterministic, overflow-safe row-by-row frame comparison in `screen.rs` that reports either `RegionSizeChanged` or percent of logical pixels whose RGBA channels exceed the configured tolerance, explicitly handling row padding/stride and allocation overflow.
- Add executor logic to capture a single immutable baseline at action start and poll fresh frames until threshold/settling is reached, cancellation/timeout occurs, or capture/backend failure happens, disposing fresh frames promptly and reporting timeout separately from backend errors. 
- Extend authoring UI and catalog to include the new action (reusing existing region controls), add user-facing descriptions and summaries, and extend validation to check thresholds, polling/timeout ranges, region validity, and impossible settling configurations; add deterministic unit tests for frame comparison behavior.

### Testing

- ✅ `git diff --check` passed.
- ✅ `git commit` of the changes succeeded (commit `1032454`, message: "Add wait for visual change macro action").
- ⚠️ `cargo fmt --check` reported a pre-existing unrelated formatting difference in `visual_overlay_windows.rs` (touched files were formatted by the patch). 
- ❌ `cargo check` could not complete on this Linux host due to unrelated repository code that unconditionally references Windows-only `windows::Win32` APIs; compilation failures are environment/platform-specific and do not indicate regressions in the added visual-change logic. 
- Note: deterministic unit tests for frame-comparison logic were added but could not be executed end-to-end here because `cargo check` did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8de1336b448332af09d55ab8992f64)