### PR TITLE
Strengthen passive overlay planning/tests and add Windows passive-preview smoke harness

### DIFF
--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -192,6 +192,25 @@ These checks are intentionally manual and destructive. They require a real inter
 
 This checklist requires a **real, interactive Windows desktop**. The native layered-window renderer cannot be visually validated in headless CI, so these checks must not be automated there. For every item, record pass/fail evidence (screenshots or video where useful) plus:
 
+#### Direct passive-preview harness
+
+Before debugging this rendering path through **Wait for Visual Change**, run the
+manual harness from a Windows terminal:
+
+```powershell
+cargo run --bin passive_overlay_smoke
+```
+
+1. Confirm four bright yellow edges appear at `(100,100)`, outlining a
+   `500×300` rectangle.
+2. Confirm all four edges remain visible for roughly 2.5 seconds.
+3. Confirm every edge disappears afterward, and that the terminal prints the
+   launch, active, and cleanup diagnostics.
+
+This harness must pass before debugging the same path through **Wait for Visual
+Change**. It is manual-only: ordinary cross-platform unit tests never execute it
+or open native windows.
+
 - Windows version and build;
 - Multi Launcher commit;
 - GPU and graphics configuration;

--- a/src/bin/passive_overlay_smoke.rs
+++ b/src/bin/passive_overlay_smoke.rs
@@ -1,0 +1,16 @@
+//! Manual Win32 smoke harness for the production passive-overlay path.
+
+#[cfg(windows)]
+fn main() {
+    if let Err(error) =
+        multi_launcher::gui::mkmacro_dialog::visual_overlay::run_passive_overlay_smoke_test()
+    {
+        eprintln!("passive-overlay-smoke: failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("passive-overlay-smoke: unsupported platform; run this manual harness on Windows");
+}

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -644,9 +644,15 @@ impl OverlayVisual {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum OutlineEdge {
     Top,
+    Right,
     Bottom,
     Left,
-    Right,
+}
+
+/// Platform-neutral styling contract for passive outline windows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PassiveWindowStyle {
+    BrightYellow,
 }
 
 impl fmt::Display for OutlineEdge {
@@ -666,6 +672,7 @@ pub(crate) enum PassiveWindowSpec {
         edge: OutlineEdge,
         target: ScreenRect,
         rect: ScreenRect,
+        style: PassiveWindowStyle,
     },
     Badge {
         monitor: ScreenRect,
@@ -689,16 +696,16 @@ pub(crate) fn outline_edge_rects(rect: ScreenRect) -> [(OutlineEdge, ScreenRect)
             ScreenRect::new(rect.x, rect.y, rect.width.max(1), horizontal),
         ),
         (
+            OutlineEdge::Right,
+            ScreenRect::new(right, rect.y, vertical, rect.height.max(1)),
+        ),
+        (
             OutlineEdge::Bottom,
             ScreenRect::new(rect.x, bottom, rect.width.max(1), horizontal),
         ),
         (
             OutlineEdge::Left,
             ScreenRect::new(rect.x, rect.y, vertical, rect.height.max(1)),
-        ),
-        (
-            OutlineEdge::Right,
-            ScreenRect::new(right, rect.y, vertical, rect.height.max(1)),
         ),
     ]
 }
@@ -744,7 +751,12 @@ pub(crate) fn passive_overlay_plan(
         for (edge, edge_rect) in outline_edge_rects(target) {
             for display in displays {
                 if let Some(rect) = rect_intersection(edge_rect, *display) {
-                    plan.push(PassiveWindowSpec::Edge { edge, target, rect });
+                    plan.push(PassiveWindowSpec::Edge {
+                        edge,
+                        target,
+                        rect,
+                        style: PassiveWindowStyle::BrightYellow,
+                    });
                 }
             }
         }
@@ -755,10 +767,26 @@ pub(crate) fn passive_overlay_plan(
             .map(|(monitor, index)| PassiveWindowSpec::Badge { monitor, index }),
     );
     plan.sort_by_key(|spec| match spec {
-        PassiveWindowSpec::Edge { edge, rect, .. } => (0, rect.x, rect.y, *edge as i32, 0),
-        PassiveWindowSpec::Badge { monitor, index } => (1, monitor.x, monitor.y, 0, *index as i32),
+        PassiveWindowSpec::Edge {
+            edge, target, rect, ..
+        } => (0, target.x, target.y, *edge as i32, rect.x, rect.y),
+        PassiveWindowSpec::Badge { monitor, index } => {
+            (1, monitor.x, monitor.y, 0, *index as i32, 0)
+        }
     });
     Some(plan)
+}
+
+/// Runs the production Win32 renderer directly for manual smoke testing.
+#[cfg(windows)]
+pub fn run_passive_overlay_smoke_test() -> Result<(), VisualOverlayError> {
+    native::run_passive_overlay_smoke_test()
+}
+
+/// Keeps the manual harness buildable while making its platform requirement explicit.
+#[cfg(not(windows))]
+pub fn run_passive_overlay_smoke_test() -> Result<(), VisualOverlayError> {
+    Err(VisualOverlayError::unsupported())
 }
 
 /// Platform-neutral description of the pixels a native overlay must produce.
@@ -1965,29 +1993,104 @@ mod tests {
             outline_edge_rects(ScreenRect::new(10, 20, 100, 50)),
             [
                 (OutlineEdge::Top, ScreenRect::new(10, 20, 100, 3)),
+                (OutlineEdge::Right, ScreenRect::new(107, 20, 3, 50)),
                 (OutlineEdge::Bottom, ScreenRect::new(10, 67, 100, 3)),
                 (OutlineEdge::Left, ScreenRect::new(10, 20, 3, 50)),
-                (OutlineEdge::Right, ScreenRect::new(107, 20, 3, 50)),
             ]
         );
         let negative = outline_edge_rects(ScreenRect::new(-20, -10, 8, 7));
-        assert_eq!(negative[1].1, ScreenRect::new(-20, -6, 8, 3));
+        assert_eq!(negative[2].1, ScreenRect::new(-20, -6, 8, 3));
         let tiny = outline_edge_rects(ScreenRect::new(-2, -3, 2, 1));
         assert!(tiny.iter().all(|(_, r)| r.width > 0 && r.height > 0));
         assert_eq!(tiny[3].1, ScreenRect::new(-2, -3, 2, 1));
     }
 
+    fn assert_four_bright_yellow_edges(
+        visual: OverlayVisual,
+        target: ScreenRect,
+        displays: &[ScreenRect],
+    ) {
+        let plan = passive_overlay_plan(&visual, displays).unwrap();
+        let expected: Vec<_> = outline_edge_rects(target)
+            .into_iter()
+            .map(|(edge, rect)| PassiveWindowSpec::Edge {
+                edge,
+                target,
+                rect,
+                style: PassiveWindowStyle::BrightYellow,
+            })
+            .collect();
+        assert_eq!(plan, expected);
+    }
+
+    #[test]
+    fn passive_single_target_variants_have_exact_order_bounds_clipping_and_style() {
+        let display = ScreenRect::new(-500, -300, 1600, 1000);
+        let rectangle = ScreenRect::new(100, 100, 500, 300);
+        assert_four_bright_yellow_edges(
+            OverlayVisual::RectanglePreview(rectangle),
+            rectangle,
+            &[display],
+        );
+
+        let monitor_descriptor = monitor(4, ScreenRect::new(-400, -200, 400, 250));
+        assert_four_bright_yellow_edges(
+            OverlayVisual::Monitor(monitor_descriptor.clone()),
+            monitor_descriptor.bounds,
+            &[display],
+        );
+
+        for area_kind in [WindowAreaKind::WholeWindow, WindowAreaKind::ClientArea] {
+            let supplied_bounds = ScreenRect::new(-125, 40, 225, 175);
+            assert_four_bright_yellow_edges(
+                OverlayVisual::Window {
+                    rect: supplied_bounds,
+                    area_kind,
+                },
+                supplied_bounds,
+                &[display],
+            );
+        }
+    }
+
+    #[test]
+    fn desktop_preview_preserves_negative_monitor_topology_and_edge_order() {
+        let left = monitor(7, ScreenRect::new(-600, -100, 300, 200));
+        let right = monitor(2, ScreenRect::new(100, 50, 400, 250));
+        let plan = passive_overlay_plan(
+            &OverlayVisual::Desktop(vec![right.clone(), left.clone()]),
+            &[left.bounds, right.bounds],
+        )
+        .unwrap();
+        let mut expected = Vec::new();
+        for target in [left.bounds, right.bounds] {
+            expected.extend(outline_edge_rects(target).map(|(edge, rect)| {
+                PassiveWindowSpec::Edge {
+                    edge,
+                    target,
+                    rect,
+                    style: PassiveWindowStyle::BrightYellow,
+                }
+            }));
+        }
+        assert_eq!(plan, expected);
+        assert!(plan.iter().all(|spec| match spec {
+            PassiveWindowSpec::Edge { rect, .. } =>
+                rect.right() <= left.bounds.right()
+                    || i64::from(rect.x) >= i64::from(right.bounds.x),
+            PassiveWindowSpec::Badge { .. } => false,
+        }));
+    }
+
     #[test]
     fn passive_plan_clips_cross_monitor_edges_and_never_bridges_a_gap() {
         let displays = [
-            ScreenRect::new(0, 0, 100, 100),
-            ScreenRect::new(200, 0, 100, 100),
+            ScreenRect::new(-200, -50, 100, 100),
+            ScreenRect::new(0, -50, 100, 100),
         ];
-        let plan = passive_overlay_plan(
-            &OverlayVisual::RectanglePreview(ScreenRect::new(50, 20, 200, 60)),
-            &displays,
-        )
-        .unwrap();
+        let target = ScreenRect::new(-150, -20, 200, 60);
+        let plan =
+            passive_overlay_plan(&OverlayVisual::RectanglePreview(target), &displays).unwrap();
         let edges: Vec<_> = plan
             .iter()
             .filter_map(|s| match s {
@@ -1995,13 +2098,24 @@ mod tests {
                 _ => None,
             })
             .collect();
+        assert!(edges.iter().all(|r| r.right() <= -100 || r.x >= 0));
+        assert_eq!(
+            plan.iter()
+                .filter(|spec| matches!(spec, PassiveWindowSpec::Edge {
+                edge: OutlineEdge::Top,
+                target: actual_target,
+                style: PassiveWindowStyle::BrightYellow,
+                ..
+            } if *actual_target == target))
+                .count(),
+            2
+        );
         assert!(
             edges
                 .iter()
-                .all(|r| r.right() <= 100 || i64::from(r.x) >= 200)
+                .any(|r| *r == ScreenRect::new(-150, -20, 50, 3))
         );
-        assert!(edges.iter().any(|r| *r == ScreenRect::new(50, 20, 50, 3)));
-        assert!(edges.iter().any(|r| *r == ScreenRect::new(200, 20, 50, 3)));
+        assert!(edges.iter().any(|r| *r == ScreenRect::new(0, -20, 50, 3)));
     }
 
     #[test]

--- a/src/gui/mkmacro_dialog/visual_overlay_windows.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay_windows.rs
@@ -279,7 +279,12 @@ impl NativeOverlayRenderer {
         };
         for spec in plan {
             let (bounds, target, hint, solid, description, badge) = match spec {
-                PassiveWindowSpec::Edge { edge, target, rect } => (
+                PassiveWindowSpec::Edge {
+                    edge,
+                    target,
+                    rect,
+                    style: PassiveWindowStyle::BrightYellow,
+                } => (
                     rect,
                     target,
                     None,
@@ -775,4 +780,57 @@ impl Drop for NativeOverlayRenderer {
     fn drop(&mut self) {
         self.close();
     }
+}
+
+/// Manual diagnostic entry point. This deliberately uses the same renderer,
+/// visual, message pump, and teardown path as production without constructing
+/// any Action Editor state.
+pub(super) fn run_passive_overlay_smoke_test() -> Result<(), VisualOverlayError> {
+    const OPERATION_ID: OperationId = 1;
+    let visual = OverlayVisual::RectanglePreview(ScreenRect::new(100, 100, 500, 300));
+    let mut renderer = NativeOverlayRenderer::default();
+
+    eprintln!("passive-overlay-smoke: launch: planning passive rectangle");
+    let physical = displays().map_err(|error| {
+        eprintln!("passive-overlay-smoke: planning failed: {error}");
+        error
+    })?;
+    let planned = passive_overlay_plan(&visual, &physical).ok_or_else(|| {
+        let error = platform("passive rectangle unexpectedly has no passive window plan");
+        eprintln!("passive-overlay-smoke: planning failed: {error}");
+        error
+    })?;
+    if planned.len() != 4 {
+        let error = platform(format!(
+            "expected four native edge windows, planned {}",
+            planned.len()
+        ));
+        eprintln!("passive-overlay-smoke: planning failed: {error}");
+        return Err(error);
+    }
+    eprintln!("passive-overlay-smoke: launch: plan ready; creating four native windows");
+    renderer
+        .show(OPERATION_ID, &visual, true)
+        .map_err(|error| {
+            eprintln!("passive-overlay-smoke: creation failed: {error}");
+            error
+        })?;
+    eprintln!(
+        "passive-overlay-smoke: active: four bright-yellow edges; pumping messages for ~2.5s"
+    );
+
+    let deadline = Instant::now() + PASSIVE_OVERLAY_DURATION;
+    while Instant::now() < deadline {
+        if let Err(error) = renderer.poll_input() {
+            eprintln!("passive-overlay-smoke: message pump failed: {error}");
+            renderer.close();
+            eprintln!("passive-overlay-smoke: cleanup: overlay windows dismissed after failure");
+            return Err(error);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    renderer.close();
+    eprintln!("passive-overlay-smoke: cleanup: all overlay windows dismissed");
+    Ok(())
 }


### PR DESCRIPTION
### Motivation

- Ensure passive overlay outlines are fully specified, styled, and deterministically ordered so native windows never bridge monitor gaps or produce nondeterministic edge windows.
- Expand unit coverage to validate geometry, clipping across displays (including negative coordinates), per-edge identity, deterministic ordering, and passive styling semantics.
- Provide a small, Windows-only manual smoke harness that exercises the production `NativeOverlayRenderer` path without routing through `ActionEditor` or other UI state.

### Description

- Add a `PassiveWindowStyle` enum and include a `style` field on `PassiveWindowSpec::Edge` so passive edges carry an explicit bright-yellow styling contract (`BrightYellow`).
- Make `OutlineEdge` ordering explicit and update `outline_edge_rects` so edges are produced as `Top`, `Right`, `Bottom`, `Left`, and change `passive_overlay_plan` to attach style and sort deterministically by `target` then clipped native bounds.
- Expand tests in `visual_overlay.rs` to assert four-edge behavior for `RectanglePreview`, `Monitor`, `Desktop`, and `Window` variants, to validate negative coordinates, cross-monitor clipping (no bridging of gaps), deterministic ordering, and the bright-yellow style in plans.
- Add a Windows-only smoke entry point: `run_passive_overlay_smoke_test()` (gated with `#[cfg(windows)]`) implemented in `visual_overlay_windows.rs` that plans the passive rectangle, creates the native overlay windows using `NativeOverlayRenderer`, pumps the Windows message loop for `PASSIVE_OVERLAY_DURATION` (~2.5s), and explicitly tears down all created windows on success or error; add the `passive_overlay_smoke` binary under `src/bin/` and document the manual invocation in `docs/manual-smoke-tests.md`.

### Testing

- Ran formatting and checks using `cargo fmt --all -- --check` and `git diff --check`, which succeeded.
- Attempted targeted unit testing (`cargo test passive_ --lib`) but the run could not complete in this Linux environment due to a native dependency failure when building `alsa-sys` (missing system `alsa.pc` / pkg-config), preventing the full test run.
- The Windows smoke harness is intentionally manual and gated with `#[cfg(windows)]`, and so was not executed in this (non-Windows) CI environment; it prints concise launch/active/cleanup diagnostics when run on Windows via `cargo run --bin passive_overlay_smoke`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91ac6f7e848332bf5c75fba6d373c4)