### PR TITLE
Move visual overlays to native worker service

### DIFF
--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -6,77 +6,227 @@
 //! nor changes launcher or dialog visibility, and has no restoration phase.
 
 use super::visual_overlay::{
-    OperationId, RectanglePurpose, VisualOverlayController, VisualOverlayEvent,
+    NativeVisualOverlayService, OperationId, OverlayErrorKind, RectanglePurpose,
+    VisualOverlayCommand, VisualOverlayController, VisualOverlayError, VisualOverlayEvent,
 };
 use crate::mkmacro::ScreenRect;
 use crate::mkmacro::{ImageAssetAuthoringService, MkMacroStore, ScreenCaptureBackend};
 use image::RgbaImage;
-use std::sync::{Arc, Mutex};
+use std::collections::VecDeque;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
-/// Cloneable, single-queue facade for the overlay controller.  Workflow events
-/// are routed to its adapter while passive/editor events remain available to
-/// the Action Editor, so two consumers never race the native queue.
+/// Cloneable command client for the thread which exclusively owns native overlays.
+/// GUI calls only enqueue work or drain already-produced semantic events.
 #[derive(Clone)]
-pub struct SharedVisualOverlayController(Arc<Mutex<SharedOverlay>>);
-struct SharedOverlay {
-    controller: VisualOverlayController,
-    editor_events: Vec<VisualOverlayEvent>,
+pub struct SharedVisualOverlayController(Arc<SharedOverlayClient>);
+struct SharedOverlayClient {
+    service: Mutex<Option<NativeVisualOverlayService>>,
+    next_id: AtomicU64,
+    active_id: AtomicU64,
+    shutdown: AtomicBool,
+    editor_events: Mutex<VecDeque<VisualOverlayEvent>>,
 }
 impl Default for SharedVisualOverlayController {
     fn default() -> Self {
-        Self::new(VisualOverlayController::default())
+        match NativeVisualOverlayService::start() {
+            Ok(service) => Self::from_service(service),
+            Err(error) => Self(Arc::new(SharedOverlayClient {
+                service: Mutex::new(None),
+                next_id: AtomicU64::new(1),
+                active_id: AtomicU64::new(0),
+                shutdown: AtomicBool::new(true),
+                editor_events: Mutex::new(VecDeque::from([VisualOverlayEvent::Error {
+                    operation_id: 1,
+                    error: VisualOverlayError {
+                        kind: OverlayErrorKind::Platform,
+                        message: format!("failed to start visual overlay worker: {error}"),
+                    },
+                }])),
+            })),
+        }
     }
 }
 impl SharedVisualOverlayController {
+    /// Test-oriented constructor; production uses `default`, constructing native state on the worker.
     pub fn new(controller: VisualOverlayController) -> Self {
-        Self(Arc::new(Mutex::new(SharedOverlay {
-            controller,
-            editor_events: vec![],
-        })))
+        match NativeVisualOverlayService::start_with(move || controller) {
+            Ok(service) => Self::from_service(service),
+            Err(_) => Self::default(),
+        }
     }
-    pub fn operation_id(&self) -> Option<OperationId> {
-        self.0.lock().unwrap().controller.operation_id()
+    fn from_service(service: NativeVisualOverlayService) -> Self {
+        Self(Arc::new(SharedOverlayClient {
+            service: Mutex::new(Some(service)),
+            next_id: AtomicU64::new(1),
+            active_id: AtomicU64::new(0),
+            shutdown: AtomicBool::new(false),
+            editor_events: Mutex::new(VecDeque::new()),
+        }))
     }
-    pub fn cancel(&self) {
-        self.0.lock().unwrap().controller.cancel();
+    fn allocate(&self) -> OperationId {
+        loop {
+            let id = self.0.next_id.fetch_add(1, Ordering::Relaxed);
+            if id != 0 {
+                return id;
+            }
+        }
     }
-    pub fn shutdown(&self) {
-        let mut shared = self.0.lock().unwrap();
-        shared.controller.shutdown();
-        shared.editor_events.clear();
+    fn send_start(&self, id: OperationId, command: VisualOverlayCommand) -> OperationId {
+        self.0.active_id.store(id, Ordering::Release);
+        let sent = self
+            .0
+            .service
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|s| s.commands.send(command).is_ok());
+        if !sent {
+            self.0
+                .active_id
+                .compare_exchange(id, 0, Ordering::AcqRel, Ordering::Acquire)
+                .ok();
+            self.0
+                .editor_events
+                .lock()
+                .unwrap()
+                .push_back(VisualOverlayEvent::Error {
+                    operation_id: id,
+                    error: VisualOverlayError {
+                        kind: OverlayErrorKind::Platform,
+                        message: "visual overlay service is shut down".into(),
+                    },
+                });
+        }
+        id
     }
-    pub fn poll(&self) -> Vec<VisualOverlayEvent> {
-        let mut shared = self.0.lock().unwrap();
-        let mut events = std::mem::take(&mut shared.editor_events);
-        events.extend(shared.controller.poll());
-        events
+    pub fn begin_rectangle_pick(
+        &self,
+        purpose: RectanglePurpose,
+        virtual_desktop: ScreenRect,
+    ) -> OperationId {
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::BeginRectanglePick {
+                operation_id: id,
+                purpose,
+                virtual_desktop,
+            },
+        )
     }
     pub fn preview_rectangle(&self, rect: ScreenRect) -> OperationId {
-        self.0.lock().unwrap().controller.preview_rectangle(rect)
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::PreviewRectangle {
+                operation_id: id,
+                rect,
+            },
+        )
     }
     pub fn highlight_monitor(&self, monitor: crate::mkmacro::MonitorDescriptor) -> OperationId {
-        self.0.lock().unwrap().controller.highlight_monitor(monitor)
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::HighlightMonitor {
+                operation_id: id,
+                monitor,
+            },
+        )
     }
     pub fn identify_monitors(
         &self,
         monitors: Vec<crate::mkmacro::MonitorDescriptor>,
     ) -> OperationId {
-        self.0
-            .lock()
-            .unwrap()
-            .controller
-            .identify_monitors(monitors)
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::IdentifyMonitors {
+                operation_id: id,
+                monitors,
+            },
+        )
     }
     pub fn highlight_window(
         &self,
         rect: ScreenRect,
-        kind: super::visual_overlay::WindowAreaKind,
+        area_kind: super::visual_overlay::WindowAreaKind,
     ) -> OperationId {
-        self.0
-            .lock()
-            .unwrap()
-            .controller
-            .highlight_window(rect, kind)
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::HighlightWindow {
+                operation_id: id,
+                rect,
+                area_kind,
+            },
+        )
+    }
+    pub fn operation_id(&self) -> Option<OperationId> {
+        match self.0.active_id.load(Ordering::Acquire) {
+            0 => None,
+            id => Some(id),
+        }
+    }
+    pub fn cancel(&self) {
+        let id = self.0.active_id.swap(0, Ordering::AcqRel);
+        if id != 0 {
+            if let Some(service) = self.0.service.lock().unwrap().as_ref() {
+                let _ = service.commands.send(VisualOverlayCommand::Cancel {
+                    expected_operation_id: Some(id),
+                });
+            }
+        }
+    }
+    pub fn shutdown(&self) {
+        if self.0.shutdown.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.0.active_id.store(0, Ordering::Release);
+        if let Some(mut service) = self.0.service.lock().unwrap().take() {
+            service.shutdown_and_join();
+        }
+    }
+    fn receive_into_editor(&self) {
+        let mut incoming = vec![];
+        if let Some(service) = self.0.service.lock().unwrap().as_ref() {
+            incoming.extend(service.events.try_iter());
+        }
+        for event in &incoming {
+            let id = match event {
+                VisualOverlayEvent::RectangleConfirmed { operation_id, .. }
+                | VisualOverlayEvent::Cancelled { operation_id }
+                | VisualOverlayEvent::Expired { operation_id }
+                | VisualOverlayEvent::Error { operation_id, .. } => *operation_id,
+            };
+            let _ = self
+                .0
+                .active_id
+                .compare_exchange(id, 0, Ordering::AcqRel, Ordering::Acquire);
+        }
+        self.0.editor_events.lock().unwrap().extend(incoming);
+    }
+    /// Drains events already produced by the native worker; it never advances native input.
+    pub fn poll(&self) -> Vec<VisualOverlayEvent> {
+        self.receive_into_editor();
+        self.0.editor_events.lock().unwrap().drain(..).collect()
+    }
+    fn poll_rectangle(&self, expected: OperationId) -> Option<VisualOverlayEvent> {
+        self.receive_into_editor();
+        let mut queue = self.0.editor_events.lock().unwrap();
+        let position=queue.iter().position(|event| matches!(event,
+            VisualOverlayEvent::RectangleConfirmed { operation_id, .. } | VisualOverlayEvent::Cancelled { operation_id } | VisualOverlayEvent::Error { operation_id, .. } if *operation_id==expected));
+        position.and_then(|index| queue.remove(index))
+    }
+}
+impl Drop for SharedOverlayClient {
+    fn drop(&mut self) {
+        if let Some(mut service) = self.service.get_mut().unwrap().take() {
+            service.shutdown_and_join();
+        }
     }
 }
 
@@ -100,13 +250,7 @@ impl VisualOverlayRectangleAdapter {
 impl RectangleOverlay for VisualOverlayRectangleAdapter {
     fn begin(&mut self, purpose: RectanglePurpose) -> Result<OperationId, String> {
         let desktop = self.backend.virtual_desktop().map_err(|e| e.to_string())?;
-        let id = self
-            .overlay
-            .0
-            .lock()
-            .unwrap()
-            .controller
-            .begin_rectangle_pick(purpose, desktop);
+        let id = self.overlay.begin_rectangle_pick(purpose, desktop);
         self.operation_id = Some(id);
         Ok(id)
     }
@@ -114,8 +258,7 @@ impl RectangleOverlay for VisualOverlayRectangleAdapter {
         let Some(expected) = self.operation_id else {
             return SelectionEvent::Pending;
         };
-        let mut shared = self.overlay.0.lock().unwrap();
-        for event in shared.controller.poll() {
+        if let Some(event) = self.overlay.poll_rectangle(expected) {
             match event {
                 VisualOverlayEvent::RectangleConfirmed {
                     operation_id, rect, ..
@@ -134,10 +277,11 @@ impl RectangleOverlay for VisualOverlayRectangleAdapter {
                         message: error.to_string(),
                     };
                 }
-                other => shared.editor_events.push(other),
+                _ => SelectionEvent::Pending,
             }
+        } else {
+            SelectionEvent::Pending
         }
-        SelectionEvent::Pending
     }
     fn cancel(&mut self) {
         self.overlay.cancel();

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -1015,6 +1015,11 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    fn advance_and_drain(controller: &mut VisualOverlayController) -> Vec<VisualOverlayEvent> {
+        controller.advance();
+        controller.drain_events()
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum RecordedCall {
         Show {
@@ -1207,7 +1212,7 @@ mod tests {
                 kind: OverlayInputKind::PointerMoved(point(30, 40)),
             },
         ];
-        assert!(c.poll().is_empty());
+        assert!(advance_and_drain(&mut c).is_empty());
         let repaints: Vec<_> = fake
             .lock()
             .unwrap()
@@ -1358,7 +1363,7 @@ mod tests {
             },
         ];
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::RectangleConfirmed {
                 operation_id: id,
                 purpose: RectanglePurpose::ReferenceImageCapture,
@@ -1390,7 +1395,7 @@ mod tests {
         );
         queue_drag(&fake, id, point(900, 700), point(100, 200));
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::RectangleConfirmed {
                 operation_id: id,
                 purpose: RectanglePurpose::SearchRegion,
@@ -1408,7 +1413,7 @@ mod tests {
         );
         queue_drag(&fake, id, point(400, 300), point(-2100, -900));
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::RectangleConfirmed {
                 operation_id: id,
                 purpose: RectanglePurpose::ReferenceImageCapture,
@@ -1430,7 +1435,7 @@ mod tests {
             );
             queue_drag(&fake, id, start, end);
             assert!(
-                c.poll().is_empty(),
+                advance_and_drain(&mut c).is_empty(),
                 "degenerate drag {start:?} -> {end:?} emitted an event"
             );
             assert_eq!(c.operation_id(), Some(id));
@@ -1520,15 +1525,15 @@ mod tests {
         let (mut c, fake, now) = controller();
         let id = c.preview_rectangle(ScreenRect::new(-10, -20, 30, 40));
         *now.lock().unwrap() = PASSIVE_OVERLAY_DURATION - Duration::from_nanos(1);
-        assert!(c.poll().is_empty());
+        assert!(advance_and_drain(&mut c).is_empty());
         assert_eq!(c.operation_id(), Some(id));
         *now.lock().unwrap() = PASSIVE_OVERLAY_DURATION;
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Expired { operation_id: id }]
         );
         assert_eq!(close_count(&fake), 1);
-        assert!(c.poll().is_empty());
+        assert!(advance_and_drain(&mut c).is_empty());
         assert_eq!(close_count(&fake), 1);
     }
 
@@ -1565,7 +1570,7 @@ mod tests {
             kind: OverlayInputKind::Escape,
         }];
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Cancelled { operation_id: id }]
         );
         assert_eq!(c.state(), &VisualOverlayState::Idle);
@@ -1584,10 +1589,10 @@ mod tests {
             operation_id: first,
             kind: OverlayInputKind::Enter,
         }];
-        assert!(c.poll().is_empty()); // Enter cannot confirm an empty drag.
+        assert!(advance_and_drain(&mut c).is_empty()); // Enter cannot confirm an empty drag.
         let second = c.preview_rectangle(ScreenRect::new(-4, -5, 6, 7));
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Cancelled {
                 operation_id: first
             }]
@@ -1608,7 +1613,7 @@ mod tests {
         );
         *now.lock().unwrap() = PASSIVE_OVERLAY_DURATION;
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Expired {
                 operation_id: second
             }]
@@ -1641,7 +1646,7 @@ mod tests {
         }];
         assert_eq!(c.operation_id(), Some(second));
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Cancelled {
                 operation_id: first
             }]
@@ -1657,15 +1662,15 @@ mod tests {
         assert_eq!(c.state(), &VisualOverlayState::Idle);
         assert_eq!(c.operation_id(), None);
         assert!(
-            matches!(c.poll().as_slice(), [VisualOverlayEvent::Error { operation_id, .. }] if *operation_id == failed)
+            matches!(advance_and_drain(&mut c).as_slice(), [VisualOverlayEvent::Error { operation_id, .. }] if *operation_id == failed)
         );
 
         let active = c.preview_rectangle(ScreenRect::new(0, 0, 2, 2));
         fake.lock().unwrap().poll_error = Some(platform_error("poll failed"));
         assert!(
-            matches!(c.poll().as_slice(), [VisualOverlayEvent::Error { operation_id, .. }] if *operation_id == active)
+            matches!(advance_and_drain(&mut c).as_slice(), [VisualOverlayEvent::Error { operation_id, .. }] if *operation_id == active)
         );
-        assert!(c.poll().is_empty());
+        assert!(advance_and_drain(&mut c).is_empty());
         assert_eq!(c.state(), &VisualOverlayState::Idle);
     }
 
@@ -1685,14 +1690,14 @@ mod tests {
             },
         ];
         assert_eq!(
-            c.poll(),
+            advance_and_drain(&mut c),
             vec![VisualOverlayEvent::Cancelled { operation_id: id }]
         );
         c.cancel();
         c.cancel();
         c.shutdown();
         c.shutdown();
-        assert!(c.poll().is_empty());
+        assert!(advance_and_drain(&mut c).is_empty());
         let closes = close_count(&fake);
         drop(c);
         assert_eq!(close_count(&fake), closes);
@@ -1717,18 +1722,18 @@ mod tests {
                 operation_id: id,
                 kind: OverlayInputKind::LeftPressed(point(20, 30)),
             }];
-            assert!(controller.poll().is_empty());
+            assert!(advance_and_drain(&mut controller).is_empty());
             fake.lock().unwrap().inputs = vec![OverlayInput {
                 operation_id: id,
                 kind: OverlayInputKind::PointerMoved(point(-40, -10)),
             }];
-            assert!(controller.poll().is_empty());
+            assert!(advance_and_drain(&mut controller).is_empty());
             fake.lock().unwrap().inputs = vec![OverlayInput {
                 operation_id: id,
                 kind: OverlayInputKind::LeftReleased(point(-40, -10)),
             }];
             assert_eq!(
-                controller.poll(),
+                advance_and_drain(&mut controller),
                 vec![VisualOverlayEvent::RectangleConfirmed {
                     operation_id: id,
                     purpose,
@@ -1794,7 +1799,7 @@ mod tests {
                     kind: OverlayInputKind::PointerMoved(point(18, 29)),
                 },
             ];
-            assert!(controller.poll().is_empty());
+            assert!(advance_and_drain(&mut controller).is_empty());
             presentations.push(
                 fake.lock()
                     .unwrap()
@@ -1842,10 +1847,10 @@ mod tests {
             });
             fake.lock().unwrap().inputs = inputs;
             assert_eq!(
-                controller.poll(),
+                advance_and_drain(&mut controller),
                 vec![VisualOverlayEvent::Cancelled { operation_id: id }]
             );
-            assert!(controller.poll().is_empty());
+            assert!(advance_and_drain(&mut controller).is_empty());
             assert_eq!(close_count(&fake), 1);
         }
     }

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -7,6 +7,8 @@ use crate::mkmacro::{MkPoint, MonitorDescriptor, ScreenRect};
 use std::{
     collections::VecDeque,
     fmt,
+    sync::mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -163,6 +165,154 @@ pub enum VisualOverlayEvent {
         operation_id: OperationId,
         error: VisualOverlayError,
     },
+}
+
+/// Messages are the only way native overlay work crosses onto its owning thread.
+#[derive(Debug)]
+pub(crate) enum VisualOverlayCommand {
+    BeginRectanglePick {
+        operation_id: OperationId,
+        purpose: RectanglePurpose,
+        virtual_desktop: ScreenRect,
+    },
+    PreviewRectangle {
+        operation_id: OperationId,
+        rect: ScreenRect,
+    },
+    HighlightMonitor {
+        operation_id: OperationId,
+        monitor: MonitorDescriptor,
+    },
+    IdentifyMonitors {
+        operation_id: OperationId,
+        monitors: Vec<MonitorDescriptor>,
+    },
+    HighlightWindow {
+        operation_id: OperationId,
+        rect: ScreenRect,
+        area_kind: WindowAreaKind,
+    },
+    Cancel {
+        expected_operation_id: Option<OperationId>,
+    },
+    Shutdown,
+}
+
+/// The channel endpoints of the long-lived native owner.  Dropping the command
+/// sender is also a shutdown request; events remain buffered by the receiver.
+pub(crate) struct NativeVisualOverlayService {
+    pub commands: Sender<VisualOverlayCommand>,
+    pub events: Receiver<VisualOverlayEvent>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl NativeVisualOverlayService {
+    pub fn start() -> Result<Self, std::io::Error> {
+        Self::start_with(|| VisualOverlayController::default())
+    }
+
+    pub(crate) fn start_with<F>(factory: F) -> Result<Self, std::io::Error>
+    where
+        F: FnOnce() -> VisualOverlayController + Send + 'static,
+    {
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+        let worker = thread::Builder::new()
+            .name("native-visual-overlay".into())
+            .spawn(move || {
+                let mut controller = factory();
+                let mut running = true;
+                while running {
+                    let active = controller.operation_id().is_some();
+                    let first = if active {
+                        match command_rx.recv_timeout(Duration::from_millis(12)) {
+                            Ok(command) => Some(command),
+                            Err(RecvTimeoutError::Timeout) => None,
+                            Err(RecvTimeoutError::Disconnected) => {
+                                running = false;
+                                None
+                            }
+                        }
+                    } else {
+                        match command_rx.recv() {
+                            Ok(command) => Some(command),
+                            Err(_) => {
+                                running = false;
+                                None
+                            }
+                        }
+                    };
+                    if let Some(command) = first {
+                        running = apply_command(&mut controller, command);
+                        while running {
+                            match command_rx.try_recv() {
+                                Ok(command) => running = apply_command(&mut controller, command),
+                                Err(mpsc::TryRecvError::Empty) => break,
+                                Err(mpsc::TryRecvError::Disconnected) => {
+                                    running = false;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if running && controller.operation_id().is_some() {
+                        controller.advance();
+                    }
+                    for event in controller.drain_events() {
+                        let _ = event_tx.send(event);
+                    }
+                }
+                controller.shutdown();
+            })?;
+        Ok(Self {
+            commands: command_tx,
+            events: event_rx,
+            worker: Some(worker),
+        })
+    }
+
+    pub fn shutdown_and_join(&mut self) {
+        if let Some(worker) = self.worker.take() {
+            let _ = self.commands.send(VisualOverlayCommand::Shutdown);
+            let _ = worker.join();
+        }
+    }
+}
+
+fn apply_command(controller: &mut VisualOverlayController, command: VisualOverlayCommand) -> bool {
+    match command {
+        VisualOverlayCommand::BeginRectanglePick {
+            operation_id,
+            purpose,
+            virtual_desktop,
+        } => controller.begin_rectangle_pick_with_id(operation_id, purpose, virtual_desktop),
+        VisualOverlayCommand::PreviewRectangle { operation_id, rect } => {
+            controller.preview_rectangle_with_id(operation_id, rect)
+        }
+        VisualOverlayCommand::HighlightMonitor {
+            operation_id,
+            monitor,
+        } => controller.highlight_monitor_with_id(operation_id, monitor),
+        VisualOverlayCommand::IdentifyMonitors {
+            operation_id,
+            monitors,
+        } => controller.identify_monitors_with_id(operation_id, monitors),
+        VisualOverlayCommand::HighlightWindow {
+            operation_id,
+            rect,
+            area_kind,
+        } => controller.highlight_window_with_id(operation_id, rect, area_kind),
+        VisualOverlayCommand::Cancel {
+            expected_operation_id,
+        } => {
+            if expected_operation_id.is_none() || expected_operation_id == controller.operation_id()
+            {
+                controller.cancel()
+            }
+        }
+        VisualOverlayCommand::Shutdown => return false,
+    }
+    true
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -368,7 +518,7 @@ impl VisualOverlayController {
         self.next_id = self.next_id.wrapping_add(1).max(1);
         id
     }
-    fn replace(&mut self) -> OperationId {
+    fn replace_with_id(&mut self, new_id: OperationId) -> OperationId {
         if let Some(id) = self.operation_id.take() {
             self.renderer.close();
             // Nothing produced by the replaced operation may be observed after
@@ -381,10 +531,31 @@ impl VisualOverlayController {
         self.state = VisualOverlayState::Idle;
         self.virtual_desktop = None;
         self.picker_pointer = None;
-        self.allocate()
+        new_id
+    }
+    fn replace(&mut self) -> OperationId {
+        let id = self.allocate();
+        self.replace_with_id(id)
     }
     fn start(&mut self, state: VisualOverlayState, visual: OverlayVisual) -> OperationId {
         let id = self.replace();
+        self.start_replaced(id, state, visual)
+    }
+    fn start_with_id(
+        &mut self,
+        id: OperationId,
+        state: VisualOverlayState,
+        visual: OverlayVisual,
+    ) -> OperationId {
+        self.replace_with_id(id);
+        self.start_replaced(id, state, visual)
+    }
+    fn start_replaced(
+        &mut self,
+        id: OperationId,
+        state: VisualOverlayState,
+        visual: OverlayVisual,
+    ) -> OperationId {
         self.shut_down = false;
         match self.renderer.show(id, &visual, visual.passive()) {
             Ok(()) => {
@@ -412,11 +583,20 @@ impl VisualOverlayController {
         purpose: RectanglePurpose,
         virtual_desktop: ScreenRect,
     ) -> OperationId {
+        let id = self.allocate();
+        self.begin_rectangle_pick_with_id(id, purpose, virtual_desktop)
+    }
+    pub(crate) fn begin_rectangle_pick_with_id(
+        &mut self,
+        requested_id: OperationId,
+        purpose: RectanglePurpose,
+        virtual_desktop: ScreenRect,
+    ) -> OperationId {
         if virtual_desktop.is_empty()
             || virtual_desktop.right() > i64::from(i32::MAX) + 1
             || virtual_desktop.bottom() > i64::from(i32::MAX) + 1
         {
-            let id = self.replace();
+            let id = self.replace_with_id(requested_id);
             self.events.push_back(VisualOverlayEvent::Error {
                 operation_id: id,
                 error: VisualOverlayError::geometry(
@@ -428,7 +608,7 @@ impl VisualOverlayController {
         let pointer = match self.renderer.cursor_position() {
             Ok(pointer) => pointer,
             Err(error) => {
-                let id = self.replace();
+                let id = self.replace_with_id(requested_id);
                 self.events.push_back(VisualOverlayEvent::Error {
                     operation_id: id,
                     error,
@@ -437,7 +617,8 @@ impl VisualOverlayController {
             }
         };
         self.picker_pointer = Some(pointer);
-        let id = self.start(
+        let id = self.start_with_id(
+            requested_id,
             VisualOverlayState::PickingRectangle {
                 start: None,
                 current: None,
@@ -465,6 +646,60 @@ impl VisualOverlayController {
             },
             OverlayVisual::RectanglePreview(rect),
         )
+    }
+    pub(crate) fn preview_rectangle_with_id(&mut self, id: OperationId, rect: ScreenRect) {
+        self.start_passive_with_id(
+            id,
+            VisualOverlayState::PreviewingRectangle {
+                rect,
+                expires_at: self.deadline(),
+            },
+            OverlayVisual::RectanglePreview(rect),
+        );
+    }
+    pub(crate) fn highlight_monitor_with_id(
+        &mut self,
+        id: OperationId,
+        descriptor: MonitorDescriptor,
+    ) {
+        self.start_passive_with_id(
+            id,
+            VisualOverlayState::HighlightingMonitor {
+                descriptor: descriptor.clone(),
+                expires_at: self.deadline(),
+            },
+            OverlayVisual::Monitor(descriptor),
+        );
+    }
+    pub(crate) fn identify_monitors_with_id(
+        &mut self,
+        id: OperationId,
+        descriptors: Vec<MonitorDescriptor>,
+    ) {
+        self.start_passive_with_id(
+            id,
+            VisualOverlayState::IdentifyingMonitors {
+                descriptors: descriptors.clone(),
+                expires_at: self.deadline(),
+            },
+            OverlayVisual::Monitors(descriptors),
+        );
+    }
+    pub(crate) fn highlight_window_with_id(
+        &mut self,
+        id: OperationId,
+        rect: ScreenRect,
+        area_kind: WindowAreaKind,
+    ) {
+        self.start_passive_with_id(
+            id,
+            VisualOverlayState::HighlightingWindow {
+                rect,
+                area_kind,
+                expires_at: self.deadline(),
+            },
+            OverlayVisual::Window { rect, area_kind },
+        );
     }
     pub fn highlight_monitor(&mut self, descriptor: MonitorDescriptor) -> OperationId {
         let state = VisualOverlayState::HighlightingMonitor {
@@ -505,6 +740,22 @@ impl VisualOverlayController {
             self.start(state, visual)
         }
     }
+    fn start_passive_with_id(
+        &mut self,
+        id: OperationId,
+        state: VisualOverlayState,
+        visual: OverlayVisual,
+    ) {
+        if geometry_of(&visual).is_some_and(ScreenRect::is_empty) {
+            self.replace_with_id(id);
+            self.events.push_back(VisualOverlayEvent::Error {
+                operation_id: id,
+                error: VisualOverlayError::geometry("overlay rectangle must be nonempty"),
+            });
+        } else {
+            self.start_with_id(id, state, visual);
+        }
+    }
     pub fn cancel(&mut self) {
         if let Some(id) = self.operation_id.take() {
             self.renderer.close();
@@ -527,7 +778,8 @@ impl VisualOverlayController {
         self.events.clear();
         self.shut_down = true;
     }
-    pub fn poll(&mut self) -> Vec<VisualOverlayEvent> {
+    /// Advances native input/message state. Only the service worker calls this in production.
+    pub fn advance(&mut self) {
         let input_result = self.renderer.poll_input();
         if let Ok(inputs) = input_result.as_ref() {
             for input in inputs.iter().copied() {
@@ -562,7 +814,15 @@ impl VisualOverlayController {
                     .push_back(VisualOverlayEvent::Expired { operation_id: id });
             }
         }
+    }
+    /// Drains semantic events without polling native resources.
+    pub fn drain_events(&mut self) -> Vec<VisualOverlayEvent> {
         self.events.drain(..).collect()
+    }
+    #[deprecated(note = "use advance followed by drain_events")]
+    pub fn poll(&mut self) -> Vec<VisualOverlayEvent> {
+        self.advance();
+        self.drain_events()
     }
     fn handle_input(&mut self, input: OverlayInput) {
         if self.operation_id != Some(input.operation_id) {

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -285,23 +285,31 @@ fn apply_command(controller: &mut VisualOverlayController, command: VisualOverla
             operation_id,
             purpose,
             virtual_desktop,
-        } => controller.begin_rectangle_pick_with_id(operation_id, purpose, virtual_desktop),
+        } => {
+            controller.begin_rectangle_pick_with_id(operation_id, purpose, virtual_desktop);
+        }
         VisualOverlayCommand::PreviewRectangle { operation_id, rect } => {
             controller.preview_rectangle_with_id(operation_id, rect)
         }
         VisualOverlayCommand::HighlightMonitor {
             operation_id,
             monitor,
-        } => controller.highlight_monitor_with_id(operation_id, monitor),
+        } => {
+            controller.highlight_monitor_with_id(operation_id, monitor);
+        }
         VisualOverlayCommand::IdentifyMonitors {
             operation_id,
             monitors,
-        } => controller.identify_monitors_with_id(operation_id, monitors),
+        } => {
+            controller.identify_monitors_with_id(operation_id, monitors);
+        }
         VisualOverlayCommand::HighlightWindow {
             operation_id,
             rect,
             area_kind,
-        } => controller.highlight_window_with_id(operation_id, rect, area_kind),
+        } => {
+            controller.highlight_window_with_id(operation_id, rect, area_kind);
+        }
         VisualOverlayCommand::Cancel {
             expected_operation_id,
         } => {


### PR DESCRIPTION
### Motivation
- Isolate native HWNDs, the Windows message pump, input polling, repainting and overlay lifetime on a single long-lived worker thread so GUI callers no longer advance native input or move already-created native resources. 
- Provide a responsive command protocol and cloneable client that allocates operation IDs on the GUI side, routes events by operation ID, supports targeted cancellation/replacement semantics, and provides idempotent shutdown semantics. 

### Description
- Add an internal command protocol `VisualOverlayCommand` and a `NativeVisualOverlayService` that spawns a named `native-visual-overlay` thread, constructs the `VisualOverlayController` on that thread, receives commands via an `mpsc` channel, polls native input with a blocking/timeout strategy while active, drains queued commands before sleeping, forwards semantic `VisualOverlayEvent`s to an event channel, and closes native resources on exit. (changes in `visual_overlay.rs`).
- Refactor `VisualOverlayController` to support operation-ID–based starts (`*_with_id`/`start_with_id`/`start_replaced`), to separate native advancement (`advance()`) from semantic draining (`drain_events()`), and to preserve replacement/cancellation semantics and shutdown behavior. (changes in `visual_overlay.rs`).
- Replace the previous `Arc<Mutex<SharedOverlay>>` facade with a cloneable `SharedVisualOverlayController` client that owns sender/event endpoints, an `AtomicU64` ID allocator, `active_id` metadata, a buffered editor-event queue, and methods that enqueue commands and return operation IDs without blocking; implement `poll()`/`poll_rectangle()` so GUI consumers drain events without advancing native input. (changes in `visual_capture_workflow.rs`).
- Preserve single-consumer routing guarantees by extracting workflow events for the rectangle adapter while leaving passive and unrelated events available to the Action Editor, and make shutdown idempotent and safe to join from the owning service object. (changes in `visual_overlay.rs` and `visual_capture_workflow.rs`).

### Testing
- ✅ `cargo fmt --all` succeeded. 
- ✅ `git diff --check` succeeded. 
- ⚠️ `cargo check` was run on the host and reached pre-existing Windows-only API resolution errors (expected on Linux and not caused by these changes). 
- ⚠️ Cross-target verification and unit test runs such as `cargo check --target x86_64-pc-windows-gnu` and `cargo test visual_overlay --lib` were attempted but blocked by environment limitations (missing MinGW toolchain / native platform differences) so end-to-end Windows-targeted compilation and some tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e248616708332b06aad1abb70203e)