### PR TITLE
Harden clipboard image acquisition diagnostics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ windows = { version = "0.58", features = [
     "Win32_System_WinRT",
     "Win32_UI_Shell",
     "Win32_System_Com",
+    "Win32_System_DataExchange",
     "Win32_System_Variant",
     "Win32_System_Ole",
     "Win32_UI_Accessibility",

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -23,6 +23,7 @@ pub mod mkmacro_dialog;
 mod mouse_gesture_settings_dialog;
 mod mouse_gestures_dialog;
 mod multi_manager_actions;
+mod note_clipboard;
 mod note_graph_dialog;
 pub(crate) mod note_mutation;
 mod note_panel;

--- a/src/gui/note_clipboard.rs
+++ b/src/gui/note_clipboard.rs
@@ -1,0 +1,172 @@
+//! Clipboard image acquisition and Windows-only format diagnostics.
+//!
+//! `arboard` remains the production decoder. Native inspection is diagnostic-only: no
+//! fallback format has yet been justified by Windows smoke-test evidence.
+
+use super::note_panel::ClipboardRgbaData;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClipboardFormatRecord {
+    id: u32,
+    registered_name: Option<Result<String, String>>,
+}
+
+fn predefined_format_name(id: u32) -> Option<&'static str> {
+    match id {
+        1 => Some("CF_TEXT"),
+        2 => Some("CF_BITMAP"),
+        8 => Some("CF_DIB"),
+        13 => Some("CF_UNICODETEXT"),
+        17 => Some("CF_DIBV5"),
+        _ => None,
+    }
+}
+
+/// Pure presentation boundary, independent of Win32 handles and UTF-16 buffers.
+fn format_clipboard_format(record: &ClipboardFormatRecord) -> String {
+    let name = predefined_format_name(record.id)
+        .map(str::to_owned)
+        .or_else(|| match &record.registered_name {
+            Some(Ok(name)) => Some(name.clone()),
+            Some(Err(error)) => Some(format!("<name unavailable: {error}>")),
+            None => None,
+        })
+        .unwrap_or_else(|| "<unknown>".to_owned());
+    format!("{} ({name})", record.id)
+}
+
+pub(super) fn read_clipboard_image() -> Result<Option<ClipboardRgbaData>, String> {
+    let mut clipboard = arboard::Clipboard::new().map_err(|error| {
+        tracing::warn!(stage = "clipboard_construct", error = %error, "note image paste failed");
+        format!("clipboard could not be opened: {error}")
+    })?;
+    match clipboard.get_image() {
+        Ok(image) => Ok(Some(ClipboardRgbaData {
+            width: image.width,
+            height: image.height,
+            bytes: image.bytes.into_owned(),
+        })),
+        Err(arboard::Error::ContentNotAvailable) => {
+            diagnose_formats_after_no_image();
+            Ok(None)
+        }
+        Err(error) => {
+            tracing::warn!(stage = "clipboard_image_decode", error = %error, "note image paste failed");
+            Err(format!("clipboard image could not be decoded: {error}"))
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn diagnose_formats_after_no_image() {}
+
+#[cfg(target_os = "windows")]
+fn diagnose_formats_after_no_image() {
+    match windows_clipboard_formats() {
+        Err(error) => {
+            tracing::debug!(error = %error, "clipboard image format diagnostics unavailable")
+        }
+        Ok(formats) if formats.is_empty() => {
+            tracing::debug!("clipboard formats were enumerated, but none were present")
+        }
+        Ok(formats) => {
+            for format in &formats {
+                tracing::debug!(format = %format_clipboard_format(format), "clipboard format available");
+            }
+            tracing::debug!(
+                format_count = formats.len(),
+                "clipboard formats were present but arboard decoded no image"
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_clipboard_formats() -> Result<Vec<ClipboardFormatRecord>, String> {
+    use windows::Win32::Foundation::{ERROR_SUCCESS, GetLastError, SetLastError};
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EnumClipboardFormats, GetClipboardFormatNameW, OpenClipboard,
+    };
+
+    struct ClipboardGuard;
+    impl ClipboardGuard {
+        fn open() -> Result<Self, String> {
+            // SAFETY: A null owner is supported and Drop pairs every successful open with close.
+            unsafe {
+                OpenClipboard(None).map_err(|e| format!("clipboard could not be opened: {e}"))?
+            };
+            Ok(Self)
+        }
+    }
+    impl Drop for ClipboardGuard {
+        fn drop(&mut self) {
+            // SAFETY: the guard is constructed only after OpenClipboard succeeds.
+            unsafe {
+                let _ = CloseClipboard();
+            }
+        }
+    }
+
+    let _guard = ClipboardGuard::open()?;
+    let mut records = Vec::new();
+    let mut current = 0;
+    loop {
+        // Zero means either exhaustion or failure, so clear last-error before enumeration.
+        unsafe { SetLastError(ERROR_SUCCESS) };
+        // SAFETY: clipboard is open and current is zero or an ID returned by this API.
+        let next = unsafe { EnumClipboardFormats(current) };
+        if next == 0 {
+            let error = unsafe { GetLastError() };
+            if error != ERROR_SUCCESS {
+                return Err(format!(
+                    "clipboard formats could not be enumerated: {error:?}"
+                ));
+            }
+            break;
+        }
+        current = next;
+        let registered_name = if next >= 0xC000 {
+            let mut buffer = [0_u16; 256];
+            // SAFETY: buffer is valid and writable for its declared length.
+            let length = unsafe { GetClipboardFormatNameW(next, &mut buffer) };
+            if length > 0 {
+                Some(String::from_utf16(&buffer[..length as usize]).map_err(|e| e.to_string()))
+            } else {
+                Some(Err(format!(
+                    "GetClipboardFormatNameW failed: {:?}",
+                    unsafe { GetLastError() }
+                )))
+            }
+        } else {
+            None
+        };
+        records.push(ClipboardFormatRecord {
+            id: next,
+            registered_name,
+        });
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_predefined_registered_unknown_and_failed_names() {
+        let formatted = |id, registered_name| {
+            format_clipboard_format(&ClipboardFormatRecord {
+                id,
+                registered_name,
+            })
+        };
+        assert_eq!(formatted(8, None), "8 (CF_DIB)");
+        assert_eq!(formatted(17, None), "17 (CF_DIBV5)");
+        assert_eq!(formatted(49_152, Some(Ok("PNG".into()))), "49152 (PNG)");
+        assert_eq!(formatted(42, None), "42 (<unknown>)");
+        assert_eq!(
+            formatted(49_153, Some(Err("invalid UTF-16".into()))),
+            "49153 (<name unavailable: invalid UTF-16>)"
+        );
+    }
+}

--- a/src/gui/note_panel.rs
+++ b/src/gui/note_panel.rs
@@ -18,7 +18,6 @@ use crate::plugins::note::{
 use crate::plugins::todo::{TODO_FILE, load_todos, todo_version};
 use crate::process::configure_background_command;
 use crate::settings::{NoteSettings, NoteViewMode};
-use arboard::Clipboard;
 use chrono::{DateTime, Local, TimeZone};
 use eframe::egui::{self, Color32, FontId, Key, RichText, popup};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
@@ -44,10 +43,10 @@ const HEAVY_RECOMPUTE_IDLE_DEBOUNCE: Duration = Duration::from_millis(250);
 const NOTE_LINK_CONTEXT_MENU_RESULT_LIMIT: usize = 50;
 
 #[derive(Debug)]
-struct ClipboardRgbaData {
-    width: usize,
-    height: usize,
-    bytes: Vec<u8>,
+pub(super) struct ClipboardRgbaData {
+    pub(super) width: usize,
+    pub(super) height: usize,
+    pub(super) bytes: Vec<u8>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2675,21 +2674,7 @@ impl NotePanel {
             text_id_source,
             available_size,
             move || native_edge,
-            || {
-                let mut clipboard = Clipboard::new().map_err(|error| {
-                    tracing::warn!(stage = "clipboard_open", error = %error, "note image paste failed");
-                    format!("could not open the clipboard: {error}")
-                })?;
-                match clipboard.get_image() {
-                    Ok(image) => Ok(Some(ClipboardRgbaData {
-                        width: image.width,
-                        height: image.height,
-                        bytes: image.bytes.into_owned(),
-                    })),
-                    Err(arboard::Error::ContentNotAvailable) => Ok(None),
-                    Err(error) => Err(format!("could not read a clipboard image: {error}")),
-                }
-            },
+            crate::gui::note_clipboard::read_clipboard_image,
             save_note_image_asset,
         )
     }


### PR DESCRIPTION
### Motivation

- Improve robustness and observability of image paste handling by extracting the inline clipboard image lookup into a focused helper and classifying failure modes. 
- Provide Windows-only, diagnostic enumeration of clipboard formats when `arboard` reports `ContentNotAvailable` so real sources (Snipping Tool / browsers) can be inspected before adding any fallback. 
- Preserve the existing `arboard` path as the primary production decoder and avoid introducing a platform fallback until smoke tests justify it.

### Description

- Extracted the production clipboard lookup into `pub(super) fn read_clipboard_image()` in `src/gui/note_clipboard.rs`, keeping `arboard::Clipboard::get_image()` as the first attempt and returning `Result<Option<ClipboardRgbaData>, String>`.
- Added Windows-only diagnostics: an RAII `ClipboardGuard` around `OpenClipboard`/`CloseClipboard`, enumeration with `EnumClipboardFormats`, and registered-name resolution via `GetClipboardFormatNameW`, and a pure helper `format_clipboard_format` to present records.
- Kept platform-specific code behind `#[cfg(target_os = "windows")]`, added unit tests covering predefined format labels, registered names, unknown numeric formats, and failed name decoding, and preserved non-fatal behavior for text-only paste.
- Updated call sites and visibility: `NotePanel` now calls `crate::gui::note_clipboard::read_clipboard_image`, `ClipboardRgbaData` fields are `pub(super)` to allow the helper, `mod note_clipboard` was added to `src/gui/mod.rs`, and `Cargo.toml` now enables the `Win32_System_DataExchange` feature required for the Win32 APIs.

### Testing

- Ran `cargo fmt --check` and formatting check passed.
- Ran `cargo check --target x86_64-pc-windows-gnu --lib` to validate Windows-target compilation and it completed successfully in this environment.
- Verified `git diff --check` (no whitespace/format issues) completed successfully.
- Attempted `cargo test note_clipboard --lib`, but tests could not be executed to completion on this Linux host because the repository contains unconditional Windows imports and Windows-only APIs that prevent running the Windows-target unit test harness here; the pure formatting/classification helper is unit-tested in-code and the tests are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90acca625c83329b18cb5901212623)