### PR TITLE
Share single dialog-owned visual-overlay service and stop editor shutdowns

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2854,8 +2854,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 }
             }
         }
-        let replacement = ActionEditorState::new(d.visual_overlay.clone());
-        let mut state = std::mem::replace(&mut d.action_editor, replacement);
+        let mut state = d.take_action_editor();
         let smooth = state.add_smooth_move;
         let activate = state.add_activate_before;
         let shortcut_payload = state.draft.as_ref().and_then(image_payload).cloned();

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -10,7 +10,6 @@ use crate::mkmacro::variables::{MkPoint, MkValue};
 use crate::mkmacro::*;
 use eframe::egui;
 
-#[derive(Default)]
 pub struct ActionEditorState {
     pub draft: Option<MkStep>,
     /// `None` means insert a new row; otherwise replace this stable step id.
@@ -30,7 +29,8 @@ pub struct ActionEditorState {
     pub add_smooth_move: bool,
     pub add_activate_before: bool,
     pub image_authoring: super::image_authoring_job::ImageAuthoringJob,
-    /// Sole owner of native visual-overlay resources for this editor draft.
+    /// Cloneable operation client borrowed from the dialog-wide visual-overlay service.
+    /// The editor owns only the operation IDs it starts, not the native service itself.
     pub visual_overlay: super::visual_capture_workflow::SharedVisualOverlayController,
     /// Installed by the owning launcher integration because it alone owns the
     /// launcher and dialog native-window visibility boundary.
@@ -241,6 +241,35 @@ fn dispatch_region_preview(
 }
 
 impl ActionEditorState {
+    pub fn new(
+        visual_overlay: super::visual_capture_workflow::SharedVisualOverlayController,
+    ) -> Self {
+        Self {
+            draft: None,
+            editing_id: None,
+            insertion: None,
+            capture_keys: false,
+            capture_message: None,
+            editor: None,
+            position_capture: None,
+            draft_generation: 0,
+            draft_changed: false,
+            image_search: None,
+            add_smooth_move: false,
+            add_activate_before: false,
+            image_authoring: Default::default(),
+            visual_overlay,
+            visual_capture: None,
+            overlay_diagnostic: None,
+            pending_visual_region: None,
+            picker: Default::default(),
+        }
+    }
+    fn cancel_owned_passive_overlay(&mut self) {
+        if let Some((operation_id, _)) = self.overlay_diagnostic.take() {
+            self.visual_overlay.cancel_operation(operation_id);
+        }
+    }
     fn preview_region(&mut self, region: SearchRegion) {
         let monitors = if matches!(region, SearchRegion::Desktop | SearchRegion::Monitor { .. }) {
             crate::mkmacro::monitor_descriptors().map_err(|e| e.to_string())
@@ -494,7 +523,7 @@ impl ActionEditorState {
         if self.draft.is_some() {
             return;
         }
-        self.visual_overlay.cancel();
+        self.cancel_owned_passive_overlay();
         self.pending_visual_region = None;
         self.image_authoring = Default::default();
         self.stop_position_capture();
@@ -528,7 +557,7 @@ impl ActionEditorState {
         });
     }
     pub fn begin_edit(&mut self, step: &MkStep) {
-        self.visual_overlay.cancel();
+        self.cancel_owned_passive_overlay();
         self.pending_visual_region = None;
         self.image_authoring = Default::default();
         self.stop_position_capture();
@@ -560,7 +589,7 @@ impl ActionEditorState {
                 workflow.tick();
             }
         }
-        self.visual_overlay.shutdown();
+        self.cancel_owned_passive_overlay();
         self.stop_position_capture();
         self.draft = None;
         self.editing_id = None;
@@ -721,7 +750,7 @@ impl ActionEditorState {
                 workflow.tick();
             }
         }
-        self.visual_overlay.shutdown();
+        self.cancel_owned_passive_overlay();
         self.stop_position_capture();
         self.sync_image_region_to_draft();
         let mut step = self.draft.take()?;
@@ -979,7 +1008,7 @@ impl Drop for ActionEditorState {
                 workflow.tick();
             }
         }
-        self.visual_overlay.shutdown();
+        self.cancel_owned_passive_overlay();
     }
 }
 
@@ -2825,7 +2854,8 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 }
             }
         }
-        let mut state = std::mem::take(&mut d.action_editor);
+        let replacement = ActionEditorState::new(d.visual_overlay.clone());
+        let mut state = std::mem::replace(&mut d.action_editor, replacement);
         let smooth = state.add_smooth_move;
         let activate = state.add_activate_before;
         let shortcut_payload = state.draft.as_ref().and_then(image_payload).cloned();
@@ -2855,6 +2885,14 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
+    fn test_editor() -> ActionEditorState {
+        ActionEditorState::new(
+            super::super::visual_capture_workflow::SharedVisualOverlayController::new(
+                super::super::visual_overlay::VisualOverlayController::default(),
+            ),
+        )
+    }
 
     #[derive(Debug, PartialEq)]
     enum PreviewCall {
@@ -3137,7 +3175,7 @@ mod tests {
         use super::super::visual_capture_workflow::{DraftToken, WorkflowOutcome};
         let a = ScreenRect::new(1, 2, 30, 40);
         let b = ScreenRect::new(50, 60, 70, 80);
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         let mut payload = WaitForVisualChange::default();
         payload.region = SearchRegion::Rectangle { rect: a };
         editor.begin_edit(&step(MkAction::WaitForVisualChange(payload)));
@@ -3174,7 +3212,7 @@ mod tests {
         use super::super::visual_capture_workflow::{DraftToken, WorkflowOutcome};
         let original = ScreenRect::new(1, 2, 3, 4);
         let selected = ScreenRect::new(8, 9, 10, 11);
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         let mut payload = WaitForVisualChange::default();
         payload.region = SearchRegion::Rectangle { rect: original };
         editor.begin_edit(&step(MkAction::WaitForVisualChange(payload.clone())));
@@ -3372,7 +3410,7 @@ mod tests {
         let region = SearchRegion::Rectangle {
             rect: ScreenRect::new(3, 4, 5, 6),
         };
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.draft_generation = 7;
         editor.draft = Some(step(MkAction::ImageFind(image_payload(1, region.clone()))));
         let executor = HeldExecutor::default();
@@ -3405,7 +3443,7 @@ mod tests {
         let region = SearchRegion::Rectangle {
             rect: ScreenRect::new(8, 9, 10, 11),
         };
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.draft_generation = 1;
         editor.draft = Some(step(MkAction::ImageFind(image_payload(41, region.clone()))));
         let executor = HeldExecutor::default();
@@ -3434,7 +3472,7 @@ mod tests {
         ActionEditorState,
         mpsc::Sender<super::super::image_authoring_job::ImageAuthoringCompletion>,
     ) {
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.draft_generation = token.draft_generation;
         editor.draft = Some(step(MkAction::ImageFind(image_payload(9, region))));
         let (sender, completion) = mpsc::channel();
@@ -3556,7 +3594,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.begin_edit(&step(MkAction::ImageFind(image_payload(
             4,
             original_region.clone(),
@@ -3615,7 +3653,7 @@ mod tests {
         use super::super::visual_capture_workflow::{DraftToken, WorkflowOutcome};
 
         let region = SearchRegion::Monitor { index: 2 };
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.begin_edit(&step(MkAction::ImageClick(image_payload(4, region))));
         let generation = editor.draft_generation;
         let before_draft = serde_json::to_vec(editor.draft.as_ref().unwrap()).unwrap();
@@ -3704,7 +3742,7 @@ mod tests {
                 super::super::window_picker::MatcherPath::VisualRegion,
             ),
         ] {
-            let mut editor = ActionEditorState::default();
+            let mut editor = test_editor();
             editor.begin_edit(&step(action));
             let request = super::super::window_picker::MatcherEditRequest {
                 destination: super::super::window_picker::MatcherDestination::Action {
@@ -3771,7 +3809,7 @@ mod tests {
             MkAction::ImageFind(payload.clone()),
             MkAction::ImageClick(payload.clone()),
         ] {
-            let mut editor = ActionEditorState::default();
+            let mut editor = test_editor();
             editor.begin_edit(&step(action));
             let image = editor.image_search.as_ref().expect("shared image editor");
             assert_eq!(
@@ -3844,7 +3882,7 @@ mod tests {
                         },
                     },
                 };
-                let mut editor = ActionEditorState::default();
+                let mut editor = test_editor();
                 editor.begin_edit(&step(action));
                 let before_cancel = editor.draft.as_ref().unwrap().action.clone();
                 // Cancellation never calls apply_window_matcher.
@@ -3881,7 +3919,7 @@ mod tests {
 
     #[test]
     fn capture_is_frame_driven_armed_and_one_shot() {
-        let mut e = ActionEditorState::default();
+        let mut e = test_editor();
         e.begin_edit(&step(MkAction::MouseMove(MkMouseMovePayload {
             target: MkCoordinateTarget::Screen {
                 point: MkPoint { x: 1, y: 2 },
@@ -3930,7 +3968,7 @@ mod tests {
             button: MkMouseButton::Left,
             clicks: 1,
         }));
-        let mut e = ActionEditorState::default();
+        let mut e = test_editor();
         e.begin_edit(&source);
         e.draft_generation = 1;
         e.position_capture = Some(capture(PositionCaptureSlot::ClickTarget));
@@ -3951,7 +3989,7 @@ mod tests {
             color: "#112233".into(),
             tolerance: 0,
         });
-        let mut editor = ActionEditorState::default();
+        let mut editor = test_editor();
         editor.begin_edit(&source);
         editor.draft_generation = 1;
         let mut pending = capture(PositionCaptureSlot::PixelColor);
@@ -3985,7 +4023,7 @@ mod tests {
             button: MkMouseButton::X2,
             duration_ms: 10,
         };
-        let mut e = ActionEditorState::default();
+        let mut e = test_editor();
         e.begin_edit(&step(MkAction::MouseDrag(drag)));
         e.draft_generation = 1;
         let mut c = capture(PositionCaptureSlot::DragFrom);
@@ -4011,7 +4049,7 @@ mod tests {
     }
     #[test]
     fn capture_chooses_press_hotkey_down_and_up() {
-        let mut e = ActionEditorState::default();
+        let mut e = test_editor();
         e.begin_edit(&step(MkAction::KeyPress(MkKey::Enter)));
         assert!(e.set_captured_keys(vec![MkKey::Character("A".into())]));
         assert!(matches!(
@@ -4040,7 +4078,7 @@ mod tests {
     fn cancel_does_not_touch_source() {
         let source = step(MkAction::Delay { milliseconds: 12 });
         let bytes = serde_json::to_vec(&source).unwrap();
-        let mut e = ActionEditorState::default();
+        let mut e = test_editor();
         e.begin_edit(&source);
         if let Some(MkStep {
             action: MkAction::Delay { milliseconds },
@@ -4203,7 +4241,7 @@ mod tests {
                     not_found_policy: MkImageNotFoundPolicy::Fail,
                     outputs: MkImageOutputs::default(),
                 };
-                let mut editor = ActionEditorState::default();
+                let mut editor = test_editor();
                 editor.begin_edit(&step(MkAction::ImageClick(payload)));
                 editor.visual_capture = Some(workflow);
                 assert_eq!(
@@ -4479,7 +4517,7 @@ mod tests {
 
         #[test]
         fn wait_visual_change_picker_requires_live_compatible_draft() {
-            let mut editor = ActionEditorState::default();
+            let mut editor = test_editor();
             editor.begin_new(MkAction::WaitForVisualChange(WaitForVisualChange::default()));
             let generation = editor.draft_generation;
             let request = MatcherEditRequest {

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1377,9 +1377,14 @@ mod tests {
     }
 }
 impl MkMacroDialog {
+    /// Returns an operation client for constructing dialog-scoped visual tools.
+    pub fn visual_overlay_controller(&self) -> SharedVisualOverlayController {
+        self.visual_overlay.clone()
+    }
+
     /// Temporarily moves the editor out while preserving its required shared
     /// visual-overlay client in the replacement state.
-    pub(crate) fn take_action_editor(&mut self) -> action_editor::ActionEditorState {
+    pub fn take_action_editor(&mut self) -> action_editor::ActionEditorState {
         std::mem::replace(
             &mut self.action_editor,
             action_editor::ActionEditorState::new(self.visual_overlay.clone()),

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -348,7 +348,7 @@ mod tests {
         {
             *count = 9;
         }
-        let mut editor = std::mem::take(&mut d.action_editor);
+        let mut editor = d.take_action_editor();
         editor.apply(&mut d).unwrap();
         d.action_editor = editor;
         assert!(matches!(
@@ -383,7 +383,7 @@ mod tests {
         d.selection.ids = [ids[0], ids[2]].into_iter().collect();
         let before = serde_json::to_vec(d.selected_macro().unwrap()).unwrap();
         action_catalog::select_descriptor(&mut d, &catalog_descriptor("If"));
-        let mut editor = std::mem::take(&mut d.action_editor);
+        let mut editor = d.take_action_editor();
         assert!(editor.apply(&mut d).is_none());
         d.action_editor = editor;
         assert_eq!(
@@ -646,7 +646,7 @@ mod tests {
         ));
         assert_eq!(d.action_editor.draft.as_ref().unwrap().action, original);
 
-        let mut editor = std::mem::take(&mut d.action_editor);
+        let mut editor = d.take_action_editor();
         assert!(editor.apply(&mut d).is_some());
         d.action_editor = editor;
         assert_eq!(d.selected_macro().unwrap().steps.len(), 1);
@@ -681,7 +681,7 @@ mod tests {
             );
 
             assert!(action_catalog::select_descriptor(&mut d, &descriptor));
-            let mut editor = std::mem::take(&mut d.action_editor);
+            let mut editor = d.take_action_editor();
             assert!(editor.apply(&mut d).is_some());
             d.action_editor = editor;
             assert_eq!(
@@ -704,7 +704,7 @@ mod tests {
                 &mut d,
                 &catalog_descriptor("Delay")
             ));
-            let mut editor = std::mem::take(&mut d.action_editor);
+            let mut editor = d.take_action_editor();
             assert!(editor.apply(&mut d).is_some());
             d.action_editor = editor;
             assert!(d.action_catalog_visible);
@@ -1024,7 +1024,7 @@ mod tests {
                 && draft_contract == action_catalog::DraftValidationContract::CommitReady
             {
                 assert!(dialog.action_editor.draft.is_some());
-                let mut editor = std::mem::take(&mut dialog.action_editor);
+                let mut editor = dialog.take_action_editor();
                 assert!(editor.apply(&mut dialog).is_some());
                 dialog.action_editor = editor;
             }
@@ -1377,6 +1377,15 @@ mod tests {
     }
 }
 impl MkMacroDialog {
+    /// Temporarily moves the editor out while preserving its required shared
+    /// visual-overlay client in the replacement state.
+    pub(crate) fn take_action_editor(&mut self) -> action_editor::ActionEditorState {
+        std::mem::replace(
+            &mut self.action_editor,
+            action_editor::ActionEditorState::new(self.visual_overlay.clone()),
+        )
+    }
+
     pub fn new(store: Arc<MkMacroStore>) -> Self {
         Self::new_with_authoring_context(store, MkMacroAuthoringContext::default())
     }

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -24,6 +24,7 @@ use crate::mkmacro::{
 };
 use std::sync::Arc;
 pub use step_table::{Selection, duplicate_steps, duplicate_steps_with_ids, move_steps};
+use visual_capture_workflow::SharedVisualOverlayController;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirtyDecision {
@@ -42,6 +43,8 @@ pub struct MkMacroDialog {
     pub open: bool,
     pub store: Arc<MkMacroStore>,
     pub authoring_context: MkMacroAuthoringContext,
+    /// Authoritative client keeping the dialog-wide native overlay service alive.
+    pub(crate) visual_overlay: SharedVisualOverlayController,
     pub draft: MkMacroDocument,
     baseline: Arc<MkMacroDocument>,
     pub dirty: bool,
@@ -1382,12 +1385,15 @@ impl MkMacroDialog {
         authoring_context: MkMacroAuthoringContext,
     ) -> Self {
         let baseline = store.snapshot();
+        let visual_overlay = SharedVisualOverlayController::default();
         Self {
             open: false,
             draft: (*baseline).clone(),
             baseline,
             store,
             authoring_context,
+            action_editor: action_editor::ActionEditorState::new(visual_overlay.clone()),
+            visual_overlay,
             dirty: false,
             conflict: false,
             selected_macro_id: None,
@@ -1403,7 +1409,6 @@ impl MkMacroDialog {
             action_search: String::new(),
             structural_insertion: None,
             uia_editor: Default::default(),
-            action_editor: Default::default(),
             window_picker: Default::default(),
             launcher_action_picker: Default::default(),
             command_error: None,

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -15,7 +15,7 @@ use image::RgbaImage;
 use std::collections::VecDeque;
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicU64, Ordering},
 };
 
 /// Cloneable command client for the thread which exclusively owns native overlays.
@@ -26,7 +26,6 @@ struct SharedOverlayClient {
     service: Mutex<Option<NativeVisualOverlayService>>,
     next_id: AtomicU64,
     active_id: AtomicU64,
-    shutdown: AtomicBool,
     editor_events: Mutex<VecDeque<VisualOverlayEvent>>,
 }
 impl Default for SharedVisualOverlayController {
@@ -37,7 +36,6 @@ impl Default for SharedVisualOverlayController {
                 service: Mutex::new(None),
                 next_id: AtomicU64::new(1),
                 active_id: AtomicU64::new(0),
-                shutdown: AtomicBool::new(true),
                 editor_events: Mutex::new(VecDeque::from([VisualOverlayEvent::Error {
                     operation_id: 1,
                     error: VisualOverlayError {
@@ -62,7 +60,6 @@ impl SharedVisualOverlayController {
             service: Mutex::new(Some(service)),
             next_id: AtomicU64::new(1),
             active_id: AtomicU64::new(0),
-            shutdown: AtomicBool::new(false),
             editor_events: Mutex::new(VecDeque::new()),
         }))
     }
@@ -205,15 +202,6 @@ impl SharedVisualOverlayController {
     pub fn cancel(&self) {
         if let Some(id) = self.operation_id() {
             self.cancel_operation(id);
-        }
-    }
-    pub fn shutdown(&self) {
-        if self.0.shutdown.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        self.0.active_id.store(0, Ordering::Release);
-        if let Some(mut service) = self.0.service.lock().unwrap().take() {
-            service.shutdown_and_join();
         }
     }
     fn receive_into_editor(&self) {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -253,7 +253,7 @@ fn production_visual_capture_dependencies(
     VisualCaptureDependencies {
         overlay: Box::new(
             mkmacro_dialog::visual_capture_workflow::VisualOverlayRectangleAdapter::new(
-                dialog.action_editor.visual_overlay.clone(),
+                dialog.visual_overlay.clone(),
                 Arc::clone(&screen_backend),
             ),
         ),

--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -212,7 +212,7 @@ fn prompt_input_authoring_apply_and_cancel_are_transactional() {
         dialog.action_editor.editor,
         Some(action_catalog::EditorKind::PromptInput)
     );
-    let mut editor = std::mem::take(&mut dialog.action_editor);
+    let mut editor = dialog.take_action_editor();
     editor
         .apply(&mut dialog)
         .expect("valid prompt draft applies");
@@ -420,7 +420,7 @@ impl RecorderControllerView for FakeRecorderView {
 }
 
 fn insert(dialog: &mut MkMacroDialog, action: MkAction) -> u64 {
-    let mut editor = ActionEditorState::default();
+    let mut editor = ActionEditorState::new(dialog.visual_overlay_controller());
     editor.begin_new(action);
     editor
         .apply(dialog)
@@ -613,7 +613,7 @@ fn complete_authoring_recording_and_playback_workflow_uses_typed_intents() {
         .find(|s| s.id == click)
         .unwrap()
         .clone();
-    let mut editor = ActionEditorState::default();
+    let mut editor = ActionEditorState::new(dialog.visual_overlay_controller());
     editor.begin_edit(&original);
     if let Some(step) = &mut editor.draft {
         if let MkAction::MouseClick(payload) = &mut step.action {


### PR DESCRIPTION
### Motivation

- Ensure there is only one native visual-overlay worker whose lifetime matches the authoring dialog instead of starting/stopping workers per editor.  
- Prevent editors from shutting down the shared native worker and instead make editors cancel only their own operations by ID.  

### Description

- Add a dialog-level `visual_overlay: SharedVisualOverlayController` to `MkMacroDialog` and construct it once in `new_with_authoring_context`.  
- Replace `ActionEditorState`'s implicit `Default` construction with an explicit `ActionEditorState::new(SharedVisualOverlayController)` which stores a clone of the dialog controller.  
- Stop calling `SharedVisualOverlayController::shutdown()` from `ActionEditorState` (in `cancel`, `apply`, and `Drop`) and instead cancel only editor-owned passive preview operations by retained operation ID.  
- Remove the public `shutdown` API from ordinary `SharedVisualOverlayController` clients and stop keeping per-editor shutdown state; rely on final-`Arc` cleanup via the shared client drop and retain `cancel_operation(expected_operation_id)` semantics.  
- Update production wiring to build `VisualOverlayRectangleAdapter` from `dialog.visual_overlay.clone()` and add a small test helper to inject a controller in unit tests so they no longer spawn native workers implicitly.  

### Testing

- ✅ Ran `cargo fmt --check` to verify formatting.  
- ✅ Ran `git diff --check` and a targeted `rg` search to verify removal of editor shutdown calls and presence of the dialog-owned controller.  
- ⚠️ Ran `cargo test --no-run` but compilation was blocked by a missing system ALSA development package in the environment, so tests could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f7aacb1a08332b897fa694ec02c7b)