### PR TITLE
mkmacro: add Notify/PlaySound actions and bump schema to 7

### DIFF
--- a/src/gui/mkmacro_dialog/action_catalog.rs
+++ b/src/gui/mkmacro_dialog/action_catalog.rs
@@ -793,6 +793,7 @@ pub fn editor_for_action(action: &MkAction) -> EditorKind {
             EditorKind::Keyboard
         }
         MkAction::Text(_) => EditorKind::Text,
+        MkAction::Notify(_) | MkAction::PlaySound(_) => EditorKind::General,
         MkAction::MouseMove(_) => EditorKind::MouseMove,
         MkAction::MouseDrag(_) => EditorKind::MouseDrag,
         MkAction::MouseClick(_) => EditorKind::MouseClick,
@@ -1047,6 +1048,8 @@ pub fn action_name(a: &MkAction) -> &'static str {
         MkAction::KeyPress(_) => "Key Press",
         MkAction::Hotkey(_) => "Hotkey",
         MkAction::Text(_) => "Text",
+        MkAction::Notify(_) => "Show Notification",
+        MkAction::PlaySound(_) => "Play Sound",
         MkAction::MouseMove(_) => "Mouse Move",
         MkAction::MouseDrag(_) => "Mouse Drag",
         MkAction::MouseClick(_) => "Mouse Click",
@@ -1146,6 +1149,15 @@ fn action_details_core(a: &MkAction, asset_name: Option<&str>, assets: &[MkImage
             },
             p.text.chars().count()
         ),
+        MkAction::Notify(p) => {
+            let symbol = if p.show_symbol {
+                format!("{} ", p.kind.symbol())
+            } else {
+                String::new()
+            };
+            format!("{symbol}{} · {:?} · {:?}", p.title, p.kind, p.duration)
+        }
+        MkAction::PlaySound(p) => p.sound.clone(),
         MkAction::MouseClick(p) => format!(
             "{} ×{} @ {}",
             mouse(&p.button),
@@ -1672,6 +1684,26 @@ mod paste_tests {
         assert!(details.contains("Horizontal Left"));
         assert!(details.contains("2 notch(es)"));
         assert!(details.contains("-240 wheel units"));
+    }
+
+    #[test]
+    fn notification_and_sound_actions_have_catalog_fallback_presentation() {
+        let notify = MkAction::Notify(MkNotifyPayload {
+            title: "Build complete".into(),
+            kind: MkNotificationKind::Success,
+            duration: MkNotificationDuration::Long,
+            ..MkNotifyPayload::default()
+        });
+        assert_eq!(editor_for_action(&notify), EditorKind::General);
+        assert_eq!(action_name(&notify), "Show Notification");
+        assert_eq!(action_details(&notify), "✓ Build complete · Success · Long");
+
+        let sound = MkAction::PlaySound(MkPlaySoundPayload {
+            sound: "ReminderStart.wav".into(),
+        });
+        assert_eq!(editor_for_action(&sound), EditorKind::General);
+        assert_eq!(action_name(&sound), "Play Sound");
+        assert_eq!(action_details(&sound), "ReminderStart.wav");
     }
 
     #[test]

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -1977,6 +1977,14 @@ impl Executor {
                 Ok(())
             }
             MkAction::PromptInput(p) => self.prompt_input(p, v),
+            MkAction::PlaySound(p) => {
+                crate::sound::play_sound(&p.sound);
+                Ok(())
+            }
+            MkAction::Notify(_) => Err(ExecutionDiagnostic::new(
+                DiagnosticKind::InvalidTarget,
+                "notification delivery is unavailable in this runtime",
+            )),
             MkAction::ImageFind(p) => self.wait_image(macro_id, p, v).map(|_| ()),
             MkAction::ImageClick(p) => {
                 let pt = self.wait_image(macro_id, p, v)?.ok_or_else(|| {
@@ -2489,7 +2497,8 @@ pub fn has_runtime_support(action: &MkAction) -> bool {
         | MkAction::UiToggle(_)
         | MkAction::UiSelect(_)
         | MkAction::UiFocus(_)
-        | MkAction::UiWait(_) => false,
+        | MkAction::UiWait(_)
+        | MkAction::Notify(_) => false,
         MkAction::KeyDown(_)
         | MkAction::KeyUp(_)
         | MkAction::KeyPress(_)
@@ -2513,6 +2522,7 @@ pub fn has_runtime_support(action: &MkAction) -> bool {
         | MkAction::SetVariable { .. }
         | MkAction::UnsetVariable { .. }
         | MkAction::PromptInput(_)
+        | MkAction::PlaySound(_)
         | MkAction::If(_)
         | MkAction::Else
         | MkAction::EndIf
@@ -2565,6 +2575,8 @@ fn action_name(a: &MkAction) -> &'static str {
         MkAction::Process(_) | MkAction::LauncherCommand { .. } => "launcher",
         MkAction::WaitUntil { .. } => "condition_evaluator",
         MkAction::PromptInput(_) => "prompt",
+        MkAction::Notify(_) => "notification",
+        MkAction::PlaySound(_) => "sound",
         _ => "runtime",
     }
 }

--- a/src/mkmacro/model.rs
+++ b/src/mkmacro/model.rs
@@ -6,11 +6,9 @@ use crate::mkmacro::variables::{MkPoint, MkValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-// Capture Screenshot is an additive action variant and does not alter the
-// representation of existing documents, so it intentionally remains in the
-// current schema generation. Bumping this value would rewrite every loaded
-// document and break stable migration/round-trip guarantees.
-pub const SCHEMA_VERSION: u32 = 6;
+// Schema 7 introduces action tags that schema-6 builds do not know how to
+// deserialize, so documents containing them must not claim schema-6 compatibility.
+pub const SCHEMA_VERSION: u32 = 7;
 fn schema() -> u32 {
     SCHEMA_VERSION
 }
@@ -371,6 +369,77 @@ pub struct MkTextPayload {
     pub text: String,
     pub mode: MkTextMode,
 }
+fn notification_title() -> String {
+    "Macro Notification".into()
+}
+fn notification_description() -> String {
+    "Macro completed".into()
+}
+fn notification_sound() -> String {
+    "ReminderStart.wav".into()
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MkNotificationKind {
+    #[default]
+    Information,
+    Success,
+    Warning,
+    Error,
+}
+impl MkNotificationKind {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Information => "ℹ",
+            Self::Success => "✓",
+            Self::Warning => "⚠",
+            Self::Error => "✕",
+        }
+    }
+}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MkNotificationDuration {
+    #[default]
+    Short,
+    Long,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MkNotifyPayload {
+    #[serde(default = "notification_title")]
+    pub title: String,
+    #[serde(default = "notification_description")]
+    pub description: String,
+    #[serde(default)]
+    pub kind: MkNotificationKind,
+    #[serde(default)]
+    pub duration: MkNotificationDuration,
+    #[serde(default = "yes")]
+    pub show_symbol: bool,
+}
+impl Default for MkNotifyPayload {
+    fn default() -> Self {
+        Self {
+            title: notification_title(),
+            description: notification_description(),
+            kind: MkNotificationKind::Information,
+            duration: MkNotificationDuration::Short,
+            show_symbol: true,
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MkPlaySoundPayload {
+    #[serde(default = "notification_sound")]
+    pub sound: String,
+}
+impl Default for MkPlaySoundPayload {
+    fn default() -> Self {
+        Self {
+            sound: notification_sound(),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MkMousePayload {
     pub target: MkCoordinateTarget,
@@ -639,6 +708,8 @@ pub enum MkAction {
     KeyPress(MkKey),
     Hotkey(Vec<MkKey>),
     Text(MkTextPayload),
+    Notify(MkNotifyPayload),
+    PlaySound(MkPlaySoundPayload),
     MouseMove(MkMouseMovePayload),
     MouseDrag(MkMouseDragPayload),
     MouseClick(MkMousePayload),
@@ -980,5 +1051,57 @@ mod mouse_scroll_serialization_tests {
         let json = serde_json::to_string(&action).unwrap();
         assert!(json.contains(r#""axis":"horizontal""#));
         assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), action);
+    }
+}
+
+#[cfg(test)]
+mod notification_serialization_tests {
+    use super::*;
+
+    #[test]
+    fn notification_enums_have_stable_values_and_round_trip() {
+        for (kind, expected) in [
+            (MkNotificationKind::Information, "information"),
+            (MkNotificationKind::Success, "success"),
+            (MkNotificationKind::Warning, "warning"),
+            (MkNotificationKind::Error, "error"),
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+            assert_eq!(
+                serde_json::from_str::<MkNotificationKind>(&json).unwrap(),
+                kind
+            );
+        }
+        for duration in [MkNotificationDuration::Short, MkNotificationDuration::Long] {
+            let json = serde_json::to_string(&duration).unwrap();
+            assert_eq!(
+                serde_json::from_str::<MkNotificationDuration>(&json).unwrap(),
+                duration
+            );
+        }
+        let omitted: MkNotifyPayload = serde_json::from_str("{}").unwrap();
+        assert_eq!(omitted, MkNotifyPayload::default());
+    }
+
+    #[test]
+    fn new_actions_have_stable_tags_and_round_trip_losslessly() {
+        let actions = [
+            MkAction::Notify(MkNotifyPayload {
+                title: "Finished ${job}".into(),
+                description: "Everything worked".into(),
+                kind: MkNotificationKind::Success,
+                duration: MkNotificationDuration::Long,
+                show_symbol: false,
+            }),
+            MkAction::PlaySound(MkPlaySoundPayload {
+                sound: "Alarm03.wav".into(),
+            }),
+        ];
+        for (action, tag) in actions.into_iter().zip(["notify", "play_sound"]) {
+            let json = serde_json::to_string(&action).unwrap();
+            assert!(json.contains(&format!(r#""type":"{tag}""#)));
+            assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), action);
+        }
     }
 }

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -419,7 +419,7 @@ fn read_document(path: &Path) -> Result<Option<(MkMacroDocument, bool)>> {
         migrate_v4_to_v5(&mut value)?;
     }
     let mut doc: MkMacroDocument = match version {
-        0 | 1 | 2 | 3 | 4 | 5 | 6 => serde_json::from_value(value)
+        0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 => serde_json::from_value(value)
             .context("mkmacros.json does not match the macro schema")?,
         _ => unreachable!(),
     };

--- a/src/mkmacro/validation.rs
+++ b/src/mkmacro/validation.rs
@@ -44,6 +44,40 @@ fn push(
         message: msg.into(),
     })
 }
+fn interpolation_syntax(template: &str) -> Result<(), &'static str> {
+    let mut cursor = 0;
+    while cursor < template.len() {
+        let rest = &template[cursor..];
+        let prefix = if rest.starts_with("$${") {
+            Some((3, "escaped "))
+        } else if rest.starts_with("${") {
+            Some((2, ""))
+        } else {
+            None
+        };
+        if let Some((offset, escaped)) = prefix {
+            let start = cursor + offset;
+            let Some(end) = template[start..].find('}').map(|end| start + end) else {
+                return Err(if escaped.is_empty() {
+                    "unclosed interpolation placeholder"
+                } else {
+                    "unclosed escaped interpolation placeholder"
+                });
+            };
+            if end == start {
+                return Err(if escaped.is_empty() {
+                    "empty interpolation placeholder"
+                } else {
+                    "empty escaped interpolation placeholder"
+                });
+            }
+            cursor = end + 1;
+        } else {
+            cursor += rest.chars().next().unwrap().len_utf8();
+        }
+    }
+    Ok(())
+}
 fn image_outputs(p: &MkImagePayload, m: u64, s: Option<u64>, out: &mut Vec<MkDiagnostic>) {
     let slots = [
         ("found", "invalid_image_output_found", &p.outputs.found),
@@ -154,6 +188,53 @@ pub fn validate_document_with_context(
                 )
             }
             match &s.action {
+                MkAction::Notify(payload) => {
+                    // Windows notifications require a title; diagnose this before delivery.
+                    if payload.title.trim().is_empty() {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "empty_notify_title",
+                            "Notification title cannot be empty",
+                        );
+                    }
+                    for (field, value, code) in [
+                        (
+                            "notify.title",
+                            &payload.title,
+                            "invalid_notify_title_interpolation",
+                        ),
+                        (
+                            "notify.description",
+                            &payload.description,
+                            "invalid_notify_description_interpolation",
+                        ),
+                    ] {
+                        if let Err(reason) = interpolation_syntax(value) {
+                            push(
+                                &mut out,
+                                m.id,
+                                sid,
+                                code,
+                                format!("Malformed interpolation in {field}: {reason}"),
+                            );
+                        }
+                    }
+                }
+                MkAction::PlaySound(payload) => {
+                    if payload.sound == "None"
+                        || !crate::sound::SOUND_NAMES.contains(&payload.sound.as_str())
+                    {
+                        push(
+                            &mut out,
+                            m.id,
+                            sid,
+                            "invalid_play_sound",
+                            format!("Unknown macro sound name '{}'", payload.sound),
+                        );
+                    }
+                }
                 MkAction::If(c) => {
                     condition(c, m.id, sid, asset_root, &mut out);
                     stack.push(("if", false))
@@ -935,5 +1016,82 @@ mod reference_image_tests {
         assert!(validate(4, Some(&root)).is_empty());
         assert!(!usable_image_dimensions(0, 1));
         assert!(!usable_image_dimensions(1, 0));
+    }
+}
+
+#[cfg(test)]
+mod notification_action_tests {
+    use super::*;
+
+    fn diagnostics(action: MkAction) -> Vec<MkDiagnostic> {
+        validate_document(
+            &MkMacroDocument {
+                macros: vec![MkMacro {
+                    id: 1,
+                    name: "test".into(),
+                    description: String::new(),
+                    enabled: true,
+                    hotkey: None,
+                    playback: MkPlayback::default(),
+                    steps: vec![MkStep {
+                        id: 1,
+                        enabled: true,
+                        repeat: 1,
+                        delay_after_ms: 0,
+                        on_error: MkErrorPolicy::default(),
+                        action,
+                    }],
+                    image_assets: vec![],
+                }],
+                ..MkMacroDocument::default()
+            },
+            None,
+        )
+    }
+
+    #[test]
+    fn only_exact_playable_macro_sound_names_validate() {
+        for sound in crate::sound::SOUND_NAMES {
+            let found = diagnostics(MkAction::PlaySound(MkPlaySoundPayload {
+                sound: (*sound).into(),
+            }));
+            assert_eq!(found.is_empty(), *sound != "None", "{sound}");
+        }
+        for sound in ["", "Unknown.wav", "sounds/Alarm.wav", "alarm.wav"] {
+            let found = diagnostics(MkAction::PlaySound(MkPlaySoundPayload {
+                sound: sound.into(),
+            }));
+            assert_eq!(found.len(), 1, "{sound}");
+            assert_eq!(found[0].code, "invalid_play_sound");
+        }
+    }
+
+    #[test]
+    fn notification_interpolation_diagnostics_identify_the_field() {
+        let found = diagnostics(MkAction::Notify(MkNotifyPayload {
+            title: "${".into(),
+            description: "${}".into(),
+            ..MkNotifyPayload::default()
+        }));
+        assert!(
+            found
+                .iter()
+                .any(|d| d.code == "invalid_notify_title_interpolation"
+                    && d.message.contains("notify.title"))
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.code == "invalid_notify_description_interpolation"
+                    && d.message.contains("notify.description"))
+        );
+        assert!(
+            diagnostics(MkAction::Notify(MkNotifyPayload {
+                title: "Done ${job}".into(),
+                description: "Result $${literal}".into(),
+                ..MkNotifyPayload::default()
+            }))
+            .is_empty()
+        );
     }
 }

--- a/tests/mkmacro_store.rs
+++ b/tests/mkmacro_store.rs
@@ -163,3 +163,79 @@ fn delete_all_is_durable_and_never_falls_back_to_legacy_file() {
     }));
     assert_eq!(fs::read(&legacy_path).unwrap(), legacy_contents);
 }
+
+#[test]
+fn schema_six_is_normalized_without_changing_actions() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(MKMACROS_FILE);
+    let original_actions = serde_json::json!([
+        {"type":"delay","data":{"milliseconds":42}},
+        {"type":"text","data":{"text":"unchanged","mode":"type"}}
+    ]);
+    fs::write(
+        &path,
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 6,
+            "macros": [{
+                "id": 1, "name": "legacy", "steps": [
+                    {"id": 1, "action": original_actions[0]},
+                    {"id": 2, "action": original_actions[1]}
+                ]
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    assert_eq!(store.snapshot().schema_version, 7);
+    let saved: serde_json::Value = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+    let saved_actions: Vec<_> = saved["macros"][0]["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|step| step["action"].clone())
+        .collect();
+    assert_eq!(saved_actions, original_actions.as_array().unwrap().clone());
+}
+
+#[test]
+fn schema_seven_new_actions_survive_store_round_trips() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(MKMACROS_FILE);
+    fs::write(
+        &path,
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 7,
+            "macros": [{"id": 1, "name": "new", "steps": [
+                {"id": 1, "action": {"type": "notify", "data": {
+                    "title": "Ready", "description": "Done", "kind": "success",
+                    "duration": "long", "show_symbol": false
+                }}},
+                {"id": 2, "action": {"type": "play_sound", "data": {"sound": "Alarm.wav"}}}
+            ]}]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let first = (*store.snapshot()).clone();
+    store.save(first.clone()).unwrap();
+    drop(store);
+    let (reloaded, _) = MkMacroStore::open(dir.path()).unwrap();
+    assert_eq!(*reloaded.snapshot(), first);
+}
+
+#[test]
+fn schema_newer_than_seven_is_rejected() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join(MKMACROS_FILE),
+        r#"{"schema_version":8,"macros":[]}"#,
+    )
+    .unwrap();
+    let (store, disposition) = MkMacroStore::open(dir.path()).unwrap();
+    assert!(
+        matches!(disposition, LoadDisposition::NeedsUserRecovery { error } if error.contains("newer than supported version 7"))
+    );
+    assert!(store.snapshot().macros.is_empty());
+}


### PR DESCRIPTION
### Motivation

- Introduce first-class macro notification and sound actions so authoring can persist notification metadata and play packaged sounds. 
- Ensure on-disk compatibility by bumping the macro schema so documents containing the new action tags are not misinterpreted by older (schema-6) builds.
- Provide centralized defaults and validation to avoid duplicated literals in the GUI and catch common authoring errors early.

### Description

- Bumped `SCHEMA_VERSION` from `6` to `7` and updated the inline comment to note that schema-6 builds cannot deserialize the new action tags. (`src/mkmacro/model.rs`)
- Added typed, serializable models `MkNotifyPayload` and `MkPlaySoundPayload` plus enums `MkNotificationKind` and `MkNotificationDuration`, deriving `Debug`, `Clone`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`, and using `#[serde(rename_all = "snake_case")]` on the enums; centralized default values via helper functions and `Default` impls. (`src/mkmacro/model.rs`)
- Added `MkNotificationKind::symbol(&self) -> &str` for cosmetic symbol mapping (Information → `ℹ`, Success → `✓`, Warning → `⚠`, Error → `✕`). (`src/mkmacro/model.rs`)
- Extended the tagged `MkAction` enum with `Notify(MkNotifyPayload)` and `PlaySound(MkPlaySoundPayload)` so their serialized tags are `"type":"notify"` and `"type":"play_sound"`. (`src/mkmacro/model.rs`)
- Kept public availability of the new types via the existing `model` re-export (no changes required in `src/mkmacro/mod.rs` because `pub use model::*;` already exposes them).
- Validation: added interpolation-syntax checks for `notify.title` and `notify.description`, a targeted diagnostic for empty notification title (`empty_notify_title`), and exact/case-sensitive sound-name validation that rejects `"None"` and unknown names with code `invalid_play_sound`. (`src/mkmacro/validation.rs`)
- Store/migration: preserved the generic migration path and acceptance of legacy documents; `read_document` now accepts version `7` and documents read from older schema versions are normalized to `schema_version = 7` on save without semantic action conversion. (`src/mkmacro/store.rs`)
- Executor/runtime: added runtime handling to play sounds via `crate::sound::play_sound` for `PlaySound` actions, and explicit runtime rejection of `Notify` delivery in this runtime with a clear execution diagnostic; updated capability metadata (`has_runtime_support` and `action_name`) accordingly. (`src/mkmacro/executor.rs`)
- Tests: added focused serialization and round-trip tests for the enums/payloads and action tags, validation tests for interpolation and sound-name rules, and store tests that verify schema-6 normalization to schema 7, schema-7 round-trips for new actions, and rejection of documents newer than schema 7. (`src/mkmacro/model.rs`, `src/mkmacro/validation.rs`, `tests/mkmacro_store.rs`)

### Testing

- Ran `cargo fmt --all -- --check`, which passed after formatting changes were applied. 
- Performed a repository scan for lingering schema-6 literals and fixtures; updated/added fixtures where appropriate so only intentional migration tests reference schema 6 (scan passed).
- Ran `cargo check --all-targets`, which could not fully complete on the current Linux environment because several Windows-specific APIs (`windows::Win32::…`) are present in the codebase and cannot be resolved on the build host; this is an environmental/platform limitation rather than a regression in the new model/validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90661f65308332833eae502a1a0560)