### PR TITLE
Refactor native overlays: add passive edge/badge path and planning

### DIFF
--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -587,9 +587,123 @@ pub enum OverlayVisual {
     },
 }
 impl OverlayVisual {
-    fn passive(&self) -> bool {
+    pub(crate) fn passive(&self) -> bool {
         !matches!(self, Self::RectanglePicker { .. })
     }
+}
+
+/// The four independently-owned windows which make up a passive outline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum OutlineEdge {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+impl fmt::Display for OutlineEdge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Top => "top",
+            Self::Bottom => "bottom",
+            Self::Left => "left",
+            Self::Right => "right",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PassiveWindowSpec {
+    Edge { edge: OutlineEdge, rect: ScreenRect },
+    Badge { monitor: ScreenRect, index: usize },
+}
+
+/// Decomposes an outline without doing arithmetic in the signed coordinate
+/// type. Overlap at the corners is intentional and prevents holes for tiny
+/// (even one-pixel) targets.
+pub(crate) fn outline_edge_rects(rect: ScreenRect) -> [(OutlineEdge, ScreenRect); 4] {
+    let horizontal = rect.height.min(RECTANGLE_OUTLINE_WIDTH as u32).max(1);
+    let vertical = rect.width.min(RECTANGLE_OUTLINE_WIDTH as u32).max(1);
+    let bottom = (rect.bottom() - i64::from(horizontal))
+        .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+    let right =
+        (rect.right() - i64::from(vertical)).clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+    [
+        (
+            OutlineEdge::Top,
+            ScreenRect::new(rect.x, rect.y, rect.width.max(1), horizontal),
+        ),
+        (
+            OutlineEdge::Bottom,
+            ScreenRect::new(rect.x, bottom, rect.width.max(1), horizontal),
+        ),
+        (
+            OutlineEdge::Left,
+            ScreenRect::new(rect.x, rect.y, vertical, rect.height.max(1)),
+        ),
+        (
+            OutlineEdge::Right,
+            ScreenRect::new(right, rect.y, vertical, rect.height.max(1)),
+        ),
+    ]
+}
+
+fn rect_intersection(a: ScreenRect, b: ScreenRect) -> Option<ScreenRect> {
+    let left = i64::from(a.x).max(i64::from(b.x));
+    let top = i64::from(a.y).max(i64::from(b.y));
+    let right = a.right().min(b.right());
+    let bottom = a.bottom().min(b.bottom());
+    (left < right && top < bottom).then(|| {
+        ScreenRect::new(
+            left as i32,
+            top as i32,
+            (right - left) as u32,
+            (bottom - top) as u32,
+        )
+    })
+}
+
+/// Produces small, platform-neutral passive windows. Edge pixels are clipped
+/// independently to real displays, so no popup bridges a virtual-desktop gap.
+pub(crate) fn passive_overlay_plan(
+    visual: &OverlayVisual,
+    displays: &[ScreenRect],
+) -> Option<Vec<PassiveWindowSpec>> {
+    if !visual.passive() {
+        return None;
+    }
+    let (targets, badges): (Vec<_>, Vec<_>) = match visual {
+        OverlayVisual::RectanglePreview(r) | OverlayVisual::Window { rect: r, .. } => {
+            (vec![*r], vec![])
+        }
+        OverlayVisual::Monitor(d) => (vec![d.bounds], vec![]),
+        OverlayVisual::Desktop(ds) => (ds.iter().map(|d| d.bounds).collect(), vec![]),
+        OverlayVisual::Monitors(ds) => (
+            ds.iter().map(|d| d.bounds).collect(),
+            ds.iter().map(|d| (d.bounds, d.index)).collect(),
+        ),
+        OverlayVisual::RectanglePicker { .. } => unreachable!(),
+    };
+    let mut plan = Vec::new();
+    for target in targets {
+        for (edge, edge_rect) in outline_edge_rects(target) {
+            for display in displays {
+                if let Some(rect) = rect_intersection(edge_rect, *display) {
+                    plan.push(PassiveWindowSpec::Edge { edge, rect });
+                }
+            }
+        }
+    }
+    plan.extend(
+        badges
+            .into_iter()
+            .map(|(monitor, index)| PassiveWindowSpec::Badge { monitor, index }),
+    );
+    plan.sort_by_key(|spec| match spec {
+        PassiveWindowSpec::Edge { edge, rect } => (0, rect.x, rect.y, *edge as i32, 0),
+        PassiveWindowSpec::Badge { monitor, index } => (1, monitor.x, monitor.y, 0, *index as i32),
+    });
+    Some(plan)
 }
 
 /// Platform-neutral description of the pixels a native overlay must produce.
@@ -1563,6 +1677,112 @@ mod tests {
             bounds,
             primary: index == 1,
         }
+    }
+
+    #[test]
+    fn passive_outline_geometry_is_exact_for_normal_negative_and_tiny_rectangles() {
+        assert_eq!(
+            outline_edge_rects(ScreenRect::new(10, 20, 100, 50)),
+            [
+                (OutlineEdge::Top, ScreenRect::new(10, 20, 100, 3)),
+                (OutlineEdge::Bottom, ScreenRect::new(10, 67, 100, 3)),
+                (OutlineEdge::Left, ScreenRect::new(10, 20, 3, 50)),
+                (OutlineEdge::Right, ScreenRect::new(107, 20, 3, 50)),
+            ]
+        );
+        let negative = outline_edge_rects(ScreenRect::new(-20, -10, 8, 7));
+        assert_eq!(negative[1].1, ScreenRect::new(-20, -6, 8, 3));
+        let tiny = outline_edge_rects(ScreenRect::new(-2, -3, 2, 1));
+        assert!(tiny.iter().all(|(_, r)| r.width > 0 && r.height > 0));
+        assert_eq!(tiny[3].1, ScreenRect::new(-2, -3, 2, 1));
+    }
+
+    #[test]
+    fn passive_plan_clips_cross_monitor_edges_and_never_bridges_a_gap() {
+        let displays = [
+            ScreenRect::new(0, 0, 100, 100),
+            ScreenRect::new(200, 0, 100, 100),
+        ];
+        let plan = passive_overlay_plan(
+            &OverlayVisual::RectanglePreview(ScreenRect::new(50, 20, 200, 60)),
+            &displays,
+        )
+        .unwrap();
+        let edges: Vec<_> = plan
+            .iter()
+            .filter_map(|s| match s {
+                PassiveWindowSpec::Edge { rect, .. } => Some(*rect),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            edges
+                .iter()
+                .all(|r| r.right() <= 100 || i64::from(r.x) >= 200)
+        );
+        assert!(edges.iter().any(|r| *r == ScreenRect::new(50, 20, 50, 3)));
+        assert!(edges.iter().any(|r| *r == ScreenRect::new(200, 20, 50, 3)));
+    }
+
+    #[test]
+    fn passive_variants_have_the_required_outline_and_badge_semantics() {
+        let a = monitor(2, ScreenRect::new(-100, 0, 100, 80));
+        let b = monitor(1, ScreenRect::new(0, 0, 120, 80));
+        let displays = [a.bounds, b.bounds];
+        let desktop = passive_overlay_plan(
+            &OverlayVisual::Desktop(vec![b.clone(), a.clone()]),
+            &displays,
+        )
+        .unwrap();
+        assert_eq!(
+            desktop
+                .iter()
+                .filter(|s| matches!(s, PassiveWindowSpec::Edge { .. }))
+                .count(),
+            8
+        );
+        assert!(
+            !desktop
+                .iter()
+                .any(|s| matches!(s, PassiveWindowSpec::Badge { .. }))
+        );
+        let selected = passive_overlay_plan(&OverlayVisual::Monitor(a.clone()), &displays).unwrap();
+        assert_eq!(selected.len(), 4);
+        let identified =
+            passive_overlay_plan(&OverlayVisual::Monitors(vec![a, b]), &displays).unwrap();
+        assert_eq!(
+            identified
+                .iter()
+                .filter(|s| matches!(s, PassiveWindowSpec::Badge { .. }))
+                .count(),
+            2
+        );
+        for kind in [WindowAreaKind::WholeWindow, WindowAreaKind::ClientArea] {
+            let rect = ScreenRect::new(-50, 5, 30, 20);
+            let plan = passive_overlay_plan(
+                &OverlayVisual::Window {
+                    rect,
+                    area_kind: kind,
+                },
+                &displays,
+            )
+            .unwrap();
+            assert!(plan.iter().any(|s| matches!(s, PassiveWindowSpec::Edge { edge: OutlineEdge::Top, rect: r } if *r == ScreenRect::new(-50, 5, 30, 3))));
+        }
+        assert!(
+            passive_overlay_plan(
+                &OverlayVisual::RectanglePicker {
+                    virtual_desktop: displays[0],
+                    selection: None,
+                    tooltip: RectangleTooltip {
+                        text: String::new(),
+                        pointer: point(0, 0)
+                    },
+                },
+                &displays
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -40,6 +40,7 @@ struct WindowPaintState {
     bounds: ScreenRect,
     frame: Vec<OverlayFramePrimitive>,
     hint: Option<String>,
+    solid: Option<COLORREF>,
 }
 struct OverlayWindow {
     hwnd: HWND,
@@ -48,7 +49,11 @@ struct OverlayWindow {
 }
 
 pub(super) struct NativeOverlayRenderer {
+    // Full-monitor, layered picker surfaces only.
     windows: Vec<OverlayWindow>,
+    // Small, opaque, non-activating passive resources.
+    passive_edges: Vec<OverlayWindow>,
+    passive_badges: Vec<OverlayWindow>,
     tooltip: Option<OverlayWindow>,
     operation_id: Option<OperationId>,
     visual: Option<OverlayVisual>,
@@ -60,6 +65,8 @@ impl Default for NativeOverlayRenderer {
     fn default() -> Self {
         Self {
             windows: vec![],
+            passive_edges: vec![],
+            passive_badges: vec![],
             tooltip: None,
             operation_id: None,
             visual: None,
@@ -104,11 +111,14 @@ unsafe fn paint_frame(dc: HDC, state: &WindowPaintState) {
         right: state.bounds.width as i32,
         bottom: state.bounds.height as i32,
     };
-    let clear = unsafe { CreateSolidBrush(TRANSPARENT_KEY) };
+    let clear = unsafe { CreateSolidBrush(state.solid.unwrap_or(TRANSPARENT_KEY)) };
     unsafe { FillRect(dc, &client, clear) };
     unsafe {
         let _ = DeleteObject(HGDIOBJ(clear.0));
     };
+    if state.solid.is_some() {
+        return;
+    }
 
     if let Some(text) = &state.hint {
         let background = unsafe { CreateSolidBrush(COLORREF(0x00202020)) };
@@ -173,7 +183,7 @@ unsafe fn draw_label(dc: HDC, origin: ScreenRect, bounds: ScreenRect, index: usi
     };
 }
 
-fn displays() -> Vec<ScreenRect> {
+fn displays() -> Result<Vec<ScreenRect>, VisualOverlayError> {
     unsafe extern "system" fn collect(
         monitor: HMONITOR,
         _: HDC,
@@ -199,15 +209,22 @@ fn displays() -> Vec<ScreenRect> {
         true.into()
     }
     let mut result = vec![];
-    unsafe {
-        let _ = EnumDisplayMonitors(
+    let ok = unsafe {
+        EnumDisplayMonitors(
             None,
             None,
             Some(collect),
             LPARAM(&mut result as *mut _ as isize),
-        );
+        )
+    };
+    if !ok.as_bool() {
+        Err(platform(format!(
+            "Could not enumerate physical monitors: {}",
+            unsafe { GetLastError().0 }
+        )))
+    } else {
+        Ok(result)
     }
-    result
 }
 
 impl NativeOverlayRenderer {
@@ -226,6 +243,108 @@ impl NativeOverlayRenderer {
         let error = platform(message);
         self.close();
         Err(error)
+    }
+
+    fn show_passive(
+        &mut self,
+        module: windows::Win32::Foundation::HMODULE,
+        class: PCWSTR,
+        visual: &OverlayVisual,
+    ) -> Result<(), VisualOverlayError> {
+        let physical = match displays() {
+            Ok(v) => v,
+            Err(e) => return self.fail(e.message),
+        };
+        let Some(plan) = passive_overlay_plan(visual, &physical) else {
+            return self.fail("Rectangle picker cannot use the passive preview path");
+        };
+        for spec in plan {
+            let (bounds, hint, solid, failure, badge) = match spec {
+                PassiveWindowSpec::Edge { edge, rect } => (
+                    rect,
+                    None,
+                    Some(OUTLINE_COLOR),
+                    format!("Could not create {edge} preview edge window for target {rect:?}"),
+                    false,
+                ),
+                PassiveWindowSpec::Badge { monitor, index } => {
+                    let text = index.to_string();
+                    let width = 32u32.saturating_add(text.len() as u32 * 12);
+                    let bounds = ScreenRect::new(
+                        monitor.x.saturating_add(24),
+                        monitor.y.saturating_add(24),
+                        width,
+                        42,
+                    );
+                    (
+                        bounds,
+                        Some(text),
+                        None,
+                        format!("Could not create monitor-identification badge for {monitor:?}"),
+                        true,
+                    )
+                }
+            };
+            let mut state = Box::new(WindowPaintState {
+                bounds,
+                frame: vec![],
+                hint,
+                solid,
+            });
+            let hwnd = match unsafe {
+                CreateWindowExW(
+                    WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+                    class,
+                    PCWSTR::null(),
+                    WS_POPUP,
+                    bounds.x,
+                    bounds.y,
+                    bounds.width as i32,
+                    bounds.height as i32,
+                    None,
+                    None,
+                    module,
+                    Some(state.as_mut() as *mut _ as *const _),
+                )
+            } {
+                Ok(hwnd) => hwnd,
+                Err(e) => return self.fail(format!("{failure}: {e}")),
+            };
+            let window = OverlayWindow { hwnd, state };
+            tracing::debug!(?hwnd, ?bounds, badge, "created passive overlay window");
+            if badge {
+                self.passive_badges.push(window);
+            } else {
+                self.passive_edges.push(window);
+            }
+            if let Err(e) = unsafe {
+                SetWindowPos(
+                    hwnd,
+                    HWND_TOPMOST,
+                    bounds.x,
+                    bounds.y,
+                    bounds.width as i32,
+                    bounds.height as i32,
+                    SWP_NOACTIVATE | SWP_SHOWWINDOW,
+                )
+            } {
+                let what = if badge {
+                    "monitor-identification badge"
+                } else {
+                    "passive preview edge"
+                };
+                return self.fail(format!("Could not position {what} at {bounds:?}: {e}"));
+            }
+            if !unsafe { InvalidateRect(hwnd, None, false) }.as_bool()
+                || !unsafe { UpdateWindow(hwnd) }.as_bool()
+            {
+                return self.fail(format!(
+                    "Could not perform initial painting for passive preview at {bounds:?}: {}",
+                    unsafe { GetLastError().0 }
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -248,6 +367,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
         visual: &OverlayVisual,
         _mouse_transparent: bool,
     ) -> Result<(), VisualOverlayError> {
+        tracing::debug!(operation_id, visual = ?visual, "showing native visual overlay; replacing current operation");
         self.close();
         if matches!(visual, OverlayVisual::RectanglePicker { .. }) {
             self.left_down = unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) } < 0;
@@ -270,6 +390,12 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 GetLastError().0
             }));
         }
+        if visual.passive() {
+            self.show_passive(module, class, visual)?;
+            self.operation_id = Some(operation_id);
+            self.visual = Some(visual.clone());
+            return Ok(());
+        }
         let monitor_bounds = match visual {
             // Preserve the descriptor topology: never create a virtual-desktop union window
             // spanning gaps between physical displays.
@@ -279,7 +405,11 @@ impl OverlayRenderer for NativeOverlayRenderer {
                     return self
                         .fail("No physical display intersects the requested preview region");
                 };
-                intersecting_monitor_bounds(&displays(), target)
+                let physical = match displays() {
+                    Ok(v) => v,
+                    Err(e) => return self.fail(e.message),
+                };
+                intersecting_monitor_bounds(&physical, target)
             }
         };
         if monitor_bounds.is_empty() {
@@ -291,6 +421,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 bounds,
                 frame: frame.clone(),
                 hint: None,
+                solid: None,
             });
             let mut ex = WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
             if overlay_is_mouse_transparent(visual) {
@@ -347,7 +478,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
             }
         }
         if let OverlayVisual::RectanglePicker { tooltip, .. } = visual {
-            let all = displays();
+            let all = displays()?;
             let monitor = monitor_nearest_pointer(&all, tooltip.pointer)
                 .ok_or_else(|| platform("No display is available for the selection tooltip"))?;
             let size = (330, 76);
@@ -358,6 +489,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 bounds,
                 frame: vec![],
                 hint: Some(tooltip.text.clone()),
+                solid: None,
             });
             let hwnd = unsafe {
                 CreateWindowExW(
@@ -426,7 +558,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
             (&mut self.tooltip, visual)
         {
             window.state.hint = Some(tooltip.text.clone());
-            let all = displays();
+            let all = displays()?;
             if let Some(monitor) = monitor_nearest_pointer(&all, tooltip.pointer) {
                 let at = place_rectangle_tooltip(
                     tooltip.pointer,
@@ -465,6 +597,11 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 DispatchMessageW(&msg);
             }
         }
+        // Passive windows have no input contract; in particular, do not let a
+        // click intended for the underlying application affect controller state.
+        if self.visual.as_ref().is_none_or(OverlayVisual::passive) {
+            return Ok(vec![]);
+        }
         let Some(id) = self.operation_id else {
             return Ok(vec![]);
         };
@@ -502,6 +639,13 @@ impl OverlayRenderer for NativeOverlayRenderer {
     }
 
     fn close(&mut self) {
+        if self.operation_id.is_some()
+            || !self.windows.is_empty()
+            || !self.passive_edges.is_empty()
+            || !self.passive_badges.is_empty()
+        {
+            tracing::debug!(operation_id = ?self.operation_id, visual = ?self.visual, "closing native visual overlay");
+        }
         if let Some(window) = self.tooltip.take() {
             unsafe {
                 SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);
@@ -509,6 +653,16 @@ impl OverlayRenderer for NativeOverlayRenderer {
             }
         }
         for window in self.windows.drain(..) {
+            unsafe {
+                SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);
+                let _ = DestroyWindow(window.hwnd);
+            }
+        }
+        for window in self
+            .passive_edges
+            .drain(..)
+            .chain(self.passive_badges.drain(..))
+        {
             unsafe {
                 SetWindowLongPtrW(window.hwnd, GWLP_USERDATA, 0);
                 let _ = DestroyWindow(window.hwnd);


### PR DESCRIPTION
### Motivation

- Separate the passive (non-interactive) preview path from the interactive Rectangle Picker so passive outlines can be implemented as small, content-sized windows rather than monitor-sized layered surfaces.
- Provide a deterministic, platform-neutral planner that decomposes a target into four thin outline edges and optional monitor-identification badges, clipping edges to physical displays and avoiding drawing across virtual-desktop gaps.
- Improve robustness at the Win32 boundary with transactional resource creation/cleanup, clearer failure messages, and lifecycle logging.

### Description

- Added platform-neutral passive planning APIs in `visual_overlay.rs`: `OutlineEdge`, `PassiveWindowSpec`, `outline_edge_rects`, `rect_intersection`, and `passive_overlay_plan` that produce clipped edge/badge window specs for passive visuals.
- Introduced `WindowPaintState::solid` and split native renderer resources in `visual_overlay_windows.rs` into interactive `windows`, `tooltip`, and passive `passive_edges` / `passive_badges`, and added `show_passive()` to create content-sized passive popups using `WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE` without layered/transparency styles.
- Kept interactive `RectanglePicker` behavior unchanged by continuing to create one layered monitor-sized surface per intersecting monitor and preserving existing extended styles and input polling for picker surfaces and tooltip placement.
- Render passive edges by painting solid outlines into small windows and render badges as content-sized label popups; make native display enumeration, creation, positioning, and painting return contextual error messages and treat resource creation as transactional so partial failures clean up created HWNDs.
- Add tracing-based lifecycle logging on `show()` and `close()` and on passive window creation/destruction to aid debugging without spamming high-frequency pointer polls.
- Added platform-neutral unit tests in `visual_overlay.rs` covering edge decomposition, negative coordinates, tiny rectangles, cross-monitor clipping, Desktop/Monitor/Monitors semantics, Window area kinds, and verification that `RectanglePicker` is excluded from the passive plan.

### Testing

- Ran `cargo fmt` successfully and validated `git diff --check` (no style or whitespace issues reported). 
- Attempted `cargo test visual_overlay --lib`, but the build could not complete in this environment because the system ALSA development package (pkg-config `alsa.pc`) is missing and caused the build to fail during dependency compilation; unit tests added are platform-neutral and should run in CI or a developer environment with required system packages installed.
- Performed local compilation attempts and manual checks for the modified code paths; creation/format checks completed, but a full `cargo test` run was blocked by the environment's missing system dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90519c99608332b6fcf0a115d4614c)