### PR TITLE
Add focused image asset browser and preview tests

### DIFF
--- a/src/gui/mkmacro_dialog/image_asset_picker.rs
+++ b/src/gui/mkmacro_dialog/image_asset_picker.rs
@@ -25,6 +25,52 @@ pub fn asset_filename(asset: &MkImageAsset) -> &str {
         .unwrap_or(&asset.relative_path)
 }
 
+/// Widget-independent description of one browser row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ImageAssetBrowserEntry<'a> {
+    pub asset_id: u64,
+    pub display_name: &'a str,
+    pub filename: &'a str,
+    pub selected: bool,
+    pub preview_key: super::image_preview::PreviewLookupKey,
+}
+
+/// Builds rows solely from the active macro's assets. A selected row which does
+/// not match the search is retained at the beginning, making its placement
+/// deterministic while leaving matching rows in document order.
+pub(crate) fn browser_entries<'a>(
+    macro_id: u64,
+    assets: &'a [MkImageAsset],
+    query: &str,
+    selected_asset_id: u64,
+) -> Vec<ImageAssetBrowserEntry<'a>> {
+    let query = query.trim().to_lowercase();
+    let matches = |asset: &MkImageAsset| {
+        query.is_empty()
+            || asset.name.to_lowercase().contains(&query)
+            || asset_filename(asset).to_lowercase().contains(&query)
+    };
+    let row = |asset: &'a MkImageAsset| ImageAssetBrowserEntry {
+        asset_id: asset.id,
+        display_name: if asset.name.is_empty() {
+            asset_filename(asset)
+        } else {
+            &asset.name
+        },
+        filename: asset_filename(asset),
+        selected: asset.id == selected_asset_id,
+        preview_key: super::image_preview::PreviewLookupKey::new(macro_id, asset.id),
+    };
+    let retained = assets
+        .iter()
+        .find(|asset| asset.id == selected_asset_id && !matches(asset));
+    retained
+        .into_iter()
+        .chain(assets.iter().filter(|asset| matches(asset)))
+        .map(row)
+        .collect()
+}
+
 /// Filters without reordering: document/source order is the deterministic UI order.
 pub fn filtered_assets<'a>(assets: &'a [MkImageAsset], query: &str) -> Vec<&'a MkImageAsset> {
     let query = query.trim().to_lowercase();
@@ -70,7 +116,7 @@ pub fn show(
             format!("Missing asset · ID {}", *asset_id),
         );
     }
-    let matches = filtered_assets(context.assets, &query);
+    let matches = browser_entries(context.macro_id, context.assets, &query, *asset_id);
     let mut selection = None;
     egui::ScrollArea::vertical()
         .id_source(id.with("scroll"))
@@ -85,7 +131,7 @@ pub fn show(
                 ui.weak("No image assets match this search.");
             }
             for asset in matches {
-                let selected = *asset_id == asset.id;
+                let selected = asset.selected;
                 let fill = if selected {
                     ui.visuals().selection.bg_fill
                 } else {
@@ -100,35 +146,36 @@ pub fn show(
                                 ui,
                                 context.store,
                                 context.macro_id,
-                                asset.id,
+                                asset.asset_id,
                                 56.0,
                             );
                             ui.vertical(|ui| {
-                                ui.strong(if asset.name.is_empty() {
-                                    asset_filename(asset)
-                                } else {
-                                    &asset.name
-                                });
-                                ui.small(asset_filename(asset));
-                                ui.small(format!("ID {}", asset.id));
+                                ui.strong(asset.display_name);
+                                ui.small(asset.filename);
+                                ui.small(format!("ID {}", asset.asset_id));
                             });
                         });
                     });
                 let response = ui.interact(
                     row.response.rect,
-                    id.with(("row", asset.id)),
+                    id.with(("row", asset.asset_id)),
                     egui::Sense::click(),
                 );
                 response.widget_info(|| {
                     egui::WidgetInfo::selected(
                         egui::WidgetType::SelectableLabel,
                         selected,
-                        format!("{}; {}; ID {}", asset.name, asset_filename(asset), asset.id),
+                        format!(
+                            "{}; {}; ID {}",
+                            asset.display_name, asset.filename, asset.asset_id
+                        ),
                     )
                 });
                 if response.clicked() {
-                    *asset_id = asset.id;
-                    selection = Some(ImageAssetSelection { asset_id: asset.id });
+                    *asset_id = asset.asset_id;
+                    selection = Some(ImageAssetSelection {
+                        asset_id: asset.asset_id,
+                    });
                 }
             }
         });
@@ -192,5 +239,64 @@ mod tests {
         let event = ImageAssetSelection { asset_id: 8 };
         selected = event.asset_id;
         assert_eq!(selected, 8);
+    }
+
+    #[test]
+    fn browser_model_is_macro_scoped_complete_and_has_preview_identity() {
+        let current = vec![
+            asset(1, "Shared", "current/same.png"),
+            asset(2, "", "current/two.png"),
+        ];
+        let other_macro = vec![
+            asset(1, "Shared", "other/same.png"),
+            asset(3, "Two", "other/two.png"),
+        ];
+        let rows = browser_entries(10, &current, "", 2);
+        assert_eq!(
+            rows.iter().map(|row| row.asset_id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(rows[1].display_name, "two.png");
+        assert!(rows[1].selected);
+        assert_eq!(
+            rows[0].preview_key,
+            super::super::image_preview::PreviewLookupKey::new(10, 1)
+        );
+        assert!(rows.iter().all(|row| {
+            !other_macro
+                .iter()
+                .any(|other| other.id == row.asset_id && other.relative_path == row.filename)
+        }));
+        assert!(browser_entries(10, &[], "same", 1).is_empty());
+    }
+
+    #[test]
+    fn browser_searches_names_and_filenames_case_insensitively() {
+        let assets = vec![
+            asset(1, "Login Button", "shots/unrelated.png"),
+            asset(2, "Animal", "shots/Siamese-Cat.PNG"),
+            asset(3, "Settings", "shots/gear.png"),
+        ];
+        assert_eq!(browser_entries(1, &assets, "  bUtTo  ", 0)[0].asset_id, 1);
+        assert_eq!(browser_entries(1, &assets, "cat.p", 0)[0].asset_id, 2);
+        assert!(browser_entries(1, &assets, "absent", 0).is_empty());
+    }
+
+    #[test]
+    fn selected_non_match_is_retained_first_without_duplicates() {
+        let assets = vec![
+            asset(1, "Alpha", "a.png"),
+            asset(2, "Beta", "b.png"),
+            asset(3, "Alphabet", "c.png"),
+        ];
+        let retained = browser_entries(7, &assets, "alpha", 2);
+        assert_eq!(
+            retained.iter().map(|row| row.asset_id).collect::<Vec<_>>(),
+            vec![2, 1, 3]
+        );
+        assert!(retained[0].selected);
+        let matching = browser_entries(7, &assets, "beta", 2);
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].asset_id, 2);
     }
 }

--- a/src/gui/mkmacro_dialog/image_preview.rs
+++ b/src/gui/mkmacro_dialog/image_preview.rs
@@ -20,6 +20,20 @@ pub const PREVIEW_BOUND: f32 = 220.0;
 pub const TARGET_THUMBNAIL_BOUND: f32 = 140.0;
 const VALIDATE_INTERVAL: Duration = Duration::from_millis(500);
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct PreviewLookupKey {
+    pub macro_id: u64,
+    pub asset_id: u64,
+}
+
+impl PreviewLookupKey {
+    pub const fn new(macro_id: u64, asset_id: u64) -> Self {
+        Self { macro_id, asset_id }
+    }
+}
+
+const PREVIEW_CACHE_ID: &str = "mkmacro-image-preview-cache-v2";
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct PreviewKey {
     macro_id: u64,
@@ -112,6 +126,9 @@ pub fn fitted_size(width: u32, height: u32, bound: f32) -> egui::Vec2 {
 }
 
 fn thumbnail_dimensions(width: u32, height: u32) -> (u32, u32) {
+    if width == 0 || height == 0 {
+        return (0, 0);
+    }
     if width <= PREVIEW_BOUND as u32 && height <= PREVIEW_BOUND as u32 {
         return (width, height);
     }
@@ -280,19 +297,20 @@ fn show_sized(
     bound: f32,
     details: bool,
 ) {
+    let lookup_key = PreviewLookupKey::new(macro_id, asset_id);
     let Ok(path) = store.asset_path(macro_id, asset_id) else {
         ui.colored_label(egui::Color32::RED, "No reference image selected");
         return;
     };
     let ctx = ui.ctx().clone();
-    let cache_id = egui::Id::new("mkmacro-image-preview-cache-v2");
+    let cache_id = egui::Id::new(PREVIEW_CACHE_ID);
     // Phase one: a short cache-only egui data section.
     let inspection = ctx.data_mut(|data| {
         inspect_cache(
             data.get_temp_mut_or_default::<PreviewCache>(cache_id),
             path.clone(),
-            macro_id,
-            asset_id,
+            lookup_key.macro_id,
+            lookup_key.asset_id,
             Instant::now(),
         )
     });
@@ -392,6 +410,11 @@ mod tests {
             assert!((th as f32 - h as f32 * scale).abs() <= 1.0);
         }
         assert_eq!(thumbnail_dimensions(20, 10), (20, 10));
+        assert_eq!(thumbnail_dimensions(1, 1), (1, 1));
+        assert_eq!(thumbnail_dimensions(0, 10), (0, 0));
+        assert_eq!(thumbnail_dimensions(10, 0), (0, 0));
+        assert_eq!(thumbnail_dimensions(0, 0), (0, 0));
+        assert_eq!(fitted_size(0, u32::MAX, PREVIEW_BOUND), egui::Vec2::ZERO);
     }
 
     #[test]
@@ -451,6 +474,83 @@ mod tests {
             retry.previous_key = Some(key.clone());
             assert!(matches!(decode_job(&retry),DecodeResult::Unchanged(k) if k==key));
         }
+    }
+
+    #[test]
+    fn missing_and_unreadable_paths_are_fallbacks_and_not_redecoded() {
+        let dir = tempfile::tempdir().unwrap();
+        for path in [dir.path().join("missing.png"), dir.path().to_path_buf()] {
+            let (tx, _) = mpsc::channel();
+            let mut job = Job {
+                path,
+                macro_id: 4,
+                asset_id: 5,
+                previous_key: None,
+                sender: tx,
+            };
+            let DecodeResult::Failed(key, message) = decode_job(&job) else {
+                panic!("invalid path must fall back")
+            };
+            assert!(!message.is_empty());
+            job.previous_key = Some(key.clone());
+            assert!(matches!(decode_job(&job), DecodeResult::Unchanged(same) if same == key));
+        }
+    }
+
+    #[test]
+    fn invalid_png_dimensions_take_the_fallback_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("zero-width.png");
+        let mut bytes = png(1, 1);
+        // PNG IHDR width occupies bytes 16..20. A zero dimension is invalid;
+        // the stale CRC is immaterial because either rejection is a fallback.
+        bytes[16..20].copy_from_slice(&0_u32.to_be_bytes());
+        fs::write(&path, bytes).unwrap();
+        let (tx, _) = mpsc::channel();
+        assert!(matches!(
+            decode_job(&Job {
+                path,
+                macro_id: 1,
+                asset_id: 9,
+                previous_key: None,
+                sender: tx
+            }),
+            DecodeResult::Failed(_, _)
+        ));
+    }
+
+    #[test]
+    fn browser_and_mouse_move_share_lookup_and_single_cache_job() {
+        // Browser rows and Mouse Move -> Image Result both ultimately pass this
+        // same identity to show_thumbnail; there is deliberately one cache ID.
+        let browser_key = PreviewLookupKey::new(12, 34);
+        let mouse_move_key = PreviewLookupKey::new(12, 34);
+        assert_eq!(browser_key, mouse_move_key);
+        assert_eq!(PREVIEW_CACHE_ID, "mkmacro-image-preview-cache-v2");
+
+        let mut cache = PreviewCache::default();
+        let now = Instant::now();
+        let first = inspect_cache(
+            &mut cache,
+            "same.png".into(),
+            browser_key.macro_id,
+            browser_key.asset_id,
+            now,
+        );
+        let second = inspect_cache(
+            &mut cache,
+            "same.png".into(),
+            mouse_move_key.macro_id,
+            mouse_move_key.asset_id,
+            now,
+        );
+        assert!(first.job.is_some());
+        assert!(second.job.is_none());
+        assert_eq!(
+            cache.assets.len(),
+            1,
+            "a Mouse Move-specific cache/decoder must not be introduced"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Separate UI rendering from browser-model preparation so the picker only renders deterministic, pre-computed rows. 
- Ensure the browser is strictly scoped to the active macro, retains the currently selected asset even when filtered out, and deterministically places retained entries. 
- Make preview handling more robust and testable by exposing a shared preview lookup identity and exercising failure/throttling/thumbnail behaviors in CPU-only tests.

### Description

- Add a widget-independent `ImageAssetBrowserEntry` and `browser_entries` builder that accept `macro_id`, the macro's `assets`, a search `query`, and `selected_asset_id`, producing deterministic rows with display name, filename, selection state, and a `PreviewLookupKey`. (image_asset_picker.rs)
- Update the egui picker to consume the prepared `browser_entries` instead of performing ad-hoc filtering and presentation preparation inside the UI loop. (image_asset_picker.rs)
- Introduce `PreviewLookupKey` and a single `PREVIEW_CACHE_ID` for shared preview cache identity, add zero-dimension guards in `thumbnail_dimensions`, and route cache lookups via the lookup key. (image_preview.rs)
- Add focused unit tests exercising: macro-scoped browser completeness and ordering, case-insensitive name/filename searches, whitespace trimming, selected-entry retention without duplication, missing/unreadable/corrupt preview fallbacks, stable cached failures/unmodified retries, thumbnail bounds/aspect preservation/no upscaling, invalid-dimension fallbacks, and cache sharing between browser and mouse-move preview paths. (tests in both modified files)

### Testing

- ✅ `cargo fmt -- --check` succeeded.
- ✅ `git diff --check` succeeded.
- ⚠️ `cargo test image_asset_picker --lib && cargo test image_preview --lib` could not complete in this environment because the system ALSA development package (`alsa.pc`) is missing causing a build-time error when compiling `alsa-sys`, so the test run was blocked by an external system dependency rather than unit test failures.
- ✅ Basic repository checks (`git status --short` and recent commit recorded locally) were run to verify changes were staged and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91b95d18b883329c8108ccaab137bb)