### PR TITLE
Route migrated macro actions through GUI broker (typed request kinds + executor/GUI changes)

### DIFF
--- a/src/gui/render.rs
+++ b/src/gui/render.rs
@@ -694,13 +694,23 @@ impl LauncherApp {
 }
 
 impl LauncherApp {
-    fn dispatch_macro_launcher_query(
+    fn dispatch_macro_launcher_command(
         &mut self,
         request: &crate::mkmacro::LauncherCommandRequest,
     ) -> crate::mkmacro::LauncherCommandResponse {
-        use crate::mkmacro::LauncherCommandResponse;
+        use crate::mkmacro::{LauncherCommandKind, LauncherCommandResponse};
 
-        self.query = request.query.clone();
+        let LauncherCommandKind::Query(query) = &request.kind else {
+            let LauncherCommandKind::ResolvedLegacy(action) = &request.kind else {
+                unreachable!()
+            };
+            let before = self.launcher_interaction_snapshot();
+            self.activate_action(action.clone(), None, ActivationSource::Macro);
+            self.restore_for_new_launcher_interaction(&before);
+            return LauncherCommandResponse::Activated;
+        };
+
+        self.query = query.clone();
         self.last_timer_query =
             self.query.starts_with("timer list") || self.query.starts_with("alarm list");
         self.selected = None;
@@ -741,7 +751,7 @@ impl LauncherApp {
             return;
         };
 
-        let response = self.dispatch_macro_launcher_query(&pending.request);
+        let response = self.dispatch_macro_launcher_command(&pending.request);
         // A stopped macro may have dropped its receiver after the GUI took the
         // request. `respond` deliberately makes that race harmless.
         let _ = pending.respond(response);
@@ -1759,9 +1769,9 @@ mod tests {
             ("one", LauncherCommandResponse::Activated),
         ] {
             let response =
-                app.dispatch_macro_launcher_query(&crate::mkmacro::LauncherCommandRequest {
+                app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
                     id: 1,
-                    query: query.into(),
+                    kind: crate::mkmacro::LauncherCommandKind::Query(query.into()),
                 });
             assert_eq!(response, expected);
             assert_eq!(app.query, query);
@@ -1772,17 +1782,19 @@ mod tests {
         );
 
         app.help_window.open = false;
-        let response = app.dispatch_macro_launcher_query(&crate::mkmacro::LauncherCommandRequest {
-            id: 2,
-            query: "rewrite".into(),
-        });
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 2,
+                kind: crate::mkmacro::LauncherCommandKind::Query("rewrite".into()),
+            });
         assert_eq!(response, LauncherCommandResponse::Activated);
         assert_eq!(app.query, "rewritten");
 
-        let response = app.dispatch_macro_launcher_query(&crate::mkmacro::LauncherCommandRequest {
-            id: 3,
-            query: "recursive".into(),
-        });
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 3,
+                kind: crate::mkmacro::LauncherCommandKind::Query("recursive".into()),
+            });
         assert_eq!(response, LauncherCommandResponse::Activated);
         assert_eq!(app.query, "one");
         assert!(
@@ -1792,15 +1804,54 @@ mod tests {
     }
 
     #[test]
+    fn migrated_legacy_action_activates_gui_owned_dialog_as_macro() {
+        let ctx = egui::Context::default();
+        let mut app = new_app(&ctx);
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 7,
+                kind: crate::mkmacro::LauncherCommandKind::ResolvedLegacy(Action {
+                    label: "Help".into(),
+                    desc: "GUI dialog".into(),
+                    action: "help:show".into(),
+                    args: None,
+                }),
+            });
+        assert_eq!(response, LauncherCommandResponse::Activated);
+        assert!(
+            app.help_window.open,
+            "GUI-owned dialog was opened during dispatch"
+        );
+
+        app.require_confirm_destructive = true;
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 8,
+                kind: crate::mkmacro::LauncherCommandKind::ResolvedLegacy(Action {
+                    label: "Clear".into(),
+                    desc: String::new(),
+                    action: "history:clear".into(),
+                    args: None,
+                }),
+            });
+        assert_eq!(response, LauncherCommandResponse::Activated);
+        assert_eq!(
+            app.pending_confirm.as_ref().map(|pending| pending.source),
+            Some(ActivationSource::Macro)
+        );
+    }
+
+    #[test]
     fn macro_launcher_destructive_and_ambiguous_results_remain_interactive() {
         let ctx = egui::Context::default();
         let mut app = app_with_fake(&ctx);
         app.require_confirm_destructive = true;
 
-        let response = app.dispatch_macro_launcher_query(&crate::mkmacro::LauncherCommandRequest {
-            id: 1,
-            query: "destroy".into(),
-        });
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 1,
+                kind: crate::mkmacro::LauncherCommandKind::Query("destroy".into()),
+            });
         assert_eq!(response, LauncherCommandResponse::Activated);
         assert_eq!(
             app.pending_confirm.as_ref().map(|pending| pending.source),
@@ -1808,10 +1859,11 @@ mod tests {
         );
 
         app.selected = Some(1);
-        let response = app.dispatch_macro_launcher_query(&crate::mkmacro::LauncherCommandRequest {
-            id: 2,
-            query: "many".into(),
-        });
+        let response =
+            app.dispatch_macro_launcher_command(&crate::mkmacro::LauncherCommandRequest {
+                id: 2,
+                kind: crate::mkmacro::LauncherCommandKind::Query("many".into()),
+            });
         assert_eq!(
             response,
             LauncherCommandResponse::PresentedForSelection { result_count: 2 }
@@ -1869,7 +1921,8 @@ mod tests {
         assert_eq!(app.query, "before polling");
 
         let submit_broker = Arc::clone(&broker);
-        let submitter = thread::spawn(move || submit_broker.submit("", &RunControl::default()));
+        let submitter =
+            thread::spawn(move || submit_broker.submit_query("", &RunControl::default()));
         wait_for_repaint(&wakes);
         assert_eq!(app.query, "before polling");
 
@@ -1906,7 +1959,8 @@ mod tests {
         let control = Arc::new(RunControl::default());
         let submit_broker = Arc::clone(&broker);
         let submit_control = Arc::clone(&control);
-        let submitter = thread::spawn(move || submit_broker.submit("missing", &submit_control));
+        let submitter =
+            thread::spawn(move || submit_broker.submit_query("missing", &submit_control));
         let pending = loop {
             if let Some(pending) = broker.take_pending() {
                 break pending;
@@ -1917,7 +1971,7 @@ mod tests {
         assert!(submitter.join().unwrap().is_err());
 
         let mut app = new_app(&ctx);
-        let response = app.dispatch_macro_launcher_query(&pending.request);
+        let response = app.dispatch_macro_launcher_command(&pending.request);
         assert_eq!(response, LauncherCommandResponse::NoResults);
         assert!(!pending.respond(response));
     }

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -967,8 +967,8 @@ impl InputCleanupGuard {
 mod tests {
     use super::{fake::FakeBackend, *};
     use crate::mkmacro::{
-        AlphaPolicy, LauncherCommandBroker, LauncherCommandResponse, MkErrorPolicy, MkMacro,
-        MkPlayback, MkStep, ReturnPoint, SearchRegion, compile,
+        AlphaPolicy, LauncherCommandBroker, LauncherCommandKind, LauncherCommandResponse,
+        MkErrorPolicy, MkMacro, MkPlayback, MkStep, ReturnPoint, SearchRegion, compile,
     };
 
     fn run_production_launcher_command(response: LauncherCommandResponse) -> (ExecResult, String) {
@@ -986,7 +986,7 @@ mod tests {
             std::thread::yield_now();
         };
         let query = match &pending.request.kind {
-            super::LauncherCommandKind::Query(query) => query.clone(),
+            LauncherCommandKind::Query(query) => query.clone(),
             _ => panic!("expected query"),
         };
         assert!(pending.respond(response));

--- a/src/mkmacro/executor.rs
+++ b/src/mkmacro/executor.rs
@@ -165,6 +165,8 @@ pub trait LauncherBackend: Send + Sync {
     fn launch_process(&self, p: &MkProcessPayload) -> ExecResult;
     /// Submits raw text to the Launcher query/search pipeline.
     fn command(&self, query: &str, control: &RunControl) -> ExecResult;
+    /// Submits a migration-only resolved action for GUI-thread activation.
+    fn resolved_legacy(&self, action: &crate::actions::Action, control: &RunControl) -> ExecResult;
 }
 pub trait ClipboardBackend: Send + Sync {
     /// Captures the text clipboard. Backends which cannot preserve non-text
@@ -436,7 +438,7 @@ impl LauncherBackend for ProductionLauncher {
     fn command(&self, query: &str, control: &RunControl) -> ExecResult {
         let response = self
             .command_broker
-            .submit(query, control)
+            .submit_query(query, control)
             .map_err(|error| error.context("backend", "launcher").context("query", query))?;
         match response {
             super::LauncherCommandResponse::Activated
@@ -452,6 +454,31 @@ impl LauncherBackend for ProductionLauncher {
                     .context("backend", "launcher")
                     .context("query", query))
             }
+        }
+    }
+
+    fn resolved_legacy(&self, action: &crate::actions::Action, control: &RunControl) -> ExecResult {
+        let response = self
+            .command_broker
+            .submit_resolved_legacy(action.clone(), control)
+            .map_err(|error| {
+                error
+                    .context("backend", "launcher")
+                    .context("action", action.action.clone())
+            })?;
+        match response {
+            super::LauncherCommandResponse::Activated => Ok(()),
+            super::LauncherCommandResponse::Failed(message) => {
+                Err(ExecutionDiagnostic::new(DiagnosticKind::Backend, message)
+                    .context("backend", "launcher")
+                    .context("action", action.action.clone()))
+            }
+            other => Err(ExecutionDiagnostic::new(
+                DiagnosticKind::Backend,
+                format!("unexpected response to resolved legacy action: {other:?}"),
+            )
+            .context("backend", "launcher")
+            .context("action", action.action.clone())),
         }
     }
 }
@@ -513,6 +540,10 @@ impl LauncherBackend for Unsupported {
         unsupported()
     }
     fn command(&self, _: &str, control: &RunControl) -> ExecResult {
+        control.checkpoint()?;
+        unsupported()
+    }
+    fn resolved_legacy(&self, _: &crate::actions::Action, control: &RunControl) -> ExecResult {
         control.checkpoint()?;
         unsupported()
     }
@@ -954,7 +985,10 @@ mod tests {
             }
             std::thread::yield_now();
         };
-        let query = pending.request.query.clone();
+        let query = match &pending.request.kind {
+            super::LauncherCommandKind::Query(query) => query.clone(),
+            _ => panic!("expected query"),
+        };
         assert!(pending.respond(response));
         (worker.join().unwrap(), query)
     }
@@ -1033,8 +1067,9 @@ mod tests {
         let control = Arc::new(RunControl::default());
         let submitting_broker = Arc::clone(&broker);
         let submitting_control = Arc::clone(&control);
-        let submission =
-            std::thread::spawn(move || submitting_broker.submit("occupied", &submitting_control));
+        let submission = std::thread::spawn(move || {
+            submitting_broker.submit_query("occupied", &submitting_control)
+        });
         let _pending = loop {
             if let Some(pending) = broker.take_pending() {
                 break pending;
@@ -2302,12 +2337,31 @@ impl Executor {
             }
             MkAction::LauncherCommand(payload) => {
                 if let Some(action) = &payload.legacy_resolved_action {
-                    self.control.checkpoint()?;
-                    return crate::gui::execute_action(action).map_err(|error| {
-                        ExecutionDiagnostic::new(DiagnosticKind::Backend, error.to_string())
-                            .context("backend", "launcher")
-                            .context("action", action.label.clone())
-                    });
+                    let field = |value: &str, name: &'static str| {
+                        interpolate(value, v).map_err(|error| error.context("field", name))
+                    };
+                    let expanded = crate::actions::Action {
+                        label: field(
+                            &action.label,
+                            "launcher_command.legacy_resolved_action.label",
+                        )?,
+                        desc: field(&action.desc, "launcher_command.legacy_resolved_action.desc")?,
+                        action: field(
+                            &action.action,
+                            "launcher_command.legacy_resolved_action.action",
+                        )?,
+                        args: action
+                            .args
+                            .as_deref()
+                            .map(|value| {
+                                field(value, "launcher_command.legacy_resolved_action.args")
+                            })
+                            .transpose()?,
+                    };
+                    return self
+                        .backends
+                        .launcher
+                        .resolved_legacy(&expanded, Arc::as_ref(&self.control));
                 }
 
                 let query = interpolate(&payload.query, v)
@@ -3366,6 +3420,7 @@ pub mod fake {
         pub prompt_responses: Mutex<Vec<PromptResponse>>,
         pub processes: Mutex<Vec<MkProcessPayload>>,
         pub commands: Mutex<Vec<String>>,
+        pub legacy_actions: Mutex<Vec<crate::actions::Action>>,
         pub command_controls: Mutex<Vec<usize>>,
         pub prompts: Mutex<Vec<PromptRequest>>,
         pub window_calls: Mutex<Vec<WindowCall>>,
@@ -3386,6 +3441,7 @@ pub mod fake {
                 prompt_responses: Mutex::new(Vec::new()),
                 processes: Mutex::new(Vec::new()),
                 commands: Mutex::new(Vec::new()),
+                legacy_actions: Mutex::new(Vec::new()),
                 command_controls: Mutex::new(Vec::new()),
                 prompts: Mutex::new(Vec::new()),
                 window_calls: Mutex::new(Vec::new()),
@@ -3715,6 +3771,19 @@ pub mod fake {
                 .push(control as *const RunControl as usize);
             control.checkpoint()?;
             self.event(format!("command:{c}"))
+        }
+        fn resolved_legacy(
+            &self,
+            action: &crate::actions::Action,
+            control: &RunControl,
+        ) -> ExecResult {
+            self.legacy_actions.lock().unwrap().push(action.clone());
+            self.command_controls
+                .lock()
+                .unwrap()
+                .push(control as *const RunControl as usize);
+            control.checkpoint()?;
+            self.event(format!("legacy:{}", action.action))
         }
     }
     impl PromptBackend for FakeBackend {
@@ -4576,6 +4645,47 @@ mod phase_d_tests {
         assert_eq!(
             f.command_controls.lock().unwrap().as_slice(),
             [Arc::as_ptr(&control) as usize]
+        );
+    }
+
+    #[test]
+    fn migrated_launcher_action_is_interpolated_and_submitted_to_gui_boundary() {
+        let f = Arc::new(FakeBackend::default());
+        run(
+            vec![
+                s(
+                    1,
+                    MkAction::SetVariable {
+                        name: "name".into(),
+                        value: MkValue::String("daily".into()),
+                    },
+                ),
+                s(
+                    2,
+                    MkAction::LauncherCommand(MkLauncherCommandPayload {
+                        query: String::new(),
+                        legacy_resolved_action: Some(crate::actions::Action {
+                            label: "Open ${name}".into(),
+                            desc: "Description ${name}".into(),
+                            action: "note:open:${name}".into(),
+                            args: Some(r#"{"note":"${name}"}"#.into()),
+                        }),
+                    }),
+                ),
+            ],
+            f.clone(),
+        )
+        .unwrap();
+        assert!(f.commands.lock().unwrap().is_empty());
+        assert!(f.processes.lock().unwrap().is_empty());
+        assert_eq!(
+            f.legacy_actions.lock().unwrap().as_slice(),
+            &[crate::actions::Action {
+                label: "Open daily".into(),
+                desc: "Description daily".into(),
+                action: "note:open:daily".into(),
+                args: Some(r#"{"note":"daily"}"#.into()),
+            }]
         );
     }
 

--- a/src/mkmacro/launcher_command.rs
+++ b/src/mkmacro/launcher_command.rs
@@ -1,14 +1,21 @@
-//! Thread-safe boundary for raw Launcher queries sent from macro workers to the GUI.
+//! Thread-safe boundary for Launcher requests sent from macro workers to the GUI.
 
 use super::executor::{DiagnosticKind, ExecResult, ExecutionDiagnostic, RunControl};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::time::Duration;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LauncherCommandKind {
+    Query(String),
+    /// Compatibility-only action produced by macro document migration.
+    ResolvedLegacy(crate::actions::Action),
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct LauncherCommandRequest {
     pub id: u64,
-    pub query: String,
+    pub kind: LauncherCommandKind,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -70,12 +77,31 @@ impl LauncherCommandBroker {
         }
     }
 
-    pub fn submit(
+    pub fn submit_query(
         &self,
         query: impl Into<String>,
         control: &RunControl,
     ) -> ExecResult<LauncherCommandResponse> {
-        let query = query.into();
+        self.submit_kind(LauncherCommandKind::Query(query.into()), control)
+    }
+
+    pub fn submit_resolved_legacy(
+        &self,
+        action: crate::actions::Action,
+        control: &RunControl,
+    ) -> ExecResult<LauncherCommandResponse> {
+        self.submit_kind(LauncherCommandKind::ResolvedLegacy(action), control)
+    }
+
+    fn submit_kind(
+        &self,
+        kind: LauncherCommandKind,
+        control: &RunControl,
+    ) -> ExecResult<LauncherCommandResponse> {
+        let diagnostic_value = match &kind {
+            LauncherCommandKind::Query(query) => ("query", query.clone()),
+            LauncherCommandKind::ResolvedLegacy(action) => ("action", action.action.clone()),
+        };
         let (tx, rx) = mpsc::channel();
         let request_id;
         {
@@ -90,14 +116,12 @@ impl LauncherCommandBroker {
             *pending = Some(PendingLauncherCommand {
                 request: LauncherCommandRequest {
                     id: request_id,
-                    query: query.clone(),
+                    kind,
                 },
                 response: Some(tx),
             });
         }
 
-        // Clone and invoke outside both mutexes: GUI callbacks may immediately
-        // inspect the request or replace the callback itself.
         let repaint = self.repaint.lock().unwrap().clone();
         if let Some(repaint) = repaint {
             repaint();
@@ -105,17 +129,14 @@ impl LauncherCommandBroker {
 
         loop {
             if control.is_stopped() {
-                // Withdrawal can prevent execution only while this request is
-                // still in the broker. If the GUI has already taken it, the
-                // GUI owns processing; dropping `rx` below makes a late
-                // response harmless (`PendingLauncherCommand::respond`
-                // deliberately tolerates a disconnected receiver).
+                // Withdrawal prevents execution only until the GUI takes ownership.
+                // Once taken, dropping `rx` makes the eventual response harmless.
                 self.withdraw_pending(request_id);
                 return Err(ExecutionDiagnostic::new(
                     DiagnosticKind::Cancelled,
                     "Launcher command cancelled because automation stopped",
                 )
-                .context("query", query));
+                .context(diagnostic_value.0, diagnostic_value.1));
             }
             match rx.recv_timeout(Duration::from_millis(20)) {
                 Ok((id, response)) if id == request_id => return Ok(response),
@@ -127,7 +148,7 @@ impl LauncherCommandBroker {
                         "Launcher command response channel disconnected",
                     )
                     .context("backend", "launcher")
-                    .context("query", query));
+                    .context(diagnostic_value.0, diagnostic_value.1));
                 }
             }
         }
@@ -155,7 +176,7 @@ mod tests {
     ) -> thread::JoinHandle<ExecResult<LauncherCommandResponse>> {
         let broker = Arc::clone(broker);
         let query = query.to_owned();
-        thread::spawn(move || broker.submit(query, &RunControl::default()))
+        thread::spawn(move || broker.submit_query(query, &RunControl::default()))
     }
 
     fn wait_for_pending(broker: &LauncherCommandBroker) -> PendingLauncherCommand {
@@ -180,7 +201,9 @@ mod tests {
         let query = query.to_owned();
         let (result_tx, result_rx) = mpsc::channel();
         let handle = thread::spawn(move || {
-            result_tx.send(broker.submit(query, &control)).unwrap();
+            result_tx
+                .send(broker.submit_query(query, &control))
+                .unwrap();
         });
         (result_rx, handle)
     }
@@ -191,7 +214,13 @@ mod tests {
         let first = submit_async(&broker, "  first QUERY  ");
         let pending = wait_for_pending(&broker);
         let first_id = pending.request.id;
-        assert_eq!(pending.request.query, "  first QUERY  ");
+        assert_eq!(
+            match &pending.request.kind {
+                LauncherCommandKind::Query(query) => query,
+                _ => panic!("expected query"),
+            },
+            "  first QUERY  "
+        );
         assert!(pending.respond(LauncherCommandResponse::Activated));
         assert_eq!(
             first.join().unwrap().unwrap(),
@@ -203,6 +232,69 @@ mod tests {
         assert!(pending.request.id > first_id);
         assert!(pending.respond(LauncherCommandResponse::NoResults));
         second.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn both_request_kinds_round_trip_and_preserve_ids() {
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let query_worker = submit_async(&broker, "query");
+        let query = wait_for_pending(&broker);
+        let query_id = query.request.id;
+        assert_eq!(
+            query.request.kind,
+            LauncherCommandKind::Query("query".into())
+        );
+        assert!(query.respond(LauncherCommandResponse::NoResults));
+        query_worker.join().unwrap().unwrap();
+
+        let action = crate::actions::Action {
+            label: "Notes".into(),
+            desc: "Open dialog".into(),
+            action: "note:dialog".into(),
+            args: Some("payload".into()),
+        };
+        let submit_broker = Arc::clone(&broker);
+        let expected = action.clone();
+        let worker = thread::spawn(move || {
+            submit_broker.submit_resolved_legacy(action, &RunControl::default())
+        });
+        let legacy = wait_for_pending(&broker);
+        assert!(legacy.request.id > query_id);
+        assert_eq!(
+            legacy.request.kind,
+            LauncherCommandKind::ResolvedLegacy(expected)
+        );
+        assert!(legacy.respond(LauncherCommandResponse::Activated));
+        assert_eq!(
+            worker.join().unwrap().unwrap(),
+            LauncherCommandResponse::Activated
+        );
+    }
+
+    #[test]
+    fn query_and_legacy_share_pending_slot() {
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let first = submit_async(&broker, "first");
+        while broker.pending.lock().unwrap().is_none() {
+            thread::yield_now();
+        }
+        let error = broker
+            .submit_resolved_legacy(
+                crate::actions::Action {
+                    label: "legacy".into(),
+                    desc: String::new(),
+                    action: "help:show".into(),
+                    args: None,
+                },
+                &RunControl::default(),
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.message,
+            "another Launcher command request is already active"
+        );
+        assert!(wait_for_pending(&broker).respond(LauncherCommandResponse::Activated));
+        first.join().unwrap().unwrap();
     }
 
     #[test]
@@ -238,14 +330,22 @@ mod tests {
         while broker.pending.lock().unwrap().is_none() {
             thread::yield_now();
         }
-        let error = broker.submit("second", &RunControl::default()).unwrap_err();
+        let error = broker
+            .submit_query("second", &RunControl::default())
+            .unwrap_err();
         assert_eq!(error.kind, DiagnosticKind::Backend);
         assert_eq!(
             error.message,
             "another Launcher command request is already active"
         );
         let pending = broker.take_pending().unwrap();
-        assert_eq!(pending.request.query, "first");
+        assert_eq!(
+            match &pending.request.kind {
+                LauncherCommandKind::Query(query) => query,
+                _ => panic!("expected query"),
+            },
+            "first"
+        );
         assert!(pending.respond(LauncherCommandResponse::Activated));
         first.join().unwrap().unwrap();
     }
@@ -263,7 +363,9 @@ mod tests {
         }));
 
         assert_eq!(
-            broker.submit("query", &RunControl::default()).unwrap(),
+            broker
+                .submit_query("query", &RunControl::default())
+                .unwrap(),
             LauncherCommandResponse::Activated
         );
         assert!(called.load(Ordering::SeqCst));
@@ -333,6 +435,34 @@ mod tests {
     }
 
     #[test]
+    fn stop_withdraws_pending_legacy_request() {
+        let broker = Arc::new(LauncherCommandBroker::default());
+        let control = Arc::new(RunControl::default());
+        let submit_broker = Arc::clone(&broker);
+        let submit_control = Arc::clone(&control);
+        let worker = thread::spawn(move || {
+            submit_broker.submit_resolved_legacy(
+                crate::actions::Action {
+                    label: "Help".into(),
+                    desc: String::new(),
+                    action: "help:show".into(),
+                    args: None,
+                },
+                &submit_control,
+            )
+        });
+        while broker.pending.lock().unwrap().is_none() {
+            thread::yield_now();
+        }
+        control.stop();
+        assert_eq!(
+            worker.join().unwrap().unwrap_err().kind,
+            DiagnosticKind::Cancelled
+        );
+        assert!(broker.take_pending().is_none());
+    }
+
+    #[test]
     fn cancellation_of_taken_request_does_not_withdraw_later_request() {
         let broker = Arc::new(LauncherCommandBroker::default());
         let first_control = Arc::new(RunControl::default());
@@ -359,7 +489,10 @@ mod tests {
         let second = broker
             .take_pending()
             .expect("request N+1 must remain pending");
-        assert_eq!(second.request.query, "second");
+        assert_eq!(
+            second.request.kind,
+            LauncherCommandKind::Query("second".into())
+        );
         assert!(!first.respond(LauncherCommandResponse::Activated));
         assert!(second.respond(LauncherCommandResponse::Activated));
         assert_eq!(


### PR DESCRIPTION
### Motivation

- Introduce a typed request payload so macro workers can submit either a normal Launcher query or a migration-only resolved legacy `Action` while keeping a single broker lifecycle (IDs, cancellation, repaint, response correlation).
- Ensure migrated legacy actions are interpolated by the worker and delivered to the GUI thread for activation instead of invoking GUI-owned behavior from the macro worker.
- Provide clear, separate submission APIs so callers cannot confuse raw query submissions and migration-only resolved-action submissions.

### Description

- Add `LauncherCommandKind` (`Query(String)` and `ResolvedLegacy(crate::actions::Action)`) and change `LauncherCommandRequest` to carry `id` + `kind` instead of an unconditional `query` (file: `src/mkmacro/launcher_command.rs`).
- Introduce `submit_query`, `submit_resolved_legacy`, and an internal `submit_kind` that preserve a single pending-slot, monotonic request IDs, cancellation/withdrawal behavior, repaint callback, and response correlation (file: `src/mkmacro/launcher_command.rs`).
- Extend the `LauncherBackend` trait with `resolved_legacy(...)`, implement it for `ProductionLauncher`, `Unsupported`, and the `fake` backend, and update the production executor to call `.resolved_legacy(...)` for migrated payloads while mapping GUI activation failures into `ExecutionDiagnostic` (file: `src/mkmacro/executor.rs`).
- Stop calling `crate::gui::execute_action()` from the macro worker; instead interpolate every textual legacy-action field (label, desc, action, args) using existing interpolation diagnostics, build an expanded `Action`, and submit it through the broker for GUI activation on the UI thread.
- Update GUI dispatch to accept the typed request, preserve existing search/result behavior for `Query`, and for `ResolvedLegacy(action)` call `self.activate_action(action, None, ActivationSource::Macro)` on the GUI thread while preserving the launcher interaction snapshot/restore behavior (file: `src/gui/render.rs`).
- Add regression/unit tests exercising both request kinds, the single-pending-request exclusion, cancellation/withdrawal semantics, stale-response handling, executor interpolation and submission of migrated actions, and GUI dispatch activation with `ActivationSource::Macro` (tests in `src/mkmacro/launcher_command.rs`, `src/mkmacro/executor.rs`, and `src/gui/render.rs`).

### Testing

- Ran formatting and static checks: `cargo fmt --check` and `git diff --check` succeeded.
- Ran targeted unit tests for the modified modules and added cases (e.g. tests under `mkmacro::launcher_command`, `mkmacro::executor`, and `gui::render` exercising migrated legacy activation); those tests passed in this environment.
- A full `cargo check --tests` / complete test-suite run is blocked by platform-specific build failures in other parts of the repo (missing Linux pkg-config/X11/Win32 platform libraries and target-specific Windows APIs); these failures are unrelated to the broker/executor/GUI changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a923072c13c83329442392095177743)