### PR TITLE
Add point-picker controller and editor integration tests with fake overlay renderer and test hooks

### DIFF
--- a/src/gui/mkmacro_dialog/action_editor.rs
+++ b/src/gui/mkmacro_dialog/action_editor.rs
@@ -6406,5 +6406,187 @@ mod tests {
             let (editor, _) = setup();
             assert_eq!(value(&editor), Some(MkPoint { x: 1, y: 2 }));
         }
+
+        fn fixture_editor() -> (
+            ActionEditorState,
+            crate::gui::mkmacro_dialog::visual_capture_workflow::TestOverlayServiceFixture,
+        ) {
+            let fixture = super::super::super::visual_capture_workflow::SharedVisualOverlayController::test_fixture();
+            let editor = ActionEditorState::new(fixture.controller.clone());
+            (editor, fixture)
+        }
+
+        fn confirmed(
+            id: OperationId,
+            request: VisualPointRequest,
+            point: MkPoint,
+        ) -> VisualOverlayEvent {
+            VisualOverlayEvent::PointConfirmed {
+                operation_id: id,
+                request,
+                point,
+            }
+        }
+
+        #[test]
+        fn request_and_result_preserve_signed_point_and_variable_name() {
+            let (mut editor, fixture) = fixture_editor();
+            editor.begin_edit(&variable_step(
+                55,
+                "screen_point",
+                MkValue::Point(MkPoint { x: 4, y: 5 }),
+            ));
+            fixture.observer.set_left_button_down(true);
+            editor.request_point_pick(7);
+            let id = editor.active_point_pick.unwrap();
+            fixture.observer.wait_for_commands(1);
+            for _ in 0..3 {
+                std::thread::sleep(std::time::Duration::from_millis(15));
+                editor.poll_visual_overlay(Some(7));
+                assert_eq!(editor.active_point_pick, Some(id));
+            }
+            fixture.observer.set_left_button_down(false);
+            fixture.observer.emit(
+                id,
+                super::super::super::visual_overlay::OverlayInputKind::LeftReleased(MkPoint {
+                    x: 4,
+                    y: 5,
+                }),
+            );
+            fixture.observer.set_cursor(MkPoint { x: -320, y: 650 });
+            fixture.observer.emit(
+                id,
+                super::super::super::visual_overlay::OverlayInputKind::LeftPressed(MkPoint {
+                    x: -320,
+                    y: 650,
+                }),
+            );
+            for _ in 0..100 {
+                editor.poll_visual_overlay(Some(7));
+                if editor.active_point_pick.is_none() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+            assert_eq!(editor.active_point_pick, None);
+            assert!(matches!(editor.draft.as_ref().map(|s| &s.action), Some(
+                MkAction::SetVariable { name, value: MkValue::Point(MkPoint { x: -320, y: 650 }) }
+            ) if name == "screen_point"));
+        }
+
+        #[test]
+        fn escape_cancellation_before_and_after_arming_preserves_existing_point() {
+            for armed in [false, true] {
+                let (mut editor, fixture) = fixture_editor();
+                editor.begin_edit(&variable_step(
+                    55,
+                    "p",
+                    MkValue::Point(MkPoint { x: 81, y: -19 }),
+                ));
+                editor.request_point_pick(7);
+                let id = editor.active_point_pick.unwrap();
+                if armed {
+                    fixture.observer.emit(
+                        id,
+                        super::super::super::visual_overlay::OverlayInputKind::LeftReleased(
+                            MkPoint { x: 0, y: 0 },
+                        ),
+                    );
+                }
+                fixture
+                    .controller
+                    .inject_editor_event_for_test(VisualOverlayEvent::Cancelled {
+                        operation_id: id,
+                    });
+                editor.poll_visual_overlay(Some(7));
+                assert_eq!(value(&editor), Some(MkPoint { x: 81, y: -19 }));
+                assert_eq!(editor.active_point_pick, None);
+            }
+        }
+
+        #[test]
+        fn stale_superseded_and_duplicate_results_only_apply_to_current_draft_once() {
+            let (mut editor, fixture) = fixture_editor();
+            editor.begin_edit(&variable_step(
+                10,
+                "a",
+                MkValue::Point(MkPoint { x: 1, y: 2 }),
+            ));
+            editor.request_point_pick(7);
+            let old_id = editor.active_point_pick.unwrap();
+            let old_request = VisualPointRequest {
+                macro_id: 7,
+                draft_generation: editor.draft_generation,
+                step_id: Some(10),
+                destination: VisualPointDestination::SetVariablePoint,
+            };
+
+            editor.begin_edit(&variable_step(
+                20,
+                "b",
+                MkValue::Point(MkPoint { x: 3, y: 4 }),
+            ));
+            fixture.controller.inject_editor_event_for_test(confirmed(
+                old_id,
+                old_request,
+                MkPoint { x: -99, y: 88 },
+            ));
+            editor.poll_visual_overlay(Some(7));
+            assert_eq!(value(&editor), Some(MkPoint { x: 3, y: 4 }));
+
+            editor.request_point_pick(7);
+            let new_id = editor.active_point_pick.unwrap();
+            let new_request = VisualPointRequest {
+                macro_id: 7,
+                draft_generation: editor.draft_generation,
+                step_id: Some(20),
+                destination: VisualPointDestination::SetVariablePoint,
+            };
+            fixture.controller.inject_editor_event_for_test(confirmed(
+                old_id,
+                new_request.clone(),
+                MkPoint { x: -1, y: -1 },
+            ));
+            fixture.controller.inject_editor_event_for_test(confirmed(
+                new_id,
+                new_request.clone(),
+                MkPoint { x: -320, y: 650 },
+            ));
+            fixture.controller.inject_editor_event_for_test(confirmed(
+                new_id,
+                new_request,
+                MkPoint { x: 9, y: 9 },
+            ));
+            editor.poll_visual_overlay(Some(7));
+            assert_eq!(value(&editor), Some(MkPoint { x: -320, y: 650 }));
+            assert_eq!(editor.active_point_pick, None);
+        }
+
+        #[test]
+        fn result_after_editor_closure_is_safely_discarded() {
+            let (mut editor, fixture) = fixture_editor();
+            editor.begin_edit(&variable_step(
+                55,
+                "p",
+                MkValue::Point(MkPoint { x: 1, y: 2 }),
+            ));
+            editor.request_point_pick(7);
+            let id = editor.active_point_pick.unwrap();
+            let request = VisualPointRequest {
+                macro_id: 7,
+                draft_generation: editor.draft_generation,
+                step_id: Some(55),
+                destination: VisualPointDestination::SetVariablePoint,
+            };
+            editor.cancel();
+            fixture.controller.inject_editor_event_for_test(confirmed(
+                id,
+                request,
+                MkPoint { x: -320, y: 650 },
+            ));
+            editor.poll_visual_overlay(Some(7));
+            assert!(editor.draft.is_none());
+            assert_eq!(editor.active_point_pick, None);
+        }
     }
 }

--- a/src/gui/mkmacro_dialog/visual_capture_workflow.rs
+++ b/src/gui/mkmacro_dialog/visual_capture_workflow.rs
@@ -103,6 +103,11 @@ impl SharedVisualOverlayController {
     }
 
     #[cfg(test)]
+    pub(crate) fn inject_editor_event_for_test(&self, event: VisualOverlayEvent) {
+        self.0.editor_events.lock().unwrap().push_back(event);
+    }
+
+    #[cfg(test)]
     pub(crate) fn test_fixture() -> TestOverlayServiceFixture {
         let observer = Arc::new(super::visual_overlay::ServiceTestObserver::default());
         let factory: OverlayServiceFactory = Arc::new({

--- a/src/gui/mkmacro_dialog/visual_overlay.rs
+++ b/src/gui/mkmacro_dialog/visual_overlay.rs
@@ -7,7 +7,7 @@ use crate::mkmacro::{MkPoint, MonitorDescriptor, ScreenRect};
 #[cfg(test)]
 use std::sync::{
     Arc, Condvar, Mutex,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::{
     collections::VecDeque,
@@ -280,11 +280,28 @@ pub(crate) struct ServiceTestObserver {
     pub joins: AtomicUsize,
     pub worker_ids: Mutex<Vec<thread::ThreadId>>,
     inputs: Mutex<Vec<OverlayInput>>,
+    left_down: AtomicBool,
+    cursor: Mutex<MkPoint>,
     changed: Condvar,
 }
 
 #[cfg(test)]
 impl ServiceTestObserver {
+    pub fn set_left_button_down(&self, down: bool) {
+        self.left_down.store(down, Ordering::SeqCst);
+    }
+
+    pub fn set_cursor(&self, point: MkPoint) {
+        *self.cursor.lock().unwrap() = point;
+    }
+
+    pub fn emit(&self, operation_id: OperationId, kind: OverlayInputKind) {
+        self.inputs
+            .lock()
+            .unwrap()
+            .push(OverlayInput { operation_id, kind });
+    }
+
     pub fn wait_for_commands(&self, count: usize) {
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut commands = self.commands.lock().unwrap();
@@ -331,10 +348,10 @@ pub(crate) struct ServiceTestRenderer(pub Arc<ServiceTestObserver>);
 #[cfg(test)]
 impl OverlayRenderer for ServiceTestRenderer {
     fn left_button_down(&mut self) -> Result<bool, VisualOverlayError> {
-        Ok(false)
+        Ok(self.0.left_down.load(Ordering::SeqCst))
     }
     fn cursor_position(&mut self) -> Result<MkPoint, VisualOverlayError> {
-        Ok(MkPoint { x: 0, y: 0 })
+        Ok(*self.0.cursor.lock().unwrap())
     }
     fn show(
         &mut self,
@@ -1811,6 +1828,50 @@ mod tests {
         );
         assert_eq!(c.state(), &VisualOverlayState::Idle);
         assert!(advance_and_drain(&mut c).is_empty());
+    }
+
+    #[test]
+    fn point_picker_held_launch_button_must_release_before_next_click() {
+        let (mut c, data, _) = controller();
+        data.lock().unwrap().left_down = true;
+        let id = c.begin_point_pick(point_request());
+
+        for _ in 0..3 {
+            assert!(advance_and_drain(&mut c).is_empty());
+            assert!(matches!(
+                c.state(),
+                VisualOverlayState::PickingPoint {
+                    phase: PointInteractionPhase::AwaitingInitialRelease,
+                    ..
+                }
+            ));
+        }
+        data.lock().unwrap().inputs.push(OverlayInput {
+            operation_id: id,
+            kind: OverlayInputKind::LeftReleased(point(12, 34)),
+        });
+        assert!(advance_and_drain(&mut c).is_empty());
+        assert!(matches!(
+            c.state(),
+            VisualOverlayState::PickingPoint {
+                phase: PointInteractionPhase::Armed,
+                ..
+            }
+        ));
+
+        data.lock().unwrap().cursor = point(-320, 650);
+        data.lock().unwrap().inputs.push(OverlayInput {
+            operation_id: id,
+            kind: OverlayInputKind::LeftPressed(point(-320, 650)),
+        });
+        assert_eq!(
+            advance_and_drain(&mut c),
+            vec![VisualOverlayEvent::PointConfirmed {
+                operation_id: id,
+                request: point_request(),
+                point: point(-320, 650),
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Add focused unit and integration tests to validate point-pick interactions, ensuring correct handling of initially-held buttons, arming behavior, signed-coordinate propagation, cancellations, stale/superseded completions, and safe editor closure.

### Description

- Introduced test-only controls to the overlay test harness by extending `ServiceTestObserver`/`ServiceTestRenderer` to track physical left-button state and cursor coordinates and to emit queued `OverlayInput` events, and added `emit`, `set_left_button_down`, and `set_cursor` helpers in `src/gui/mkmacro_dialog/visual_overlay.rs`.
- Added a test-only injection API `inject_editor_event_for_test` to `SharedVisualOverlayController` in `src/gui/mkmacro_dialog/visual_capture_workflow.rs` so editor tests can deterministically deliver `VisualOverlayEvent`s.
- Implemented controller-level coverage in `src/gui/mkmacro_dialog/visual_overlay.rs` that verifies an initially-held launch button is consumed (picker arms only after release) and that the subsequent click confirms with the exact signed coordinate `(-320, 650)` and correct operation id.
- Implemented editor-integration tests in `src/gui/mkmacro_dialog/action_editor.rs` covering held-button request flow, negative-coordinate preservation when applying a `SetVariable` draft, Escape cancellation before and after arming, stale/superseded operation-id handling, and safe discard of results after the editor is closed.
- Committed changes on the current branch with message `test point picker controller and editor routing` and updated the test fixtures and assertions to keep negative-coordinate checks at both controller and editor levels.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran repository checks (`git diff --check`) which succeeded and committed the changes locally.
- Attempted `cargo test point_picker --lib` but the build failed in this environment due to a missing system dependency: the `alsa` development package (`alsa.pc`) required by `alsa-sys` is not available, so the added tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91c83644cc8332ba046b962142d379)