### PR TITLE
Add structured, non-fatal variable warnings and Mouse Move diagnostics

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -1784,6 +1784,14 @@ fn target_ui_with_variables(
                 variable_picker_ui(ui, picker_id, name, catalog, |value_type| {
                     value_type == VariableValueType::Point
                 });
+                if let Some(warning) =
+                    catalog.warning_for_expected_type(name, VariableValueType::Point)
+                {
+                    ui.colored_label(
+                        egui::Color32::YELLOW,
+                        format!("⚠ {}", warning.message_for_consumer("Mouse Move")),
+                    );
+                }
             } else {
                 ui.horizontal(|ui| {
                     ui.label("Variable");

--- a/src/gui/mkmacro_dialog/variable_catalog.rs
+++ b/src/gui/mkmacro_dialog/variable_catalog.rs
@@ -30,6 +30,73 @@ pub enum VariableUncertaintyReason {
     MayBeNullIfNotFound,
 }
 
+/// A non-fatal authoring diagnostic for a variable consumer.
+///
+/// The kind, variable name, and producer metadata deliberately remain
+/// structured; callers should use
+/// [`VariableConsumerWarning::message_for_consumer`] rather than assembling
+/// UI-specific wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableWarningKind {
+    NoKnownPriorProducer,
+    KnownWrongType {
+        actual: VariableValueType,
+        expected: VariableValueType,
+    },
+    PossiblyUnavailable {
+        reason: VariableUncertaintyReason,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariableWarningSource {
+    pub step_id: u64,
+    pub step_index: usize,
+    pub step_number: usize,
+    pub action_label: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariableConsumerWarning {
+    pub variable_name: String,
+    pub expected_type: VariableValueType,
+    pub source: Option<VariableWarningSource>,
+    pub kind: VariableWarningKind,
+}
+
+impl VariableConsumerWarning {
+    pub fn message_for_consumer(&self, consumer_label: &str) -> String {
+        match self.kind {
+            VariableWarningKind::NoKnownPriorProducer => format!(
+                "No earlier action is known to produce {} variable \"{}\". Manual/dynamic variables are still allowed.",
+                variable_type_label(self.expected_type),
+                self.variable_name
+            ),
+            VariableWarningKind::KnownWrongType { actual, expected } => format!(
+                "\"{}\" is currently known as {}; {} requires {}.",
+                self.variable_name,
+                variable_type_label(actual),
+                consumer_label,
+                variable_type_label(expected)
+            ),
+            VariableWarningKind::PossiblyUnavailable { .. } => format!(
+                "\"{}\" is produced conditionally and may be Null/unavailable here.",
+                self.variable_name
+            ),
+        }
+    }
+}
+
+fn variable_type_label(value_type: VariableValueType) -> &'static str {
+    match value_type {
+        VariableValueType::String => "String",
+        VariableValueType::Number => "Number",
+        VariableValueType::Boolean => "Boolean",
+        VariableValueType::Point => "Point",
+        VariableValueType::Unknown => "Unknown",
+    }
+}
+
 impl VariableUncertaintyReason {
     pub fn help_text(self) -> &'static str {
         match self {
@@ -145,6 +212,49 @@ impl VariableCatalog {
     /// then by that action's output order.
     pub fn effective_variables(&self) -> &[VariableDescriptor] {
         &self.effective
+    }
+
+    /// Checks an exact variable name against its effective preceding
+    /// definition. Lookup intentionally happens before type comparison, so a
+    /// wrong-typed shadowing definition cannot reveal an older compatible one.
+    pub fn warning_for_expected_type(
+        &self,
+        name: &str,
+        expected: VariableValueType,
+    ) -> Option<VariableConsumerWarning> {
+        if name.is_empty() {
+            return None;
+        }
+        let descriptor = self.effective.iter().find(|item| item.name == name);
+        let source = descriptor.map(|item| VariableWarningSource {
+            step_id: item.source_step_id,
+            step_index: item.source_step_index,
+            step_number: item.source_step_number,
+            action_label: item.source_action_label,
+        });
+        let kind = match descriptor {
+            None => VariableWarningKind::NoKnownPriorProducer,
+            Some(item) if item.value_type != expected => VariableWarningKind::KnownWrongType {
+                actual: item.value_type,
+                expected,
+            },
+            Some(item) if item.availability == VariableAvailability::PossiblyUnavailable => {
+                VariableWarningKind::PossiblyUnavailable {
+                    reason: item
+                        .uncertainty_reasons
+                        .first()
+                        .copied()
+                        .unwrap_or(VariableUncertaintyReason::MayBeNullIfNotFound),
+                }
+            }
+            Some(_) => return None,
+        };
+        Some(VariableConsumerWarning {
+            variable_name: name.to_owned(),
+            expected_type: expected,
+            source,
+            kind,
+        })
     }
 
     /// Effective picker entries of `value_type`. Shadowing is deliberately
@@ -605,6 +715,84 @@ mod tests {
         // keeps the two runtime keys distinct.
         assert_eq!(effective, vec![("middle", 1), ("Target", 2), ("target", 3)]);
         assert!(!catalog.history().iter().any(|item| item.name == "future"));
+    }
+
+    #[test]
+    fn expected_type_warnings_obey_lookup_precedence() {
+        let point = |id, name: &str| set_value(id, name, MkValue::Point(MkPoint { x: 1, y: 2 }));
+        let string = |id, name: &str| set_value(id, name, MkValue::String("text".into()));
+
+        let unknown = VariableCatalog::before_step(&[point(9, "future")], 0)
+            .warning_for_expected_type("point", VariableValueType::Point)
+            .unwrap();
+        assert_eq!(unknown.kind, VariableWarningKind::NoKnownPriorProducer);
+        assert_eq!(unknown.source, None);
+        assert_eq!(
+            unknown.message_for_consumer("Mouse Move"),
+            "No earlier action is known to produce Point variable \"point\". Manual/dynamic variables are still allowed."
+        );
+
+        let wrong =
+            VariableCatalog::before_step(&[point(1, "point"), string(2, "point")], usize::MAX)
+                .warning_for_expected_type("point", VariableValueType::Point)
+                .unwrap();
+        assert!(matches!(
+            wrong.kind,
+            VariableWarningKind::KnownWrongType {
+                actual: VariableValueType::String,
+                expected: VariableValueType::Point
+            }
+        ));
+        assert_eq!(wrong.source.as_ref().unwrap().step_id, 2);
+        assert_eq!(
+            wrong.message_for_consumer("Mouse Move"),
+            "\"point\" is currently known as String; Mouse Move requires Point."
+        );
+
+        let latest_point =
+            VariableCatalog::before_step(&[string(1, "point"), point(2, "point")], usize::MAX);
+        assert_eq!(
+            latest_point.warning_for_expected_type("point", VariableValueType::Point),
+            None
+        );
+    }
+
+    #[test]
+    fn conditional_and_nullable_points_each_produce_one_warning() {
+        let conditional = VariableCatalog::before_step(
+            &[
+                step(1, MkAction::If(empty_condition())),
+                set_value(2, "point", MkValue::Point(MkPoint { x: 1, y: 2 })),
+                step(3, MkAction::EndIf),
+            ],
+            usize::MAX,
+        );
+        let warning = conditional
+            .warning_for_expected_type("point", VariableValueType::Point)
+            .unwrap();
+        assert!(matches!(
+            warning.kind,
+            VariableWarningKind::PossiblyUnavailable {
+                reason: VariableUncertaintyReason::ProducedInside(MkBlockKind::If)
+            }
+        ));
+
+        let nullable = VariableCatalog::before_step(&[step(4, image(outputs()))], usize::MAX);
+        let warnings: Vec<_> =
+            std::iter::once(nullable.warning_for_expected_type("point", VariableValueType::Point))
+                .flatten()
+                .collect();
+        assert_eq!(warnings.len(), 1, "one consumer/name/reason diagnostic");
+        assert!(matches!(
+            warnings[0].kind,
+            VariableWarningKind::PossiblyUnavailable {
+                reason: VariableUncertaintyReason::MayBeNullIfNotFound
+            }
+        ));
+        assert_eq!(
+            warnings[0].message_for_consumer("Mouse Move"),
+            "\"point\" is produced conditionally and may be Null/unavailable here."
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Provide a single, structured, non-fatal diagnostic API for variable consumers so the editor and (nonfatal) compile-time validation can share the same warnings and wording.
- Surface helpful, predictable warnings for `Mouse Move` variable targets when the named variable is unknown, the wrong type, or may be unavailable, without changing the Apply validity predicate.

### Description

- Added a structured warning model in `src/gui/mkmacro_dialog/variable_catalog.rs`: `VariableWarningKind`, `VariableWarningSource`, and `VariableConsumerWarning` with a renderer `message_for_consumer` and helper `variable_type_label`.
- Implemented `VariableCatalog::warning_for_expected_type(name, expected)` which performs exact-name lookup against the effective preceding descriptor and enforces precedence: `NoKnownPriorProducer` → `KnownWrongType` → `PossiblyUnavailable`, with `None` when a definite matching producer exists.
- Plumbed editor UI rendering in `src/gui/mkmacro_dialog/action_editor.rs` to display Mouse Move variable warnings adjacent to the picker using yellow warning styling (`ui.colored_label(..., egui::Color32::YELLOW)`), leaving the Apply validity predicate unchanged.
- Added unit tests in `variable_catalog` to exercise lookup precedence and nullable/conditional Point warnings and to capture the intended cases (unknown name, wrong-type shadowing, latest compatible definitions, conditional/nullable producers, and single diagnostic per consumer/name/reason).

### Testing

- Ran formatting: `cargo fmt -- --check` (passed).
- Attempted `cargo test variable_catalog --lib`; formatting and compilation were exercised locally, and the new unit tests were added (`expected_type_warnings_obey_lookup_precedence`, `conditional_and_nullable_points_each_produce_one_warning`) to cover lookup precedence and conditional/nullable Point warnings, but a complete test run in this environment was blocked by unrelated platform-specific build failures (missing native packages and Windows API binding resolution) while compiling other workspace crates, so full integration test execution could not be completed here.
- The warning API and UI changes are non-fatal and do not alter runtime compilation semantics for manual/dynamic variable references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9189a29a6c8332840ea6c54adbf810)