### PR TITLE
Deterministic visual-overlay fixture and lifecycle regression tests

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2884,8 +2884,43 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
 mod tests {
     use super::super::visual_overlay::{OperationId, VisualOverlayCommand, VisualOverlayEvent};
     use super::*;
+    use image::RgbaImage;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
+
+    struct TestDesktop;
+    impl ScreenCaptureBackend for TestDesktop {
+        fn virtual_desktop(&self) -> ExecResult<ScreenRect> {
+            Ok(ScreenRect::new(-100, -100, 1000, 1000))
+        }
+        fn region_bounds(&self, _: &SearchRegion) -> ExecResult<ScreenRect> {
+            self.virtual_desktop()
+        }
+        fn capture_rect(&self, rect: ScreenRect, _: &dyn Fn() -> bool) -> ExecResult<RgbaImage> {
+            Ok(RgbaImage::new(rect.width, rect.height))
+        }
+    }
+    struct TestAssets;
+    impl super::super::visual_capture_workflow::AssetStoreAdapter for TestAssets {
+        fn write_png_asset(&mut self, _: u64, _: &RgbaImage) -> Result<u64, String> {
+            Ok(91)
+        }
+    }
+
+    fn install_real_service_workflow(editor: &mut ActionEditorState) {
+        use super::super::visual_capture_workflow::{
+            ScreenCaptureAdapter, VisualCaptureWorkflow, VisualOverlayRectangleAdapter,
+        };
+        let desktop: Arc<dyn ScreenCaptureBackend> = Arc::new(TestDesktop);
+        editor.visual_capture = Some(VisualCaptureWorkflow::new(
+            Box::new(VisualOverlayRectangleAdapter::new(
+                editor.visual_overlay.clone(),
+                desktop.clone(),
+            )),
+            Box::new(ScreenCaptureAdapter(desktop)),
+            Box::new(TestAssets),
+        ));
+    }
 
     fn test_editor() -> ActionEditorState {
         ActionEditorState::new(
@@ -2957,6 +2992,89 @@ mod tests {
         );
         assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
         assert!(!dialog.visual_overlay_controller().poll().iter().any(|e| matches!(e, VisualOverlayEvent::Error { error, .. } if error.message.contains("shut down"))));
+    }
+
+    fn assert_plain_transaction_then_reference_capture(apply: bool, image: MkAction) {
+        let (_dir, mut dialog, fixture) = shared_dialog();
+        // This ordinary action never owns an overlay. On the pre-ownership-fix baseline,
+        // applying/cancelling it dropped the service-owning editor and the assertion below
+        // observed `visual overlay service is shut down` instead of BeginRectanglePick.
+        dialog
+            .action_editor
+            .begin_new(MkAction::Delay { milliseconds: 5 });
+        let mut plain = dialog.take_action_editor();
+        if apply {
+            assert!(plain.apply(&mut dialog).is_some());
+        } else {
+            plain.cancel();
+        }
+        dialog.action_editor = plain;
+
+        dialog.action_editor.begin_new(image);
+        install_real_service_workflow(&mut dialog.action_editor);
+        let macro_id = dialog.selected_macro_id.unwrap();
+        dialog
+            .action_editor
+            .request_rectangle_selection(
+                macro_id,
+                RectanglePurpose::ReferenceImageCapture,
+                VisualRegionDestination::ImageActionReferenceAsset,
+            )
+            .unwrap();
+        let operation_id = dialog
+            .action_editor
+            .visual_capture
+            .as_ref()
+            .and_then(|w| match w.state() {
+                super::super::visual_capture_workflow::WorkflowState::Selecting {
+                    operation_id,
+                    ..
+                } => Some(*operation_id),
+                _ => None,
+            })
+            .unwrap();
+        fixture.observer.wait_for_commands(1);
+        assert!(matches!(fixture.observer.commands.lock().unwrap().last(),
+            Some(VisualOverlayCommand::BeginRectanglePick { operation_id: id, purpose: RectanglePurpose::ReferenceImageCapture, .. }) if *id == operation_id));
+        assert_ne!(operation_id, 0);
+        assert_eq!(fixture.observer.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.observer.shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+        assert!(!dialog.visual_overlay_controller().poll().iter().any(|event|
+            matches!(event, VisualOverlayEvent::Error { error, .. } if error.message.contains("visual overlay service is shut down"))));
+
+        let original = dialog.action_editor.draft.clone();
+        fixture.observer.cancel_rectangle(operation_id);
+        for _ in 0..100 {
+            dialog.action_editor.tick_visual_capture(Some(macro_id));
+            if !dialog
+                .action_editor
+                .visual_capture
+                .as_ref()
+                .unwrap()
+                .active()
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert_eq!(dialog.action_editor.draft, original);
+        assert_eq!(fixture.observer.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.observer.shutdowns.load(Ordering::SeqCst), 0);
+        assert_eq!(fixture.observer.joins.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn apply_then_capture_uses_the_original_dialog_worker() {
+        assert_plain_transaction_then_reference_capture(true, image_action());
+    }
+
+    #[test]
+    fn cancel_then_capture_uses_the_original_dialog_worker() {
+        let MkAction::ImageFind(payload) = image_action() else {
+            unreachable!()
+        };
+        assert_plain_transaction_then_reference_capture(false, MkAction::ImageClick(payload));
     }
 
     #[test]

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -2882,7 +2882,9 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::visual_overlay::{OperationId, VisualOverlayCommand, VisualOverlayEvent};
+    use super::super::visual_overlay::{
+        OperationId, RectanglePurpose, VisualOverlayCommand, VisualOverlayEvent,
+    };
     use super::*;
     use image::RgbaImage;
     use std::sync::atomic::Ordering;
@@ -3381,7 +3383,7 @@ mod tests {
             assert_eq!(operation.rectangle_purpose(), None);
         }
     }
-    use image::{GenericImageView, Rgba, RgbaImage};
+    use image::{GenericImageView, Rgba};
     use std::sync::mpsc;
 
     #[derive(Default)]

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -68,7 +68,14 @@ impl SharedVisualOverlayController {
     pub(crate) fn test_fixture() -> TestOverlayServiceFixture {
         let observer = Arc::new(super::visual_overlay::ServiceTestObserver::default());
         let service = NativeVisualOverlayService::start_with_observer(
-            VisualOverlayController::default,
+            {
+                let observer = observer.clone();
+                move || {
+                    VisualOverlayController::new(Box::new(
+                        super::visual_overlay::ServiceTestRenderer(observer),
+                    ))
+                }
+            },
             observer.clone(),
         )
         .expect("test overlay worker must start");

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -242,6 +242,7 @@ pub(crate) struct ServiceTestObserver {
     pub shutdowns: AtomicUsize,
     pub joins: AtomicUsize,
     pub worker_ids: Mutex<Vec<thread::ThreadId>>,
+    inputs: Mutex<Vec<OverlayInput>>,
     changed: Condvar,
 }
 
@@ -265,6 +266,54 @@ impl ServiceTestObserver {
             );
         }
     }
+
+    pub fn confirm_rectangle(&self, operation_id: OperationId, from: MkPoint, to: MkPoint) {
+        self.inputs.lock().unwrap().extend([
+            OverlayInput {
+                operation_id,
+                kind: OverlayInputKind::LeftPressed(from),
+            },
+            OverlayInput {
+                operation_id,
+                kind: OverlayInputKind::LeftReleased(to),
+            },
+        ]);
+    }
+
+    pub fn cancel_rectangle(&self, operation_id: OperationId) {
+        self.inputs.lock().unwrap().push(OverlayInput {
+            operation_id,
+            kind: OverlayInputKind::Escape,
+        });
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ServiceTestRenderer(pub Arc<ServiceTestObserver>);
+
+#[cfg(test)]
+impl OverlayRenderer for ServiceTestRenderer {
+    fn left_button_down(&mut self) -> Result<bool, VisualOverlayError> {
+        Ok(false)
+    }
+    fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
+        Ok(MkPoint { x: 0, y: 0 })
+    }
+    fn show(
+        &mut self,
+        _: OperationId,
+        _: &OverlayVisual,
+        _: bool,
+    ) -> Result<(), VisualOverlayError> {
+        Ok(())
+    }
+    fn repaint(&mut self, _: OperationId, _: &OverlayVisual) -> Result<(), VisualOverlayError> {
+        Ok(())
+    }
+    fn poll_input(&mut self) -> Result<Vec<OverlayInput>, VisualOverlayError> {
+        Ok(std::mem::take(&mut *self.0.inputs.lock().unwrap()))
+    }
+    fn close(&mut self) {}
 }
 
 impl NativeVisualOverlayService {


### PR DESCRIPTION
### Motivation

- Prevent transient editor actions (apply/cancel/replace) from shutting down the long-lived native visual-overlay worker and ensure the dialog remains the single owner of that service.
- Provide deterministic, test-driven coverage of the overlay command loop and worker lifecycle so regressions (apply/cancel then capture) are reproducible and asserted.

### Description

- Add queued semantic input support and helpers to the test observer by extending `ServiceTestObserver` with an `inputs` queue and `confirm_rectangle`/`cancel_rectangle` helpers in `src/gui/mkmacro_dialog/visual_overlay.rs` so the real service loop can receive synthetic input events.
- Introduce `ServiceTestRenderer` (an `OverlayRenderer`) that consumes synthetic inputs from the observer and use it to run the real `NativeVisualOverlayService` loop deterministically in tests by wiring the renderer into the test fixture in `src/gui/mkmacro_dialog/visual_capture_workflow.rs`.
- Wire the dialog-wide `SharedVisualOverlayController` test fixture to start the real worker with the deterministic renderer, preserving observer access to command history, `starts`/`shutdowns`/`joins`, and `worker_ids` for identity checks (changes in `visual_capture_workflow.rs`).
- Add integration-style tests in `src/gui/mkmacro_dialog/action_editor.rs` that install the real `VisualCaptureWorkflow` boundary with small fake capture/store adapters and assert the exact “Apply then Capture” and “Cancel then Capture” regressions along with preservation of draft state and that only one worker is started and no shutdown/join occurs during the dialog lifetime.
- Provide a `TestDesktop` `ScreenCaptureBackend` and `TestAssets` `AssetStoreAdapter` in tests and a helper `install_real_service_workflow` to exercise the real workflow/overlay boundary without relying on fully production capture/IO.

### Testing

- Ran `cargo fmt` and ensured the code is formatted.
- Ran `cargo test -q gui::mkmacro_dialog::visual_capture_workflow::tests` and the visual-capture workflow unit tests passed.
- Ran `cargo test -q gui::mkmacro_dialog::action_editor::tests` including the new `apply_then_capture_uses_the_original_dialog_worker` and `cancel_then_capture_uses_the_original_dialog_worker` tests, which passed and assert worker start count remains one and no shutdown/join occurred during dialog transactions.
- Verified `git diff --check` produced no whitespace errors after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9024c9fe848332b71b48b32375ae41)