### PR TITLE
Add shared image asset picker and thumbnail preview for condition editors

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1615,6 +1615,7 @@ fn action_ui(
     step: &mut MkStep,
     capture: &mut bool,
     image_assets: &[MkImageAsset],
+    image_context: super::image_asset_picker::ImageAssetUiContext<'_>,
     draft_generation: u64,
 ) -> (
     Option<PositionCaptureSlot>,
@@ -2049,7 +2050,7 @@ fn action_ui(
         }
         MkAction::If(condition) | MkAction::WhileStart { condition } => {
             if let Some(request) =
-                super::condition_editor::condition_ui_with_assets(ui, condition, image_assets)
+                super::condition_editor::condition_ui_with_context(ui, condition, image_context)
             {
                 match request {
                     super::condition_editor::ConditionEditorRequest::WindowMatcher { path } => {
@@ -2064,7 +2065,7 @@ fn action_ui(
         }
         MkAction::WaitUntil { condition, wait } => {
             if let Some(request) =
-                super::condition_editor::condition_ui_with_assets(ui, condition, image_assets)
+                super::condition_editor::condition_ui_with_context(ui, condition, image_context)
             {
                 match request {
                     super::condition_editor::ConditionEditorRequest::WindowMatcher { path } => {
@@ -2803,7 +2804,12 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
             let editor = state.editor.expect("action editor draft has no editor strategy");
             assert!(super::action_catalog::editor_route_recognizes(&step.action, editor), "action editor strategy does not match draft action");
             let action_before = step.action.clone();
-            let (position, mut window, launcher, image, condition_image, preview)=action_ui(ui, step, &mut state.capture_keys, &image_assets, draft_generation);
+            let image_context = super::image_asset_picker::ImageAssetUiContext {
+                macro_id: d.selected_macro_id.unwrap_or(0),
+                assets: &image_assets,
+                store: &d.store,
+            };
+            let (position, mut window, launcher, image, condition_image, preview)=action_ui(ui, step, &mut state.capture_keys, &image_assets, image_context, draft_generation);
             if step.action != action_before { state.draft_changed = true; }
             pick_request = position;
             image_request = image;

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -1,6 +1,7 @@
 //! Recursive editor and pure mutation operations for macro conditions.
 
 use super::action_editor::{matcher_ui, target_ui, value_ui};
+use super::image_asset_picker::ImageAssetUiContext;
 use crate::mkmacro::variables::{MkPoint, MkValue};
 use crate::mkmacro::{
     AlphaPolicy, MkCompareOp, MkCondition, MkCoordinateTarget, MkImageAsset,
@@ -360,6 +361,128 @@ pub fn condition_ui_with_assets(
         }
     });
     requested
+}
+
+/// Condition editor used by the action dialog. The active macro context is
+/// passed unchanged through the whole condition tree.
+pub fn condition_ui_with_context(
+    ui: &mut egui::Ui,
+    condition: &mut MkCondition,
+    context: ImageAssetUiContext<'_>,
+) -> Option<ConditionEditorRequest> {
+    condition_ui_context_at(ui, condition, context, &ConditionPath::root())
+}
+
+fn condition_ui_context_at(
+    ui: &mut egui::Ui,
+    condition: &mut MkCondition,
+    context: ImageAssetUiContext<'_>,
+    path: &ConditionPath,
+) -> Option<ConditionEditorRequest> {
+    // The established editor handles all non-browser controls and request
+    // routing. Temporarily rendering ImageSearch ourselves avoids maintaining
+    // a second asset selector while leaving its capture controls untouched.
+    if let MkCondition::ImageSearch { search, found } = condition {
+        let mut requested = None;
+        ui.group(|ui| {
+            egui::ComboBox::from_label("Condition type")
+                .selected_text(kind_label(ConditionKind::ImageSearch))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut ConditionKind::ImageSearch,
+                        ConditionKind::ImageSearch,
+                        kind_label(ConditionKind::ImageSearch),
+                    );
+                });
+            super::image_asset_picker::show(ui, path.indexes(), context, &mut search.asset_id);
+            if let Some(operation) = super::image_search_controls::show_shared_fields(
+                ui,
+                &mut search.asset_id,
+                &mut search.region,
+                &mut search.tolerance,
+                &mut search.alpha,
+                &mut search.return_point,
+                context.assets,
+            ) {
+                use super::image_search_controls::SharedImageOperation as S;
+                use ConditionImageOperation as O;
+                let operation = match operation {
+                    S::ImportPng => O::ImportPng,
+                    S::CaptureRectangle => O::CaptureRectangle,
+                    S::PickRectangle => O::PickRectangle,
+                    S::PreviewRectangle => O::PreviewRectangle,
+                    S::HighlightMonitor => O::HighlightMonitor,
+                    S::PickWindow => O::PickWindow,
+                    S::HighlightWindow => O::HighlightWindow,
+                };
+                requested = Some(ConditionEditorRequest::Image(ConditionImageRequest {
+                    path: path.clone(),
+                    operation,
+                }));
+            }
+            egui::ComboBox::from_label("Expected")
+                .selected_text(if *found { "Found" } else { "Not Found" })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(found, true, "Found");
+                    ui.selectable_value(found, false, "Not found");
+                });
+        });
+        return requested;
+    }
+    // Recursive containers need the context-aware path before their child is
+    // rendered, both for request routing and stable per-node picker state.
+    match condition {
+        MkCondition::All { conditions } => {
+            let mut request = None;
+            for (index, child) in conditions.iter_mut().enumerate() {
+                let branch = ConditionBranch::All(index);
+                let mut child_path = path.clone();
+                child_path.push(branch);
+                ui.indent(index, |ui| {
+                    if let Some(r) = condition_ui_context_at(ui, child, context, &child_path) {
+                        request = Some(r);
+                    }
+                });
+            }
+            if ui.button("+ Add Condition").clicked() {
+                conditions.push(default_condition(ConditionKind::Variable));
+            }
+            request
+        }
+        MkCondition::Any { conditions } => {
+            let mut request = None;
+            for (index, child) in conditions.iter_mut().enumerate() {
+                let mut child_path = path.clone();
+                child_path.push(ConditionBranch::Any(index));
+                ui.indent(index, |ui| {
+                    if let Some(r) = condition_ui_context_at(ui, child, context, &child_path) {
+                        request = Some(r);
+                    }
+                });
+            }
+            if ui.button("+ Add Condition").clicked() {
+                conditions.push(default_condition(ConditionKind::Variable));
+            }
+            request
+        }
+        MkCondition::Not { condition } => {
+            let mut child_path = path.clone();
+            child_path.push(ConditionBranch::Not);
+            ui.indent("not-child", |ui| {
+                condition_ui_context_at(ui, condition, context, &child_path)
+            })
+            .inner
+        }
+        _ => condition_ui_with_assets(ui, condition, context.assets).map(|mut request| {
+            match &mut request {
+                ConditionEditorRequest::WindowMatcher { path: p }
+                | ConditionEditorRequest::Image(ConditionImageRequest { path: p, .. }) => {
+                    *p = path.clone()
+                }
+            }
+            request
+        }),
+    }
 }
 fn group_ui(
     ui: &mut egui::Ui,

--- a/src/gui/mkmacro_dialog/image_asset_picker.rs
+++ b/src/gui/mkmacro_dialog/image_asset_picker.rs
@@ -1,0 +1,195 @@
+//! Shared, searchable browser for image assets owned by the active macro.
+
+use crate::mkmacro::{MkImageAsset, MkMacroStore};
+use eframe::egui;
+use std::path::Path;
+
+/// Everything the picker may inspect. Callers must pass the complete asset
+/// collection of `macro_id`; the picker deliberately never queries other macros.
+#[derive(Clone, Copy)]
+pub struct ImageAssetUiContext<'a> {
+    pub macro_id: u64,
+    pub assets: &'a [MkImageAsset],
+    pub store: &'a MkMacroStore,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImageAssetSelection {
+    pub asset_id: u64,
+}
+
+pub fn asset_filename(asset: &MkImageAsset) -> &str {
+    Path::new(&asset.relative_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&asset.relative_path)
+}
+
+/// Filters without reordering: document/source order is the deterministic UI order.
+pub fn filtered_assets<'a>(assets: &'a [MkImageAsset], query: &str) -> Vec<&'a MkImageAsset> {
+    let query = query.trim().to_lowercase();
+    assets
+        .iter()
+        .filter(|asset| {
+            query.is_empty()
+                || asset.name.to_lowercase().contains(&query)
+                || asset_filename(asset).to_lowercase().contains(&query)
+                || asset.id.to_string().contains(&query)
+        })
+        .collect()
+}
+
+pub fn selected_asset<'a>(assets: &'a [MkImageAsset], asset_id: u64) -> Option<&'a MkImageAsset> {
+    assets.iter().find(|asset| asset.id == asset_id)
+}
+
+/// Render a picker whose persistent state is isolated by `editor_id`.
+pub fn show(
+    ui: &mut egui::Ui,
+    editor_id: impl std::hash::Hash,
+    context: ImageAssetUiContext<'_>,
+    asset_id: &mut u64,
+) -> Option<ImageAssetSelection> {
+    let id = ui.make_persistent_id(("image-asset-picker", editor_id));
+    ui.label("Reference Image");
+    let mut query = ui
+        .ctx()
+        .data_mut(|data| data.get_temp::<String>(id).unwrap_or_default());
+    let search = ui.add(
+        egui::TextEdit::singleline(&mut query)
+            .hint_text("Search assets...")
+            .id_source(id.with("search")),
+    );
+    search.widget_info(|| egui::WidgetInfo::text_edit("", "Search image assets"));
+    ui.ctx()
+        .data_mut(|data| data.insert_temp(id, query.clone()));
+
+    if *asset_id != 0 && selected_asset(context.assets, *asset_id).is_none() {
+        ui.colored_label(
+            ui.visuals().warn_fg_color,
+            format!("Missing asset · ID {}", *asset_id),
+        );
+    }
+    let matches = filtered_assets(context.assets, &query);
+    let mut selection = None;
+    egui::ScrollArea::vertical()
+        .id_source(id.with("scroll"))
+        .max_height(230.0)
+        .auto_shrink([false, true])
+        .show(ui, |ui| {
+            if context.assets.is_empty() {
+                ui.weak(
+                    "No image assets belong to this macro. Select PNG… or Capture… to add one.",
+                );
+            } else if matches.is_empty() {
+                ui.weak("No image assets match this search.");
+            }
+            for asset in matches {
+                let selected = *asset_id == asset.id;
+                let fill = if selected {
+                    ui.visuals().selection.bg_fill
+                } else {
+                    egui::Color32::TRANSPARENT
+                };
+                let row = egui::Frame::none()
+                    .fill(fill)
+                    .inner_margin(egui::Margin::same(4.0))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            super::image_preview::show_thumbnail(
+                                ui,
+                                context.store,
+                                context.macro_id,
+                                asset.id,
+                                56.0,
+                            );
+                            ui.vertical(|ui| {
+                                ui.strong(if asset.name.is_empty() {
+                                    asset_filename(asset)
+                                } else {
+                                    &asset.name
+                                });
+                                ui.small(asset_filename(asset));
+                                ui.small(format!("ID {}", asset.id));
+                            });
+                        });
+                    });
+                let response = ui.interact(
+                    row.response.rect,
+                    id.with(("row", asset.id)),
+                    egui::Sense::click(),
+                );
+                response.widget_info(|| {
+                    egui::WidgetInfo::selected(
+                        egui::WidgetType::SelectableLabel,
+                        selected,
+                        format!("{}; {}; ID {}", asset.name, asset_filename(asset), asset.id),
+                    )
+                });
+                if response.clicked() {
+                    *asset_id = asset.id;
+                    selection = Some(ImageAssetSelection { asset_id: asset.id });
+                }
+            }
+        });
+    selection
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn asset(id: u64, name: &str, file: &str) -> MkImageAsset {
+        MkImageAsset {
+            id,
+            name: name.into(),
+            relative_path: file.into(),
+        }
+    }
+
+    #[test]
+    fn filtering_covers_names_files_ids_case_whitespace_and_empty() {
+        let assets = vec![
+            asset(42, "Login Button", "m/LOGIN.png"),
+            asset(7, "Other", "m/cat.png"),
+        ];
+        assert_eq!(filtered_assets(&assets, " login ")[0].id, 42);
+        assert_eq!(filtered_assets(&assets, "CAT")[0].id, 7);
+        assert_eq!(filtered_assets(&assets, " 42 ")[0].id, 42);
+        assert!(filtered_assets(&assets, "missing").is_empty());
+        assert_eq!(
+            filtered_assets(&assets, "")
+                .iter()
+                .map(|a| a.id)
+                .collect::<Vec<_>>(),
+            vec![42, 7]
+        );
+        assert_eq!(filtered_assets(&assets, "   ").len(), 2);
+    }
+
+    #[test]
+    fn source_list_is_complete_and_deterministically_ordered() {
+        let assets = vec![asset(9, "Unused", "9.png"), asset(2, "Used", "2.png")];
+        assert_eq!(
+            filtered_assets(&assets, "")
+                .iter()
+                .map(|a| a.id)
+                .collect::<Vec<_>>(),
+            vec![9, 2]
+        );
+    }
+
+    #[test]
+    fn selected_and_missing_lookup_are_explicit() {
+        let assets = vec![asset(3, "Three", "3.png")];
+        assert_eq!(selected_asset(&assets, 3).unwrap().id, 3);
+        assert!(selected_asset(&assets, 99).is_none());
+    }
+
+    #[test]
+    fn selection_event_updates_only_the_passed_value() {
+        let mut selected = 4;
+        let event = ImageAssetSelection { asset_id: 8 };
+        selected = event.asset_id;
+        assert_eq!(selected, 8);
+    }
+}

--- a/src/gui/mkmacro_dialog/image_authoring_destination.rs
+++ b/src/gui/mkmacro_dialog/image_authoring_destination.rs
@@ -42,6 +42,9 @@ impl ConditionPath {
     pub(crate) fn prepend(&mut self, branch: ConditionBranch) {
         self.0.insert(0, branch);
     }
+    pub(crate) fn push(&mut self, branch: ConditionBranch) {
+        self.0.push(branch);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/gui/mkmacro_dialog/image_preview.rs
+++ b/src/gui/mkmacro_dialog/image_preview.rs
@@ -254,6 +254,30 @@ fn inspect_cache(
 }
 
 pub fn show(ui: &mut egui::Ui, store: &MkMacroStore, macro_id: u64, asset_id: u64) {
+    show_sized(ui, store, macro_id, asset_id, PREVIEW_BOUND, true);
+}
+
+/// A compact view backed by the exact same asynchronous decode and texture
+/// cache as [`show`]. The decoded pixels are never recreated merely because a
+/// caller requests a different logical display size.
+pub fn show_thumbnail(
+    ui: &mut egui::Ui,
+    store: &MkMacroStore,
+    macro_id: u64,
+    asset_id: u64,
+    max_size: f32,
+) {
+    show_sized(ui, store, macro_id, asset_id, max_size.max(1.0), false);
+}
+
+fn show_sized(
+    ui: &mut egui::Ui,
+    store: &MkMacroStore,
+    macro_id: u64,
+    asset_id: u64,
+    bound: f32,
+    details: bool,
+) {
     let Ok(path) = store.asset_path(macro_id, asset_id) else {
         ui.colored_label(egui::Color32::RED, "No reference image selected");
         return;
@@ -301,22 +325,32 @@ pub fn show(ui: &mut egui::Ui, store: &MkMacroStore, macro_id: u64, asset_id: u6
     if let Some(ready) = uploaded_ready.or(inspection.ready) {
         ui.image((
             ready.texture.id(),
-            egui::vec2(
-                ready.thumbnail_size[0] as f32,
-                ready.thumbnail_size[1] as f32,
-            ),
+            fitted_size(ready.width, ready.height, bound),
         ));
-        ui.label(format!(
-            "{} — {} × {} px",
-            path.file_name().unwrap_or_default().to_string_lossy(),
-            ready.width,
-            ready.height
-        ));
-        ui.small(format!("Asset ID {asset_id}"));
+        if details {
+            ui.label(format!(
+                "{} — {} × {} px",
+                path.file_name().unwrap_or_default().to_string_lossy(),
+                ready.width,
+                ready.height
+            ));
+            ui.small(format!("Asset ID {asset_id}"));
+        }
     } else if let Some(error) = inspection.failed {
-        ui.colored_label(egui::Color32::RED, format!("{error} (asset {asset_id})"));
+        ui.colored_label(
+            egui::Color32::RED,
+            if details {
+                format!("{error} (asset {asset_id})")
+            } else {
+                "Unavailable".into()
+            },
+        );
     } else {
-        ui.small("Loading reference image preview...");
+        ui.small(if details {
+            "Loading reference image preview..."
+        } else {
+            "Loading…"
+        });
     }
 }
 

--- a/src/gui/mkmacro_dialog/image_search_controls.rs
+++ b/src/gui/mkmacro_dialog/image_search_controls.rs
@@ -221,7 +221,7 @@ pub fn show_shared_fields(
     tolerance: &mut u8,
     alpha: &mut AlphaPolicy,
     return_point: &mut ReturnPoint,
-    assets: &[crate::mkmacro::MkImageAsset],
+    _assets: &[crate::mkmacro::MkImageAsset],
 ) -> Option<SharedImageOperation> {
     let mut request = None;
     ui.heading("Reference Image");
@@ -233,17 +233,6 @@ pub fn show_shared_fields(
             request = Some(SharedImageOperation::CaptureRectangle)
         }
     });
-    egui::ComboBox::from_label("Reference image")
-        .selected_text(super::action_editor::image_asset_label(*asset_id, assets))
-        .show_ui(ui, |ui| {
-            for asset in assets {
-                ui.selectable_value(
-                    asset_id,
-                    asset.id,
-                    super::action_editor::image_asset_label(asset.id, assets),
-                );
-            }
-        });
     ui.add(egui::Slider::new(tolerance, 0..=255).text("Tolerance"));
     egui::ComboBox::from_label("Alpha handling")
         .selected_text(format!("{alpha:?}"))

--- a/src/gui/mkmacro_dialog/mod.rs
+++ b/src/gui/mkmacro_dialog/mod.rs
@@ -1,6 +1,7 @@
 pub mod action_catalog;
 pub mod action_editor;
 pub mod condition_editor;
+pub mod image_asset_picker;
 pub mod image_authoring_destination;
 pub mod image_authoring_job;
 pub mod image_preview;


### PR DESCRIPTION
### Motivation
- Provide a single, reusable image-asset browser used by image-search conditions instead of multiple ad-hoc selectors. 
- Keep asset browsing scoped to the active macro and make picker state (search, scroll, selection) stable across egui frames and nested condition renderings. 
- Reuse the existing asynchronous decode/cache image pipeline for compact thumbnails to avoid expensive synchronous decoding every frame.

### Description
- Add a new `src/gui/mkmacro_dialog/image_asset_picker.rs` with `ImageAssetUiContext<'a>`, `ImageAssetSelection`, `filtered_assets`, `selected_asset`, and `show` picker UI API that renders thumbnail, name, filename, and `ID N` rows and updates `asset_id` immediately on selection. 
- Export the picker from `src/gui/mkmacro_dialog/mod.rs` and thread `ImageAssetUiContext` through the editors by adding `condition_ui_with_context` in `condition_editor.rs` and updating `action_editor.rs` to construct and pass the context to recursive condition rendering. 
- Add a compact thumbnail entry point `show_thumbnail` (and internal `show_sized`) in `image_preview.rs` that reuses the existing async decode + texture cache, preserves aspect ratio via `fitted_size`, bounds dimensions, and shows stable loading/unavailable/error states. 
- Replace the inline ComboBox-based asset selector in `image_search_controls::show_shared_fields` (it no longer queries assets directly) and ensure missing asset IDs are reported as `Missing asset · ID N` without invoking thumbnail rendering. 
- Add deterministic, case-insensitive filtering logic and unit tests for the picker behavior and selection semantics, and add a small `ConditionPath::push` helper used by typed condition paths.

### Testing
- Ran formatting check with `cargo fmt --all -- --check`, which succeeded. 
- Ran repository checks with `git diff --check`, which succeeded. 
- Ran `cargo check`, which did not complete to a successful build in this environment because native platform dependencies and unconditional Windows API imports in the application crate prevented completion; attempts to install missing Linux native libs resolved some native errors but the build then failed on platform-specific `windows::Win32` symbols, so unit tests included in the new picker were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90d460997483328b0e76a27c3f64e0)