### PR TITLE
Rectangle picker: deterministic tooltip text, style, and native Windows tooltip

### DIFF
--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -13,6 +13,64 @@ use std::{
 /// Passive overlays remain visible long enough to be recognized without
 /// becoming persistent desktop furniture.
 pub const PASSIVE_OVERLAY_DURATION: Duration = Duration::from_millis(2500);
+pub const RECTANGLE_OUTLINE_WIDTH: i32 = 3;
+pub const RECTANGLE_TOOLTIP_OFFSET: (i32, i32) = (16, 16);
+pub const RECTANGLE_INSTRUCTION: &str = "Draw a rectangle around the region — Esc to cancel";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RectangleTooltip {
+    pub text: String,
+    pub pointer: MkPoint,
+}
+
+pub fn rectangle_tooltip_text(selection: Option<ScreenRect>) -> String {
+    match selection {
+        None => RECTANGLE_INSTRUCTION.to_owned(),
+        Some(rect) => format!(
+            "X: {}  Y: {}\nW: {}  H: {}\nRelease to select — Esc to cancel",
+            rect.x, rect.y, rect.width, rect.height
+        ),
+    }
+}
+
+/// Places a tooltip near a pointer, flipping before it at crowded right/bottom edges.
+pub fn place_rectangle_tooltip(
+    pointer: MkPoint,
+    size: (u32, u32),
+    monitor: ScreenRect,
+    offset: (i32, i32),
+) -> MkPoint {
+    let width = i64::from(size.0);
+    let height = i64::from(size.1);
+    let left = i64::from(monitor.x);
+    let top = i64::from(monitor.y);
+    let max_x = (monitor.right() - width).max(left);
+    let max_y = (monitor.bottom() - height).max(top);
+    let preferred_x = i64::from(pointer.x) + i64::from(offset.0);
+    let preferred_y = i64::from(pointer.y) + i64::from(offset.1);
+    let x = if preferred_x + width <= monitor.right() {
+        preferred_x
+    } else {
+        i64::from(pointer.x) - i64::from(offset.0) - width
+    };
+    let y = if preferred_y + height <= monitor.bottom() {
+        preferred_y
+    } else {
+        i64::from(pointer.y) - i64::from(offset.1) - height
+    };
+    MkPoint {
+        x: x.clamp(left, max_x) as i32,
+        y: y.clamp(top, max_y) as i32,
+    }
+}
+
+pub fn monitor_nearest_pointer(monitors: &[ScreenRect], pointer: MkPoint) -> Option<ScreenRect> {
+    monitors.iter().copied().min_by_key(|m| {
+        let x = i64::from(pointer.x).clamp(i64::from(m.x), m.right().saturating_sub(1));
+        let y = i64::from(pointer.y).clamp(i64::from(m.y), m.bottom().saturating_sub(1));
+        (i64::from(pointer.x) - x).pow(2) + (i64::from(pointer.y) - y).pow(2)
+    })
+}
 
 pub type OperationId = u64;
 
@@ -126,6 +184,7 @@ pub enum OverlayVisual {
     RectanglePicker {
         virtual_desktop: ScreenRect,
         selection: Option<ScreenRect>,
+        tooltip: RectangleTooltip,
     },
     RectanglePreview(ScreenRect),
     Monitor(MonitorDescriptor),
@@ -229,6 +288,7 @@ pub(crate) fn overlay_is_mouse_transparent(visual: &OverlayVisual) -> bool {
 /// Isolates native windows, input, painting and resource ownership from the
 /// deterministic state machine.
 pub trait OverlayRenderer: Send {
+    fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError>;
     fn show(
         &mut self,
         operation_id: OperationId,
@@ -271,6 +331,7 @@ pub struct VisualOverlayController {
     clock: Box<dyn OverlayClock>,
     events: VecDeque<VisualOverlayEvent>,
     virtual_desktop: Option<ScreenRect>,
+    picker_pointer: Option<MkPoint>,
     shut_down: bool,
 }
 
@@ -292,6 +353,7 @@ impl VisualOverlayController {
             clock,
             events: VecDeque::new(),
             virtual_desktop: None,
+            picker_pointer: None,
             shut_down: false,
         }
     }
@@ -318,6 +380,7 @@ impl VisualOverlayController {
         }
         self.state = VisualOverlayState::Idle;
         self.virtual_desktop = None;
+        self.picker_pointer = None;
         self.allocate()
     }
     fn start(&mut self, state: VisualOverlayState, visual: OverlayVisual) -> OperationId {
@@ -362,6 +425,18 @@ impl VisualOverlayController {
             });
             return id;
         }
+        let pointer = match self.renderer.cursor_position() {
+            Ok(pointer) => pointer,
+            Err(error) => {
+                let id = self.replace();
+                self.events.push_back(VisualOverlayEvent::Error {
+                    operation_id: id,
+                    error,
+                });
+                return id;
+            }
+        };
+        self.picker_pointer = Some(pointer);
         let id = self.start(
             VisualOverlayState::PickingRectangle {
                 start: None,
@@ -371,6 +446,10 @@ impl VisualOverlayController {
             OverlayVisual::RectanglePicker {
                 virtual_desktop,
                 selection: None,
+                tooltip: RectangleTooltip {
+                    text: rectangle_tooltip_text(None),
+                    pointer,
+                },
             },
         );
         if self.operation_id == Some(id) {
@@ -434,6 +513,7 @@ impl VisualOverlayController {
         }
         self.state = VisualOverlayState::Idle;
         self.virtual_desktop = None;
+        self.picker_pointer = None;
     }
     pub fn shutdown(&mut self) {
         if self.shut_down {
@@ -443,6 +523,7 @@ impl VisualOverlayController {
         self.operation_id = None;
         self.state = VisualOverlayState::Idle;
         self.virtual_desktop = None;
+        self.picker_pointer = None;
         self.events.clear();
         self.shut_down = true;
     }
@@ -496,18 +577,18 @@ impl VisualOverlayController {
                 };
                 *start = Some(point);
                 *current = Some(point);
+                self.picker_pointer = Some(point);
                 self.repaint_picker();
             }
             OverlayInputKind::PointerMoved(point) => {
-                let VisualOverlayState::PickingRectangle {
-                    start: Some(_),
-                    current,
-                    ..
-                } = &mut self.state
+                let VisualOverlayState::PickingRectangle { start, current, .. } = &mut self.state
                 else {
                     return;
                 };
-                *current = Some(point);
+                if start.is_some() {
+                    *current = Some(point);
+                }
+                self.picker_pointer = Some(point);
                 self.repaint_picker();
             }
             OverlayInputKind::LeftReleased(point) => {
@@ -520,6 +601,7 @@ impl VisualOverlayController {
                     return;
                 };
                 *current = Some(point);
+                self.picker_pointer = Some(point);
                 // Publish the final pointer position through the same repaint
                 // path as press/move before confirmation tears the windows down.
                 self.repaint_picker();
@@ -537,12 +619,21 @@ impl VisualOverlayController {
             .zip(current)
             .and_then(|(a, b)| normalized_rect(a, b).ok())
             .filter(|r| !r.is_empty());
+        let pointer = self
+            .picker_pointer
+            .or(current)
+            .or(start)
+            .unwrap_or(MkPoint { x: 0, y: 0 });
         if let (Some(id), Some(virtual_desktop)) = (self.operation_id, self.virtual_desktop) {
             if let Err(error) = self.renderer.repaint(
                 id,
                 &OverlayVisual::RectanglePicker {
                     virtual_desktop,
                     selection,
+                    tooltip: RectangleTooltip {
+                        text: rectangle_tooltip_text(selection),
+                        pointer,
+                    },
                 },
             ) {
                 self.renderer.close();
@@ -631,6 +722,9 @@ use native::NativeOverlayRenderer;
 struct NativeOverlayRenderer;
 #[cfg(not(windows))]
 impl OverlayRenderer for NativeOverlayRenderer {
+    fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
+        Err(VisualOverlayError::unsupported())
+    }
     fn show(
         &mut self,
         _: OperationId,
@@ -677,6 +771,9 @@ mod tests {
     }
     struct FakeRenderer(Arc<Mutex<FakeData>>);
     impl OverlayRenderer for FakeRenderer {
+        fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
+            Ok(point(40, 50))
+        }
         fn show(
             &mut self,
             operation_id: OperationId,
@@ -777,6 +874,103 @@ mod tests {
     }
 
     #[test]
+    fn tooltip_text_is_deterministic_for_every_direction_and_negative_geometry() {
+        let expected = "X: -20  Y: -30\nW: 30  H: 50\nRelease to select — Esc to cancel";
+        for (a, b) in [
+            (point(-20, -30), point(10, 20)),
+            (point(10, -30), point(-20, 20)),
+            (point(-20, 20), point(10, -30)),
+            (point(10, 20), point(-20, -30)),
+        ] {
+            assert_eq!(
+                rectangle_tooltip_text(Some(normalized_rect(a, b).unwrap())),
+                expected
+            );
+        }
+        assert_eq!(rectangle_tooltip_text(None), RECTANGLE_INSTRUCTION);
+    }
+
+    #[test]
+    fn tooltip_placement_flips_clamps_and_supports_signed_offset_monitors() {
+        let monitor = ScreenRect::new(-1000, 200, 800, 600);
+        assert_eq!(
+            place_rectangle_tooltip(point(-990, 210), (100, 50), monitor, (16, 16)),
+            point(-974, 226)
+        );
+        assert_eq!(
+            place_rectangle_tooltip(point(-210, 790), (100, 50), monitor, (16, 16)),
+            point(-326, 724)
+        );
+        assert_eq!(
+            place_rectangle_tooltip(point(-500, 500), (900, 700), monitor, (16, 16)),
+            point(-1000, 200)
+        );
+        assert_eq!(
+            monitor_nearest_pointer(
+                &[monitor, ScreenRect::new(0, -500, 500, 500)],
+                point(-20, -20)
+            ),
+            Some(ScreenRect::new(0, -500, 500, 500))
+        );
+    }
+
+    #[test]
+    fn picker_shows_initial_hint_and_moves_replace_geometry_and_hint_together() {
+        let (mut c, fake, _) = controller();
+        let id = c.begin_rectangle_pick(
+            RectanglePurpose::SearchRegion,
+            ScreenRect::new(-100, -100, 400, 400),
+        );
+        let calls = fake.lock().unwrap().calls.clone();
+        assert!(
+            matches!(&calls[0], RecordedCall::Show { visual: OverlayVisual::RectanglePicker { selection: None, tooltip, .. }, .. } if tooltip.text == RECTANGLE_INSTRUCTION && tooltip.pointer == point(40, 50))
+        );
+        fake.lock().unwrap().inputs = vec![
+            OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::LeftPressed(point(10, 20)),
+            },
+            OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::PointerMoved(point(-10, -20)),
+            },
+            OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::PointerMoved(point(30, 40)),
+            },
+        ];
+        assert!(c.poll().is_empty());
+        let repaints: Vec<_> = fake
+            .lock()
+            .unwrap()
+            .calls
+            .iter()
+            .filter_map(|call| match call {
+                RecordedCall::Repaint { visual, .. } => Some(visual.clone()),
+                _ => None,
+            })
+            .collect();
+        for visual in &repaints {
+            let OverlayVisual::RectanglePicker {
+                selection, tooltip, ..
+            } = visual
+            else {
+                panic!()
+            };
+            let frame = overlay_frame(visual);
+            assert_eq!(frame.first(), Some(&OverlayFramePrimitive::Clear));
+            assert_eq!(
+                frame.get(1),
+                selection.map(OverlayFramePrimitive::Outline).as_ref()
+            );
+            assert_eq!(tooltip.text, rectangle_tooltip_text(*selection));
+        }
+        assert!(
+            matches!(repaints.last(), Some(OverlayVisual::RectanglePicker { selection: Some(r), .. }) if *r == ScreenRect::new(10, 20, 20, 20))
+        );
+    }
+
+    #[test]
     fn half_open_drag_geometry_is_identical_in_all_four_directions() {
         let expected = ScreenRect::new(500, 300, 700, 600);
         for (a, b) in [
@@ -835,6 +1029,10 @@ mod tests {
         let picker = OverlayVisual::RectanglePicker {
             virtual_desktop: ScreenRect::new(0, 0, 1, 1),
             selection: None,
+            tooltip: RectangleTooltip {
+                text: rectangle_tooltip_text(None),
+                pointer: point(0, 0),
+            },
         };
         assert!(!overlay_is_mouse_transparent(&picker));
         assert!(overlay_is_mouse_transparent(
@@ -853,6 +1051,10 @@ mod tests {
             let frame = overlay_frame(&OverlayVisual::RectanglePicker {
                 virtual_desktop: ScreenRect::new(-100, -100, 200, 200),
                 selection,
+                tooltip: RectangleTooltip {
+                    text: rectangle_tooltip_text(selection),
+                    pointer: point(0, 0),
+                },
             });
             assert_eq!(frame.first(), Some(&OverlayFramePrimitive::Clear));
             assert_eq!(

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -2,32 +2,32 @@
 //! physical monitor: a single virtual-desktop popup would cover monitor gaps.
 use super::*;
 use windows::{
-    core::PCWSTR,
     Win32::{
         Foundation::{
-            GetLastError, COLORREF, ERROR_CLASS_ALREADY_EXISTS, HWND, LPARAM, LRESULT, POINT, RECT,
+            COLORREF, ERROR_CLASS_ALREADY_EXISTS, GetLastError, HWND, LPARAM, LRESULT, POINT, RECT,
             WPARAM,
         },
         Graphics::Gdi::{
             BeginPaint, CreatePen, CreateSolidBrush, DeleteObject, EndPaint, EnumDisplayMonitors,
-            FillRect, GetMonitorInfoW, GetStockObject, InvalidateRect, Rectangle, SelectObject,
-            SetBkMode, SetTextColor, TextOutW, UpdateWindow, HDC, HGDIOBJ, HMONITOR, MONITORINFO,
-            NULL_BRUSH, PAINTSTRUCT, PS_SOLID, TRANSPARENT,
+            FillRect, GetMonitorInfoW, GetStockObject, HDC, HGDIOBJ, HMONITOR, InvalidateRect,
+            MONITORINFO, NULL_BRUSH, PAINTSTRUCT, PS_SOLID, Rectangle, SelectObject, SetBkMode,
+            SetTextColor, TRANSPARENT, TextOutW, UpdateWindow,
         },
         System::LibraryLoader::GetModuleHandleW,
         UI::{
             Input::KeyboardAndMouse::{GetAsyncKeyState, VK_ESCAPE, VK_LBUTTON},
             WindowsAndMessaging::{
-                CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetCursorPos,
-                GetWindowLongPtrW, PeekMessageW, RegisterClassW, SetLayeredWindowAttributes,
-                SetWindowLongPtrW, SetWindowPos, ShowWindow, TranslateMessage, CREATESTRUCTW,
-                CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HWND_TOPMOST, LWA_COLORKEY, MSG, PM_REMOVE,
-                SWP_NOACTIVATE, SWP_SHOWWINDOW, SW_SHOWNOACTIVATE, WM_ERASEBKGND, WM_NCCREATE,
-                WM_PAINT, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
-                WS_EX_TRANSPARENT, WS_POPUP,
+                CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, CreateWindowExW, DefWindowProcW,
+                DestroyWindow, DispatchMessageW, GWLP_USERDATA, GetCursorPos, GetWindowLongPtrW,
+                HWND_TOPMOST, LWA_COLORKEY, MSG, PM_REMOVE, PeekMessageW, RegisterClassW,
+                SW_SHOWNOACTIVATE, SWP_NOACTIVATE, SWP_NOSIZE, SWP_SHOWWINDOW,
+                SetLayeredWindowAttributes, SetWindowLongPtrW, SetWindowPos, ShowWindow,
+                TranslateMessage, WM_ERASEBKGND, WM_NCCREATE, WM_PAINT, WNDCLASSW, WS_EX_LAYERED,
+                WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
             },
         },
     },
+    core::PCWSTR,
 };
 
 // COLORREF is 0x00bbggrr. Magenta is reserved exclusively for transparency.
@@ -39,6 +39,7 @@ const LABEL_COLOR: COLORREF = COLORREF(0x00ffffff);
 struct WindowPaintState {
     bounds: ScreenRect,
     frame: Vec<OverlayFramePrimitive>,
+    hint: Option<String>,
 }
 struct OverlayWindow {
     hwnd: HWND,
@@ -48,6 +49,7 @@ struct OverlayWindow {
 
 pub(super) struct NativeOverlayRenderer {
     windows: Vec<OverlayWindow>,
+    tooltip: Option<OverlayWindow>,
     operation_id: Option<OperationId>,
     visual: Option<OverlayVisual>,
     left_down: bool,
@@ -58,6 +60,7 @@ impl Default for NativeOverlayRenderer {
     fn default() -> Self {
         Self {
             windows: vec![],
+            tooltip: None,
             operation_id: None,
             visual: None,
             left_down: false,
@@ -107,7 +110,25 @@ unsafe fn paint_frame(dc: HDC, state: &WindowPaintState) {
         let _ = DeleteObject(HGDIOBJ(clear.0));
     };
 
-    let pen = unsafe { CreatePen(PS_SOLID, 5, OUTLINE_COLOR) };
+    if let Some(text) = &state.hint {
+        let background = unsafe { CreateSolidBrush(COLORREF(0x00202020)) };
+        unsafe { FillRect(dc, &client, background) };
+        unsafe {
+            let _ = DeleteObject(HGDIOBJ(background.0));
+        }
+        unsafe {
+            SetBkMode(dc, TRANSPARENT);
+            SetTextColor(dc, LABEL_COLOR);
+        }
+        for (line, value) in text.lines().enumerate() {
+            let encoded: Vec<u16> = value.encode_utf16().collect();
+            unsafe {
+                let _ = TextOutW(dc, 10, 9 + line as i32 * 18, &encoded);
+            }
+        }
+        return;
+    }
+    let pen = unsafe { CreatePen(PS_SOLID, RECTANGLE_OUTLINE_WIDTH, OUTLINE_COLOR) };
     let old_pen = unsafe { SelectObject(dc, HGDIOBJ(pen.0)) };
     let old_brush = unsafe { SelectObject(dc, GetStockObject(NULL_BRUSH)) };
     for primitive in &state.frame {
@@ -208,6 +229,15 @@ impl NativeOverlayRenderer {
 }
 
 impl OverlayRenderer for NativeOverlayRenderer {
+    fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
+        let mut point = POINT::default();
+        unsafe { GetCursorPos(&mut point) }
+            .map_err(|e| platform(format!("cursor query failed: {e}")))?;
+        Ok(MkPoint {
+            x: point.x,
+            y: point.y,
+        })
+    }
     fn show(
         &mut self,
         operation_id: OperationId,
@@ -244,6 +274,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
             let mut state = Box::new(WindowPaintState {
                 bounds,
                 frame: frame.clone(),
+                hint: None,
             });
             let mut ex = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
             if overlay_is_mouse_transparent(visual) {
@@ -299,6 +330,57 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 }));
             }
         }
+        if let OverlayVisual::RectanglePicker { tooltip, .. } = visual {
+            let all = displays();
+            let monitor = monitor_nearest_pointer(&all, tooltip.pointer)
+                .ok_or_else(|| platform("No display is available for the selection tooltip"))?;
+            let size = (330, 76);
+            let at =
+                place_rectangle_tooltip(tooltip.pointer, size, monitor, RECTANGLE_TOOLTIP_OFFSET);
+            let bounds = ScreenRect::new(at.x, at.y, size.0, size.1);
+            let mut state = Box::new(WindowPaintState {
+                bounds,
+                frame: vec![],
+                hint: Some(tooltip.text.clone()),
+            });
+            let hwnd = unsafe {
+                CreateWindowExW(
+                    WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
+                    class,
+                    PCWSTR::null(),
+                    WS_POPUP,
+                    at.x,
+                    at.y,
+                    size.0 as i32,
+                    size.1 as i32,
+                    None,
+                    None,
+                    module,
+                    Some(state.as_mut() as *mut _ as *const _),
+                )
+            }
+            .map_err(|e| platform(format!("tooltip window creation failed: {e}")))?;
+            self.tooltip = Some(OverlayWindow { hwnd, state });
+            unsafe { SetLayeredWindowAttributes(hwnd, TRANSPARENT_KEY, 0, LWA_COLORKEY) }
+                .map_err(|e| platform(format!("tooltip layered configuration failed: {e}")))?;
+            unsafe {
+                SetWindowPos(
+                    hwnd,
+                    HWND_TOPMOST,
+                    at.x,
+                    at.y,
+                    size.0 as i32,
+                    size.1 as i32,
+                    SWP_NOACTIVATE | SWP_SHOWWINDOW,
+                )
+            }
+            .map_err(|e| platform(format!("tooltip positioning failed: {e}")))?;
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+                let _ = InvalidateRect(hwnd, None, false);
+                let _ = UpdateWindow(hwnd);
+            }
+        }
         self.operation_id = Some(operation_id);
         self.visual = Some(visual.clone());
         Ok(())
@@ -322,6 +404,38 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 return Err(platform(format!("overlay repaint failed: {}", unsafe {
                     GetLastError().0
                 })));
+            }
+        }
+        if let (Some(window), OverlayVisual::RectanglePicker { tooltip, .. }) =
+            (&mut self.tooltip, visual)
+        {
+            window.state.hint = Some(tooltip.text.clone());
+            let all = displays();
+            if let Some(monitor) = monitor_nearest_pointer(&all, tooltip.pointer) {
+                let at = place_rectangle_tooltip(
+                    tooltip.pointer,
+                    (window.state.bounds.width, window.state.bounds.height),
+                    monitor,
+                    RECTANGLE_TOOLTIP_OFFSET,
+                );
+                window.state.bounds.x = at.x;
+                window.state.bounds.y = at.y;
+                unsafe {
+                    SetWindowPos(
+                        window.hwnd,
+                        HWND_TOPMOST,
+                        at.x,
+                        at.y,
+                        0,
+                        0,
+                        SWP_NOACTIVATE | SWP_NOSIZE,
+                    )
+                }
+                .map_err(|e| platform(format!("tooltip move failed: {e}")))?;
+                unsafe {
+                    let _ = InvalidateRect(window.hwnd, None, false);
+                    let _ = UpdateWindow(window.hwnd);
+                }
             }
         }
         Ok(())
@@ -374,6 +488,12 @@ impl OverlayRenderer for NativeOverlayRenderer {
     }
 
     fn close(&mut self) {
+        if let Some(window) = self.tooltip.take() {
+            unsafe {
+                SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);
+                let _ = DestroyWindow(window.hwnd);
+            }
+        }
         for window in self.windows.drain(..) {
             unsafe {
                 SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);


### PR DESCRIPTION
### Motivation

- Provide a platform-neutral, deterministic presentation for rectangle selection tooltips with mkmacro-specific high-contrast drawing defaults and correct multi-monitor placement. 
- Ensure the controller shows the instruction tooltip immediately, keeps tooltip state in sync with every repaint, and prevents stale input from affecting active operations. 

### Description

- Introduce mkmacro rectangle defaults and pure helpers: `RECTANGLE_OUTLINE_WIDTH`, `RECTANGLE_TOOLTIP_OFFSET`, `RECTANGLE_INSTRUCTION`, `RectangleTooltip`, `rectangle_tooltip_text`, `place_rectangle_tooltip`, and `monitor_nearest_pointer`. These encapsulate formatting and placement logic for unit testing. (src/gui/mkmacro_dialog/visual_overlay.rs)
- Extend the rectangle visual with `tooltip: RectangleTooltip` and add deterministic tooltip population to `repaint_picker` so tooltip text and pointer travel with the visual model rather than being rendered by egui. (src/gui/mkmacro_dialog/visual_overlay.rs)
- Extend `OverlayRenderer` with `cursor_position` so the controller can place the initial instruction tooltip from the renderer-supplied pointer, and update `NativeOverlayRenderer`/fake renderers accordingly. (src/gui/mkmacro_dialog/visual_overlay.rs, src/gui/mkmacro_dialog/visual_overlay_windows.rs)
- Update `VisualOverlayController` lifecycle to show the initial hint immediately in `begin_rectangle_pick`, track a `picker_pointer` for deterministic placement, normalize selection on every relevant pointer event, repaint rectangle + tooltip together (always emitting `Clear` first), and preserve operation-id checks for stale inputs. (src/gui/mkmacro_dialog/visual_overlay.rs)
- Implement a native, always-on-top, non-activating, mouse-transparent tooltip window on Windows that is kept separate from the per-monitor outline windows, uses `SetWindowPos(..., SWP_NOACTIVATE[, SWP_NOSIZE])` to move instead of recreate, paints compact high-contrast multiline text, and is destroyed on `close` and failure paths. Also replace the hard-coded five-pixel pen with the `RECTANGLE_OUTLINE_WIDTH` style. (src/gui/mkmacro_dialog/visual_overlay_windows.rs)
- Add deterministic unit tests covering tooltip text formatting, placement flipping/clamping (including negative-coordinate monitors and oversized-tooltip clamping), initial tooltip visibility, repaint clearing behavior, four-direction normalization, and integration between repaint frames and hint content using the `FakeRenderer`. (src/gui/mkmacro_dialog/visual_overlay.rs tests)

### Testing

- Ran `cargo fmt --all` successfully to format changes. 
- Ran `git diff --check` and repository diff/stat checks for changed files with no style findings. 
- Ran the overlay unit tests target `cargo test --lib gui::mkmacro_dialog::visual_overlay::tests`, but full compilation of the application crate is blocked by unrelated platform-specific build/resolution issues in the repository (the non-Windows host build emits errors resolving the unconditional `windows`-scoped modules); installation of missing system dev packages (ALSA/X11) progressed tests further but the build still fails on unrelated platform-specific symbols outside these changes. 
- Added the new tests and ensured the fake-renderer paths exercise tooltip text and placement logic; the deterministic helpers are pure and unit-testable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e0a5124b083328d088135051ceadf)