### PR TITLE
Poll launcher commands on the GUI thread

### DIFF
--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1728,10 +1728,18 @@ mod tests {
         app.command_cache = two_results();
         app.query = "before polling".into();
 
-        // Consume repaint requests made while constructing the app. Otherwise
-        // egui may coalesce the worker's wakeup with that already-pending frame,
-        // and the counter below would not identify broker submission.
-        let _ = ctx.run(egui::RawInput::default(), |_| {});
+        // Consume repaint requests made while constructing the app. An immediate
+        // egui repaint intentionally remains outstanding for another frame, so
+        // one frame is not sufficient to put the context back to sleep. If a
+        // repaint is already pending, another `request_repaint` is coalesced and
+        // does not invoke the integration callback.
+        for _ in 0..8 {
+            let _ = ctx.run(egui::RawInput::default(), |_| {});
+            if !ctx.has_requested_repaint() {
+                break;
+            }
+        }
+        assert!(!ctx.has_requested_repaint());
         let wakes = Arc::new(AtomicUsize::new(0));
         let callback_wakes = Arc::clone(&wakes);
         ctx.set_request_repaint_callback(move |_| {

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -1723,15 +1723,20 @@ mod tests {
     #[test]
     fn macro_launcher_poll_consumes_one_request_and_mutates_query_on_gui_dispatch() {
         let ctx = egui::Context::default();
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let mut app = new_app(&ctx);
+        app.command_cache = two_results();
+        app.query = "before polling".into();
+
+        // Consume repaint requests made while constructing the app. Otherwise
+        // egui may coalesce the worker's wakeup with that already-pending frame,
+        // and the counter below would not identify broker submission.
+        let _ = ctx.run(egui::RawInput::default(), |_| {});
         let wakes = Arc::new(AtomicUsize::new(0));
         let callback_wakes = Arc::clone(&wakes);
         ctx.set_request_repaint_callback(move |_| {
             callback_wakes.fetch_add(1, Ordering::SeqCst);
         });
-        let broker = Arc::new(LauncherCommandBroker::default());
-        let mut app = new_app(&ctx);
-        app.command_cache = two_results();
-        app.query = "before polling".into();
 
         // The empty poll installs the wakeup callback but changes no GUI state.
         app.poll_macro_launcher_commands_from(&ctx, &broker);

--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -694,6 +694,65 @@ impl LauncherApp {
 }
 
 impl LauncherApp {
+    fn dispatch_macro_launcher_query(
+        &mut self,
+        request: &crate::mkmacro::LauncherCommandRequest,
+    ) -> crate::mkmacro::LauncherCommandResponse {
+        use crate::mkmacro::LauncherCommandResponse;
+
+        let previous_error = self.error.clone();
+        self.query = request.query.clone();
+        self.last_results_valid = false;
+        self.search();
+        if self.error != previous_error
+            && let Some(message) = self.error.clone()
+        {
+            return LauncherCommandResponse::Failed(message);
+        }
+
+        match self.results.as_slice() {
+            [] => LauncherCommandResponse::NoResults,
+            [action] => {
+                let action = action.clone();
+                self.activate_action(action, None, ActivationSource::Enter);
+                if self.error != previous_error
+                    && let Some(message) = self.error.clone()
+                {
+                    LauncherCommandResponse::Failed(message)
+                } else {
+                    LauncherCommandResponse::Activated
+                }
+            }
+            results => LauncherCommandResponse::PresentedForSelection {
+                result_count: results.len(),
+            },
+        }
+    }
+
+    fn poll_macro_launcher_commands_from(
+        &mut self,
+        ctx: &egui::Context,
+        broker: &crate::mkmacro::LauncherCommandBroker,
+    ) {
+        broker.set_repaint(std::sync::Arc::new({
+            let ctx = ctx.clone();
+            move || ctx.request_repaint()
+        }));
+        let Some(pending) = broker.take_pending() else {
+            return;
+        };
+
+        let response = self.dispatch_macro_launcher_query(&pending.request);
+        // A stopped macro may have dropped its receiver after the GUI took the
+        // request. `respond` deliberately makes that race harmless.
+        let _ = pending.respond(response);
+    }
+
+    fn poll_macro_launcher_commands(&mut self, ctx: &egui::Context) {
+        let broker = crate::mkmacro::production_launcher_command_broker();
+        self.poll_macro_launcher_commands_from(ctx, &broker);
+    }
+
     fn poll_macro_launcher_query(&mut self, ctx: &egui::Context) {
         let broker = crate::mkmacro::production_launcher_query_broker();
         broker.set_repaint(std::sync::Arc::new({
@@ -811,6 +870,7 @@ impl eframe::App for LauncherApp {
         }
 
         self.poll_macro_launcher_query(ctx);
+        self.poll_macro_launcher_commands(ctx);
         self.poll_macro_prompt(ctx);
 
         // tracing::debug!("LauncherApp::update called");
@@ -1605,9 +1665,20 @@ impl eframe::App for LauncherApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{plugin::PluginManager, settings::Settings};
+    use crate::{
+        mkmacro::{LauncherCommandBroker, LauncherCommandResponse, RunControl},
+        plugin::PluginManager,
+        settings::Settings,
+    };
     use eframe::egui;
-    use std::sync::{Arc, atomic::AtomicBool};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
 
     fn new_app(ctx: &egui::Context) -> LauncherApp {
         LauncherApp::new(
@@ -1626,6 +1697,98 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             Arc::new(AtomicBool::new(false)),
         )
+    }
+
+    fn two_results() -> Vec<Action> {
+        (0..2)
+            .map(|index| Action {
+                label: format!("Result {index}"),
+                desc: "Test".into(),
+                action: format!("test:{index}"),
+                args: None,
+            })
+            .collect()
+    }
+
+    fn wait_for_repaint(wakes: &AtomicUsize) {
+        for _ in 0..100 {
+            if wakes.load(Ordering::SeqCst) != 0 {
+                return;
+            }
+            thread::sleep(Duration::from_millis(2));
+        }
+        panic!("worker submission did not wake egui");
+    }
+
+    #[test]
+    fn macro_launcher_poll_consumes_one_request_and_mutates_query_on_gui_dispatch() {
+        let ctx = egui::Context::default();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let callback_wakes = Arc::clone(&wakes);
+        ctx.set_request_repaint_callback(move |_| {
+            callback_wakes.fetch_add(1, Ordering::SeqCst);
+        });
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let mut app = new_app(&ctx);
+        app.command_cache = two_results();
+        app.query = "before polling".into();
+
+        // The empty poll installs the wakeup callback but changes no GUI state.
+        app.poll_macro_launcher_commands_from(&ctx, &broker);
+        assert_eq!(app.query, "before polling");
+
+        let submit_broker = Arc::clone(&broker);
+        let submitter = thread::spawn(move || submit_broker.submit("", &RunControl::default()));
+        wait_for_repaint(&wakes);
+        assert_eq!(app.query, "before polling");
+
+        app.poll_macro_launcher_commands_from(&ctx, &broker);
+        assert_eq!(app.query, "");
+        assert!(broker.take_pending().is_none());
+        assert_eq!(
+            submitter.join().unwrap().unwrap(),
+            LauncherCommandResponse::PresentedForSelection { result_count: 2 }
+        );
+
+        // A second poll cannot respond to, or otherwise process, the request again.
+        app.poll_macro_launcher_commands_from(&ctx, &broker);
+        assert_eq!(app.query, "");
+    }
+
+    #[test]
+    fn empty_macro_launcher_broker_is_a_no_op() {
+        let ctx = egui::Context::default();
+        let broker = LauncherCommandBroker::default();
+        let mut app = new_app(&ctx);
+        app.query = "unchanged".into();
+
+        app.poll_macro_launcher_commands_from(&ctx, &broker);
+
+        assert_eq!(app.query, "unchanged");
+        assert!(app.results.is_empty());
+    }
+
+    #[test]
+    fn disconnected_macro_launcher_waiter_does_not_panic_gui_dispatch() {
+        let ctx = egui::Context::default();
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let control = Arc::new(RunControl::default());
+        let submit_broker = Arc::clone(&broker);
+        let submit_control = Arc::clone(&control);
+        let submitter = thread::spawn(move || submit_broker.submit("missing", &submit_control));
+        let pending = loop {
+            if let Some(pending) = broker.take_pending() {
+                break pending;
+            }
+            thread::yield_now();
+        };
+        control.stop();
+        assert!(submitter.join().unwrap().is_err());
+
+        let mut app = new_app(&ctx);
+        let response = app.dispatch_macro_launcher_query(&pending.request);
+        assert_eq!(response, LauncherCommandResponse::NoResults);
+        assert!(!pending.respond(response));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure launcher command requests submitted by macro workers are processed synchronously on the GUI thread without allowing worker-thread mutation of `LauncherApp` state.
- Wake egui frames when a worker submits a launcher command so the GUI can respond promptly via its repaint callback.
- Convert recoverable GUI-side failures into `LauncherCommandResponse::Failed` so workers never block indefinitely or panic when a GUI-side error occurs.

### Description

- Added a GUI-only dispatch helper `dispatch_macro_launcher_query(&mut self, request: &crate::mkmacro::LauncherCommandRequest) -> crate::mkmacro::LauncherCommandResponse` that updates `self.query`, runs `self.search()`, performs activation when a single result exists, and returns `Activated`, `PresentedForSelection`, `NoResults`, or `Failed` as appropriate.
- Added `poll_macro_launcher_commands_from` and `poll_macro_launcher_commands` which obtain `production_launcher_command_broker()`, install/refresh the egui repaint callback, take at most one pending request, call the dispatch helper while holding `&mut LauncherApp`, and call `PendingLauncherCommand::respond` exactly once (tolerating disconnected waiters).
- Wired the new polling into `eframe::App::update` near the existing `poll_macro_prompt`/`poll_macro_launcher_query` calls so query/result changes are visible in the same frame.
- Kept all GUI mutations (e.g. `query`, `results`, timer flags, focus flags, dialog/panel state) on the GUI thread and isolated request-processing logic for unit testing; added unit tests in the existing GUI test module that cover broker consumption, empty-broker no-op, repaint wake behavior, and disconnected/cancelled waiter handling.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `git diff --check` which succeeded and resulted in a single commit adding the polling and tests (`Poll launcher command broker on GUI thread`).
- Attempted to run the new GUI unit tests via `cargo test` for the added cases, but a full test build in this environment failed due to a missing system dependency (`alsa`/`alsa.pc`) required by `alsa-sys` during crate compilation, so the test run could not complete here; the tests are included in `src/gui/render.rs` and exercise: broker consumption and response, empty-broker no-op, repaint wake callback, GUI-only query mutation during dispatch, and disconnected waiter behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91f27d0b4c83329b29de8c8c19dd33)