### PR TITLE
Add independent point-picking overlay and Set Variable point routing

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -42,6 +42,7 @@ pub struct ActionEditorState {
     /// launcher and dialog native-window visibility boundary.
     pub visual_capture: Option<super::visual_capture_workflow::VisualCaptureWorkflow>,
     overlay_diagnostic: Option<(super::visual_overlay::OperationId, String)>,
+    active_point_pick: Option<super::visual_overlay::OperationId>,
     pending_visual_region: Option<PendingVisualRegionOperation>,
     picker: NativePositionPicker,
     notification_preview: NotificationPreview,
@@ -289,6 +290,7 @@ impl ActionEditorState {
             visual_overlay,
             visual_capture: None,
             overlay_diagnostic: None,
+            active_point_pick: None,
             pending_visual_region: None,
             picker: Default::default(),
             notification_preview: Arc::new(production_notification_preview),
@@ -326,6 +328,9 @@ impl ActionEditorState {
         self.variable_catalog = VariableCatalog::before_step(steps, index);
     }
     fn cancel_owned_passive_overlay(&mut self) {
+        if let Some(operation_id) = self.active_point_pick.take() {
+            self.visual_overlay.cancel_operation(operation_id);
+        }
         if let Some((operation_id, _)) = self.overlay_diagnostic.take() {
             self.visual_overlay.cancel_operation(operation_id);
         }
@@ -888,10 +893,93 @@ impl ActionEditorState {
             }
         }
     }
-    fn poll_visual_overlay(&mut self) {
+    fn poll_visual_overlay(&mut self, current_macro_id: Option<u64>) {
         for event in self.visual_overlay.poll() {
-            apply_overlay_diagnostic(&mut self.capture_message, &self.overlay_diagnostic, event);
+            match event {
+                super::visual_overlay::VisualOverlayEvent::PointConfirmed {
+                    operation_id,
+                    request,
+                    point,
+                } => {
+                    if self.active_point_pick == Some(operation_id) {
+                        self.active_point_pick = None;
+                        self.apply_point_confirmation(&request, point, current_macro_id);
+                    }
+                }
+                super::visual_overlay::VisualOverlayEvent::Cancelled { operation_id }
+                    if self.active_point_pick == Some(operation_id) =>
+                {
+                    self.active_point_pick = None;
+                }
+                super::visual_overlay::VisualOverlayEvent::Error {
+                    operation_id,
+                    ref error,
+                } if self.active_point_pick == Some(operation_id) => {
+                    self.active_point_pick = None;
+                    self.capture_message = Some(format!("Unable to pick position: {error}"));
+                }
+                event => apply_overlay_diagnostic(
+                    &mut self.capture_message,
+                    &self.overlay_diagnostic,
+                    event,
+                ),
+            }
         }
+    }
+    fn apply_point_confirmation(
+        &mut self,
+        request: &super::visual_overlay::VisualPointRequest,
+        point: MkPoint,
+        current_macro_id: Option<u64>,
+    ) -> bool {
+        if current_macro_id != Some(request.macro_id)
+            || self.draft_generation != request.draft_generation
+            || self.editing_id != request.step_id
+            || !matches!(
+                request.destination,
+                super::visual_overlay::VisualPointDestination::SetVariablePoint
+            )
+        {
+            return false;
+        }
+        let Some(MkStep {
+            action:
+                MkAction::SetVariable {
+                    value: MkValue::Point(target),
+                    ..
+                },
+            ..
+        }) = self.draft.as_mut()
+        else {
+            return false;
+        };
+        *target = point;
+        self.draft_changed = true;
+        true
+    }
+    fn request_point_pick(&mut self, macro_id: u64) {
+        if self.active_point_pick.is_some() {
+            return;
+        }
+        if !matches!(
+            self.draft.as_ref().map(|s| &s.action),
+            Some(MkAction::SetVariable {
+                value: MkValue::Point(_),
+                ..
+            })
+        ) {
+            return;
+        }
+        let id = self
+            .visual_overlay
+            .begin_point_pick(super::visual_overlay::VisualPointRequest {
+                macro_id,
+                draft_generation: self.draft_generation,
+                step_id: self.editing_id,
+                destination: super::visual_overlay::VisualPointDestination::SetVariablePoint,
+            });
+        self.active_point_pick = Some(id);
+        self.capture_message = None;
     }
     pub fn apply(&mut self, dialog: &mut MkMacroDialog) -> Option<u64> {
         if self.image_authoring.is_importing() {
@@ -1929,6 +2017,7 @@ fn action_ui(
     image_context: super::image_asset_picker::ImageAssetUiContext<'_>,
     draft_generation: u64,
     variable_catalog: &VariableCatalog,
+    point_pick_active: bool,
 ) -> (
     Option<PositionCaptureSlot>,
     Option<super::window_picker::MatcherPath>,
@@ -1936,6 +2025,7 @@ fn action_ui(
     Option<ImageAuthoringRequest>,
     Option<super::condition_editor::ConditionImageRequest>,
     Option<PreviewRequest>,
+    bool,
 ) {
     let target_context = TargetEditorContext {
         macro_id: image_context.macro_id,
@@ -1948,6 +2038,7 @@ fn action_ui(
     let image_request = None;
     let mut condition_image_request = None;
     let mut preview_request = None;
+    let mut point_pick = false;
     let draft_id = step.id;
     match &mut step.action {
         MkAction::KeyPress(k) | MkAction::KeyDown(k) | MkAction::KeyUp(k) => {
@@ -2342,6 +2433,11 @@ fn action_ui(
                 ui.text_edit_singleline(name);
             });
             value_ui(ui, value);
+            if matches!(value, MkValue::Point(_)) {
+                point_pick = ui
+                    .add_enabled(!point_pick_active, egui::Button::new("Pick Position"))
+                    .clicked();
+            }
         }
         MkAction::UnsetVariable { name } => {
             ui.horizontal(|ui| {
@@ -2724,6 +2820,7 @@ fn action_ui(
         image_request,
         condition_image_request,
         preview_request,
+        point_pick,
     )
 }
 
@@ -3032,7 +3129,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         ctx.request_repaint();
     }
     let overlay_was_active = d.action_editor.visual_overlay.operation_id().is_some();
-    d.action_editor.poll_visual_overlay();
+    d.action_editor.poll_visual_overlay(d.selected_macro_id);
     if overlay_was_active || d.action_editor.visual_overlay.operation_id().is_some() {
         ctx.request_repaint();
     }
@@ -3064,6 +3161,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
     let mut screenshot_region_request = false;
     let mut condition_image_request = None;
     let mut preview_request = None;
+    let mut point_pick_request = false;
     // Execute after egui releases the mutable draft borrow held by `step`.
     let mut region_preview_request = None;
     let image_assets = d
@@ -3084,6 +3182,7 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
           egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
             let state = &mut d.action_editor;
             let draft_generation = state.draft_generation;
+            let point_pick_active = state.active_point_pick.is_some();
             let step = state.draft.as_mut().unwrap();
             let editor = state.editor.expect("action editor draft has no editor strategy");
             assert!(super::action_catalog::editor_route_recognizes(&step.action, editor), "action editor strategy does not match draft action");
@@ -3093,19 +3192,21 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
                 assets: &image_assets,
                 store: &d.store,
             };
-            let (position, mut window, launcher, image, condition_image, preview)=action_ui(
+            let (position, mut window, launcher, image, condition_image, preview, pick_point)=action_ui(
                 ui,
                 step,
                 &mut state.capture_keys,
                 image_context,
                 draft_generation,
                 &state.variable_catalog,
+                point_pick_active,
             );
             if step.action != action_before { state.draft_changed = true; }
             pick_request = position;
             image_request = image;
             condition_image_request = condition_image;
             preview_request = preview;
+            point_pick_request = pick_point;
             if matches!(
                 step.action,
                 MkAction::WaitForVisualChange(_) | MkAction::CaptureScreenshot(_)
@@ -3268,6 +3369,10 @@ pub(super) fn show(ctx: &egui::Context, d: &mut MkMacroDialog) {
         });
     if let Some(request) = preview_request {
         dispatch_preview(&mut d.action_editor, request);
+    }
+    if point_pick_request {
+        d.action_editor
+            .request_point_pick(d.selected_macro_id.unwrap_or(0));
     }
     if let Some(region) = region_preview_request {
         d.action_editor.preview_region(region);
@@ -5623,6 +5728,86 @@ mod tests {
             );
             editor.draft_generation += 1;
             assert!(!editor.apply_window_matcher(&request, MkWindowMatcher::default(), Some(7)));
+        }
+    }
+
+    mod point_picker_routing_tests {
+        use super::*;
+        use crate::gui::mkmacro_dialog::visual_overlay::{
+            VisualPointDestination, VisualPointRequest,
+        };
+
+        fn setup() -> (ActionEditorState, VisualPointRequest) {
+            let mut editor = test_editor();
+            let step = MkStep {
+                id: 55,
+                enabled: true,
+                repeat: 1,
+                delay_after_ms: 0,
+                on_error: MkErrorPolicy::Stop,
+                action: MkAction::SetVariable {
+                    name: "p".into(),
+                    value: MkValue::Point(MkPoint { x: 1, y: 2 }),
+                },
+            };
+            editor.begin_edit(&step);
+            let request = VisualPointRequest {
+                macro_id: 7,
+                draft_generation: editor.draft_generation,
+                step_id: Some(55),
+                destination: VisualPointDestination::SetVariablePoint,
+            };
+            (editor, request)
+        }
+        fn value(editor: &ActionEditorState) -> Option<MkPoint> {
+            match &editor.draft.as_ref()?.action {
+                MkAction::SetVariable {
+                    value: MkValue::Point(p),
+                    ..
+                } => Some(*p),
+                _ => None,
+            }
+        }
+
+        #[test]
+        fn matching_confirmation_updates_both_axes_atomically() {
+            let (mut editor, request) = setup();
+            assert!(editor.apply_point_confirmation(&request, MkPoint { x: -8, y: 99 }, Some(7)));
+            assert_eq!(value(&editor), Some(MkPoint { x: -8, y: 99 }));
+        }
+
+        #[test]
+        fn stale_identity_and_changed_draft_are_ignored() {
+            for mutation in 0..5 {
+                let (mut editor, mut request) = setup();
+                match mutation {
+                    0 => request.macro_id = 8,
+                    1 => request.draft_generation += 1,
+                    2 => request.step_id = Some(56),
+                    3 => {
+                        editor.draft.as_mut().unwrap().action =
+                            MkAction::UnsetVariable { name: "p".into() }
+                    }
+                    _ => {
+                        if let MkAction::SetVariable { value, .. } =
+                            &mut editor.draft.as_mut().unwrap().action
+                        {
+                            *value = MkValue::Number(1.0)
+                        }
+                    }
+                }
+                assert!(!editor.apply_point_confirmation(
+                    &request,
+                    MkPoint { x: 10, y: 20 },
+                    Some(7)
+                ));
+            }
+        }
+
+        #[test]
+        fn cancellation_preserves_original_point() {
+            let (editor, _) = setup();
+            assert_eq!(value(&editor), Some(MkPoint { x: 1, y: 2 }));
         }
     }
 }

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -254,6 +254,19 @@ impl SharedVisualOverlayController {
             },
         )
     }
+    pub fn begin_point_pick(
+        &self,
+        request: super::visual_overlay::VisualPointRequest,
+    ) -> OperationId {
+        let id = self.allocate();
+        self.send_with_recovery(
+            id,
+            VisualOverlayCommand::PickPoint {
+                operation_id: id,
+                request,
+            },
+        )
+    }
     pub fn preview_rectangle(&self, rect: ScreenRect) -> OperationId {
         let id = self.allocate();
         self.send_with_recovery(
@@ -351,7 +364,8 @@ impl SharedVisualOverlayController {
         }
         for event in &incoming {
             let id = match event {
-                VisualOverlayEvent::RectangleConfirmed { operation_id, .. }
+                VisualOverlayEvent::PointConfirmed { operation_id, .. }
+                | VisualOverlayEvent::RectangleConfirmed { operation_id, .. }
                 | VisualOverlayEvent::Cancelled { operation_id }
                 | VisualOverlayEvent::Expired { operation_id }
                 | VisualOverlayEvent::Error { operation_id, .. } => *operation_id,

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -23,6 +23,7 @@ pub const PASSIVE_OVERLAY_DURATION: Duration = Duration::from_millis(2500);
 pub const RECTANGLE_OUTLINE_WIDTH: i32 = 3;
 pub const RECTANGLE_TOOLTIP_OFFSET: (i32, i32) = (16, 16);
 pub const RECTANGLE_INSTRUCTION: &str = "Draw a rectangle around the region — Esc to cancel";
+pub const POINT_INSTRUCTION: &str = "Click a screen position — Esc to cancel";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RectangleTooltip {
@@ -82,6 +83,26 @@ pub fn monitor_nearest_pointer(monitors: &[ScreenRect], pointer: MkPoint) -> Opt
 pub type OperationId = u64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisualPointDestination {
+    SetVariablePoint,
+}
+
+/// Complete editor identity travels to the native worker and back unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisualPointRequest {
+    pub macro_id: u64,
+    pub draft_generation: u64,
+    pub step_id: Option<u64>,
+    pub destination: VisualPointDestination,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointInteractionPhase {
+    AwaitingInitialRelease,
+    Armed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RectanglePurpose {
     SearchRegion,
     ReferenceImageCapture,
@@ -113,6 +134,12 @@ pub enum VisualOverlayState {
         virtual_desktop: ScreenRect,
         pointer: MkPoint,
         phase: RectangleInteractionPhase,
+    },
+    PickingPoint {
+        operation_id: OperationId,
+        request: VisualPointRequest,
+        pointer: MkPoint,
+        phase: PointInteractionPhase,
     },
     PreviewingRectangle {
         rect: ScreenRect,
@@ -172,6 +199,11 @@ impl std::error::Error for VisualOverlayError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VisualOverlayEvent {
+    PointConfirmed {
+        operation_id: OperationId,
+        request: VisualPointRequest,
+        point: MkPoint,
+    },
     RectangleConfirmed {
         operation_id: OperationId,
         purpose: RectanglePurpose,
@@ -192,6 +224,10 @@ pub enum VisualOverlayEvent {
 /// Messages are the only way native overlay work crosses onto its owning thread.
 #[derive(Debug, Clone)]
 pub(crate) enum VisualOverlayCommand {
+    PickPoint {
+        operation_id: OperationId,
+        request: VisualPointRequest,
+    },
     BeginRectanglePick {
         operation_id: OperationId,
         purpose: RectanglePurpose,
@@ -507,6 +543,12 @@ impl NativeVisualOverlayService {
 
 fn apply_command(controller: &mut VisualOverlayController, command: VisualOverlayCommand) -> bool {
     match command {
+        VisualOverlayCommand::PickPoint {
+            operation_id,
+            request,
+        } => {
+            controller.begin_point_pick_with_id(operation_id, request);
+        }
         VisualOverlayCommand::BeginRectanglePick {
             operation_id,
             purpose,
@@ -571,6 +613,9 @@ pub struct OverlayInput {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OverlayVisual {
+    PointPicker {
+        pointer: MkPoint,
+    },
     RectanglePicker {
         virtual_desktop: ScreenRect,
         selection: Option<ScreenRect>,
@@ -588,7 +633,10 @@ pub enum OverlayVisual {
 }
 impl OverlayVisual {
     pub(crate) fn passive(&self) -> bool {
-        !matches!(self, Self::RectanglePicker { .. })
+        !matches!(
+            self,
+            Self::RectanglePicker { .. } | Self::PointPicker { .. }
+        )
     }
 }
 
@@ -689,7 +737,7 @@ pub(crate) fn passive_overlay_plan(
             ds.iter().map(|d| d.bounds).collect(),
             ds.iter().map(|d| (d.bounds, d.index)).collect(),
         ),
-        OverlayVisual::RectanglePicker { .. } => unreachable!(),
+        OverlayVisual::RectanglePicker { .. } | OverlayVisual::PointPicker { .. } => unreachable!(),
     };
     let mut plan = Vec::new();
     for target in targets {
@@ -726,6 +774,7 @@ pub(crate) enum OverlayFramePrimitive {
 pub(crate) fn overlay_frame(visual: &OverlayVisual) -> Vec<OverlayFramePrimitive> {
     let mut frame = vec![OverlayFramePrimitive::Clear];
     match visual {
+        OverlayVisual::PointPicker { .. } => {}
         OverlayVisual::RectanglePicker { selection, .. } => {
             if let Some(rect) = selection {
                 frame.push(OverlayFramePrimitive::Outline(*rect));
@@ -962,6 +1011,38 @@ impl VisualOverlayController {
     ) -> OperationId {
         let id = self.allocate();
         self.begin_rectangle_pick_with_id(id, purpose, virtual_desktop)
+    }
+    pub fn begin_point_pick(&mut self, request: VisualPointRequest) -> OperationId {
+        let id = self.allocate();
+        self.begin_point_pick_with_id(id, request)
+    }
+    pub(crate) fn begin_point_pick_with_id(
+        &mut self,
+        id: OperationId,
+        request: VisualPointRequest,
+    ) -> OperationId {
+        let pointer = match self.renderer.cursor_position() {
+            Ok(point) => point,
+            Err(error) => {
+                self.replace_with_id(id);
+                self.renderer.close();
+                self.events.push_back(VisualOverlayEvent::Error {
+                    operation_id: id,
+                    error,
+                });
+                return id;
+            }
+        };
+        self.start_with_id(
+            id,
+            VisualOverlayState::PickingPoint {
+                operation_id: id,
+                request,
+                pointer,
+                phase: PointInteractionPhase::AwaitingInitialRelease,
+            },
+            OverlayVisual::PointPicker { pointer },
+        )
     }
     pub(crate) fn begin_rectangle_pick_with_id(
         &mut self,
@@ -1243,6 +1324,28 @@ impl VisualOverlayController {
             self.cancel();
             return;
         }
+        if let VisualOverlayState::PickingPoint { pointer, phase, .. } = &mut self.state {
+            match input.kind {
+                OverlayInputKind::PointerMoved(point) => {
+                    *pointer = point;
+                    self.repaint_point_picker();
+                }
+                OverlayInputKind::LeftReleased(point)
+                    if matches!(phase, PointInteractionPhase::AwaitingInitialRelease) =>
+                {
+                    *pointer = point;
+                    *phase = PointInteractionPhase::Armed;
+                    self.repaint_point_picker();
+                }
+                OverlayInputKind::LeftPressed(_)
+                    if matches!(phase, PointInteractionPhase::Armed) =>
+                {
+                    self.confirm_point();
+                }
+                _ => {}
+            }
+            return;
+        }
         let VisualOverlayState::PickingRectangle { pointer, phase, .. } = &mut self.state else {
             return;
         };
@@ -1286,6 +1389,57 @@ impl VisualOverlayController {
             OverlayInputKind::Enter
             | OverlayInputKind::LeftPressed(_)
             | OverlayInputKind::Escape => {}
+        }
+    }
+    fn repaint_point_picker(&mut self) {
+        let VisualOverlayState::PickingPoint { pointer, .. } = self.state else {
+            return;
+        };
+        let Some(id) = self.operation_id else { return };
+        if let Err(error) = self
+            .renderer
+            .repaint(id, &OverlayVisual::PointPicker { pointer })
+        {
+            self.renderer.close();
+            self.operation_id = None;
+            self.state = VisualOverlayState::Idle;
+            self.events.push_back(VisualOverlayEvent::Error {
+                operation_id: id,
+                error,
+            });
+        }
+    }
+    fn confirm_point(&mut self) {
+        let VisualOverlayState::PickingPoint {
+            request: ref request_value,
+            ..
+        } = self.state
+        else {
+            return;
+        };
+        let request = request_value.clone();
+        let id = self
+            .operation_id
+            .take()
+            .expect("point picker must be active");
+        match self.renderer.cursor_position() {
+            Ok(point) => {
+                self.renderer.close();
+                self.state = VisualOverlayState::Idle;
+                self.events.push_back(VisualOverlayEvent::PointConfirmed {
+                    operation_id: id,
+                    request,
+                    point,
+                });
+            }
+            Err(error) => {
+                self.renderer.close();
+                self.state = VisualOverlayState::Idle;
+                self.events.push_back(VisualOverlayEvent::Error {
+                    operation_id: id,
+                    error,
+                });
+            }
         }
     }
     fn repaint_picker(&mut self) {
@@ -1377,7 +1531,8 @@ fn passive_expiry(state: &VisualOverlayState) -> Option<Duration> {
 
 fn event_operation_id(event: &VisualOverlayEvent) -> OperationId {
     match event {
-        VisualOverlayEvent::RectangleConfirmed { operation_id, .. }
+        VisualOverlayEvent::PointConfirmed { operation_id, .. }
+        | VisualOverlayEvent::RectangleConfirmed { operation_id, .. }
         | VisualOverlayEvent::Cancelled { operation_id }
         | VisualOverlayEvent::Expired { operation_id }
         | VisualOverlayEvent::Error { operation_id, .. } => *operation_id,
@@ -1472,13 +1627,25 @@ mod tests {
         Close,
     }
 
-    #[derive(Default)]
     struct FakeData {
         left_down: bool,
+        cursor: MkPoint,
         inputs: Vec<OverlayInput>,
         calls: Vec<RecordedCall>,
         show_error: Option<VisualOverlayError>,
         poll_error: Option<VisualOverlayError>,
+    }
+    impl Default for FakeData {
+        fn default() -> Self {
+            Self {
+                left_down: false,
+                cursor: point(40, 50),
+                inputs: vec![],
+                calls: vec![],
+                show_error: None,
+                poll_error: None,
+            }
+        }
     }
     struct FakeRenderer(Arc<Mutex<FakeData>>);
     impl OverlayRenderer for FakeRenderer {
@@ -1486,7 +1653,7 @@ mod tests {
             Ok(self.0.lock().unwrap().left_down)
         }
         fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
-            Ok(point(40, 50))
+            Ok(self.0.lock().unwrap().cursor)
         }
         fn show(
             &mut self,
@@ -1553,6 +1720,93 @@ mod tests {
     }
     fn point(x: i32, y: i32) -> MkPoint {
         MkPoint { x, y }
+    }
+
+    fn point_request() -> VisualPointRequest {
+        VisualPointRequest {
+            macro_id: 9,
+            draft_generation: 4,
+            step_id: Some(77),
+            destination: VisualPointDestination::SetVariablePoint,
+        }
+    }
+
+    #[test]
+    fn point_picker_arms_then_confirms_once_and_preserves_negative_coordinates() {
+        let (mut c, data, _) = controller();
+        let id = c.begin_point_pick(point_request());
+        data.lock().unwrap().inputs.push(OverlayInput {
+            operation_id: id,
+            kind: OverlayInputKind::LeftPressed(point(1, 2)),
+        });
+        assert!(
+            advance_and_drain(&mut c).is_empty(),
+            "initiating press is ignored"
+        );
+        assert!(matches!(
+            c.state(),
+            VisualOverlayState::PickingPoint {
+                phase: PointInteractionPhase::AwaitingInitialRelease,
+                ..
+            }
+        ));
+        data.lock().unwrap().inputs.push(OverlayInput {
+            operation_id: id,
+            kind: OverlayInputKind::LeftReleased(point(1, 2)),
+        });
+        assert!(advance_and_drain(&mut c).is_empty());
+        assert!(matches!(
+            c.state(),
+            VisualOverlayState::PickingPoint {
+                phase: PointInteractionPhase::Armed,
+                ..
+            }
+        ));
+        data.lock().unwrap().cursor = point(-321, -45);
+        data.lock().unwrap().inputs.extend([
+            OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::LeftPressed(point(0, 0)),
+            },
+            OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::LeftPressed(point(0, 0)),
+            },
+        ]);
+        assert_eq!(
+            advance_and_drain(&mut c),
+            vec![VisualOverlayEvent::PointConfirmed {
+                operation_id: id,
+                request: point_request(),
+                point: point(-321, -45)
+            }]
+        );
+        assert_eq!(c.state(), &VisualOverlayState::Idle);
+        assert!(advance_and_drain(&mut c).is_empty());
+    }
+
+    #[test]
+    fn point_picker_escape_cancels_before_and_after_arming() {
+        for arm in [false, true] {
+            let (mut c, data, _) = controller();
+            let id = c.begin_point_pick(point_request());
+            if arm {
+                data.lock().unwrap().inputs.push(OverlayInput {
+                    operation_id: id,
+                    kind: OverlayInputKind::LeftReleased(point(0, 0)),
+                });
+                assert!(advance_and_drain(&mut c).is_empty());
+            }
+            data.lock().unwrap().inputs.push(OverlayInput {
+                operation_id: id,
+                kind: OverlayInputKind::Escape,
+            });
+            assert_eq!(
+                advance_and_drain(&mut c),
+                vec![VisualOverlayEvent::Cancelled { operation_id: id }]
+            );
+            assert_eq!(c.state(), &VisualOverlayState::Idle);
+        }
     }
 
     fn close_count(fake: &Arc<Mutex<FakeData>>) -> usize {

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -247,6 +247,7 @@ fn displays() -> Result<Vec<ScreenRect>, VisualOverlayError> {
 impl NativeOverlayRenderer {
     fn target(visual: &OverlayVisual) -> Option<ScreenRect> {
         match visual {
+            OverlayVisual::PointPicker { .. } => None,
             OverlayVisual::RectanglePicker {
                 virtual_desktop, ..
             } => Some(*virtual_desktop),
@@ -429,6 +430,12 @@ impl OverlayRenderer for NativeOverlayRenderer {
         if matches!(visual, OverlayVisual::RectanglePicker { .. }) {
             self.left_down = unsafe { GetAsyncKeyState(VK_LBUTTON.0 as i32) } < 0;
             self.escape_down = unsafe { GetAsyncKeyState(VK_ESCAPE.0 as i32) } < 0;
+        } else if matches!(visual, OverlayVisual::PointPicker { .. }) {
+            // Treat the launch click as held until polling observes an actual
+            // up state. This also synthesizes the arming release when command
+            // dispatch happens just after the GUI button was released.
+            self.left_down = true;
+            self.escape_down = unsafe { GetAsyncKeyState(VK_ESCAPE.0 as i32) } < 0;
         }
         let module = unsafe { GetModuleHandleW(None) }
             .map_err(|e| platform(format!("overlay module lookup failed: {e}")))?;
@@ -454,6 +461,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
             return Ok(());
         }
         let monitor_bounds = match visual {
+            OverlayVisual::PointPicker { .. } => vec![],
             // Preserve the descriptor topology: never create a virtual-desktop union window
             // spanning gaps between physical displays.
             OverlayVisual::Desktop(descriptors) => descriptors.iter().map(|d| d.bounds).collect(),
@@ -469,7 +477,7 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 intersecting_monitor_bounds(&physical, target)
             }
         };
-        if monitor_bounds.is_empty() {
+        if monitor_bounds.is_empty() && !matches!(visual, OverlayVisual::PointPicker { .. }) {
             return self.fail("No physical display intersects the requested preview region");
         }
         let frame = overlay_frame(visual);
@@ -541,18 +549,26 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 }));
             }
         }
-        if let OverlayVisual::RectanglePicker { tooltip, .. } = visual {
+        let tooltip_spec = match visual {
+            OverlayVisual::RectanglePicker { tooltip, .. } => {
+                Some((tooltip.pointer, tooltip.text.clone(), (330, 76)))
+            }
+            OverlayVisual::PointPicker { pointer } => {
+                Some((*pointer, POINT_INSTRUCTION.to_owned(), (300, 42)))
+            }
+            _ => None,
+        };
+        if let Some((tooltip_pointer, tooltip_text, size)) = tooltip_spec {
             let all = displays()?;
-            let monitor = monitor_nearest_pointer(&all, tooltip.pointer)
+            let monitor = monitor_nearest_pointer(&all, tooltip_pointer)
                 .ok_or_else(|| platform("No display is available for the selection tooltip"))?;
-            let size = (330, 76);
             let at =
-                place_rectangle_tooltip(tooltip.pointer, size, monitor, RECTANGLE_TOOLTIP_OFFSET);
+                place_rectangle_tooltip(tooltip_pointer, size, monitor, RECTANGLE_TOOLTIP_OFFSET);
             let bounds = ScreenRect::new(at.x, at.y, size.0, size.1);
             let mut state = Box::new(WindowPaintState {
                 bounds,
                 frame: vec![],
-                hint: Some(tooltip.text.clone()),
+                hint: Some(tooltip_text),
                 solid: None,
                 operation_id,
                 description: "tooltip",
@@ -625,14 +641,19 @@ impl OverlayRenderer for NativeOverlayRenderer {
                 })));
             }
         }
-        if let (Some(window), OverlayVisual::RectanglePicker { tooltip, .. }) =
-            (&mut self.tooltip, visual)
-        {
-            window.state.hint = Some(tooltip.text.clone());
+        if let Some(window) = &mut self.tooltip {
+            let (pointer, text) = match visual {
+                OverlayVisual::RectanglePicker { tooltip, .. } => {
+                    (tooltip.pointer, tooltip.text.clone())
+                }
+                OverlayVisual::PointPicker { pointer } => (*pointer, POINT_INSTRUCTION.to_owned()),
+                _ => return Ok(()),
+            };
+            window.state.hint = Some(text);
             let all = displays()?;
-            if let Some(monitor) = monitor_nearest_pointer(&all, tooltip.pointer) {
+            if let Some(monitor) = monitor_nearest_pointer(&all, pointer) {
                 let at = place_rectangle_tooltip(
-                    tooltip.pointer,
+                    pointer,
                     (window.state.bounds.width, window.state.bounds.height),
                     monitor,
                     RECTANGLE_TOOLTIP_OFFSET,


### PR DESCRIPTION
### Motivation

- Provide a reusable, identity-bearing point-pick protocol that runs in the independent native overlay worker instead of the GUI-polled `NativePositionPicker` so picks are robust and reject stale results.
- Support editor workflows that need an atomic, stale-safe way to set variable points (X/Y) from a desktop click with explicit arming and cancellation semantics.
- Keep the overlay behavior platform-native (Windows cursor/virtual-desktop coordinates, DPI-aware tooltip) while making the protocol and controller platform-independent and testable.

### Description

- Added a point-pick protocol and identity carrying types: `VisualPointDestination`, `VisualPointRequest`, and `PointInteractionPhase`, and extended `VisualOverlayState` with `PickingPoint`. (see `visual_overlay.rs`).
- Added `VisualOverlayCommand::PickPoint`, `VisualOverlayEvent::PointConfirmed`, and an `OverlayVisual::PointPicker` visual; routed `PickPoint` through the existing shared overlay service (`visual_capture_workflow.rs`).
- Implemented the native interaction state machine in the overlay controller/renderer: `begin_point_pick_with_id`, release-to-arm semantics (ignore initiating press, arm on release, confirm on next press), Escape cancellation, tooltip text near cursor, and use of virtual-desktop coordinates; native-window handling and tooltip logic updated in `visual_overlay_windows.rs` and `visual_overlay.rs`.
- Editor integration: `action_editor.rs` now exposes a `Pick Position` button for `MkValue::Point`, tracks an `active_point_pick` operation id, issues `begin_point_pick` requests targeting `SetVariablePoint`, validates request identity on `PointConfirmed`, and atomically updates both X/Y only when macro id, draft generation, stable step id, action and value type match.
- Tests: added platform-independent state-machine tests for the point picker in `visual_overlay.rs` and editor-routing tests in `action_editor.rs` covering arming, confirmation, cancellation, exactly-once semantics, negative-coordinates preservation, and stale-result rejection.

### Testing

- ✅ `cargo fmt --check` (formatting verified).
- ✅ `git diff --check` (no whitespace/diff warnings in changed files).
- ⚠️ `cargo test point_picker --lib` was attempted but could not complete in this environment because the repository’s top-level build still compiles unconditional Windows-only modules (unresolved `windows::Win32` / `windows::core` imports) leading to platform-specific compilation failures; the new point-picker unit tests are platform-independent and exercise the controller/renderer logic under the test fake renderer, but running the crate-wide test suite in this non-Windows environment produced unrelated platform errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9191bd01108332af3976f363865411)