### PR TITLE
Add shared search-region preview dispatcher and desktop overlay support

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -110,7 +110,131 @@ struct NativePositionPicker {
     escape_down: bool,
 }
 
+trait RegionPreviewBoundary {
+    fn preview_desktop(
+        &self,
+        monitors: Vec<MonitorDescriptor>,
+    ) -> super::visual_overlay::OperationId;
+    fn highlight_monitor(&self, monitor: MonitorDescriptor) -> super::visual_overlay::OperationId;
+    fn preview_rectangle(&self, rect: ScreenRect) -> super::visual_overlay::OperationId;
+    fn highlight_window(
+        &self,
+        rect: ScreenRect,
+        kind: super::visual_overlay::WindowAreaKind,
+    ) -> super::visual_overlay::OperationId;
+}
+impl RegionPreviewBoundary for super::visual_capture_workflow::SharedVisualOverlayController {
+    fn preview_desktop(
+        &self,
+        monitors: Vec<MonitorDescriptor>,
+    ) -> super::visual_overlay::OperationId {
+        self.preview_desktop(monitors)
+    }
+    fn highlight_monitor(&self, monitor: MonitorDescriptor) -> super::visual_overlay::OperationId {
+        self.highlight_monitor(monitor)
+    }
+    fn preview_rectangle(&self, rect: ScreenRect) -> super::visual_overlay::OperationId {
+        self.preview_rectangle(rect)
+    }
+    fn highlight_window(
+        &self,
+        rect: ScreenRect,
+        kind: super::visual_overlay::WindowAreaKind,
+    ) -> super::visual_overlay::OperationId {
+        self.highlight_window(rect, kind)
+    }
+}
+
+fn dispatch_region_preview(
+    region: &SearchRegion,
+    monitors: &Result<Vec<MonitorDescriptor>, String>,
+    resolve_window: &dyn Fn(&MkWindowMatcher, bool) -> ExecResult<ScreenRect>,
+    preview: &dyn RegionPreviewBoundary,
+) -> Result<(super::visual_overlay::OperationId, String), String> {
+    use super::visual_overlay::WindowAreaKind;
+    let monitor_list = || {
+        monitors
+            .as_ref()
+            .map_err(|e| format!("Monitor discovery failed: {e}"))
+    };
+    match region {
+        SearchRegion::Desktop => {
+            let descriptors = monitor_list()?;
+            if descriptors.is_empty() {
+                return Err("No monitors are currently available".into());
+            }
+            Ok((
+                preview.preview_desktop(descriptors.clone()),
+                "Unable to preview desktop monitors".into(),
+            ))
+        }
+        SearchRegion::Monitor { index } => {
+            let descriptor = monitor_list()?
+                .iter()
+                .find(|m| m.index == *index)
+                .cloned()
+                .ok_or_else(|| format!("Monitor index {index} no longer exists"))?;
+            Ok((
+                preview.highlight_monitor(descriptor),
+                format!("Unable to highlight monitor {index}"),
+            ))
+        }
+        SearchRegion::Rectangle { rect } => {
+            if rect.is_empty() {
+                return Err("Rectangle is invalid: width and height must be positive".into());
+            }
+            Ok((
+                preview.preview_rectangle(*rect),
+                format!("Unable to preview rectangle {rect:?}"),
+            ))
+        }
+        SearchRegion::Window { matcher } | SearchRegion::ClientArea { matcher } => {
+            let client = matches!(region, SearchRegion::ClientArea { .. });
+            let rect = resolve_window(matcher, client).map_err(|e| match e.kind {
+                DiagnosticKind::TargetNotFound => "Window target was not found".into(),
+                DiagnosticKind::AmbiguousTarget => "Window matcher is ambiguous".into(),
+                _ => format!("Unable to resolve window target: {e}"),
+            })?;
+            let kind = if client {
+                WindowAreaKind::ClientArea
+            } else {
+                WindowAreaKind::WholeWindow
+            };
+            Ok((
+                preview.highlight_window(rect, kind),
+                format!(
+                    "Unable to preview {}",
+                    if client {
+                        "client area"
+                    } else {
+                        "whole window"
+                    }
+                ),
+            ))
+        }
+    }
+}
+
 impl ActionEditorState {
+    fn preview_region(&mut self, region: SearchRegion) {
+        let monitors = if matches!(region, SearchRegion::Desktop | SearchRegion::Monitor { .. }) {
+            crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string())
+        } else {
+            Ok(vec![])
+        };
+        match dispatch_region_preview(
+            &region,
+            &monitors,
+            &crate::mkmacro::resolve_window_screen_rect,
+            &self.visual_overlay,
+        ) {
+            Ok((id, context)) => {
+                self.overlay_diagnostic = Some((id, context));
+                self.capture_message = None;
+            }
+            Err(message) => self.capture_message = Some(message),
+        }
+    }
     pub fn condition_destination(
         &self,
         macro_id: u64,
@@ -460,15 +584,7 @@ impl ActionEditorState {
     }
     fn poll_visual_overlay(&mut self) {
         for event in self.visual_overlay.poll() {
-            if let super::visual_overlay::VisualOverlayEvent::Error {
-                operation_id,
-                error,
-            } = event
-                && self.overlay_diagnostic.as_ref().map(|v| v.0) == Some(operation_id)
-            {
-                let context = &self.overlay_diagnostic.as_ref().unwrap().1;
-                self.capture_message = Some(format!("{context}: {error}"));
-            }
+            apply_overlay_diagnostic(&mut self.capture_message, &self.overlay_diagnostic, event);
         }
     }
     pub fn apply(&mut self, dialog: &mut MkMacroDialog) -> Option<u64> {
@@ -714,6 +830,21 @@ impl ActionEditorState {
         };
         self.capture_keys = false;
         true
+    }
+}
+
+fn apply_overlay_diagnostic(
+    message: &mut Option<String>,
+    current: &Option<(super::visual_overlay::OperationId, String)>,
+    event: super::visual_overlay::VisualOverlayEvent,
+) {
+    if let super::visual_overlay::VisualOverlayEvent::Error {
+        operation_id,
+        error,
+    } = event
+        && current.as_ref().map(|v| v.0) == Some(operation_id)
+    {
+        *message = Some(format!("{}: {error}", current.as_ref().unwrap().1));
     }
 }
 
@@ -2316,12 +2447,8 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                         R::RefreshMonitors => region_state.refresh_monitors(),
                         R::IdentifyMonitors => {},
                         R::PreviewRegion => {
-                            match region_state.kind {
-                                super::image_search_controls::SearchRegionKind::Rectangle => { let rect=region_state.rectangle; if rect.is_empty(){state.capture_message=Some("Rectangle width and height must be positive".into())} else { state.visual_overlay.preview_rectangle(rect); } },
-                                super::image_search_controls::SearchRegionKind::Monitor => { region_state.refresh_monitors(); if let Ok(ms)=&region_state.monitors { if let Some(m)=ms.iter().find(|m|m.index==region_state.monitor_index){state.visual_overlay.highlight_monitor(m.clone());} else {state.capture_message=Some(format!("Monitor {} is currently unavailable",region_state.monitor_index));} } },
-                                super::image_search_controls::SearchRegionKind::Window|super::image_search_controls::SearchRegionKind::ClientArea => {},
-                                super::image_search_controls::SearchRegionKind::Desktop => {},
-                            }
+                            let region = region_state.selected_region();
+                            state.preview_region(region);
                         }
                     }
                 }
@@ -2335,40 +2462,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     Some(CaptureRectangle) => image_request = Some(ImageAuthoringRequest::CaptureRectangle),
                     Some(SelectRegion) => image_request = Some(ImageAuthoringRequest::PickRectangle),
                     Some(PickWindow { .. }) => window = Some(super::window_picker::MatcherPath::VisualRegion),
-                    Some(PreviewRegion) => {
-                        let image = state.image_search.as_ref().unwrap();
-                        if image.rectangle.is_empty() {
-                            state.capture_message = Some("Rectangle width and height must be positive".into());
-                        } else {
-                            let rect = image.rectangle;
-                            let id = state.visual_overlay.preview_rectangle(rect);
-                            state.overlay_diagnostic =
-                                Some((id, format!("Unable to preview region {rect:?}")));
-                            if state.visual_overlay.operation_id() == Some(id) {
-                                state.capture_message = None;
-                            }
-                        }
-                    }
-                    Some(HighlightMonitor) => {
-                        let image = state.image_search.as_mut().unwrap();
-                        image.refresh_monitors();
-                        match &image.monitors {
-                            Ok(monitors) => match monitors.iter().find(|m| m.index == image.monitor_index) {
-                                Some(m) => {
-                                    let index = m.index;
-                                    let id = state.visual_overlay.highlight_monitor(m.clone());
-                                    state.overlay_diagnostic = Some((
-                                        id,
-                                        format!("Unable to highlight monitor {index}"),
-                                    ));
-                                    if state.visual_overlay.operation_id() == Some(id) {
-                                        state.capture_message = None;
-                                    }
-                                }
-                                None => state.capture_message = Some(format!("Monitor {} is currently unavailable", image.monitor_index)),
-                            },
-                            Err(error) => state.capture_message = Some(format!("Monitor information unavailable: {error}")),
-                        }
+                    Some(PreviewRegion) | Some(HighlightMonitor) | Some(HighlightWindow { .. }) => {
+                        let region = state.image_search.as_ref().unwrap().selected_region();
+                        state.preview_region(region);
                     }
                     Some(IdentifyMonitors) => {
                         let image = state.image_search.as_mut().unwrap();
@@ -2388,26 +2484,6 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     }
                     Some(AddSmoothMouseMove) => state.add_smooth_move = true,
                     Some(AddActivateWindowBefore) => state.add_activate_before = true,
-                    Some(HighlightWindow { client_area }) => {
-                        let image = state.image_search.as_ref().unwrap();
-                        let matcher = if client_area { &image.client_matcher } else { &image.window_matcher };
-                        match crate::mkmacro::resolve_window_screen_rect(matcher, client_area) {
-                            Ok(rect) => {
-                                let kind = if client_area { super::visual_overlay::WindowAreaKind::ClientArea } else { super::visual_overlay::WindowAreaKind::WholeWindow };
-                                let id = state.visual_overlay.highlight_window(rect, kind);
-                                let area = if client_area { "client area" } else { "whole window" };
-                                state.overlay_diagnostic =
-                                    Some((id, format!("Unable to create {area} overlay")));
-                                if state.visual_overlay.operation_id() == Some(id) {
-                                    state.capture_message = None;
-                                }
-                            }
-                            Err(error) => {
-                                let area = if client_area { "client-area" } else { "whole-window" };
-                                state.capture_message = Some(format!("Unable to resolve {area} target: {error}"));
-                            }
-                        }
-                    }
                     None => {}
                 }
             }
@@ -2553,6 +2629,38 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             }
         }
     }
+    if let Some(request) = condition_image_request
+        && matches!(
+            request.operation,
+            super::condition_editor::ConditionImageOperation::PreviewRectangle
+                | super::condition_editor::ConditionImageOperation::HighlightMonitor
+                | super::condition_editor::ConditionImageOperation::HighlightWindow
+        )
+    {
+        let region = d
+            .action_editor
+            .draft
+            .as_ref()
+            .and_then(|step| match &step.action {
+                MkAction::If(c)
+                | MkAction::WhileStart { condition: c }
+                | MkAction::WaitUntil { condition: c, .. } => {
+                    super::condition_editor::resolve_condition(c, &request.path)
+                }
+                _ => None,
+            })
+            .and_then(|condition| match condition {
+                MkCondition::ImageSearch { search, .. } => Some(search.region.clone()),
+                _ => None,
+            });
+        match region {
+            Some(region) => d.action_editor.preview_region(region),
+            None => {
+                d.action_editor.capture_message =
+                    Some("Image-search condition is no longer available".into())
+            }
+        }
+    }
     if let Some(slot) = pick_request {
         if let Err(error) = d.action_editor.start_position_capture(slot) {
             d.action_editor.capture_message = Some(error);
@@ -2607,6 +2715,215 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, PartialEq)]
+    enum PreviewCall {
+        Desktop(Vec<MonitorDescriptor>),
+        Monitor(MonitorDescriptor),
+        Rectangle(ScreenRect),
+        Window(ScreenRect, super::super::visual_overlay::WindowAreaKind),
+    }
+    #[derive(Default)]
+    struct FakePreview(Mutex<Vec<PreviewCall>>);
+    impl RegionPreviewBoundary for FakePreview {
+        fn preview_desktop(&self, v: Vec<MonitorDescriptor>) -> u64 {
+            self.0.lock().unwrap().push(PreviewCall::Desktop(v));
+            1
+        }
+        fn highlight_monitor(&self, v: MonitorDescriptor) -> u64 {
+            self.0.lock().unwrap().push(PreviewCall::Monitor(v));
+            2
+        }
+        fn preview_rectangle(&self, v: ScreenRect) -> u64 {
+            self.0.lock().unwrap().push(PreviewCall::Rectangle(v));
+            3
+        }
+        fn highlight_window(
+            &self,
+            r: ScreenRect,
+            k: super::super::visual_overlay::WindowAreaKind,
+        ) -> u64 {
+            self.0.lock().unwrap().push(PreviewCall::Window(r, k));
+            4
+        }
+    }
+    fn monitor(index: usize, rect: ScreenRect) -> MonitorDescriptor {
+        MonitorDescriptor {
+            index,
+            bounds: rect,
+            primary: index == 0,
+        }
+    }
+    fn resolve(rect: ScreenRect) -> impl Fn(&MkWindowMatcher, bool) -> ExecResult<ScreenRect> {
+        move |_, _| Ok(rect)
+    }
+
+    #[test]
+    fn region_preview_dispatches_each_authored_variant_without_desktop_union() {
+        use super::super::visual_overlay::WindowAreaKind;
+        let monitors = Ok(vec![
+            monitor(0, ScreenRect::new(-100, 0, 100, 80)),
+            monitor(7, ScreenRect::new(50, 20, 70, 60)),
+        ]);
+        let fake = FakePreview::default();
+        dispatch_region_preview(
+            &SearchRegion::Desktop,
+            &monitors,
+            &resolve(ScreenRect::new(0, 0, 1, 1)),
+            &fake,
+        )
+        .unwrap();
+        dispatch_region_preview(
+            &SearchRegion::Monitor { index: 7 },
+            &monitors,
+            &resolve(ScreenRect::new(0, 0, 1, 1)),
+            &fake,
+        )
+        .unwrap();
+        let signed = ScreenRect::new(-42, -9, 31, 27);
+        dispatch_region_preview(
+            &SearchRegion::Rectangle { rect: signed },
+            &monitors,
+            &resolve(signed),
+            &fake,
+        )
+        .unwrap();
+        dispatch_region_preview(
+            &SearchRegion::Window {
+                matcher: Default::default(),
+            },
+            &monitors,
+            &resolve(signed),
+            &fake,
+        )
+        .unwrap();
+        dispatch_region_preview(
+            &SearchRegion::ClientArea {
+                matcher: Default::default(),
+            },
+            &monitors,
+            &resolve(signed),
+            &fake,
+        )
+        .unwrap();
+        assert_eq!(
+            *fake.0.lock().unwrap(),
+            vec![
+                PreviewCall::Desktop(monitors.unwrap()),
+                PreviewCall::Monitor(monitor(7, ScreenRect::new(50, 20, 70, 60))),
+                PreviewCall::Rectangle(signed),
+                PreviewCall::Window(signed, WindowAreaKind::WholeWindow),
+                PreviewCall::Window(signed, WindowAreaKind::ClientArea)
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_region_resolution_is_visible_and_never_starts_preview() {
+        let cases: Vec<(
+            SearchRegion,
+            Result<Vec<MonitorDescriptor>, String>,
+            Box<dyn Fn(&MkWindowMatcher, bool) -> ExecResult<ScreenRect>>,
+            &str,
+        )> = vec![
+            (
+                SearchRegion::Rectangle {
+                    rect: ScreenRect::new(1, 2, 0, 4),
+                },
+                Ok(vec![]),
+                Box::new(resolve(ScreenRect::new(0, 0, 1, 1))),
+                "invalid",
+            ),
+            (
+                SearchRegion::Desktop,
+                Ok(vec![]),
+                Box::new(resolve(ScreenRect::new(0, 0, 1, 1))),
+                "No monitors",
+            ),
+            (
+                SearchRegion::Desktop,
+                Err("adapter offline".into()),
+                Box::new(resolve(ScreenRect::new(0, 0, 1, 1))),
+                "adapter offline",
+            ),
+            (
+                SearchRegion::Monitor { index: 9 },
+                Ok(vec![monitor(1, ScreenRect::new(0, 0, 1, 1))]),
+                Box::new(resolve(ScreenRect::new(0, 0, 1, 1))),
+                "no longer exists",
+            ),
+            (
+                SearchRegion::Window {
+                    matcher: Default::default(),
+                },
+                Ok(vec![]),
+                Box::new(|_, _| {
+                    Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::TargetNotFound,
+                        "x",
+                    ))
+                }),
+                "not found",
+            ),
+            (
+                SearchRegion::ClientArea {
+                    matcher: Default::default(),
+                },
+                Ok(vec![]),
+                Box::new(|_, _| {
+                    Err(ExecutionDiagnostic::new(
+                        DiagnosticKind::AmbiguousTarget,
+                        "x",
+                    ))
+                }),
+                "ambiguous",
+            ),
+        ];
+        for (region, monitors, resolver, expected) in cases {
+            let fake = FakePreview::default();
+            let error =
+                dispatch_region_preview(&region, &monitors, resolver.as_ref(), &fake).unwrap_err();
+            assert!(error.contains(expected), "{error:?}");
+            assert!(fake.0.lock().unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn stale_overlay_error_cannot_replace_current_preview_status() {
+        use super::super::visual_overlay::{
+            OverlayErrorKind, VisualOverlayError, VisualOverlayEvent,
+        };
+        let current = Some((22, "Unable to preview current rectangle".into()));
+        let mut message = None;
+        apply_overlay_diagnostic(
+            &mut message,
+            &current,
+            VisualOverlayEvent::Error {
+                operation_id: 21,
+                error: VisualOverlayError {
+                    kind: OverlayErrorKind::Platform,
+                    message: "old failure".into(),
+                },
+            },
+        );
+        assert_eq!(message, None);
+        apply_overlay_diagnostic(
+            &mut message,
+            &current,
+            VisualOverlayEvent::Error {
+                operation_id: 22,
+                error: VisualOverlayError {
+                    kind: OverlayErrorKind::Platform,
+                    message: "current failure".into(),
+                },
+            },
+        );
+        assert_eq!(
+            message.as_deref(),
+            Some("Unable to preview current rectangle: current failure")
+        );
+    }
 
     #[test]
     fn every_typed_rectangle_request_has_one_explicit_purpose() {

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2417,6 +2417,8 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
     let mut pick_request = None;
     let mut image_request = None;
     let mut condition_image_request = None;
+    // Execute after egui releases the mutable draft borrow held by `step`.
+    let mut region_preview_request = None;
     let image_assets = d
         .selected_macro()
         .map(|m| m.image_assets.clone())
@@ -2447,8 +2449,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                         R::RefreshMonitors => region_state.refresh_monitors(),
                         R::IdentifyMonitors => {},
                         R::PreviewRegion => {
-                            let region = region_state.selected_region();
-                            state.preview_region(region);
+                            region_preview_request = Some(region_state.selected_region());
                         }
                     }
                 }
@@ -2463,8 +2464,8 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                     Some(SelectRegion) => image_request = Some(ImageAuthoringRequest::PickRectangle),
                     Some(PickWindow { .. }) => window = Some(super::window_picker::MatcherPath::VisualRegion),
                     Some(PreviewRegion) | Some(HighlightMonitor) | Some(HighlightWindow { .. }) => {
-                        let region = state.image_search.as_ref().unwrap().selected_region();
-                        state.preview_region(region);
+                        region_preview_request =
+                            Some(state.image_search.as_ref().unwrap().selected_region());
                     }
                     Some(IdentifyMonitors) => {
                         let image = state.image_search.as_mut().unwrap();
@@ -2574,6 +2575,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             });
           });
         });
+    if let Some(region) = region_preview_request {
+        d.action_editor.preview_region(region);
+    }
     if (workflow_active || importing) && image_request.is_some() {
         d.action_editor.capture_message = Some(
             if importing {
@@ -2610,7 +2614,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             d.action_editor.capture_message = Some(format!("Reference image: {error:#}"));
         }
     }
-    if let Some(request) = condition_image_request
+    if let Some(ref request) = condition_image_request
         && let Some(purpose) = request.operation.rectangle_purpose()
     {
         let macro_id = d.selected_macro_id.unwrap_or(0);
@@ -2618,7 +2622,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             d.action_editor.capture_message =
                 Some("Finish or cancel the active authoring operation first".into());
         } else {
-            let destination = d.action_editor.condition_destination(macro_id, request);
+            let destination = d
+                .action_editor
+                .condition_destination(macro_id, request.clone());
             d.action_editor.pending_condition_rectangle = Some(destination);
             if let Err(error) = d
                 .action_editor
@@ -2629,7 +2635,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             }
         }
     }
-    if let Some(request) = condition_image_request
+    if let Some(ref request) = condition_image_request
         && matches!(
             request.operation,
             super::condition_editor::ConditionImageOperation::PreviewRectangle

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -71,6 +71,21 @@ pub fn resolve_condition_mut<'a>(
     }
     Some(condition)
 }
+pub fn resolve_condition<'a>(
+    mut condition: &'a MkCondition,
+    path: &ConditionPath,
+) -> Option<&'a MkCondition> {
+    for &index in path.indexes() {
+        condition = match condition {
+            MkCondition::All { conditions } | MkCondition::Any { conditions } => {
+                conditions.get(index)?
+            }
+            MkCondition::Not { condition } if index == 0 => condition,
+            _ => return None,
+        };
+    }
+    Some(condition)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ConditionKind {

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -150,6 +150,16 @@ impl SharedVisualOverlayController {
             },
         )
     }
+    pub fn preview_desktop(&self, monitors: Vec<crate::mkmacro::MonitorDescriptor>) -> OperationId {
+        let id = self.allocate();
+        self.send_start(
+            id,
+            VisualOverlayCommand::PreviewDesktop {
+                operation_id: id,
+                monitors,
+            },
+        )
+    }
     pub fn highlight_window(
         &self,
         rect: ScreenRect,

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -121,6 +121,10 @@ pub enum VisualOverlayState {
         descriptors: Vec<MonitorDescriptor>,
         expires_at: Duration,
     },
+    PreviewingDesktop {
+        descriptors: Vec<MonitorDescriptor>,
+        expires_at: Duration,
+    },
     HighlightingWindow {
         rect: ScreenRect,
         area_kind: WindowAreaKind,
@@ -197,6 +201,10 @@ pub(crate) enum VisualOverlayCommand {
         monitor: MonitorDescriptor,
     },
     IdentifyMonitors {
+        operation_id: OperationId,
+        monitors: Vec<MonitorDescriptor>,
+    },
+    PreviewDesktop {
         operation_id: OperationId,
         monitors: Vec<MonitorDescriptor>,
     },
@@ -328,6 +336,12 @@ fn apply_command(controller: &mut VisualOverlayController, command: VisualOverla
         } => {
             controller.identify_monitors_with_id(operation_id, monitors);
         }
+        VisualOverlayCommand::PreviewDesktop {
+            operation_id,
+            monitors,
+        } => {
+            controller.preview_desktop_with_id(operation_id, monitors);
+        }
         VisualOverlayCommand::HighlightWindow {
             operation_id,
             rect,
@@ -372,6 +386,8 @@ pub enum OverlayVisual {
     RectanglePreview(ScreenRect),
     Monitor(MonitorDescriptor),
     Monitors(Vec<MonitorDescriptor>),
+    /// Ordinary desktop coverage preview: outlines only, never identification labels.
+    Desktop(Vec<MonitorDescriptor>),
     Window {
         rect: ScreenRect,
         area_kind: WindowAreaKind,
@@ -418,6 +434,11 @@ pub(crate) fn overlay_frame(visual: &OverlayVisual) -> Vec<OverlayFramePrimitive
                     bounds: monitor.bounds,
                     index: monitor.index,
                 });
+            }
+        }
+        OverlayVisual::Desktop(monitors) => {
+            for monitor in monitors {
+                frame.push(OverlayFramePrimitive::Outline(monitor.bounds));
             }
         }
     }
@@ -738,6 +759,20 @@ impl VisualOverlayController {
             OverlayVisual::Monitors(descriptors),
         );
     }
+    pub(crate) fn preview_desktop_with_id(
+        &mut self,
+        id: OperationId,
+        descriptors: Vec<MonitorDescriptor>,
+    ) {
+        self.start_passive_with_id(
+            id,
+            VisualOverlayState::PreviewingDesktop {
+                descriptors: descriptors.clone(),
+                expires_at: self.deadline(),
+            },
+            OverlayVisual::Desktop(descriptors),
+        );
+    }
     pub(crate) fn highlight_window_with_id(
         &mut self,
         id: OperationId,
@@ -854,6 +889,7 @@ impl VisualOverlayController {
             VisualOverlayState::PreviewingRectangle { expires_at, .. }
             | VisualOverlayState::HighlightingMonitor { expires_at, .. }
             | VisualOverlayState::IdentifyingMonitors { expires_at, .. }
+            | VisualOverlayState::PreviewingDesktop { expires_at, .. }
             | VisualOverlayState::HighlightingWindow { expires_at, .. } => {
                 self.clock.now() >= *expires_at
             }

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -219,6 +219,7 @@ impl NativeOverlayRenderer {
             OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => Some(*r),
             OverlayVisual::Monitor(d) => Some(d.bounds),
             OverlayVisual::Monitors(ds) => monitor_union(ds),
+            OverlayVisual::Desktop(_) => None,
         }
     }
     fn fail<T>(&mut self, message: impl Into<String>) -> Result<T, VisualOverlayError> {
@@ -269,10 +270,18 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 GetLastError().0
             }));
         }
-        let Some(target) = Self::target(visual) else {
-            return self.fail("No physical display intersects the requested preview region");
+        let monitor_bounds = match visual {
+            // Preserve the descriptor topology: never create a virtual-desktop union window
+            // spanning gaps between physical displays.
+            OverlayVisual::Desktop(descriptors) => descriptors.iter().map(|d| d.bounds).collect(),
+            _ => {
+                let Some(target) = Self::target(visual) else {
+                    return self
+                        .fail("No physical display intersects the requested preview region");
+                };
+                intersecting_monitor_bounds(&displays(), target)
+            }
         };
-        let monitor_bounds = intersecting_monitor_bounds(&displays(), target);
         if monitor_bounds.is_empty() {
             return self.fail("No physical display intersects the requested preview region");
         }


### PR DESCRIPTION
### Motivation
- Consolidate and reuse the disparate preview logic for authored `SearchRegion` variants so action UIs do not duplicate monitor/rectangle/window preview decisions.
- Provide explicit, per-monitor desktop preview semantics (outlines only, no identification labels) and avoid constructing a virtual-desktop union that highlights gaps between monitors.
- Route both synchronous resolution failures and asynchronous overlay errors into the action editor status area and avoid starting overlays when validation or resolution fails.\

### Description
- Added a `RegionPreviewBoundary` trait and `dispatch_region_preview` helper to `src/gui/mkmacro_dialog/action_editor.rs` and wired the action editor to call `preview_region(...)` for `SearchRegion` requests instead of inline branches for rectangles, monitors and windows.\
- Implemented desktop-preview plumbing: new `PreviewDesktop` command and `PreviewingDesktop` state plus an `OverlayVisual::Desktop` variant in `src/gui/mkmacro_dialog/visual_overlay.rs`, and a `preview_desktop` API on the shared overlay controller in `src/gui/mkmacro_dialog/visual_capture_workflow.rs`.\
- Updated the Windows overlay renderer in `src/gui/mkmacro_dialog/visual_overlay_windows.rs` to create one native overlay window per supplied monitor descriptor instead of using a union/virtual-desktop bounding rectangle.\
- Centralized asynchronous overlay diagnostic handling via `apply_overlay_diagnostic(...)` so asynchronous overlay errors are associated with their `OperationId` and cannot overwrite newer preview statuses, and added a read-only `resolve_condition(...)` helper in `src/gui/mkmacro_dialog/condition_editor.rs` so condition-image preview requests reuse the same dispatcher.\
- Replaced multiple per-UI preview call sites with calls into the dispatcher for `WaitForVisualChange`, image actions and compatible image-condition requests, and cleared obsolete diagnostics on successful preview start.\
- Added unit tests in the action editor test module that use a fake preview boundary to assert: desktop dispatch uses each supplied descriptor (no union), monitor/rectangle/window/client-area dispatch call the correct preview API with exact values, validation and resolution failures emit visible diagnostics and do not start previews, and stale asynchronous overlay errors do not replace current preview status.\

### Testing
- Ran `cargo fmt --all` and `git diff --check` to validate formatting and local diffs, both completed successfully.\
- Attempted `cargo check`; the run exposed unrelated platform build issues in this Linux environment (missing system libraries and numerous Windows-only API imports), so a full compile/test run could not be completed here.\
- Added focused unit tests that exercise the new dispatcher via a fake preview boundary, but they were not executed in this environment due to the platform-specific build failures described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f50183e288332a3c4c95652a9cd41)