### PR TITLE
Track structural availability in the variable catalog

### DIFF
--- a/src/gui/mkmacro_dialog/variable_catalog.rs
+++ b/src/gui/mkmacro_dialog/variable_catalog.rs
@@ -4,7 +4,10 @@
 //! rebuild whenever a picker opens and is never serialized with a macro.
 
 use super::action_catalog::action_name;
-use crate::mkmacro::{MkAction, MkImageNotFoundPolicy, MkImageOutputs, MkStep, MkValue};
+use crate::mkmacro::{
+    MkAction, MkBlockKind, MkImageNotFoundPolicy, MkImageOutputs, MkStep, MkValue,
+    structure::analyze_structure,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VariableValueType {
@@ -21,16 +24,45 @@ pub enum VariableAvailability {
     PossiblyUnavailable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableUncertaintyReason {
+    ProducedInside(MkBlockKind),
+    MayBeNullIfNotFound,
+}
+
+impl VariableUncertaintyReason {
+    pub fn help_text(self) -> &'static str {
+        match self {
+            Self::ProducedInside(MkBlockKind::If) => "Produced inside If",
+            Self::ProducedInside(MkBlockKind::While) => "Produced inside While",
+            Self::ProducedInside(MkBlockKind::Repeat) => "Produced inside Repeat",
+            Self::MayBeNullIfNotFound => "May be Null if not found",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableDescriptor {
     pub name: String,
     pub value_type: VariableValueType,
     pub source_step_id: u64,
     pub source_step_index: usize,
+    /// One-based step number suitable for presentation in the picker.
+    pub source_step_number: usize,
     pub source_action_label: &'static str,
     pub availability: VariableAvailability,
+    /// Structured causes used by picker warning icons and tooltips.
+    pub uncertainty_reasons: Vec<VariableUncertaintyReason>,
     /// Extra picker guidance, including when a value can be Null at runtime.
     pub help_text: Option<&'static str>,
+}
+
+impl VariableDescriptor {
+    /// Marker rendered beside entries whose producer may not execute or may
+    /// yield Null.
+    pub fn warning_marker(&self) -> Option<&'static str> {
+        (self.availability == VariableAvailability::PossiblyUnavailable).then_some("⚠")
+    }
 }
 
 /// Source-ordered history of all variable definitions visible at a location.
@@ -46,10 +78,34 @@ impl VariableCatalog {
     /// `usize::MAX` useful for asking for the catalog at the end of a macro.
     pub fn before_step(steps: &[MkStep], consumer_index: usize) -> Self {
         let end = consumer_index.min(steps.len());
+        // Analyze once for the whole construction. In particular, do not
+        // reproduce block parsing here: structure analysis also owns the
+        // conservative semantics for incomplete editor drafts.
+        let structure = analyze_structure(steps);
         let descriptors = steps[..end]
             .iter()
             .enumerate()
-            .flat_map(|(index, step)| descriptors_for_action(step, index))
+            .flat_map(|(index, step)| {
+                let complete_kind = structure
+                    .step(step.id)
+                    .and_then(|_| structure.containing_block(step.id))
+                    .map(|block| block.kind);
+                let enclosing_kind =
+                    complete_kind.or_else(|| structure.editor_enclosing_kind(step.id));
+                descriptors_for_action(step, index)
+                    .into_iter()
+                    .map(move |mut descriptor| {
+                        if let Some(kind) = enclosing_kind {
+                            descriptor.availability = VariableAvailability::PossiblyUnavailable;
+                            descriptor
+                                .uncertainty_reasons
+                                .insert(0, VariableUncertaintyReason::ProducedInside(kind));
+                            descriptor.help_text =
+                                Some(VariableUncertaintyReason::ProducedInside(kind).help_text());
+                        }
+                        descriptor
+                    })
+            })
             .collect();
         Self { descriptors }
     }
@@ -87,8 +143,14 @@ pub fn descriptors_for_action(step: &MkStep, step_index: usize) -> Vec<VariableD
                 value_type,
                 source_step_id: step.id,
                 source_step_index: step_index,
+                source_step_number: step_index + 1,
                 source_action_label: label,
                 availability,
+                uncertainty_reasons: if availability == VariableAvailability::PossiblyUnavailable {
+                    vec![VariableUncertaintyReason::MayBeNullIfNotFound]
+                } else {
+                    Vec::new()
+                },
                 help_text,
             });
         }
@@ -179,9 +241,9 @@ fn add_visual_outputs(
 mod tests {
     use super::*;
     use crate::mkmacro::{
-        AlphaPolicy, MkFileCollisionPolicy, MkImagePayload, MkPixelSearchPayload, MkPoint,
-        MkPromptInputPayload, MkScreenshotDestination, MkScreenshotFormat, MkScreenshotPayload,
-        MkWaitOptions, ReturnPoint, SearchRegion,
+        AlphaPolicy, MkBlockKind, MkCondition, MkFileCollisionPolicy, MkImagePayload,
+        MkPixelSearchPayload, MkPoint, MkPromptInputPayload, MkScreenshotDestination,
+        MkScreenshotFormat, MkScreenshotPayload, MkWaitOptions, ReturnPoint, SearchRegion,
     };
 
     fn step(id: u64, action: MkAction) -> MkStep {
@@ -224,6 +286,18 @@ mod tests {
             not_found_policy: MkImageNotFoundPolicy::Continue,
             outputs,
         })
+    }
+    fn set(id: u64, name: &str) -> MkStep {
+        step(
+            id,
+            MkAction::SetVariable {
+                name: name.into(),
+                value: MkValue::Number(id as f64),
+            },
+        )
+    }
+    fn empty_condition() -> MkCondition {
+        MkCondition::All { conditions: vec![] }
     }
 
     #[test]
@@ -388,6 +462,127 @@ mod tests {
                 .map(|d| &*d.name)
                 .collect::<Vec<_>>(),
             vec!["b", "a", "later"]
+        );
+    }
+
+    #[test]
+    fn structural_enclosures_make_producers_possibly_unavailable() {
+        let cases = [
+            (
+                vec![
+                    step(1, MkAction::If(empty_condition())),
+                    set(2, "if_body"),
+                    step(3, MkAction::EndIf),
+                ],
+                MkBlockKind::If,
+            ),
+            (
+                vec![
+                    step(1, MkAction::If(empty_condition())),
+                    step(2, MkAction::Else),
+                    set(3, "else_body"),
+                    step(4, MkAction::EndIf),
+                ],
+                MkBlockKind::If,
+            ),
+            (
+                vec![
+                    step(
+                        1,
+                        MkAction::WhileStart {
+                            condition: empty_condition(),
+                        },
+                    ),
+                    set(2, "while_body"),
+                    step(3, MkAction::WhileEnd),
+                ],
+                MkBlockKind::While,
+            ),
+            (
+                vec![
+                    step(1, MkAction::RepeatStart { count: 2 }),
+                    set(2, "repeat_body"),
+                    step(3, MkAction::RepeatEnd),
+                ],
+                MkBlockKind::Repeat,
+            ),
+        ];
+        for (steps, kind) in cases {
+            let descriptor = &VariableCatalog::before_step(&steps, usize::MAX).descriptors()[0];
+            assert_eq!(
+                descriptor.availability,
+                VariableAvailability::PossiblyUnavailable
+            );
+            assert_eq!(
+                descriptor.uncertainty_reasons,
+                vec![VariableUncertaintyReason::ProducedInside(kind)]
+            );
+            assert_eq!(descriptor.warning_marker(), Some("⚠"));
+        }
+    }
+
+    #[test]
+    fn nested_production_stays_possible_but_completed_block_restores_top_level() {
+        let steps = vec![
+            set(10, "top"),
+            step(11, MkAction::If(empty_condition())),
+            step(12, MkAction::RepeatStart { count: 2 }),
+            set(13, "nested"),
+            step(14, MkAction::RepeatEnd),
+            step(15, MkAction::EndIf),
+            set(16, "after"),
+        ];
+        let catalog = VariableCatalog::before_step(&steps, usize::MAX);
+        let descriptors = catalog.descriptors();
+        assert_eq!(
+            descriptors[0].availability,
+            VariableAvailability::DefinitelyAvailable
+        );
+        assert_eq!(
+            descriptors[1].availability,
+            VariableAvailability::PossiblyUnavailable
+        );
+        assert_eq!(
+            descriptors[2].availability,
+            VariableAvailability::DefinitelyAvailable
+        );
+    }
+
+    #[test]
+    fn unclosed_draft_is_conservative_and_preserves_source_metadata() {
+        let steps = vec![step(40, MkAction::If(empty_condition())), set(987, "draft")];
+        let catalog = VariableCatalog::before_step(&steps, usize::MAX);
+        let descriptor = &catalog.descriptors()[0];
+        assert_eq!(
+            descriptor.availability,
+            VariableAvailability::PossiblyUnavailable
+        );
+        assert_eq!(descriptor.source_step_id, 987);
+        assert_eq!(descriptor.source_step_index, 1);
+        assert_eq!(descriptor.source_step_number, 2);
+        assert_eq!(descriptor.source_action_label, "Set Variable");
+    }
+
+    #[test]
+    fn top_level_nullable_point_remains_possibly_unavailable() {
+        let steps = vec![step(
+            55,
+            image(MkImageOutputs {
+                found: None,
+                point: Some("location".into()),
+                x: None,
+                y: None,
+            }),
+        )];
+        let catalog = VariableCatalog::before_step(&steps, usize::MAX);
+        let descriptor = &catalog.descriptors()[0];
+        assert_eq!(
+            descriptor.availability,
+            VariableAvailability::PossiblyUnavailable
+        );
+        assert_eq!(
+            descriptor.uncertainty_reasons,
+            vec![VariableUncertaintyReason::MayBeNullIfNotFound]
         );
     }
 }

--- a/src/gui/mkmacro_dialog/variable_catalog.rs
+++ b/src/gui/mkmacro_dialog/variable_catalog.rs
@@ -508,7 +508,8 @@ mod tests {
             ),
         ];
         for (steps, kind) in cases {
-            let descriptor = &VariableCatalog::before_step(&steps, usize::MAX).descriptors()[0];
+            let catalog = VariableCatalog::before_step(&steps, usize::MAX);
+            let descriptor = &catalog.descriptors()[0];
             assert_eq!(
                 descriptor.availability,
                 VariableAvailability::PossiblyUnavailable

--- a/src/mkmacro/structure.rs
+++ b/src/mkmacro/structure.rs
@@ -22,6 +22,11 @@ pub struct StepStructure {
     pub depth: usize,
     /// Stable ID of the innermost complete containing block's opener.
     pub containing_block: Option<u64>,
+    /// Kind of the innermost editor enclosure, including an unclosed draft.
+    ///
+    /// Unlike `containing_block`, this is intentionally conservative: an
+    /// opener remains an enclosure until a matching closer is encountered.
+    pub editor_enclosing_kind: Option<BlockKind>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,6 +70,11 @@ impl StructureAnalysis {
         let opener = self.step(id)?.containing_block?;
         self.block_for_marker(opener)
     }
+    /// Returns the innermost enclosure visible while editing, even when that
+    /// enclosure has not yet acquired a matching closer.
+    pub fn editor_enclosing_kind(&self, id: u64) -> Option<BlockKind> {
+        self.step(id)?.editor_enclosing_kind
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -87,6 +97,10 @@ pub fn analyze_structure(steps: &[MkStep]) -> StructureAnalysis {
             index,
             depth,
             containing_block: None,
+            editor_enclosing_kind: depth
+                .checked_sub(1)
+                .and_then(|enclosing| stack.get(enclosing))
+                .map(|open| open.kind),
         });
         result.step_by_id.entry(step.id).or_insert(index);
         if let Some(MkBlockMarker::Open(kind)) = marker {
@@ -292,6 +306,24 @@ mod tests {
         for v in cases {
             assert!(!analyze_structure(&v).diagnostics.is_empty());
         }
+    }
+    #[test]
+    fn editor_enclosure_query_covers_nested_and_unclosed_blocks() {
+        let v = vec![
+            s(1, MkAction::If(MkCondition::All { conditions: vec![] })),
+            delay(2),
+            s(3, MkAction::RepeatStart { count: 2 }),
+            delay(4),
+            s(5, MkAction::RepeatEnd),
+            delay(6),
+            // Deliberately leave the If open as an editor draft.
+        ];
+        let a = analyze_structure(&v);
+        assert_eq!(a.editor_enclosing_kind(2), Some(BlockKind::If));
+        assert_eq!(a.editor_enclosing_kind(4), Some(BlockKind::Repeat));
+        assert_eq!(a.editor_enclosing_kind(6), Some(BlockKind::If));
+        assert!(a.containing_block(6).is_none());
+        assert!(a.editor_enclosing_kind(999).is_none());
     }
     #[test]
     fn controls_are_not_markers() {


### PR DESCRIPTION
### Motivation

- Ensure the variable picker can conservatively detect when a producer may not actually run because it is enclosed by a structural block (If/Else/While/Repeat) or can produce null (image/pixel searches). 
- Reuse the existing editor-oriented structure analysis to avoid re-parsing block markers and to handle malformed/unclosed editor drafts safely and consistently. 
- Surface structured metadata for the UI (one-based step number, warning markers, and reasons) so the picker can render warnings and tooltips without parsing strings.

### Description

- Run `analyze_structure(steps)` once during `VariableCatalog::before_step` and use `StructureAnalysis::step`, `containing_block`, and a new editor-oriented query to determine enclosure and depth when constructing descriptors. 
- Add `VariableUncertaintyReason` (structured reasons and a `help_text()` accessor), a one-based `source_step_number`, `uncertainty_reasons`, and a `warning_marker()` helper to `VariableDescriptor`. 
- Combine structural enclosure and producer-level nullability conservatively so that top-level non-nullable producers remain `DefinitelyAvailable`, producers inside any If/Else/While/Repeat become `PossiblyUnavailable`, nullable image/pixel outputs are `PossiblyUnavailable` even at top level, and nested/repeated production is never upgraded back to definite. 
- Extend `StructureAnalysis` with `editor_enclosing_kind` (and a per-step `editor_enclosing_kind` field) that reports the innermost enclosure visible while editing (including unclosed openers) so malformed editor drafts are treated conservatively. 
- Add unit tests in `variable_catalog.rs` covering top-level definite Set Variable, If/Else bodies, While and Repeat bodies, nested blocks, restored top-level after a completed block, malformed/unclosed drafts, nullable image point output, and stable step ID / one-based display index, and add focused tests in `structure.rs` for the new editor-oriented enclosure query.

### Testing

- `cargo fmt -- --check` completed successfully. 
- `git diff --check` completed successfully. 
- Ran `cargo test variable_catalog --lib` and `cargo test mkmacro::structure::tests --lib`, but full test execution is blocked by unrelated, pre-existing cross-platform compilation issues (Windows-specific `windows` crate imports and platform bindings) in other crates, so the new unit tests could not be executed end-to-end in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a916b226b9083328ce6b51b6c1811b6)