### PR TITLE
Refactor target editing to use TargetEditorContext and add bounded image-result thumbnails

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1705,7 +1705,6 @@ fn action_ui(
     ui: &mut egui::Ui,
     step: &mut MkStep,
     capture: &mut bool,
-    image_assets: &[MkImageAsset],
     image_context: super::image_asset_picker::ImageAssetUiContext<'_>,
     draft_generation: u64,
 ) -> (
@@ -2861,7 +2860,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 assets: &image_assets,
                 store: &d.store,
             };
-            let (position, mut window, launcher, image, condition_image, preview)=action_ui(ui, step, &mut state.capture_keys, &image_assets, image_context, draft_generation);
+            let (position, mut window, launcher, image, condition_image, preview)=action_ui(ui, step, &mut state.capture_keys, image_context, draft_generation);
             if step.action != action_before { state.draft_changed = true; }
             pick_request = position;
             image_request = image;

--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1472,11 +1472,31 @@ pub(crate) fn change_target_kind(
     };
 }
 
+/// Immutable document state shared by every coordinate-target editor.
+///
+/// Keeping this separate from the mutable target makes it impossible for the
+/// widget to silently repair (or replace) a dangling asset reference.
+#[derive(Clone, Copy)]
+pub(super) struct TargetEditorContext<'a> {
+    pub macro_id: u64,
+    pub assets: &'a [MkImageAsset],
+    pub store: &'a MkMacroStore,
+}
+
+impl<'a> TargetEditorContext<'a> {
+    pub(super) fn resolve_asset(&self, asset_id: u64) -> Option<&'a MkImageAsset> {
+        (asset_id != 0)
+            .then(|| self.assets.iter().find(|asset| asset.id == asset_id))
+            .flatten()
+    }
+}
+
 pub(super) fn target_ui(
     ui: &mut egui::Ui,
     target: &mut MkCoordinateTarget,
-    assets: &[MkImageAsset],
+    context: &TargetEditorContext<'_>,
 ) -> TargetUiOutcome {
+    let assets = context.assets;
     let kind = match target {
         MkCoordinateTarget::Screen { .. } => 0,
         MkCoordinateTarget::ActiveWindow { .. } => 1,
@@ -1575,6 +1595,24 @@ pub(super) fn target_ui(
                             }
                         }
                     });
+            }
+            ui.label("Reference/result image:");
+            if *asset_id == 0 {
+                ui.weak("No image result selected");
+            } else if context.resolve_asset(*asset_id).is_some() {
+                super::image_preview::show_thumbnail(
+                    ui,
+                    context.store,
+                    context.macro_id,
+                    *asset_id,
+                    super::image_preview::TARGET_THUMBNAIL_BOUND,
+                );
+                ui.weak("Visual reference for the selected image-search result; Mouse Move does not run a new search.");
+            } else {
+                ui.colored_label(
+                    ui.visuals().warn_fg_color,
+                    format!("Missing asset · ID {}", *asset_id),
+                );
             }
             ui.heading("Offset");
             ui.horizontal(|ui| {
@@ -1678,6 +1716,11 @@ fn action_ui(
     Option<super::condition_editor::ConditionImageRequest>,
     Option<PreviewRequest>,
 ) {
+    let target_context = TargetEditorContext {
+        macro_id: image_context.macro_id,
+        assets: image_context.assets,
+        store: image_context.store,
+    };
     let mut pick = None;
     let mut window_pick = None;
     let mut launcher_pick = None;
@@ -1783,7 +1826,7 @@ fn action_ui(
             }
         }
         MkAction::MouseMove(p) => {
-            let response = target_ui(ui, &mut p.target, image_assets);
+            let response = target_ui(ui, &mut p.target, &target_context);
             if response.pick_position {
                 pick = Some(PositionCaptureSlot::MoveTarget);
             }
@@ -1813,7 +1856,7 @@ fn action_ui(
         }
         MkAction::MouseDrag(p) => {
             ui.label("Start");
-            let response = target_ui(ui, &mut p.from, image_assets);
+            let response = target_ui(ui, &mut p.from, &target_context);
             if response.pick_position {
                 pick = Some(PositionCaptureSlot::DragFrom);
             }
@@ -1823,7 +1866,7 @@ fn action_ui(
                 ));
             }
             ui.label("Destination");
-            let response = target_ui(ui, &mut p.to, image_assets);
+            let response = target_ui(ui, &mut p.to, &target_context);
             if response.pick_position {
                 pick = Some(PositionCaptureSlot::DragTo);
             }
@@ -1851,7 +1894,7 @@ fn action_ui(
             });
         }
         MkAction::MouseClick(p) => {
-            let response = target_ui(ui, &mut p.target, image_assets);
+            let response = target_ui(ui, &mut p.target, &target_context);
             if response.pick_position {
                 pick = Some(PositionCaptureSlot::ClickTarget);
             }
@@ -2402,7 +2445,7 @@ fn action_ui(
             tolerance,
         } => {
             ui.heading("Coordinate");
-            let response = target_ui(ui, target, image_assets);
+            let response = target_ui(ui, target, &target_context);
             if response.pick_position {
                 pick = Some(PositionCaptureSlot::PixelPosition);
             }
@@ -3173,6 +3216,26 @@ mod tests {
     use image::RgbaImage;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn target_context_resolves_only_nonzero_current_macro_assets() {
+        let directory = tempfile::tempdir().unwrap();
+        let (store, _) = MkMacroStore::open(directory.path()).unwrap();
+        let assets = vec![MkImageAsset {
+            id: 14,
+            name: "needle".into(),
+            relative_path: "mkmacro_assets/7/14.png".into(),
+        }];
+        let context = TargetEditorContext {
+            macro_id: 7,
+            assets: &assets,
+            store: &store,
+        };
+
+        assert_eq!(context.resolve_asset(14).map(|asset| asset.id), Some(14));
+        assert!(context.resolve_asset(0).is_none());
+        assert!(context.resolve_asset(99).is_none());
+    }
 
     struct TestDesktop;
     impl ScreenCaptureBackend for TestDesktop {

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -1,6 +1,6 @@
 //! Recursive editor and pure mutation operations for macro conditions.
 
-use super::action_editor::{matcher_ui, target_ui, value_ui};
+use super::action_editor::{TargetEditorContext, matcher_ui, target_ui, value_ui};
 use super::image_asset_picker::ImageAssetUiContext;
 use crate::mkmacro::variables::{MkPoint, MkValue};
 use crate::mkmacro::{
@@ -178,13 +178,6 @@ pub fn remove_child(c: &mut MkCondition, index: usize) -> bool {
     }
 }
 
-pub fn condition_ui(
-    ui: &mut egui::Ui,
-    condition: &mut MkCondition,
-) -> Option<ConditionEditorRequest> {
-    condition_ui_with_assets(ui, condition, &[])
-}
-
 /// Resolves the same recursive path shape returned by `condition_ui` when the
 /// picker button for the first window condition is requested. Kept private to
 /// the dialog module so routing tests do not expose editor internals publicly.
@@ -214,8 +207,9 @@ pub(super) fn first_window_picker_path(condition: &MkCondition) -> Option<Vec<us
 pub fn condition_ui_with_assets(
     ui: &mut egui::Ui,
     condition: &mut MkCondition,
-    assets: &[MkImageAsset],
+    context: &TargetEditorContext<'_>,
 ) -> Option<ConditionEditorRequest> {
+    let assets = context.assets;
     let mut requested = None;
     ui.group(|ui| {
         let kind = condition_kind(condition);
@@ -340,7 +334,7 @@ pub fn condition_ui_with_assets(
                 color,
                 tolerance,
             } => {
-                let _ = target_ui(ui, target, assets);
+                let _ = target_ui(ui, target, context);
                 ui.horizontal(|ui| {
                     ui.label("Color");
                     ui.text_edit_singleline(color);
@@ -348,11 +342,11 @@ pub fn condition_ui_with_assets(
                     ui.add(egui::DragValue::new(tolerance));
                 });
             }
-            MkCondition::All { conditions } => requested = group_ui(ui, conditions, assets, true),
-            MkCondition::Any { conditions } => requested = group_ui(ui, conditions, assets, false),
+            MkCondition::All { conditions } => requested = group_ui(ui, conditions, context, true),
+            MkCondition::Any { conditions } => requested = group_ui(ui, conditions, context, false),
             MkCondition::Not { condition } => {
                 ui.indent("not-child", |ui| {
-                    if let Some(mut request) = condition_ui_with_assets(ui, condition, assets) {
+                    if let Some(mut request) = condition_ui_with_assets(ui, condition, context) {
                         prepend_request(&mut request, ConditionBranch::Not);
                         requested = Some(request)
                     }
@@ -370,13 +364,25 @@ pub fn condition_ui_with_context(
     condition: &mut MkCondition,
     context: ImageAssetUiContext<'_>,
 ) -> Option<ConditionEditorRequest> {
-    condition_ui_context_at(ui, condition, context, &ConditionPath::root())
+    let target_context = TargetEditorContext {
+        macro_id: context.macro_id,
+        assets: context.assets,
+        store: context.store,
+    };
+    condition_ui_context_at(
+        ui,
+        condition,
+        context,
+        &target_context,
+        &ConditionPath::root(),
+    )
 }
 
 fn condition_ui_context_at(
     ui: &mut egui::Ui,
     condition: &mut MkCondition,
     context: ImageAssetUiContext<'_>,
+    target_context: &TargetEditorContext<'_>,
     path: &ConditionPath,
 ) -> Option<ConditionEditorRequest> {
     // The established editor handles all non-browser controls and request
@@ -439,7 +445,9 @@ fn condition_ui_context_at(
                 let mut child_path = path.clone();
                 child_path.push(branch);
                 ui.indent(index, |ui| {
-                    if let Some(r) = condition_ui_context_at(ui, child, context, &child_path) {
+                    if let Some(r) =
+                        condition_ui_context_at(ui, child, context, target_context, &child_path)
+                    {
                         request = Some(r);
                     }
                 });
@@ -455,7 +463,9 @@ fn condition_ui_context_at(
                 let mut child_path = path.clone();
                 child_path.push(ConditionBranch::Any(index));
                 ui.indent(index, |ui| {
-                    if let Some(r) = condition_ui_context_at(ui, child, context, &child_path) {
+                    if let Some(r) =
+                        condition_ui_context_at(ui, child, context, target_context, &child_path)
+                    {
                         request = Some(r);
                     }
                 });
@@ -469,11 +479,11 @@ fn condition_ui_context_at(
             let mut child_path = path.clone();
             child_path.push(ConditionBranch::Not);
             ui.indent("not-child", |ui| {
-                condition_ui_context_at(ui, condition, context, &child_path)
+                condition_ui_context_at(ui, condition, context, target_context, &child_path)
             })
             .inner
         }
-        _ => condition_ui_with_assets(ui, condition, context.assets).map(|mut request| {
+        _ => condition_ui_with_assets(ui, condition, target_context).map(|mut request| {
             match &mut request {
                 ConditionEditorRequest::WindowMatcher { path: p }
                 | ConditionEditorRequest::Image(ConditionImageRequest { path: p, .. }) => {
@@ -487,14 +497,14 @@ fn condition_ui_context_at(
 fn group_ui(
     ui: &mut egui::Ui,
     conditions: &mut Vec<MkCondition>,
-    assets: &[MkImageAsset],
+    context: &TargetEditorContext<'_>,
     is_all: bool,
 ) -> Option<ConditionEditorRequest> {
     let mut remove = None;
     let mut requested = None;
     for (index, child) in conditions.iter_mut().enumerate() {
         ui.indent(index, |ui| {
-            if let Some(mut request) = condition_ui_with_assets(ui, child, assets) {
+            if let Some(mut request) = condition_ui_with_assets(ui, child, context) {
                 prepend_request(
                     &mut request,
                     if is_all {

--- a/src/gui/mkmacro_dialog/condition_editor.rs
+++ b/src/gui/mkmacro_dialog/condition_editor.rs
@@ -204,7 +204,7 @@ pub(super) fn first_window_picker_path(condition: &MkCondition) -> Option<Vec<us
 /// Edits a condition tree using only assets from the active macro.  The same
 /// catalog is threaded through every recursive child, so nested conditions do
 /// not lose their authoring context.
-pub fn condition_ui_with_assets(
+pub(super) fn condition_ui_with_assets(
     ui: &mut egui::Ui,
     condition: &mut MkCondition,
     context: &TargetEditorContext<'_>,

--- a/src/gui/mkmacro_dialog/image_asset_picker.rs
+++ b/src/gui/mkmacro_dialog/image_asset_picker.rs
@@ -188,6 +188,7 @@ mod tests {
     #[test]
     fn selection_event_updates_only_the_passed_value() {
         let mut selected = 4;
+        assert_eq!(selected, 4);
         let event = ImageAssetSelection { asset_id: 8 };
         selected = event.asset_id;
         assert_eq!(selected, 8);

--- a/src/gui/mkmacro_dialog/image_preview.rs
+++ b/src/gui/mkmacro_dialog/image_preview.rs
@@ -16,6 +16,8 @@ use std::{
 };
 
 pub const PREVIEW_BOUND: f32 = 220.0;
+/// Compact bound used inside a coordinate target form.
+pub const TARGET_THUMBNAIL_BOUND: f32 = 140.0;
 const VALIDATE_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -390,6 +392,16 @@ mod tests {
             assert!((th as f32 - h as f32 * scale).abs() <= 1.0);
         }
         assert_eq!(thumbnail_dimensions(20, 10), (20, 10));
+    }
+
+    #[test]
+    fn target_thumbnail_is_bounded_for_wide_tall_and_square_images() {
+        for (width, height) in [(1200, 200), (200, 1200), (1200, 1200)] {
+            let size = fitted_size(width, height, TARGET_THUMBNAIL_BOUND);
+            assert!(size.x <= TARGET_THUMBNAIL_BOUND);
+            assert!(size.y <= TARGET_THUMBNAIL_BOUND);
+            assert!((size.x / size.y - width as f32 / height as f32).abs() < 0.001);
+        }
     }
 
     #[test]

--- a/src/gui/mkmacro_dialog/image_search_controls.rs
+++ b/src/gui/mkmacro_dialog/image_search_controls.rs
@@ -220,7 +220,7 @@ pub enum SharedImageOperation {
 /// Render the persisted fields that deliberately have identical semantics in actions and conditions.
 pub fn show_shared_fields(
     ui: &mut egui::Ui,
-    asset_id: &mut u64,
+    _asset_id: &mut u64,
     region: &mut SearchRegion,
     tolerance: &mut u8,
     alpha: &mut AlphaPolicy,


### PR DESCRIPTION
### Motivation

- Reduce unrelated positional parameters in target editors by centralizing immutable editor state (macro id, assets, store) into a single context. 
- Provide a stable, non-blocking visual reference for ImageResult targets without performing a new search or synchronously decoding files in the editor UI. 
- Ensure missing or zero asset IDs are surfaced safely without being mutated or replaced by the UI.

### Description

- Introduce `TargetEditorContext<'a>` carrying `macro_id`, `assets`, and a `&MkMacroStore`, and add `resolve_asset` that treats zero and absent IDs as unresolved. 【F:src/gui/mkmacro_dialog/action_editor.rs†L1475-L1491】
- Change `target_ui()` to accept `&TargetEditorContext` and thread the same context through all call sites in `action_ui()` and condition editors so callers construct/pass a single context even when previews are unused. 【F:src/gui/mkmacro_dialog/action_editor.rs†L1494-L1500】【F:src/gui/mkmacro_dialog/action_editor.rs†L1804-L1812】【F:src/gui/mkmacro_dialog/condition_editor.rs†L360-L387】
- Render a compact, bounded visual reference for `MkTarget::ImageResult` immediately after the existing selector while preserving the selector and offset fields; missing/zero IDs render neutral or explicit missing labels and do not trigger decoding or substitution. The preview uses the shared asynchronous cache via the thumbnail API. 【F:src/gui/mkmacro_dialog/action_editor.rs†L1581-L1616】【F:src/gui/mkmacro_dialog/image_preview.rs†L18-L20】
- Add `TARGET_THUMBNAIL_BOUND` (140 px) in `image_preview.rs` and reuse the existing async decode/texture cache and show/thumbnail helper so previews remain bounded, aspect-preserving, and non-blocking. 【F:src/gui/mkmacro_dialog/image_preview.rs†L18-L21】【F:src/gui/mkmacro_dialog/image_preview.rs†L270-L298】
- Add unit tests covering context resolution and thumbnail sizing: `target_context_resolves_only_nonzero_current_macro_assets` and `target_thumbnail_is_bounded_for_wide_tall_and_square_images`. 【F:src/gui/mkmacro_dialog/action_editor.rs†L3211-L3228】【F:src/gui/mkmacro_dialog/image_preview.rs†L373-L381】

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `git diff --check` which produced no formatting/diff warnings for the modified files. 
- Attempted `cargo test --no-run` / compile: this was blocked in the environment due to unrelated platform and system-dependency issues (unavailable pkg-config/system libs and unconditional Windows API imports reported by the build), so the repository-wide test build could not be completed here; the added unit tests are present and validate the new behavior when the codebase is built in an environment matching the project requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90dcb5f9648332bc6093a8f61d71f7)