### PR TITLE
Unify visual search region authoring

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -264,7 +264,13 @@ impl ActionEditorState {
         let Some(step) = self.draft.as_mut() else {
             return false;
         };
-        if matches!(path, super::window_picker::MatcherPath::ImageRegion) {
+        if matches!(path, super::window_picker::MatcherPath::VisualRegion) {
+            if !matches!(
+                step.action,
+                MkAction::ImageFind(_) | MkAction::ImageClick(_) | MkAction::WaitForVisualChange(_)
+            ) {
+                return false;
+            }
             let Some(image) = self.image_search.as_mut() else {
                 return false;
             };
@@ -313,7 +319,10 @@ impl ActionEditorState {
         self.editor = Some(editor);
         self.image_search = match &action {
             MkAction::ImageFind(p) | MkAction::ImageClick(p) => {
-                Some(super::image_search_editor::ImageSearchEditorState::from_payload(p))
+                Some(super::image_search_editor::ImageSearchEditorState::from_region(&p.region))
+            }
+            MkAction::WaitForVisualChange(p) => {
+                Some(super::image_search_editor::ImageSearchEditorState::from_region(&p.region))
             }
             _ => None,
         };
@@ -339,7 +348,10 @@ impl ActionEditorState {
         self.draft = Some(step.clone());
         self.image_search = match &step.action {
             MkAction::ImageFind(p) | MkAction::ImageClick(p) => {
-                Some(super::image_search_editor::ImageSearchEditorState::from_payload(p))
+                Some(super::image_search_editor::ImageSearchEditorState::from_region(&p.region))
+            }
+            MkAction::WaitForVisualChange(p) => {
+                Some(super::image_search_editor::ImageSearchEditorState::from_region(&p.region))
             }
             _ => None,
         };
@@ -437,10 +449,13 @@ impl ActionEditorState {
         }
     }
     fn sync_image_region_to_draft(&mut self) {
-        if let (Some(step), Some(image)) = (&mut self.draft, &self.image_search)
-            && let Some(payload) = image_payload_mut(step)
-        {
-            payload.region = image.selected_region();
+        if let (Some(step), Some(image)) = (&mut self.draft, &self.image_search) {
+            let region = image.selected_region();
+            match &mut step.action {
+                MkAction::ImageFind(p) | MkAction::ImageClick(p) => p.region = region,
+                MkAction::WaitForVisualChange(p) => p.region = region,
+                _ => {}
+            }
         }
     }
     fn poll_visual_overlay(&mut self) {
@@ -1624,50 +1639,6 @@ fn action_ui(
         MkAction::ImageFind(_) | MkAction::ImageClick(_) => {}
         MkAction::WaitForVisualChange(p) => {
             ui.heading("Wait for Visual Change");
-            let mut region =
-                super::image_search_controls::ImageSearchControlState::from_region(&p.region);
-            egui::ComboBox::from_label("Region")
-                .selected_text(format!("{:?}", region.kind))
-                .show_ui(ui, |ui| {
-                    use super::image_search_controls::SearchRegionKind as K;
-                    for (kind, label) in [
-                        (K::Desktop, "Desktop"),
-                        (K::Monitor, "Monitor"),
-                        (K::Rectangle, "Rectangle"),
-                        (K::Window, "Window"),
-                        (K::ClientArea, "Client Area"),
-                    ] {
-                        ui.selectable_value(&mut region.kind, kind, label);
-                    }
-                });
-            match region.kind {
-                super::image_search_controls::SearchRegionKind::Monitor => {
-                    ui.add(egui::DragValue::new(&mut region.monitor_index).prefix("Monitor "));
-                }
-                super::image_search_controls::SearchRegionKind::Rectangle => {
-                    ui.horizontal(|ui| {
-                        ui.add(egui::DragValue::new(&mut region.rectangle.x).prefix("X "));
-                        ui.add(egui::DragValue::new(&mut region.rectangle.y).prefix("Y "));
-                        ui.add(egui::DragValue::new(&mut region.rectangle.width).prefix("W "));
-                        ui.add(egui::DragValue::new(&mut region.rectangle.height).prefix("H "));
-                    });
-                }
-                super::image_search_controls::SearchRegionKind::Window
-                | super::image_search_controls::SearchRegionKind::ClientArea => {
-                    let matcher = if matches!(
-                        region.kind,
-                        super::image_search_controls::SearchRegionKind::Window
-                    ) {
-                        &mut region.window_matcher
-                    } else {
-                        &mut region.client_matcher
-                    };
-                    ui.label("Window matcher");
-                    ui.text_edit_singleline(matcher.title.get_or_insert_default());
-                }
-                _ => {}
-            }
-            p.region = region.selected_region();
             ui.horizontal(|ui| {
                 ui.label("Change threshold (%)");
                 ui.add(
@@ -2241,8 +2212,14 @@ fn matcher_at_path<'a>(
             | MkAction::WaitUntil { condition: c, .. } => condition_at_path(c, path),
             _ => None,
         },
-        MatcherPath::ImageRegion => match action {
+        MatcherPath::VisualRegion => match action {
             MkAction::ImageFind(p) | MkAction::ImageClick(p) => match &mut p.region {
+                SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } => {
+                    Some(matcher)
+                }
+                _ => None,
+            },
+            MkAction::WaitForVisualChange(p) => match &mut p.region {
                 SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } => {
                     Some(matcher)
                 }
@@ -2328,6 +2305,27 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             pick_request = position;
             image_request = image;
             condition_image_request = condition_image;
+            if matches!(step.action, MkAction::WaitForVisualChange(_)) {
+                ui.separator(); ui.heading("Region");
+                let region_state = state.image_search.as_mut().expect("visual change requires region state");
+                if let Some(request) = super::image_search_controls::show_search_region_fields(ui, region_state) {
+                    use super::image_search_controls::SearchRegionRequest as R;
+                    match request {
+                        R::SelectRectangle => image_request = Some(ImageAuthoringRequest::PickRectangle),
+                        R::PickWindow => window = Some(super::window_picker::MatcherPath::VisualRegion),
+                        R::RefreshMonitors => region_state.refresh_monitors(),
+                        R::IdentifyMonitors => {},
+                        R::PreviewRegion => {
+                            match region_state.kind {
+                                super::image_search_controls::SearchRegionKind::Rectangle => { let rect=region_state.rectangle; if rect.is_empty(){state.capture_message=Some("Rectangle width and height must be positive".into())} else { state.visual_overlay.preview_rectangle(rect); } },
+                                super::image_search_controls::SearchRegionKind::Monitor => { region_state.refresh_monitors(); if let Ok(ms)=&region_state.monitors { if let Some(m)=ms.iter().find(|m|m.index==region_state.monitor_index){state.visual_overlay.highlight_monitor(m.clone());} else {state.capture_message=Some(format!("Monitor {} is currently unavailable",region_state.monitor_index));} } },
+                                super::image_search_controls::SearchRegionKind::Window|super::image_search_controls::SearchRegionKind::ClientArea => {},
+                                super::image_search_controls::SearchRegionKind::Desktop => {},
+                            }
+                        }
+                    }
+                }
+            }
             let find_action = matches!(step.action, MkAction::ImageFind(_));
             if let Some(payload) = image_payload_mut(step) {
                 let request = super::image_search_editor::show(ui, payload, state.image_search.as_mut().expect("image action requires image editor state"), &d.store, d.selected_macro_id.unwrap_or(0), importing, find_action, image_assets.iter().any(|asset| asset.id == payload.asset_id));
@@ -2335,9 +2333,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 match request {
                     Some(ImportPng) => image_request = Some(ImageAuthoringRequest::Import),
                     Some(CaptureRectangle) => image_request = Some(ImageAuthoringRequest::CaptureRectangle),
-                    Some(PickRectangle) => image_request = Some(ImageAuthoringRequest::PickRectangle),
-                    Some(PickWindow { .. }) => window = Some(super::window_picker::MatcherPath::ImageRegion),
-                    Some(PreviewRectangle) => {
+                    Some(SelectRegion) => image_request = Some(ImageAuthoringRequest::PickRectangle),
+                    Some(PickWindow { .. }) => window = Some(super::window_picker::MatcherPath::VisualRegion),
+                    Some(PreviewRegion) => {
                         let image = state.image_search.as_ref().unwrap();
                         if image.rectangle.is_empty() {
                             state.capture_message = Some("Rectangle width and height must be positive".into());
@@ -2414,7 +2412,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 }
             }
             if let Some(path)=window {
-                let original = if matches!(path, super::window_picker::MatcherPath::ImageRegion) {
+                let original = if matches!(path, super::window_picker::MatcherPath::VisualRegion) {
                     let image=state.image_search.as_ref().expect("image picker requires image state");
                     if image.kind == super::image_search_editor::SearchRegionKind::ClientArea { image.client_matcher.clone() } else { image.window_matcher.clone() }
                 } else { matcher_at_path(&mut step.action, &path).expect("picker path must resolve").clone() };
@@ -3137,7 +3135,7 @@ mod tests {
                         poll_interval_ms: 1,
                     },
                 }),
-                super::super::window_picker::MatcherPath::ImageRegion,
+                super::super::window_picker::MatcherPath::VisualRegion,
             ),
         ] {
             let mut editor = ActionEditorState::default();
@@ -3151,7 +3149,7 @@ mod tests {
                 original: MkWindowMatcher::default(),
             };
             assert!(editor.apply_window_matcher(&request, replacement.clone(), Some(5)));
-            if matches!(path, super::super::window_picker::MatcherPath::ImageRegion) {
+            if matches!(path, super::super::window_picker::MatcherPath::VisualRegion) {
                 // Image regions intentionally remain in the UI-only per-mode
                 // cache until Apply; picker results must not mutate the
                 // serialized action draft behind the editor's back.
@@ -3897,6 +3895,49 @@ mod tests {
                 &snapshots.1,
                 "A stale Capture result must not overwrite the search rectangle"
             );
+        }
+    }
+
+    #[cfg(test)]
+    mod visual_region_picker_tests {
+        use super::*;
+
+        #[test]
+        fn wait_visual_change_picker_requires_live_compatible_draft() {
+            let mut editor = ActionEditorState::default();
+            editor.begin_new(MkAction::WaitForVisualChange(WaitForVisualChange::default()));
+            let generation = editor.draft_generation;
+            let request = super::super::window_picker::MatcherEditRequest {
+                destination: super::super::window_picker::MatcherDestination::Action {
+                    macro_id: 7,
+                    draft_generation: generation,
+                    path: super::super::window_picker::MatcherPath::VisualRegion,
+                },
+                original: MkWindowMatcher::default(),
+            };
+            let matcher = MkWindowMatcher {
+                title: Some("picked".into()),
+                ..Default::default()
+            };
+            assert!(!editor.apply_window_matcher(&request, matcher.clone(), Some(7)));
+            editor.image_search.as_mut().unwrap().kind =
+                super::super::image_search_controls::SearchRegionKind::ClientArea;
+            assert!(editor.apply_window_matcher(&request, matcher.clone(), Some(7)));
+            assert_eq!(
+                editor.image_search.as_ref().unwrap().client_matcher,
+                matcher
+            );
+            assert!(
+                editor
+                    .image_search
+                    .as_ref()
+                    .unwrap()
+                    .window_matcher
+                    .title
+                    .is_none()
+            );
+            editor.draft_generation += 1;
+            assert!(!editor.apply_window_matcher(&request, MkWindowMatcher::default(), Some(7)));
         }
     }
 }

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -3213,10 +3213,7 @@ mod tests {
                 super::super::image_search_editor::SearchRegionKind::Rectangle
             );
             assert_eq!(image.rectangle, ScreenRect::new(-10, 20, 30, 40));
-            assert_eq!(
-                image.pending_request, None,
-                "both actions expose the same typed request channel"
-            );
+            assert_eq!(image.selected_region(), payload.region);
         }
     }
 
@@ -3901,17 +3898,21 @@ mod tests {
     #[cfg(test)]
     mod visual_region_picker_tests {
         use super::*;
+        use crate::gui::mkmacro_dialog::{
+            image_search_controls::SearchRegionKind,
+            window_picker::{MatcherDestination, MatcherEditRequest, MatcherPath},
+        };
 
         #[test]
         fn wait_visual_change_picker_requires_live_compatible_draft() {
             let mut editor = ActionEditorState::default();
             editor.begin_new(MkAction::WaitForVisualChange(WaitForVisualChange::default()));
             let generation = editor.draft_generation;
-            let request = super::super::window_picker::MatcherEditRequest {
-                destination: super::super::window_picker::MatcherDestination::Action {
+            let request = MatcherEditRequest {
+                destination: MatcherDestination::Action {
                     macro_id: 7,
                     draft_generation: generation,
-                    path: super::super::window_picker::MatcherPath::VisualRegion,
+                    path: MatcherPath::VisualRegion,
                 },
                 original: MkWindowMatcher::default(),
             };
@@ -3920,8 +3921,7 @@ mod tests {
                 ..Default::default()
             };
             assert!(!editor.apply_window_matcher(&request, matcher.clone(), Some(7)));
-            editor.image_search.as_mut().unwrap().kind =
-                super::super::image_search_controls::SearchRegionKind::ClientArea;
+            editor.image_search.as_mut().unwrap().kind = SearchRegionKind::ClientArea;
             assert!(editor.apply_window_matcher(&request, matcher.clone(), Some(7)));
             assert_eq!(
                 editor.image_search.as_ref().unwrap().client_matcher,

--- a/src/gui/mkmacro_dialog/image_search_controls.rs
+++ b/src/gui/mkmacro_dialog/image_search_controls.rs
@@ -27,7 +27,7 @@ impl SearchRegionKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImageSearchControlState {
+pub struct SearchRegionEditorState {
     pub kind: SearchRegionKind,
     pub monitor_index: usize,
     pub rectangle: ScreenRect,
@@ -36,7 +36,7 @@ pub struct ImageSearchControlState {
     pub monitors: Result<Vec<MonitorDescriptor>, String>,
 }
 
-impl ImageSearchControlState {
+impl SearchRegionEditorState {
     pub fn from_region(region: &SearchRegion) -> Self {
         let mut s = Self {
             kind: SearchRegionKind::from_region(region),
@@ -75,6 +75,132 @@ impl ImageSearchControlState {
     pub fn refresh_monitors(&mut self) {
         self.monitors = crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string());
     }
+    pub fn select(&mut self, kind: SearchRegionKind) {
+        self.kind = kind;
+    }
+    pub fn validation_error(&self) -> Option<String> {
+        match self.kind {
+            SearchRegionKind::Rectangle if self.rectangle.is_empty() => {
+                Some("Rectangle width and height must be positive".into())
+            }
+            SearchRegionKind::Monitor => match &self.monitors {
+                Ok(ms) if !ms.iter().any(|m| m.index == self.monitor_index) => Some(format!(
+                    "Monitor {} is currently unavailable",
+                    self.monitor_index
+                )),
+                Err(e) => Some(format!("Monitor information unavailable: {e}")),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+pub type ImageSearchControlState = SearchRegionEditorState;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SearchRegionRequest {
+    SelectRectangle,
+    PreviewRegion,
+    PickWindow,
+    RefreshMonitors,
+    IdentifyMonitors,
+}
+
+/// Edits only a screen region. Native workflows are deliberately returned to the owner.
+pub fn show_search_region_fields(
+    ui: &mut egui::Ui,
+    state: &mut SearchRegionEditorState,
+) -> Option<SearchRegionRequest> {
+    let mut out = None;
+    egui::ComboBox::from_label("Area")
+        .selected_text(match state.kind {
+            SearchRegionKind::Desktop => "Desktop",
+            SearchRegionKind::Monitor => "Monitor",
+            SearchRegionKind::Rectangle => "Rectangle",
+            SearchRegionKind::Window => "Window",
+            SearchRegionKind::ClientArea => "Client Area",
+        })
+        .show_ui(ui, |ui| {
+            for (k, l) in [
+                (SearchRegionKind::Desktop, "Desktop"),
+                (SearchRegionKind::Monitor, "Monitor"),
+                (SearchRegionKind::Rectangle, "Rectangle"),
+                (SearchRegionKind::Window, "Window"),
+                (SearchRegionKind::ClientArea, "Client Area"),
+            ] {
+                ui.selectable_value(&mut state.kind, k, l);
+            }
+        });
+    match state.kind {
+        SearchRegionKind::Monitor => {
+            if ui.button("Refresh Monitors").clicked() {
+                out = Some(SearchRegionRequest::RefreshMonitors);
+            }
+            match &state.monitors {
+                Ok(ms) => {
+                    let selected = ms
+                        .iter()
+                        .find(|m| m.index == state.monitor_index)
+                        .map(MonitorDescriptor::label)
+                        .unwrap_or_else(|| {
+                            format!("Monitor {} — unavailable", state.monitor_index)
+                        });
+                    egui::ComboBox::from_label("Monitor")
+                        .selected_text(selected)
+                        .show_ui(ui, |ui| {
+                            for m in ms {
+                                ui.selectable_value(&mut state.monitor_index, m.index, m.label());
+                            }
+                        });
+                }
+                Err(e) => {
+                    ui.colored_label(
+                        egui::Color32::YELLOW,
+                        format!("Monitor information unavailable: {e}"),
+                    );
+                }
+            }
+        }
+        SearchRegionKind::Rectangle => {
+            ui.horizontal(|ui| {
+                for (l, v) in [
+                    ("X", &mut state.rectangle.x),
+                    ("Y", &mut state.rectangle.y),
+                    ("W", &mut state.rectangle.width),
+                    ("H", &mut state.rectangle.height),
+                ] {
+                    ui.label(l);
+                    ui.add(egui::DragValue::new(v));
+                }
+            });
+            if ui.button("Select Region").clicked() {
+                out = Some(SearchRegionRequest::SelectRectangle);
+            }
+        }
+        SearchRegionKind::Window | SearchRegionKind::ClientArea => {
+            let m = if state.kind == SearchRegionKind::Window {
+                &mut state.window_matcher
+            } else {
+                &mut state.client_matcher
+            };
+            if super::action_editor::matcher_ui(ui, m) || ui.button("Pick Window").clicked() {
+                out = Some(SearchRegionRequest::PickWindow);
+            }
+        }
+        SearchRegionKind::Desktop => {}
+    }
+    if !matches!(
+        out,
+        Some(SearchRegionRequest::PickWindow | SearchRegionRequest::SelectRectangle)
+    ) && ui.button("Preview Region").clicked()
+    {
+        out = Some(SearchRegionRequest::PreviewRegion);
+    }
+    if let Some(e) = state.validation_error() {
+        ui.colored_label(egui::Color32::YELLOW, e);
+    }
+    out
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,61 +257,22 @@ pub fn show_shared_fields(
         ui.selectable_value(return_point, ReturnPoint::Center, "Center");
         ui.selectable_value(return_point, ReturnPoint::TopLeft, "Top-left");
     });
-    let mut state = ImageSearchControlState::from_region(region);
-    egui::ComboBox::from_label("Area")
-        .selected_text(format!("{:?}", state.kind))
-        .show_ui(ui, |ui| {
-            for (k, l) in [
-                (SearchRegionKind::Desktop, "Desktop"),
-                (SearchRegionKind::Monitor, "Monitor"),
-                (SearchRegionKind::Rectangle, "Rectangle"),
-                (SearchRegionKind::Window, "Window"),
-                (SearchRegionKind::ClientArea, "Client Area"),
-            ] {
-                ui.selectable_value(&mut state.kind, k, l);
+    let mut state = SearchRegionEditorState::from_region(region);
+    if let Some(r) = show_search_region_fields(ui, &mut state) {
+        request = Some(match r {
+            SearchRegionRequest::SelectRectangle => SharedImageOperation::PickRectangle,
+            SearchRegionRequest::PreviewRegion => match state.kind {
+                SearchRegionKind::Monitor => SharedImageOperation::HighlightMonitor,
+                SearchRegionKind::Window | SearchRegionKind::ClientArea => {
+                    SharedImageOperation::HighlightWindow
+                }
+                _ => SharedImageOperation::PreviewRectangle,
+            },
+            SearchRegionRequest::PickWindow => SharedImageOperation::PickWindow,
+            SearchRegionRequest::RefreshMonitors | SearchRegionRequest::IdentifyMonitors => {
+                SharedImageOperation::HighlightMonitor
             }
         });
-    match state.kind {
-        SearchRegionKind::Monitor => {
-            ui.add(egui::DragValue::new(&mut state.monitor_index).prefix("Monitor "));
-            if ui.button("Highlight Monitor").clicked() {
-                request = Some(SharedImageOperation::HighlightMonitor)
-            }
-        }
-        SearchRegionKind::Rectangle => {
-            ui.horizontal(|ui| {
-                ui.add(egui::DragValue::new(&mut state.rectangle.x).prefix("X "));
-                ui.add(egui::DragValue::new(&mut state.rectangle.y).prefix("Y "));
-                ui.add(egui::DragValue::new(&mut state.rectangle.width).prefix("W "));
-                ui.add(egui::DragValue::new(&mut state.rectangle.height).prefix("H "));
-            });
-            ui.horizontal(|ui| {
-                if ui.button("Pick Region").clicked() {
-                    request = Some(SharedImageOperation::PickRectangle)
-                }
-                if ui.button("Preview Region").clicked() {
-                    request = Some(SharedImageOperation::PreviewRectangle)
-                }
-            });
-        }
-        SearchRegionKind::Window | SearchRegionKind::ClientArea => {
-            let matcher = if state.kind == SearchRegionKind::Window {
-                &mut state.window_matcher
-            } else {
-                &mut state.client_matcher
-            };
-            if super::action_editor::matcher_ui(ui, matcher) || ui.button("Pick Window").clicked() {
-                request = Some(SharedImageOperation::PickWindow)
-            }
-            if ui
-                .add_enabled(cfg!(windows), egui::Button::new("Highlight Window"))
-                .on_disabled_hover_text("Window highlighting is available on Windows only.")
-                .clicked()
-            {
-                request = Some(SharedImageOperation::HighlightWindow)
-            }
-        }
-        SearchRegionKind::Desktop => {}
     }
     *region = state.selected_region();
     request

--- a/src/gui/mkmacro_dialog/image_search_controls.rs
+++ b/src/gui/mkmacro_dialog/image_search_controls.rs
@@ -164,15 +164,14 @@ pub fn show_search_region_fields(
         }
         SearchRegionKind::Rectangle => {
             ui.horizontal(|ui| {
-                for (l, v) in [
-                    ("X", &mut state.rectangle.x),
-                    ("Y", &mut state.rectangle.y),
-                    ("W", &mut state.rectangle.width),
-                    ("H", &mut state.rectangle.height),
-                ] {
-                    ui.label(l);
-                    ui.add(egui::DragValue::new(v));
-                }
+                ui.label("X");
+                ui.add(egui::DragValue::new(&mut state.rectangle.x));
+                ui.label("Y");
+                ui.add(egui::DragValue::new(&mut state.rectangle.y));
+                ui.label("W");
+                ui.add(egui::DragValue::new(&mut state.rectangle.width));
+                ui.label("H");
+                ui.add(egui::DragValue::new(&mut state.rectangle.height));
             });
             if ui.button("Select Region").clicked() {
                 out = Some(SearchRegionRequest::SelectRectangle);

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -5,117 +5,21 @@ use crate::mkmacro::{
 };
 use eframe::egui;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SearchRegionKind {
-    Desktop,
-    Monitor,
-    Rectangle,
-    Window,
-    ClientArea,
-}
-
-impl SearchRegionKind {
-    pub fn from_region(region: &SearchRegion) -> Self {
-        match region {
-            SearchRegion::Desktop => Self::Desktop,
-            SearchRegion::Monitor { .. } => Self::Monitor,
-            SearchRegion::Rectangle { .. } => Self::Rectangle,
-            SearchRegion::Window { .. } => Self::Window,
-            SearchRegion::ClientArea { .. } => Self::ClientArea,
-        }
-    }
-}
+pub use super::image_search_controls::SearchRegionKind;
+pub type ImageSearchEditorState = super::image_search_controls::SearchRegionEditorState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageEditorRequest {
     ImportPng,
     CaptureRectangle,
-    PickRectangle,
-    PreviewRectangle,
+    SelectRegion,
+    PreviewRegion,
     HighlightMonitor,
     IdentifyMonitors,
     PickWindow { client_area: bool },
     HighlightWindow { client_area: bool },
     AddSmoothMouseMove,
     AddActivateWindowBefore,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImageSearchEditorState {
-    pub kind: SearchRegionKind,
-    pub monitor_index: usize,
-    pub rectangle: ScreenRect,
-    pub window_matcher: MkWindowMatcher,
-    pub client_matcher: MkWindowMatcher,
-    pub monitors: Result<Vec<MonitorDescriptor>, String>,
-    pub pending_request: Option<ImageEditorRequest>,
-    pub preview_error: Option<String>,
-}
-
-impl ImageSearchEditorState {
-    pub fn from_payload(payload: &MkImagePayload) -> Self {
-        let mut state = Self {
-            kind: SearchRegionKind::from_region(&payload.region),
-            monitor_index: 0,
-            rectangle: ScreenRect::new(0, 0, 640, 480),
-            window_matcher: MkWindowMatcher::default(),
-            client_matcher: MkWindowMatcher::default(),
-            monitors: crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string()),
-            pending_request: None,
-            preview_error: None,
-        };
-        match &payload.region {
-            SearchRegion::Monitor { index } => state.monitor_index = *index,
-            SearchRegion::Rectangle { rect } => state.rectangle = *rect,
-            SearchRegion::Window { matcher } => state.window_matcher = matcher.clone(),
-            SearchRegion::ClientArea { matcher } => state.client_matcher = matcher.clone(),
-            SearchRegion::Desktop => {}
-        }
-        state
-    }
-
-    pub fn select(&mut self, kind: SearchRegionKind) {
-        self.kind = kind;
-    }
-    /// Refreshes display metadata without changing the persisted playback
-    /// index.  In particular, disconnecting a display must not silently point
-    /// an existing action at a different monitor.
-    pub fn refresh_monitors(&mut self) {
-        self.monitors = crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string());
-    }
-
-    pub fn validation_error(&self) -> Option<String> {
-        match self.kind {
-            SearchRegionKind::Rectangle if self.rectangle.is_empty() => {
-                Some("Rectangle width and height must be positive".into())
-            }
-            SearchRegionKind::Monitor => match &self.monitors {
-                Ok(monitors) if !monitors.iter().any(|m| m.index == self.monitor_index) => Some(
-                    format!("Monitor {} is currently unavailable", self.monitor_index),
-                ),
-                Err(error) => Some(format!("Monitor information unavailable: {error}")),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-    pub fn selected_region(&self) -> SearchRegion {
-        match self.kind {
-            SearchRegionKind::Desktop => SearchRegion::Desktop,
-            SearchRegionKind::Monitor => SearchRegion::Monitor {
-                index: self.monitor_index,
-            },
-            SearchRegionKind::Rectangle => SearchRegion::Rectangle {
-                rect: self.rectangle,
-            },
-            SearchRegionKind::Window => SearchRegion::Window {
-                matcher: self.window_matcher.clone(),
-            },
-            SearchRegionKind::ClientArea => SearchRegion::ClientArea {
-                matcher: self.client_matcher.clone(),
-            },
-        }
-    }
 }
 
 fn request(
@@ -277,148 +181,29 @@ pub(super) fn show(
 
     ui.separator();
     ui.heading("Search Area");
-    egui::ComboBox::from_label("Area")
-        .selected_text(match state.kind {
-            SearchRegionKind::Desktop => "Entire Desktop",
-            SearchRegionKind::Monitor => "Selected Monitor",
-            SearchRegionKind::Rectangle => "Rectangle",
-            SearchRegionKind::Window => "Window",
-            SearchRegionKind::ClientArea => "Window Client Area",
-        })
-        .show_ui(ui, |ui| {
-            ui.selectable_value(&mut state.kind, SearchRegionKind::Desktop, "Entire Desktop");
-            ui.selectable_value(
-                &mut state.kind,
-                SearchRegionKind::Monitor,
-                "Selected Monitor",
-            );
-            ui.selectable_value(&mut state.kind, SearchRegionKind::Rectangle, "Rectangle");
-            ui.selectable_value(&mut state.kind, SearchRegionKind::Window, "Window");
-            ui.selectable_value(
-                &mut state.kind,
-                SearchRegionKind::ClientArea,
-                "Window Client Area",
-            );
-        });
-    match state.kind {
-        SearchRegionKind::Desktop => {
-            ui.label("Searches the complete virtual desktop across all connected monitors.");
-        }
-        SearchRegionKind::Monitor => {
-            if ui.button("Refresh").clicked() {
-                state.refresh_monitors();
-            }
-            match &state.monitors {
-                Ok(monitors) => {
-                    let selected = monitors
-                        .iter()
-                        .find(|m| m.index == state.monitor_index)
-                        .map(|m| m.label())
-                        .unwrap_or_else(|| {
-                            format!("Monitor {} — unavailable", state.monitor_index)
-                        });
-                    egui::ComboBox::from_label("Monitor")
-                        .selected_text(selected)
-                        .show_ui(ui, |ui| {
-                            for m in monitors {
-                                ui.selectable_value(&mut state.monitor_index, m.index, m.label());
-                            }
-                        });
-                    if !monitors.iter().any(|m| m.index == state.monitor_index) {
-                        ui.colored_label(egui::Color32::YELLOW, format!("Stored monitor {} is currently unavailable; it has been preserved.", state.monitor_index));
+    if let Some(region_request) = super::image_search_controls::show_search_region_fields(ui, state)
+    {
+        use super::image_search_controls::SearchRegionRequest as R;
+        out = Some(match region_request {
+            R::SelectRectangle => ImageEditorRequest::SelectRegion,
+            R::PreviewRegion => match state.kind {
+                SearchRegionKind::Monitor => ImageEditorRequest::HighlightMonitor,
+                SearchRegionKind::Window | SearchRegionKind::ClientArea => {
+                    ImageEditorRequest::HighlightWindow {
+                        client_area: state.kind == SearchRegionKind::ClientArea,
                     }
                 }
-                Err(error) => {
-                    ui.colored_label(
-                        egui::Color32::YELLOW,
-                        format!("Monitor information unavailable: {error}"),
-                    );
-                }
+                _ => ImageEditorRequest::PreviewRegion,
+            },
+            R::PickWindow => ImageEditorRequest::PickWindow {
+                client_area: state.kind == SearchRegionKind::ClientArea,
+            },
+            R::RefreshMonitors => {
+                state.refresh_monitors();
+                ImageEditorRequest::IdentifyMonitors
             }
-            ui.horizontal_wrapped(|ui| {
-                request(
-                    ui,
-                    "Highlight Selected",
-                    ImageEditorRequest::HighlightMonitor,
-                    &mut out,
-                );
-                request(
-                    ui,
-                    "Identify All Monitors",
-                    ImageEditorRequest::IdentifyMonitors,
-                    &mut out,
-                );
-            });
-        }
-        SearchRegionKind::Rectangle => {
-            ui.horizontal_wrapped(|ui| {
-                ui.label("X");
-                ui.add(egui::DragValue::new(&mut state.rectangle.x));
-                ui.label("Y");
-                ui.add(egui::DragValue::new(&mut state.rectangle.y));
-            });
-            ui.horizontal_wrapped(|ui| {
-                ui.label("Width");
-                ui.add(egui::DragValue::new(&mut state.rectangle.width));
-                ui.label("Height");
-                ui.add(egui::DragValue::new(&mut state.rectangle.height));
-            });
-            if state.rectangle.is_empty() {
-                ui.colored_label(egui::Color32::RED, "Width and height must be positive.");
-            }
-            ui.horizontal_wrapped(|ui| {
-                request(
-                    ui,
-                    "Pick Region",
-                    ImageEditorRequest::PickRectangle,
-                    &mut out,
-                );
-                request(
-                    ui,
-                    "Preview Region",
-                    ImageEditorRequest::PreviewRectangle,
-                    &mut out,
-                );
-            });
-        }
-        SearchRegionKind::Window | SearchRegionKind::ClientArea => {
-            let client = state.kind == SearchRegionKind::ClientArea;
-            if client {
-                ui.label("Searches only the window client area; title bars, borders, and other non-client chrome are excluded.");
-            }
-            let matcher = if client {
-                &mut state.client_matcher
-            } else {
-                &mut state.window_matcher
-            };
-            if super::action_editor::matcher_ui(ui, matcher) {
-                out = Some(ImageEditorRequest::PickWindow {
-                    client_area: client,
-                });
-            }
-            ui.horizontal_wrapped(|ui| {
-                request(
-                    ui,
-                    "Pick Window",
-                    ImageEditorRequest::PickWindow {
-                        client_area: client,
-                    },
-                    &mut out,
-                );
-                request(
-                    ui,
-                    if client {
-                        "Highlight Client Area"
-                    } else {
-                        "Highlight Window"
-                    },
-                    ImageEditorRequest::HighlightWindow {
-                        client_area: client,
-                    },
-                    &mut out,
-                );
-            });
-        }
+            R::IdentifyMonitors => ImageEditorRequest::IdentifyMonitors,
+        });
     }
     ui.separator();
     ui.heading("Related actions");
@@ -487,7 +272,7 @@ mod tests {
                 matcher: MkWindowMatcher::default(),
             },
         ] {
-            let s = ImageSearchEditorState::from_payload(&payload(region.clone()));
+            let s = ImageSearchEditorState::from_region(&payload(region.clone()));
             assert_eq!(
                 SearchRegionKind::from_region(&s.selected_region()),
                 SearchRegionKind::from_region(&region)
@@ -496,7 +281,7 @@ mod tests {
     }
     #[test]
     fn drafts_survive_switches_and_matchers_are_independent() {
-        let mut s = ImageSearchEditorState::from_payload(&payload(SearchRegion::Desktop));
+        let mut s = ImageSearchEditorState::from_region(&SearchRegion::Desktop);
         s.rectangle = ScreenRect::new(-9, 8, 7, 6);
         s.window_matcher.title = Some("whole".into());
         s.client_matcher.title = Some("client".into());
@@ -515,7 +300,7 @@ mod tests {
     #[test]
     fn transient_state_is_not_serialized_with_payload() {
         let p = payload(SearchRegion::Desktop);
-        let mut s = ImageSearchEditorState::from_payload(&p);
+        let mut s = ImageSearchEditorState::from_region(&p.region);
         s.pending_request = Some(ImageEditorRequest::CaptureRectangle);
         let json = serde_json::to_string(&p).unwrap();
         assert!(
@@ -527,9 +312,9 @@ mod tests {
 
     #[test]
     fn validation_preserves_invalid_rectangle_and_missing_monitor_index() {
-        let mut s = ImageSearchEditorState::from_payload(&payload(SearchRegion::Rectangle {
+        let mut s = ImageSearchEditorState::from_region(&SearchRegion::Rectangle {
             rect: ScreenRect::new(-10, -20, 0, 30),
-        }));
+        });
         assert!(s.validation_error().unwrap().contains("positive"));
         assert_eq!(s.rectangle, ScreenRect::new(-10, -20, 0, 30));
 
@@ -551,8 +336,7 @@ mod tests {
             bounds: ScreenRect::new(x, -40, 800, 600),
             primary,
         };
-        let mut s =
-            ImageSearchEditorState::from_payload(&payload(SearchRegion::Monitor { index: 42 }));
+        let mut s = ImageSearchEditorState::from_region(&SearchRegion::Monitor { index: 42 });
         s.monitors = Ok(vec![descriptor(7, -800, false), descriptor(42, 0, true)]);
         assert_eq!(s.monitor_index, 42);
         assert_eq!(

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -271,7 +271,7 @@ mod tests {
                 matcher: MkWindowMatcher::default(),
             },
         ] {
-            let s = ImageSearchEditorState::from_region(&payload(region.clone()));
+            let s = ImageSearchEditorState::from_region(&region);
             assert_eq!(
                 SearchRegionKind::from_region(&s.selected_region()),
                 SearchRegionKind::from_region(&region)
@@ -300,7 +300,7 @@ mod tests {
     fn transient_state_is_not_serialized_with_payload() {
         let p = payload(SearchRegion::Desktop);
         let mut s = ImageSearchEditorState::from_region(&p.region);
-        s.pending_request = Some(ImageEditorRequest::CaptureRectangle);
+        s.monitors = Err("transient discovery failure".into());
         let json = serde_json::to_string(&p).unwrap();
         assert!(
             !json.contains("pending_request")

--- a/src/gui/mkmacro_dialog/image_search_editor.rs
+++ b/src/gui/mkmacro_dialog/image_search_editor.rs
@@ -234,7 +234,6 @@ pub(super) fn show(
             out = Some(ImageEditorRequest::AddActivateWindowBefore);
         }
     }
-    state.pending_request = out;
     out
 }
 

--- a/src/gui/mkmacro_dialog/window_picker.rs
+++ b/src/gui/mkmacro_dialog/window_picker.rs
@@ -15,7 +15,7 @@ pub enum MatcherDestination {
 pub enum MatcherPath {
     Action,
     Condition(Vec<usize>),
-    ImageRegion,
+    VisualRegion,
     Coordinate(CoordinateMatcherPath),
 }
 


### PR DESCRIPTION
### Motivation

- Remove duplicated region-authoring logic and provide a single, reference-image‑independent region editor used by image actions, image-search conditions, and `WaitForVisualChange`.
- Preserve per-mode transient state (rectangle, per-mode matchers, monitor indices) across mode switches and expose monitor discovery/validation helpers independent of image payloads.

### Description

- Introduce `SearchRegionEditorState` (aliasable as `ImageSearchControlState`) that stores `SearchRegionKind`, monitor index, cached rectangle, separate whole-window and client-area `MkWindowMatcher` caches, discovered `MonitorDescriptor` results or an error, and helpers `from_region`, `selected_region`, `refresh_monitors`, `select`, and `validation_error`.
- Add `show_search_region_fields(...)` which renders the unified region selector and per-kind controls, and returns a typed `SearchRegionRequest` instead of performing native workflows; it supports `SelectRectangle`, `PreviewRegion`, `PickWindow`, `RefreshMonitors`, and `IdentifyMonitors` requests and shows descriptive monitor labels (including negative coordinates) and validation messages.
- Split image-only controls from region editing: keep reference-image, tolerance, alpha, return-point, timeout/outputs under image-specific UI, and consume the shared region renderer for image actions and conditions.
- Consolidate the image-search editor to reuse the shared state (moved/aliased to `image_search_controls`), and update `ImageEditorRequest` names to semantic request names (e.g. `SelectRegion` / `PreviewRegion`).
- Update `ActionEditorState` to initialize the common region state when opening `ImageFind`, `ImageClick`, and `WaitForVisualChange` drafts and to synchronize the shared region back into the respective action payloads through the transactional draft workflow.
- Generalize window-picker routing to `MatcherPath::VisualRegion`, enforce macro id / draft generation / action-type compatibility before applying picked matchers, and preserve the distinction between whole-window and client-area matcher caches when applying picker results.
- Add focused unit tests exercising round-trips, preservation of transient state across switches, monitor label formatting and missing-index validation, parity between region values across image actions/conditions/`WaitForVisualChange`, and a test ensuring the visual-region window-picker applies only to a live compatible draft.

### Testing

- Ran `cargo fmt --all` successfully to ensure formatting compliance.
- Built and type-checked with `cargo check -q` and ran the full test suite with `cargo test -q`, both of which completed successfully.
- Executed the new focused test `visual_region_picker_tests` (and related unit tests touching region state) as part of `cargo test`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e3c94cf048332a2d90d0791a37d24)