### PR TITLE
Add deterministic tests and test fixture to validate shared visual-overlay ownership and cancellation

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2882,8 +2882,10 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
 
 #[cfg(test)]
 mod tests {
+    use super::super::visual_overlay::{OperationId, VisualOverlayCommand, VisualOverlayEvent};
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Mutex};
 
     fn test_editor() -> ActionEditorState {
         ActionEditorState::new(
@@ -2891,6 +2893,134 @@ mod tests {
                 super::super::visual_overlay::VisualOverlayController::default(),
             ),
         )
+    }
+
+    fn image_action() -> MkAction {
+        MkAction::ImageFind(MkImagePayload {
+            asset_id: 1,
+            region: SearchRegion::Rectangle {
+                rect: ScreenRect::new(1, 2, 30, 40),
+            },
+            wait: MkWaitOptions::default(),
+            tolerance: 0,
+            alpha: AlphaPolicy::Ignore,
+            return_point: ReturnPoint::TopLeft,
+            not_found_policy: MkImageNotFoundPolicy::Fail,
+            outputs: MkImageOutputs::default(),
+        })
+    }
+
+    fn shared_dialog() -> (
+        tempfile::TempDir,
+        MkMacroDialog,
+        super::super::visual_capture_workflow::TestOverlayServiceFixture,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+        let fixture =
+            super::super::visual_capture_workflow::SharedVisualOverlayController::test_fixture();
+        let mut dialog = MkMacroDialog::new(Arc::new(store));
+        dialog.visual_overlay = fixture.controller.clone();
+        dialog.action_editor = ActionEditorState::new(dialog.visual_overlay.clone());
+        dialog.create_macro();
+        (dir, dialog, fixture)
+    }
+
+    fn begin_owned_preview(editor: &mut ActionEditorState) -> OperationId {
+        editor.begin_new(image_action());
+        editor.preview_region(SearchRegion::Rectangle {
+            rect: ScreenRect::new(4, 5, 6, 7),
+        });
+        editor.visual_overlay.operation_id().unwrap()
+    }
+
+    fn assert_transaction_reuses_service(apply: bool) {
+        let (_dir, mut dialog, fixture) = shared_dialog();
+        let mut editor = ActionEditorState::new(dialog.visual_overlay_controller());
+        let owned = begin_owned_preview(&mut editor);
+        fixture.observer.wait_for_commands(1);
+        if apply {
+            assert!(editor.apply(&mut dialog).is_some());
+        } else {
+            editor.cancel();
+        }
+        fixture.observer.wait_for_commands(2);
+        assert!(
+            matches!(fixture.observer.commands.lock().unwrap()[1], VisualOverlayCommand::Cancel { expected_operation_id: Some(id) } if id == owned)
+        );
+        let fresh = dialog
+            .visual_overlay_controller()
+            .preview_rectangle(ScreenRect::new(8, 9, 10, 11));
+        fixture.observer.wait_for_commands(3);
+        assert!(
+            matches!(fixture.observer.commands.lock().unwrap()[2], VisualOverlayCommand::PreviewRectangle { operation_id, .. } if operation_id == fresh)
+        );
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+        assert!(!dialog.visual_overlay_controller().poll().iter().any(|e| matches!(e, VisualOverlayEvent::Error { error, .. } if error.message.contains("shut down"))));
+    }
+
+    #[test]
+    fn cancel_cleans_up_only_its_operation_and_leaves_dialog_service_reusable() {
+        assert_transaction_reuses_service(false);
+    }
+
+    #[test]
+    fn apply_cleans_up_only_its_operation_and_leaves_dialog_service_reusable() {
+        assert_transaction_reuses_service(true);
+    }
+
+    #[test]
+    fn dropping_editor_cancels_at_most_once_and_final_dialog_handle_owns_join() {
+        let (_dir, dialog, fixture) = shared_dialog();
+        let mut editor = ActionEditorState::new(dialog.visual_overlay_controller());
+        let owned = begin_owned_preview(&mut editor);
+        fixture.observer.wait_for_commands(1);
+        drop(editor);
+        fixture.observer.wait_for_commands(2);
+        let cancel_count = fixture.observer.commands.lock().unwrap().iter().filter(|c| matches!(c, VisualOverlayCommand::Cancel { expected_operation_id: Some(id) } if *id == owned)).count();
+        assert_eq!(cancel_count, 1);
+        dialog
+            .visual_overlay_controller()
+            .preview_rectangle(ScreenRect::new(9, 9, 2, 2));
+        fixture.observer.wait_for_commands(3);
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+        drop(dialog);
+        drop(fixture.controller);
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn repeated_action_transactions_never_poison_shared_overlay_client() {
+        let (_dir, mut dialog, fixture) = shared_dialog();
+        for (index, apply) in [true, false, true, false].into_iter().enumerate() {
+            let mut editor = ActionEditorState::new(dialog.visual_overlay_controller());
+            let _ = begin_owned_preview(&mut editor);
+            if index == 2 {
+                editor.begin_edit(&MkStep {
+                    id: 55,
+                    enabled: true,
+                    repeat: 1,
+                    delay_after_ms: 0,
+                    on_error: Default::default(),
+                    action: MkAction::ImageClick(match image_action() {
+                        MkAction::ImageFind(p) => p,
+                        _ => unreachable!(),
+                    }),
+                });
+            }
+            if apply {
+                let _ = editor.apply(&mut dialog);
+            } else {
+                editor.cancel();
+            }
+            let id = dialog
+                .visual_overlay_controller()
+                .preview_rectangle(ScreenRect::new(index as i32, 0, 2, 2));
+            fixture.observer.wait_for_commands((index + 1) * 3);
+            assert_eq!(dialog.visual_overlay_controller().operation_id(), Some(id));
+            assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+        }
+        assert_eq!(fixture.observer.starts.load(Ordering::SeqCst), 1);
     }
 
     #[derive(Debug, PartialEq)]

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -63,6 +63,20 @@ impl SharedVisualOverlayController {
             editor_events: Mutex::new(VecDeque::new()),
         }))
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_fixture() -> TestOverlayServiceFixture {
+        let observer = Arc::new(super::visual_overlay::ServiceTestObserver::default());
+        let service = NativeVisualOverlayService::start_with_observer(
+            VisualOverlayController::default,
+            observer.clone(),
+        )
+        .expect("test overlay worker must start");
+        TestOverlayServiceFixture {
+            controller: Self::from_service(service),
+            observer,
+        }
+    }
     fn allocate(&self) -> OperationId {
         loop {
             let id = self.0.next_id.fetch_add(1, Ordering::Relaxed);
@@ -240,6 +254,12 @@ impl SharedVisualOverlayController {
         });
         position.and_then(|index| queue.remove(index))
     }
+}
+
+#[cfg(test)]
+pub(crate) struct TestOverlayServiceFixture {
+    pub controller: SharedVisualOverlayController,
+    pub observer: Arc<super::visual_overlay::ServiceTestObserver>,
 }
 impl Drop for SharedOverlayClient {
     fn drop(&mut self) {
@@ -523,7 +543,65 @@ impl Drop for VisualCaptureWorkflow {
 mod tests {
     use super::*;
     use image::{Rgba, RgbaImage};
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
+
+    struct Desktop;
+    impl ScreenCaptureBackend for Desktop {
+        fn virtual_desktop(&self) -> crate::mkmacro::ExecResult<ScreenRect> {
+            Ok(ScreenRect::new(-10, -10, 100, 100))
+        }
+        fn region_bounds(
+            &self,
+            _: &crate::mkmacro::SearchRegion,
+        ) -> crate::mkmacro::ExecResult<ScreenRect> {
+            self.virtual_desktop()
+        }
+        fn capture_rect(
+            &self,
+            rect: ScreenRect,
+            _: &dyn Fn() -> bool,
+        ) -> crate::mkmacro::ExecResult<RgbaImage> {
+            Ok(RgbaImage::new(rect.width, rect.height))
+        }
+    }
+
+    #[test]
+    fn cloned_clients_cancel_operations_without_terminating_the_shared_service() {
+        let fixture = SharedVisualOverlayController::test_fixture();
+        let dialog = fixture.controller.clone();
+        let editor = dialog.clone();
+        let mut adapter = VisualOverlayRectangleAdapter::new(dialog.clone(), Arc::new(Desktop));
+
+        let first = editor.preview_rectangle(ScreenRect::new(1, 2, 3, 4));
+        editor.cancel_operation(first);
+        fixture.observer.wait_for_commands(2);
+        let second = adapter.begin(RectanglePurpose::SearchRegion).unwrap();
+        fixture.observer.wait_for_commands(3);
+        assert_ne!(first, second);
+        assert_eq!(fixture.observer.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.observer.worker_ids.lock().unwrap().len(), 1);
+        assert!(
+            matches!(fixture.observer.commands.lock().unwrap()[1], VisualOverlayCommand::Cancel { expected_operation_id: Some(id) } if id == first)
+        );
+        assert!(
+            matches!(fixture.observer.commands.lock().unwrap()[2], VisualOverlayCommand::BeginRectanglePick { operation_id, .. } if operation_id == second)
+        );
+        assert!(!dialog.poll().iter().any(|event| matches!(event, VisualOverlayEvent::Error { error, .. } if error.message.contains("shut down"))));
+
+        drop(editor);
+        drop(adapter);
+        let third = dialog.preview_rectangle(ScreenRect::new(5, 6, 7, 8));
+        fixture.observer.wait_for_commands(4);
+        assert!(
+            matches!(fixture.observer.commands.lock().unwrap()[3], VisualOverlayCommand::PreviewRectangle { operation_id, .. } if operation_id == third)
+        );
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+        drop(dialog);
+        drop(fixture.controller);
+        assert_eq!(fixture.observer.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 1);
+    }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     enum Call {

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -4,6 +4,11 @@
 //! native implementation is responsible for converting window-client input to
 //! desktop coordinates before returning an [`OverlayInput`].
 use crate::mkmacro::{MkPoint, MonitorDescriptor, ScreenRect};
+#[cfg(test)]
+use std::sync::{
+    Arc, Condvar, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 use std::{
     collections::VecDeque,
     fmt,
@@ -185,7 +190,7 @@ pub enum VisualOverlayEvent {
 }
 
 /// Messages are the only way native overlay work crosses onto its owning thread.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum VisualOverlayCommand {
     BeginRectanglePick {
         operation_id: OperationId,
@@ -225,6 +230,41 @@ pub(crate) struct NativeVisualOverlayService {
     pub commands: Sender<VisualOverlayCommand>,
     pub events: Receiver<VisualOverlayEvent>,
     worker: Option<JoinHandle<()>>,
+    #[cfg(test)]
+    observer: Option<Arc<ServiceTestObserver>>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct ServiceTestObserver {
+    pub commands: Mutex<Vec<VisualOverlayCommand>>,
+    pub starts: AtomicUsize,
+    pub shutdowns: AtomicUsize,
+    pub joins: AtomicUsize,
+    pub worker_ids: Mutex<Vec<thread::ThreadId>>,
+    changed: Condvar,
+}
+
+#[cfg(test)]
+impl ServiceTestObserver {
+    pub fn wait_for_commands(&self, count: usize) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut commands = self.commands.lock().unwrap();
+        while commands.len() < count {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "overlay worker received only {} of {count} expected commands: {commands:?}",
+                commands.len()
+            );
+            let (next, result) = self.changed.wait_timeout(commands, remaining).unwrap();
+            commands = next;
+            assert!(
+                !result.timed_out() || commands.len() >= count,
+                "timed out waiting for overlay command {count}; received: {commands:?}"
+            );
+        }
+    }
 }
 
 impl NativeVisualOverlayService {
@@ -239,6 +279,21 @@ impl NativeVisualOverlayService {
         Self::start_with_wait_interval(factory, Duration::from_millis(12))
     }
 
+    #[cfg(test)]
+    pub(crate) fn start_with_observer<F>(
+        factory: F,
+        observer: Arc<ServiceTestObserver>,
+    ) -> Result<Self, std::io::Error>
+    where
+        F: FnOnce() -> VisualOverlayController + Send + 'static,
+    {
+        Self::start_with_wait_interval_and_observer(
+            factory,
+            Duration::from_millis(12),
+            Some(observer),
+        )
+    }
+
     /// Test hook for running the real service loop with a deterministic controller and
     /// a nonblocking wait. Production deliberately uses a modest blocking interval.
     pub(crate) fn start_with_wait_interval<F>(
@@ -248,11 +303,40 @@ impl NativeVisualOverlayService {
     where
         F: FnOnce() -> VisualOverlayController + Send + 'static,
     {
-        let (command_tx, command_rx) = mpsc::channel();
+        #[cfg(test)]
+        {
+            Self::start_with_wait_interval_and_observer(factory, active_wait, None)
+        }
+        #[cfg(not(test))]
+        {
+            Self::start_with_wait_interval_and_observer(factory, active_wait)
+        }
+    }
+
+    fn start_with_wait_interval_and_observer<F>(
+        factory: F,
+        active_wait: Duration,
+        #[cfg(test)] observer: Option<Arc<ServiceTestObserver>>,
+    ) -> Result<Self, std::io::Error>
+    where
+        F: FnOnce() -> VisualOverlayController + Send + 'static,
+    {
+        let (command_tx, command_rx) = mpsc::channel::<VisualOverlayCommand>();
         let (event_tx, event_rx) = mpsc::channel();
+        #[cfg(test)]
+        let worker_observer = observer.clone();
         let worker = thread::Builder::new()
             .name("native-visual-overlay".into())
             .spawn(move || {
+                #[cfg(test)]
+                if let Some(observer) = &worker_observer {
+                    observer.starts.fetch_add(1, Ordering::SeqCst);
+                    observer
+                        .worker_ids
+                        .lock()
+                        .unwrap()
+                        .push(thread::current().id());
+                }
                 let mut controller = factory();
                 let mut running = true;
                 while running {
@@ -276,10 +360,22 @@ impl NativeVisualOverlayService {
                         }
                     };
                     if let Some(command) = first {
+                        #[cfg(test)]
+                        if let Some(observer) = &worker_observer {
+                            observer.commands.lock().unwrap().push(command.clone());
+                            observer.changed.notify_all();
+                        }
                         running = apply_command(&mut controller, command);
                         while running {
                             match command_rx.try_recv() {
-                                Ok(command) => running = apply_command(&mut controller, command),
+                                Ok(command) => {
+                                    #[cfg(test)]
+                                    if let Some(observer) = &worker_observer {
+                                        observer.commands.lock().unwrap().push(command.clone());
+                                        observer.changed.notify_all();
+                                    }
+                                    running = apply_command(&mut controller, command)
+                                }
                                 Err(mpsc::TryRecvError::Empty) => break,
                                 Err(mpsc::TryRecvError::Disconnected) => {
                                     running = false;
@@ -296,11 +392,18 @@ impl NativeVisualOverlayService {
                     }
                 }
                 controller.shutdown();
+                #[cfg(test)]
+                if let Some(observer) = &worker_observer {
+                    observer.shutdowns.fetch_add(1, Ordering::SeqCst);
+                    observer.changed.notify_all();
+                }
             })?;
         Ok(Self {
             commands: command_tx,
             events: event_rx,
             worker: Some(worker),
+            #[cfg(test)]
+            observer,
         })
     }
 
@@ -308,6 +411,10 @@ impl NativeVisualOverlayService {
         if let Some(worker) = self.worker.take() {
             let _ = self.commands.send(VisualOverlayCommand::Shutdown);
             let _ = worker.join();
+            #[cfg(test)]
+            if let Some(observer) = &self.observer {
+                observer.joins.fetch_add(1, Ordering::SeqCst);
+            }
         }
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3228,6 +3228,30 @@ mod tests {
         }
         fn cancel(&mut self, _expected_operation_id: u64) {}
     }
+    struct SharedHostOverlay {
+        controller: mkmacro_dialog::visual_capture_workflow::SharedVisualOverlayController,
+        operation: Option<u64>,
+    }
+    impl mkmacro_dialog::visual_capture_workflow::RectangleOverlay for SharedHostOverlay {
+        fn begin(
+            &mut self,
+            purpose: mkmacro_dialog::visual_overlay::RectanglePurpose,
+        ) -> Result<u64, String> {
+            let id = self
+                .controller
+                .begin_rectangle_pick(purpose, crate::mkmacro::ScreenRect::new(0, 0, 100, 100));
+            self.operation = Some(id);
+            Ok(id)
+        }
+        fn poll(&mut self) -> mkmacro_dialog::visual_capture_workflow::SelectionEvent {
+            mkmacro_dialog::visual_capture_workflow::SelectionEvent::Pending
+        }
+        fn cancel(&mut self, expected: u64) {
+            if self.operation.take() == Some(expected) {
+                self.controller.cancel_operation(expected);
+            }
+        }
+    }
     struct HostCapture(Arc<Mutex<HostCaptureLog>>);
     impl mkmacro_dialog::visual_capture_workflow::CaptureAdapter for HostCapture {
         fn capture_rect(&mut self, rect: crate::mkmacro::ScreenRect) -> Result<RgbaImage, String> {
@@ -3295,6 +3319,59 @@ mod tests {
                 .unwrap()
                 .active()
         );
+    }
+
+    #[test]
+    fn installed_workflow_and_action_editor_reuse_dialog_overlay_worker() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        let fixture =
+            mkmacro_dialog::visual_capture_workflow::SharedVisualOverlayController::test_fixture();
+        app.mkmacro_dialog.visual_overlay = fixture.controller.clone();
+        app.mkmacro_dialog.action_editor = mkmacro_dialog::action_editor::ActionEditorState::new(
+            app.mkmacro_dialog.visual_overlay_controller(),
+        );
+        let log = Arc::new(Mutex::new(HostCaptureLog::default()));
+        install_visual_capture(
+            &mut app.mkmacro_dialog,
+            VisualCaptureDependencies {
+                overlay: Box::new(SharedHostOverlay {
+                    controller: fixture.controller.clone(),
+                    operation: None,
+                }),
+                capture: Box::new(HostCapture(log.clone())),
+                assets: Box::new(HostAssets(log)),
+            },
+        );
+
+        let editor_id = app
+            .mkmacro_dialog
+            .action_editor
+            .visual_overlay
+            .preview_rectangle(crate::mkmacro::ScreenRect::new(1, 1, 5, 5));
+        fixture.observer.wait_for_commands(1);
+        app.mkmacro_dialog
+            .action_editor
+            .begin_new(host_image_action());
+        app.mkmacro_dialog
+            .action_editor
+            .request_rectangle_selection(
+                9,
+                mkmacro_dialog::visual_overlay::RectanglePurpose::SearchRegion,
+                mkmacro_dialog::action_editor::VisualRegionDestination::ImageActionSearchRegion,
+            )
+            .unwrap();
+        fixture.observer.wait_for_commands(2);
+        let commands = fixture.observer.commands.lock().unwrap();
+        assert!(
+            matches!(commands[0], mkmacro_dialog::visual_overlay::VisualOverlayCommand::PreviewRectangle { operation_id, .. } if operation_id == editor_id)
+        );
+        assert!(matches!(
+            commands[1],
+            mkmacro_dialog::visual_overlay::VisualOverlayCommand::BeginRectanglePick { .. }
+        ));
+        assert_eq!(fixture.observer.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.observer.worker_ids.lock().unwrap().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure action transactions (apply/cancel/drop) cleanly cancel their own overlay operations without shutting down or joining the shared native overlay worker. 
- Provide deterministic, test-only instrumentation to observe worker lifecycle, commands, cancellations, and join counts so tests don't rely on sleeps or fragile timing.

### Description

- Added a test observer and hooks to the native overlay owner by introducing `ServiceTestObserver`, `NativeVisualOverlayService::start_with_observer`, and wiring an optional `observer` into `NativeVisualOverlayService` to record commands, starts, worker IDs, shutdowns, and join counts; `VisualOverlayCommand` was made `Clone` to allow recording. (modified: `src/gui/mkmacro_dialog/visual_overlay.rs`)
- Added a test fixture constructor `SharedVisualOverlayController::test_fixture()` and `TestOverlayServiceFixture` to start a deterministic service with an injected `VisualOverlayController` and observable lifecycle state. (modified: `src/gui/mkmacro_dialog/visual_capture_workflow.rs`)
- Implemented deterministic regression tests that exercise controller sharing and ownership semantics: cloned-controller test in `visual_capture_workflow` verifies cancel/start reuse and single worker lifetime, action-editor tests in `action_editor` verify `cancel()` and `apply()` cleanup and a drop-specific test to ensure editor drop cancels at most once, plus a repeated-transaction test covering apply/cancel and action switching, and a GUI dependency wiring test in `gui/mod.rs` ensuring both the workflow and action editor use the same dialog-owned command stream. (added/modified tests in `src/gui/mkmacro_dialog/visual_capture_workflow.rs`, `src/gui/mkmacro_dialog/action_editor.rs`, and `src/gui/mod.rs`)
- Minor API and test plumbing changes to support deterministic tests, including typing the command channel, small formatting adjustments, and helper `Desktop` backend used by tests.

### Testing

- Ran formatting and style checks (`cargo fmt` and `cargo fmt -- --check`) and `git diff --check`, all of which succeeded. 
- Attempted focused test builds and runs for the newly added/modified targets (the `mkmacro_dialog::visual_capture_workflow` tests, `mkmacro_dialog::action_editor` tests, the GUI wiring test, and existing `mkmacro_dialog::visual_overlay` tests), but executing the test suite in this Linux environment failed due to platform-specific build errors caused by unconditional Windows-only APIs (e.g. `windows::Win32` and `WindowsScreenCaptureBackend::system()`), so the tests could not be run here; the new tests are written to be deterministic and should run on a supported Windows test host or CI. 
- Committed changes with message `test shared visual overlay transaction ownership` and verified repository formatting and lint checks post-edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f917fa0008332824cac9c58fdf9dc)