### PR TITLE
Test image outputs through compiled executor playback

### DIFF
--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -4672,11 +4672,11 @@ mod phase_d_tests {
     }
 
     #[test]
-    fn compiled_image_output_flows_to_following_mouse_move_in_one_execution() {
+    fn find_image_point_output_mandatory_match_moves_mouse_in_one_compiled_playback() {
         let fake = Arc::new(FakeBackend::default());
-        let point = MkPoint { x: 500, y: 300 };
+        let point = MkPoint { x: 823, y: 441 };
         fake.script_image(10, Ok(Some(point)));
-        let mut payload = image_payload(10, MkImageNotFoundPolicy::Continue);
+        let mut payload = image_payload(10, MkImageNotFoundPolicy::Fail);
         payload.outputs = MkImageOutputs {
             point: Some("point".into()),
             ..Default::default()
@@ -4693,14 +4693,21 @@ mod phase_d_tests {
         assert_eq!(
             fake.events()
                 .iter()
-                .filter(|event| **event == "move:500,300")
+                .filter(|event| event.starts_with("move:"))
+                .collect::<Vec<_>>(),
+            ["move:823,441"]
+        );
+        assert_eq!(
+            fake.events()
+                .iter()
+                .filter(|event| **event == "move:823,441")
                 .count(),
             1
         );
     }
 
     #[test]
-    fn continued_image_miss_nulls_stale_output_and_following_move_reports_type_mismatch() {
+    fn find_image_point_output_continued_miss_writes_null_and_reports_variable_type() {
         let fake = Arc::new(FakeBackend::default());
         fake.script_image(10, Ok(None));
         let mut payload = image_payload(10, MkImageNotFoundPolicy::Continue);
@@ -4728,10 +4735,64 @@ mod phase_d_tests {
         assert_eq!(snapshots[0].get("point"), Some(&MkValue::Null));
         assert_eq!(error.kind, DiagnosticKind::TypeMismatch);
         assert_eq!(
+            error.message,
+            "Variable 'point' contains Null; coordinate target requires Point"
+        );
+        assert_eq!(
+            error.context.get("variable").map(String::as_str),
+            Some("point")
+        );
+        assert_eq!(
             error.context.get("expected").map(String::as_str),
             Some("Point")
         );
+        assert_eq!(
+            error.context.get("action").map(String::as_str),
+            Some("Mouse Move")
+        );
         assert!(!fake.events().iter().any(|event| event.starts_with("move:")));
+    }
+
+    #[test]
+    fn repeated_find_image_point_output_match_then_miss_overwrites_same_runtime_value() {
+        let fake = Arc::new(FakeBackend::default());
+        fake.script_image(10, Ok(Some(MkPoint { x: 10, y: 20 })));
+        fake.script_image(10, Ok(None));
+        let mut payload = image_payload(10, MkImageNotFoundPolicy::Continue);
+        payload.outputs = MkImageOutputs {
+            point: Some("point".into()),
+            ..Default::default()
+        };
+
+        let error = run(
+            vec![
+                s(1, MkAction::ImageFind(payload.clone())),
+                s(2, variable_move()),
+                s(3, MkAction::ImageFind(payload)),
+                s(4, variable_move()),
+            ],
+            fake.clone(),
+        )
+        .unwrap_err();
+
+        let snapshots = fake.resolved_variables.lock().unwrap();
+        assert_eq!(
+            snapshots[0].get("point"),
+            Some(&MkValue::Point(MkPoint { x: 10, y: 20 }))
+        );
+        assert_eq!(snapshots[1].get("point"), Some(&MkValue::Null));
+        assert_ne!(
+            snapshots[1].get("point"),
+            Some(&MkValue::Point(MkPoint { x: 10, y: 20 }))
+        );
+        assert_eq!(error.kind, DiagnosticKind::TypeMismatch);
+        assert_eq!(
+            fake.events()
+                .iter()
+                .filter(|event| event.starts_with("move:"))
+                .collect::<Vec<_>>(),
+            ["move:10,20"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure Find Image outputs flow through the compiled executor into subsequent variable-targeted Mouse Move actions, exercising the `MkImageOutputs` write path, runtime variable store, variable-target resolution, and the fake mouse backend. 
- Verify that continued misses explicitly null the named outputs in the runtime and produce a precise TypeMismatch diagnostic that includes the consuming variable name and action. 
- Cover repeated searches within a single runtime to confirm outputs are overwritten (not retained) and retain a guard that separate executor invocations do not share runtime outputs.

### Description

- Added a mandatory match-path integration test that compiles and executes a macro with Find Image (point output) followed by Mouse Move, using a fake image match at `(823, 441)` and asserting the runtime variable becomes `MkValue::Point(823, 441)` and the fake mouse receives exactly one `move:823,441` event. 
- Modified the previous miss-path test to use the compiled executor flow, assert the named point output is written as `MkValue::Null`, assert no mouse move occurs, and assert the diagnostic message and context include the consuming variable name (`"point"`) and the `"Mouse Move"` action. 
- Added a repeated-search test that first returns `MkValue::Point(10, 20)` then returns no match, asserting the first value is observable to a Mouse Move and that the second search overwrites the runtime output with `MkValue::Null` (not retaining `(10,20)`). 
- Left the existing executor-invocation isolation test intact to ensure separate runs do not share runtime outputs or mutate the compiled plan.

### Testing

- ✅ `cargo fmt --check` 
- ✅ `git diff --check` 
- ⚠️ `cargo test find_image_point_output --lib` — attempted but could not complete on this Linux host due to platform-specific native dependencies and Windows-only API imports in unrelated modules; earlier runs failed on missing system libs (`alsa`, `x11`) which were partially resolved by installing system packages, but final compilation still fails with unresolved Windows API imports, so the test could not be exercised to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91cfdf9b3c8332b217de1c7399ed68)