### PR TITLE
Add macro notification integration coverage

### DIFF
--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -359,6 +359,65 @@ fn deleting_last_macro_clears_editor_requests_and_persists_empty_document() {
     let (reopened, _) = MkMacroStore::open(dir.path()).unwrap();
     assert!(reopened.snapshot().macros.is_empty());
 }
+
+#[test]
+fn duplicate_save_reload_keeps_independent_notification_payloads() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let store = Arc::new(store);
+    let mut dialog = MkMacroDialog::new(Arc::clone(&store));
+    dialog.create_macro();
+    insert(
+        &mut dialog,
+        MkAction::Notify(MkNotifyPayload {
+            title: "Original".into(),
+            description: "${files_copied} to ${destination}".into(),
+            kind: MkNotificationKind::Warning,
+            duration: MkNotificationDuration::Long,
+            show_symbol: false,
+        }),
+    );
+    insert(
+        &mut dialog,
+        MkAction::PlaySound(MkPlaySoundPayload {
+            sound: "ReminderStart.wav".into(),
+        }),
+    );
+    let original_id = dialog.selected_macro_id.unwrap();
+    dialog.duplicate_selected_macro();
+    let duplicate_id = dialog.selected_macro_id.unwrap();
+    if let MkAction::Notify(payload) = &mut dialog.selected_macro_mut().unwrap().steps[0].action {
+        payload.title = "Duplicate".into();
+    } else {
+        panic!("notify payload dropped")
+    }
+    dialog.save().unwrap();
+    drop(dialog);
+    let (reopened, _) = MkMacroStore::open(dir.path()).unwrap();
+    let document = reopened.snapshot();
+    let original = document
+        .macros
+        .iter()
+        .find(|m| m.id == original_id)
+        .unwrap();
+    let duplicate = document
+        .macros
+        .iter()
+        .find(|m| m.id == duplicate_id)
+        .unwrap();
+    assert!(
+        matches!(&original.steps[0].action, MkAction::Notify(p) if p.title == "Original" && p.kind == MkNotificationKind::Warning && p.duration == MkNotificationDuration::Long && !p.show_symbol)
+    );
+    assert!(
+        matches!(&duplicate.steps[0].action, MkAction::Notify(p) if p.title == "Duplicate" && p.description == "${files_copied} to ${destination}")
+    );
+    assert!(
+        matches!(&original.steps[1].action, MkAction::PlaySound(p) if p.sound == "ReminderStart.wav")
+    );
+    assert!(
+        matches!(&duplicate.steps[1].action, MkAction::PlaySound(p) if p.sound == "ReminderStart.wav")
+    );
+}
 use std::{
     sync::Arc,
     thread,

--- a/tests/mkmacro_runtime.rs
+++ b/tests/mkmacro_runtime.rs
@@ -86,6 +86,135 @@ fn matcher() -> MkWindowMatcher {
     }
 }
 
+fn notification_sequence(policy: MkErrorPolicy) -> MkMacro {
+    let mut notify = s(
+        3,
+        MkAction::Notify(MkNotifyPayload {
+            title: "Backup".into(),
+            description: r"Copied ${files_copied} files to ${destination}".into(),
+            kind: MkNotificationKind::Success,
+            duration: MkNotificationDuration::Long,
+            show_symbol: false,
+        }),
+    );
+    notify.on_error = policy;
+    MkMacro {
+        id: 700,
+        name: "notification sequence".into(),
+        description: String::new(),
+        enabled: true,
+        hotkey: None,
+        playback: Default::default(),
+        steps: vec![
+            s(
+                1,
+                MkAction::SetVariable {
+                    name: "files_copied".into(),
+                    value: MkValue::Number(42.0),
+                },
+            ),
+            s(
+                2,
+                MkAction::SetVariable {
+                    name: "destination".into(),
+                    value: MkValue::String(r"D:\Backup".into()),
+                },
+            ),
+            notify,
+            s(
+                4,
+                MkAction::PlaySound(MkPlaySoundPayload {
+                    sound: "ReminderStart.wav".into(),
+                }),
+            ),
+            s(
+                5,
+                MkAction::Text(MkTextPayload {
+                    text: "final".into(),
+                    mode: MkTextMode::Type,
+                }),
+            ),
+        ],
+        image_assets: vec![],
+    }
+}
+
+fn run_notification_sequence(
+    policy: MkErrorPolicy,
+    fail: bool,
+) -> (RuntimeSnapshot, Arc<FakeBackend>) {
+    let dir = tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let continues = matches!(&policy, MkErrorPolicy::Continue);
+    store
+        .save(MkMacroDocument {
+            schema_version: 7,
+            settings: Default::default(),
+            macros: vec![notification_sequence(policy)],
+        })
+        .unwrap();
+    drop(store);
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    compile(&store.snapshot().macros[0]).unwrap();
+    let fake = Arc::new(FakeBackend::default());
+    if fail {
+        fake.fail(
+            "notification",
+            ExecutionDiagnostic::new(DiagnosticKind::Backend, "fake notification failure"),
+        );
+    }
+    let runtime = MacroRuntime::new(Arc::new(store), fake.clone().backends());
+    assert_eq!(
+        runtime.command(RuntimeCommand::Run(700)),
+        CommandResult::Accepted
+    );
+    let terminal = if fail && !continues {
+        RuntimeState::Failed
+    } else {
+        RuntimeState::Completed
+    };
+    (wait(&runtime, terminal), fake)
+}
+
+#[test]
+fn reopened_notification_and_sound_execute_silently_in_order() {
+    let (snapshot, fake) = run_notification_sequence(MkErrorPolicy::Stop, false);
+    assert!(snapshot.latest_failure.is_none());
+    let notifications = fake.notifications();
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].description.contains("42"));
+    assert!(notifications[0].description.contains(r"D:\Backup"));
+    assert_eq!(fake.sounds(), ["ReminderStart.wav"]);
+    assert_eq!(fake.events(), ["notification", "sound", "text:final"]);
+}
+
+#[test]
+fn notification_error_policies_gate_sound_and_following_action() {
+    let (_, stop) = run_notification_sequence(MkErrorPolicy::Stop, true);
+    assert_eq!(stop.notifications().len(), 1);
+    assert!(stop.sounds().is_empty());
+    assert_eq!(stop.events(), ["notification"]);
+
+    let (_, keep_going) = run_notification_sequence(MkErrorPolicy::Continue, true);
+    assert_eq!(keep_going.notifications().len(), 1);
+    assert_eq!(keep_going.sounds(), ["ReminderStart.wav"]);
+    assert_eq!(keep_going.events(), ["notification", "sound", "text:final"]);
+
+    let (_, retry) = run_notification_sequence(
+        MkErrorPolicy::Retry(MkRetry {
+            attempts: 3,
+            delay_ms: 0,
+        }),
+        true,
+    );
+    assert_eq!(retry.notifications().len(), 3);
+    assert!(retry.sounds().is_empty());
+    assert_eq!(
+        retry.events(),
+        ["notification", "notification", "notification"]
+    );
+}
+
 #[test]
 fn image_find_result_drives_following_mouse_move_without_platform_effects() {
     let d = tempdir().unwrap();

--- a/tests/mkmacro_store.rs
+++ b/tests/mkmacro_store.rs
@@ -223,6 +223,100 @@ fn schema_seven_new_actions_survive_store_round_trips() {
     drop(store);
     let (reloaded, _) = MkMacroStore::open(dir.path()).unwrap();
     assert_eq!(*reloaded.snapshot(), first);
+
+    let structural = serde_json::to_value(reloaded.snapshot().as_ref()).unwrap();
+    assert_eq!(structural["schema_version"], 7);
+    assert_eq!(
+        structural["macros"][0]["steps"][0]["action"]["type"],
+        "notify"
+    );
+    assert_eq!(
+        structural["macros"][0]["steps"][0]["action"]["data"]["kind"],
+        "success"
+    );
+    assert_eq!(
+        structural["macros"][0]["steps"][0]["action"]["data"]["duration"],
+        "long"
+    );
+    assert_eq!(
+        structural["macros"][0]["steps"][1]["action"]["type"],
+        "play_sound"
+    );
+    assert_eq!(
+        structural["macros"][0]["steps"][1]["action"]["data"]["sound"],
+        "Alarm.wav"
+    );
+}
+
+#[test]
+fn schema_seven_notification_sequence_preserves_order_and_payloads() {
+    let dir = tempdir().unwrap();
+    let (store, _) = MkMacroStore::open(dir.path()).unwrap();
+    let actions = vec![
+        MkAction::SetVariable {
+            name: "files_copied".into(),
+            value: MkValue::Number(42.0),
+        },
+        MkAction::SetVariable {
+            name: "destination".into(),
+            value: MkValue::String(r"D:\Backup".into()),
+        },
+        MkAction::Notify(MkNotifyPayload {
+            title: "Backup complete".into(),
+            description: r"Copied ${files_copied} files to ${destination}".into(),
+            kind: MkNotificationKind::Success,
+            duration: MkNotificationDuration::Long,
+            show_symbol: false,
+        }),
+        MkAction::PlaySound(MkPlaySoundPayload {
+            sound: "ReminderStart.wav".into(),
+        }),
+        MkAction::Text(MkTextPayload {
+            text: "observable".into(),
+            mode: MkTextMode::Type,
+        }),
+    ];
+    let steps = actions
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, action)| MkStep {
+            id: i as u64 + 1,
+            enabled: true,
+            repeat: 1,
+            delay_after_ms: 0,
+            on_error: MkErrorPolicy::Stop,
+            action,
+        })
+        .collect();
+    store
+        .save(MkMacroDocument {
+            schema_version: 7,
+            settings: Default::default(),
+            macros: vec![MkMacro {
+                id: 77,
+                name: "backup".into(),
+                description: String::new(),
+                enabled: true,
+                hotkey: None,
+                playback: Default::default(),
+                steps,
+                image_assets: vec![],
+            }],
+        })
+        .unwrap();
+    drop(store);
+    let (reopened, _) = MkMacroStore::open(dir.path()).unwrap();
+    let snapshot = reopened.snapshot();
+    assert_eq!(snapshot.schema_version, 7);
+    assert_eq!(
+        snapshot.macros[0]
+            .steps
+            .iter()
+            .map(|s| &s.action)
+            .collect::<Vec<_>>(),
+        actions.iter().collect::<Vec<_>>()
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Add focused integration tests to exercise schema-7 macros that mix variable assignments, `Notify`, `PlaySound`, and a final observable action to validate save/reload, migration, and runtime behavior without introducing a new harness.
- Ensure structural round-trips and explicit JSON tags/enum spellings catch accidental serde/name regressions for notifications and sounds.
- Verify error-policy semantics (`Stop`, `Continue`, `Retry`) for notification delivery while keeping tests platform-neutral using fake backends.

### Description

- Added structural and round-trip assertions to `tests/mkmacro_store.rs` that check `schema_version == 7`, action ordering, explicit JSON tags (`"type": "notify"`, `"play_sound"`), enum spellings (`"success"`, `"long"`), and exact sound filenames (e.g. `"Alarm.wav"`).
- Added `schema_seven_notification_sequence_preserves_order_and_payloads` in `tests/mkmacro_store.rs` to build a schema-7 macro with `SetVariable`, `Notify`, `PlaySound`, and a final `Text` action and assert the saved/reloaded actions match exactly.
- Added runtime integration tests and helpers to `tests/mkmacro_runtime.rs` (`notification_sequence`, `run_notification_sequence`, `reopened_notification_and_sound_execute_silently_in_order`, `notification_error_policies_gate_sound_and_following_action`) that save, reopen, compile, and execute the macro using `executor::fake::FakeBackend` and assert interpolation, single notification/sound requests, silent `Notify` behavior, ordering (`notification` -> `sound` -> final action), and error-policy effects.
- Added authoring coverage in `tests/mkmacro_authoring.rs` (`duplicate_save_reload_keeps_independent_notification_payloads`) to assert duplicated macros keep independent notification payloads and sound payloads across save/reload.
- All new tests use the existing fake backends (`FakeBackend`) to avoid platform side effects and to make assertions on recorded `notifications()`, `sounds()`, and `events()`.

### Testing

- Ran formatting and repository checks: `cargo fmt --all -- --check` and `git diff --check` which both passed.
- Attempted to run the modified test suites with `cargo test --test mkmacro_store --test mkmacro_runtime --test mkmacro_authoring`, but the build aborted during compilation due to a missing system dependency required by `alsa-sys` (`alsa.pc` not found), so the full test run could not complete in this environment. 
- Local/CI expectation: tests exercise only fake backends and should be fully automated and non-interactive once system development packages (for optional native sound backends) are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9099c40dc08332b23b7896e011d562)