### PR TITLE
Refactor Launcher Command picker to safe query suggestions

### DIFF
--- a/src/gui/mkmacro_dialog/launcher_action_picker.rs
+++ b/src/gui/mkmacro_dialog/launcher_action_picker.rs
@@ -143,10 +143,38 @@ pub fn apply_program_action(payload: &mut MkProcessPayload, action: &Action) {
     }
 }
 
-pub fn apply_launcher_action(target: &mut MkAction, action: &Action) {
+/// A launcher action that can be represented without persisting a resolved
+/// target. Everything else is deliberately absent from the command picker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LauncherQuerySuggestion {
+    Query(String),
+    Application(String),
+}
+
+pub fn launcher_query_suggestion(action: &Action) -> Option<LauncherQuerySuggestion> {
+    if let Some(query) = action.action.strip_prefix("query:") {
+        return Some(LauncherQuerySuggestion::Query(
+            crate::mkmacro::store::query_action_text(query, action.args.as_deref()),
+        ));
+    }
+
+    // A resolved application is useful only as a normal Launcher search when
+    // the immutable authoring snapshot supplied an actual display name.
+    let label = action.label.trim();
+    if is_direct_program(&action.action)
+        && !action.action.starts_with("http://")
+        && !action.action.starts_with("https://")
+        && !label.is_empty()
+        && label != action.action.trim()
+    {
+        return Some(LauncherQuerySuggestion::Application(label.to_owned()));
+    }
+    None
+}
+
+fn set_launcher_query(target: &mut MkAction, query: String) {
     *target = MkAction::LauncherCommand(MkLauncherCommandPayload {
-        // Picker rows are suggestions for search text, not resolved actions.
-        query: action.action.clone(),
+        query,
         legacy_resolved_action: None,
     });
 }
@@ -188,7 +216,14 @@ impl super::action_editor::ActionEditorState {
                 apply_program_action(payload, action);
             }
             PickerPurpose::Process if convert => {
-                apply_launcher_action(&mut step.action, action);
+                let Some(suggestion) = launcher_query_suggestion(action) else {
+                    return false;
+                };
+                let query = match suggestion {
+                    LauncherQuerySuggestion::Query(query)
+                    | LauncherQuerySuggestion::Application(query) => query,
+                };
+                set_launcher_query(&mut step.action, query);
                 self.editor = Some(super::action_catalog::EditorKind::Launcher);
             }
             PickerPurpose::Process => return false,
@@ -196,7 +231,14 @@ impl super::action_editor::ActionEditorState {
                 if !matches!(step.action, MkAction::LauncherCommand(_)) {
                     return false;
                 }
-                apply_launcher_action(&mut step.action, action);
+                let Some(suggestion) = launcher_query_suggestion(action) else {
+                    return false;
+                };
+                let query = match suggestion {
+                    LauncherQuerySuggestion::Query(query)
+                    | LauncherQuerySuggestion::Application(query) => query,
+                };
+                set_launcher_query(&mut step.action, query);
             }
         }
         true
@@ -211,100 +253,133 @@ pub fn show(ctx: &egui::Context, dialog: &mut super::MkMacroDialog) {
     let mut open = true;
     let mut choose = false;
     let mut cancel = false;
-    egui::Window::new("Choose Launcher Action")
-        .collapsible(false)
-        .open(&mut open)
-        .default_width(680.0)
-        .show(ctx, |ui| {
-            let state = &mut dialog.launcher_action_picker;
-            let response = ui.add(
-                egui::TextEdit::singleline(&mut state.search)
-                    .hint_text("Search label, description, action, or arguments"),
-            );
-            response.request_focus();
-            let visible = matching_action_indices(&actions, &state.search);
-            if actions.is_empty() {
-                ui.label("No launcher actions are available in this authoring snapshot.");
-            } else if visible.is_empty() {
-                ui.label("No launcher actions match this search.");
-            }
-            egui::ScrollArea::vertical()
-                .max_height(320.0)
-                .show(ui, |ui| {
-                    for &index in &visible {
-                        let a = &actions[index];
-                        let text = format!(
-                            "{}\n{}\n{}{}",
-                            a.label,
-                            a.desc,
+    let purpose = dialog
+        .launcher_action_picker
+        .request
+        .as_ref()
+        .map(|r| r.purpose);
+    egui::Window::new(match purpose {
+        Some(PickerPurpose::LauncherCommand) => "Choose Launcher Command Suggestion",
+        _ => "Choose Program or Launcher Query",
+    })
+    .collapsible(false)
+    .open(&mut open)
+    .default_width(680.0)
+    .show(ctx, |ui| {
+        let state = &mut dialog.launcher_action_picker;
+        let response = ui.add(
+            egui::TextEdit::singleline(&mut state.search)
+                .hint_text("Search command/query suggestions"),
+        );
+        response.request_focus();
+        let eligible: Vec<usize> = actions
+            .iter()
+            .enumerate()
+            .filter(|(_, action)| {
+                purpose != Some(PickerPurpose::LauncherCommand)
+                    || launcher_query_suggestion(action).is_some()
+            })
+            .map(|(index, _)| index)
+            .collect();
+        let ranked = matching_action_indices(&actions, &state.search);
+        let visible: Vec<usize> = ranked
+            .into_iter()
+            .filter(|index| eligible.contains(index))
+            .collect();
+        if eligible.is_empty() {
+            ui.label("No safe Launcher command/query suggestions are available.");
+        } else if visible.is_empty() {
+            ui.label("No Launcher command/query suggestions match this search.");
+        }
+        egui::ScrollArea::vertical()
+            .max_height(320.0)
+            .show(ui, |ui| {
+                for &index in &visible {
+                    let a = &actions[index];
+                    let detail = match purpose {
+                        Some(PickerPurpose::LauncherCommand) => launcher_query_suggestion(a)
+                            .map(|suggestion| match suggestion {
+                                LauncherQuerySuggestion::Query(query)
+                                | LauncherQuerySuggestion::Application(query) => {
+                                    format!("Query suggestion: {query}")
+                                }
+                            })
+                            .unwrap_or_default(),
+                        _ => format!(
+                            "Program/action: {}{}",
                             a.action,
                             a.args
                                 .as_ref()
                                 .map(|v| format!("  {v}"))
                                 .unwrap_or_default()
-                        );
-                        let row = ui.selectable_label(state.selected == Some(index), text);
-                        if row.clicked() {
-                            state.selected = Some(index);
-                        }
-                        if row.double_clicked() {
-                            state.selected = Some(index);
-                            choose = true;
-                        }
+                        ),
+                    };
+                    let text = format!("{}\n{}\n{}", a.label, a.desc, detail);
+                    let row = ui.selectable_label(state.selected == Some(index), text);
+                    if row.clicked() {
+                        state.selected = Some(index);
                     }
-                });
-            let down = ui.input(|i| i.key_pressed(egui::Key::ArrowDown));
-            let up = ui.input(|i| i.key_pressed(egui::Key::ArrowUp));
-            if (down || up) && !visible.is_empty() {
-                let pos = state
-                    .selected
-                    .and_then(|s| visible.iter().position(|i| *i == s));
-                let next = if down {
-                    pos.map_or(0, |p| (p + 1).min(visible.len() - 1))
-                } else {
-                    pos.map_or(visible.len() - 1, |p| p.saturating_sub(1))
-                };
-                state.selected = Some(visible[next]);
-            }
-            if ui.input(|i| i.key_pressed(egui::Key::Enter)) && state.selected.is_some() {
-                choose = true;
-            }
-            if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-                cancel = true;
-            }
-            ui.horizontal(|ui| {
-                if ui
-                    .add_enabled(
-                        state.selected.is_some(),
-                        egui::Button::new("Use Selected Action"),
-                    )
-                    .clicked()
-                {
-                    choose = true;
-                }
-                if ui.button("Cancel").clicked() {
-                    cancel = true;
+                    if row.double_clicked() {
+                        state.selected = Some(index);
+                        choose = true;
+                    }
                 }
             });
-            if let Some(action) = state.conversion_confirmation.clone() {
-                ui.separator();
-                ui.label("This is a launcher command rather than a directly runnable program.");
-                if ui.button("Use as Launcher Command instead").clicked() {
-                    if let Some(request) = state.request.clone() {
-                        dialog.action_editor.apply_launcher_picker_action(
-                            &request,
-                            &action,
-                            dialog.selected_macro_id,
-                            true,
-                        );
-                    }
-                    cancel = true;
-                }
-                if ui.button("Keep Run Program").clicked() {
-                    state.conversion_confirmation = None;
-                }
+        let down = ui.input(|i| i.key_pressed(egui::Key::ArrowDown));
+        let up = ui.input(|i| i.key_pressed(egui::Key::ArrowUp));
+        if (down || up) && !visible.is_empty() {
+            let pos = state
+                .selected
+                .and_then(|s| visible.iter().position(|i| *i == s));
+            let next = if down {
+                pos.map_or(0, |p| (p + 1).min(visible.len() - 1))
+            } else {
+                pos.map_or(visible.len() - 1, |p| p.saturating_sub(1))
+            };
+            state.selected = Some(visible[next]);
+        }
+        if ui.input(|i| i.key_pressed(egui::Key::Enter)) && state.selected.is_some() {
+            choose = true;
+        }
+        if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+            cancel = true;
+        }
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(
+                    state.selected.is_some(),
+                    egui::Button::new(match purpose {
+                        Some(PickerPurpose::LauncherCommand) => "Use Query Suggestion",
+                        _ => "Use Selected Program",
+                    }),
+                )
+                .clicked()
+            {
+                choose = true;
+            }
+            if ui.button("Cancel").clicked() {
+                cancel = true;
             }
         });
+        if let Some(action) = state.conversion_confirmation.clone() {
+            ui.separator();
+            ui.label("This choice can be stored as a safe Launcher query instead of a program.");
+            if ui.button("Use Launcher Query instead").clicked() {
+                if let Some(request) = state.request.clone() {
+                    dialog.action_editor.apply_launcher_picker_action(
+                        &request,
+                        &action,
+                        dialog.selected_macro_id,
+                        true,
+                    );
+                }
+                cancel = true;
+            }
+            if ui.button("Keep Run Program").clicked() {
+                state.conversion_confirmation = None;
+            }
+        }
+    });
     if !open || cancel {
         dialog.launcher_action_picker.cancel();
         return;
@@ -314,7 +389,9 @@ pub fn show(ctx: &egui::Context, dialog: &mut super::MkMacroDialog) {
         if let (Some(index), Some(request)) = (state.selected, state.request.clone()) {
             if let Some(action) = actions.get(index) {
                 if request.purpose == PickerPurpose::Process && !is_direct_program(&action.action) {
-                    state.conversion_confirmation = Some(action.clone());
+                    if launcher_query_suggestion(action).is_some() {
+                        state.conversion_confirmation = Some(action.clone());
+                    }
                 } else {
                     dialog.action_editor.apply_launcher_picker_action(
                         &request,
@@ -416,24 +493,113 @@ mod tests {
     }
 
     #[test]
-    fn launcher_transfer_persists_no_display_metadata() {
-        let selected = action(
-            "Secret label",
-            "Secret description",
-            "notes:dialog",
-            Some("  "),
+    fn query_actions_use_the_launcher_argument_contract() {
+        for (command, args, expected) in [
+            ("query:bm list", None, "bm list"),
+            ("query:f list", None, "f list"),
+            (
+                "query:note  open ${name}",
+                Some(r#"{"query":"  --exact ${name}"}"#),
+                "note  open ${name} --exact ${name}",
+            ),
+            ("query:f list", Some("   "), "f list"),
+        ] {
+            let selected = action("Suggestion", "", command, args);
+            assert_eq!(
+                launcher_query_suggestion(&selected),
+                Some(LauncherQuerySuggestion::Query(expected.into()))
+            );
+        }
+    }
+
+    #[test]
+    fn unsafe_resolved_targets_are_not_raw_queries() {
+        for command in ["notes:dialog", "https://example.test", "/usr/bin/tool"] {
+            let selected = action(command, "", command, None);
+            assert_eq!(launcher_query_suggestion(&selected), None, "{command}");
+        }
+    }
+
+    #[test]
+    fn application_uses_searchable_display_name() {
+        let selected = action("Firefox", "Web browser", "/usr/bin/firefox", None);
+        assert_eq!(
+            launcher_query_suggestion(&selected),
+            Some(LauncherQuerySuggestion::Application("Firefox".into()))
         );
-        let mut target = MkAction::Delay { milliseconds: 1 };
-        apply_launcher_action(&mut target, &selected);
+    }
+
+    #[test]
+    fn launcher_query_payload_clears_legacy_data_and_serializes_only_v8_data() {
+        let mut target = MkAction::LauncherCommand(MkLauncherCommandPayload {
+            query: "old".into(),
+            legacy_resolved_action: Some(action(
+                "Secret label",
+                "Secret description",
+                "notes:dialog",
+                None,
+            )),
+        });
+        set_launcher_query(&mut target, "bm list".into());
         assert_eq!(
             target,
             MkAction::LauncherCommand(MkLauncherCommandPayload {
-                query: "notes:dialog".into(),
+                query: "bm list".into(),
                 legacy_resolved_action: None,
             })
         );
         let json = serde_json::to_string(&target).unwrap();
         assert!(!json.contains("Secret"));
+        assert!(!json.contains("legacy_resolved_action"));
         assert_eq!(serde_json::from_str::<MkAction>(&json).unwrap(), target);
+    }
+
+    #[test]
+    fn stale_picker_request_does_not_mutate_draft() {
+        let overlay = super::super::visual_capture_workflow::SharedVisualOverlayController::new(
+            super::super::visual_overlay::VisualOverlayController::default(),
+        );
+        let mut editor = super::super::action_editor::ActionEditorState::new(overlay);
+        editor.editing_id = Some(7);
+        editor.draft = Some(crate::mkmacro::MkStep {
+            id: 7,
+            enabled: true,
+            repeat: 1,
+            delay_after_ms: 0,
+            on_error: Default::default(),
+            action: MkAction::LauncherCommand(MkLauncherCommandPayload {
+                query: "unchanged".into(),
+                legacy_resolved_action: None,
+            }),
+        });
+        let before = editor.draft.clone();
+        let valid = LauncherActionRequest {
+            purpose: PickerPurpose::LauncherCommand,
+            macro_id: 12,
+            step_id: Some(7),
+            draft_generation: 0,
+        };
+        for request in [
+            LauncherActionRequest {
+                macro_id: 13,
+                ..valid.clone()
+            },
+            LauncherActionRequest {
+                step_id: Some(8),
+                ..valid.clone()
+            },
+            LauncherActionRequest {
+                draft_generation: 1,
+                ..valid.clone()
+            },
+        ] {
+            assert!(!editor.apply_launcher_picker_action(
+                &request,
+                &action("Bookmarks", "", "query:bm list", None),
+                Some(12),
+                false,
+            ));
+            assert_eq!(editor.draft, before);
+        }
     }
 }

--- a/src/mkmacro/store.rs
+++ b/src/mkmacro/store.rs
@@ -491,7 +491,7 @@ fn join_legacy_text(command: &str, args: Option<&str>) -> String {
     }
 }
 
-fn query_action_text(query: &str, args: Option<&str>) -> String {
+pub(crate) fn query_action_text(query: &str, args: Option<&str>) -> String {
     // This is the only argument contract implemented by Launcher `query:` actions.
     // Arbitrary action args are deliberately not guessed into the query.
     let query_arg = args

--- a/tests/mkmacro_authoring.rs
+++ b/tests/mkmacro_authoring.rs
@@ -248,6 +248,12 @@ fn launcher_snapshot_picker_is_transactional_convertible_and_stale_safe() {
             action: "notes:dialog".into(),
             args: None,
         },
+        Action {
+            label: "List notes".into(),
+            desc: "query suggestion".into(),
+            action: "query:note list".into(),
+            args: Some(r#"{"query":"${project}"}"#.into()),
+        },
     ]);
     let mut dialog = MkMacroDialog::new_with_authoring_context(
         Arc::new(store),
@@ -296,14 +302,23 @@ fn launcher_snapshot_picker_is_transactional_convertible_and_stale_safe() {
     let conversion = dialog
         .action_editor
         .launcher_picker_request(PickerPurpose::Process, macro_id);
+    assert!(
+        !dialog.action_editor.apply_launcher_picker_action(
+            &conversion,
+            &actions[1],
+            Some(macro_id),
+            true
+        ),
+        "a resolved dialog action cannot be converted into a raw query"
+    );
     assert!(dialog.action_editor.apply_launcher_picker_action(
         &conversion,
-        &actions[1],
+        &actions[2],
         Some(macro_id),
         true
     ));
     assert!(
-        matches!(&dialog.action_editor.draft.as_ref().unwrap().action, MkAction::LauncherCommand(payload) if payload.query == "notes:dialog")
+        matches!(&dialog.action_editor.draft.as_ref().unwrap().action, MkAction::LauncherCommand(payload) if payload.query == "note list ${project}" && payload.legacy_resolved_action.is_none())
     );
     dialog.action_editor.cancel();
     dialog


### PR DESCRIPTION
### Motivation

- Make the Launcher picker produce query-oriented payloads instead of persisting resolved canonical targets or exposing unsafe IDs/URLs/paths.
- Reuse the Launcher’s existing `query:` argument contract so queries are reconstructed exactly as the runtime expects without inventing shell quoting.
- Keep Process-picker behavior and stale-request guards (`macro_id`, `step_id`, `draft_generation`) intact while preventing accidental draft mutation from stale requests.

### Description

- Replaced the old `apply_launcher_action` behavior with a typed classifier `LauncherQuerySuggestion` and helper `launcher_query_suggestion` that recognizes `query:` actions and trustworthy application display-name suggestions, and hides unsafe canonical targets and URLs; added `set_launcher_query` to populate only `MkLauncherCommandPayload.query` and always clear `legacy_resolved_action` (files changed: `src/gui/mkmacro_dialog/launcher_action_picker.rs`, `src/mkmacro/store.rs`).
- Exported `query_action_text` as `pub(crate)` in `src/mkmacro/store.rs` and reused it to reconstruct `query:` actions according to the Launcher’s contract while preserving internal whitespace and variable syntax and ignoring blank args.
- Filtered the `PickerPurpose::LauncherCommand` view to only show safe query or application suggestions, updated window title, search hint, empty-state messages, item detail text, confirmation text, and button labels to reflect query-oriented behavior, and required explicit confirmation for conversion of Process choices to a Launcher query.
- Reworked conversion logic so Process→Launcher conversion uses the same safe classification (no bypass), preserved the existing stale-request guard checks in `apply_launcher_picker_action`, and ensured serialization after selection contains only the v8 query payload with `legacy_resolved_action = None`.
- Replaced and extended unit tests in the picker module to cover `query:bm list` → `bm list`, `query:f list` → `f list`, query reconstruction when nonblank `action.args` exist, ignoring blank args, excluding unsafe canonical `notes:dialog`, URLs and absolute executable paths from raw-query choices, application suggestions using display-name where trustworthy, clearing any preexisting `legacy_resolved_action`, and rejecting stale picker requests without mutating the draft.

### Testing

- Ran `cargo fmt --check` which passed and verified formatting.
- Ran `git diff --check` which passed with no issues reported.
- Attempted `cargo test launcher_action_picker --lib`; the new unit tests are present but the full test/build could not complete in this Linux environment because the workspace contains Windows-targeted crates and native dependencies (Windows API and system libs) that cannot be built on the current platform, so the CI-level test run failed to finish here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92b9300ffc8332a08f176fe9d55f40)